### PR TITLE
fix: add `solana-bpf-sdk-install` command to permit users to easily update their bpf-sdk

### DIFF
--- a/bin/bpf-sdk-install.sh
+++ b/bin/bpf-sdk-install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+installDir=$1
+if [[ -z $installDir ]]; then
+  installDir="$(cd "$(dirname "$0")"/..; pwd)"
+fi
+
+channel=$("$(dirname "$0")"/testnet-default-channel.js)
+if [[ -n $2 ]]; then
+  channel=$2
+fi
+[[ $channel = edge || $channel = beta ]] || {
+  echo "Error: Invalid channel: $channel"
+  exit 1
+}
+
+echo "Installing $channel BPF SDK into $installDir"
+
+set -x
+cd "$installDir/"
+curl -L  --retry 5 --retry-delay 2 -o bpf-sdk.tar.bz2 \
+  http://solana-sdk.s3.amazonaws.com/"$channel"/bpf-sdk.tar.bz2
+rm -rf bpf-sdk
+mkdir -p bpf-sdk
+tar jxf bpf-sdk.tar.bz2
+rm -f bpf-sdk.tar.bz2
+
+cat bpf-sdk/version.txt

--- a/bin/localnet.sh
+++ b/bin/localnet.sh
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-channel=$(
-  cd "$(dirname "$0")";
-  node -p '
-    let p = [
-      "../lib/node_modules/@solana/web3.js/package.json",
-      "../@solana/web3.js/package.json",
-      "../package.json"
-    ].find(require("fs").existsSync);
-    if (!p) throw new Error("Unable to locate solana-web3.js directory");
-    require(p)["testnetDefaultChannel"]
-  '
-)
+channel=$("$(dirname "$0")"/testnet-default-channel.js)
 
 usage() {
   exitcode=0

--- a/bin/testnet-default-channel.js
+++ b/bin/testnet-default-channel.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+let p = [
+  __dirname + '/../lib/node_modules/@solana/web3.js/package.json',
+  __dirname + '/../@solana/web3.js/package.json',
+  __dirname + '/../package.json'
+].find(require('fs').existsSync);
+if (!p) throw new Error('Unable to locate solana-web3.js directory');
+
+console.log(require(p)['testnetDefaultChannel']);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "bin": {
+    "solana-bpf-sdk-install": "bin/bpf-sdk-install.sh",
     "solana-localnet": "bin/localnet.sh"
   },
   "testnetDefaultChannel": "edge",
@@ -35,11 +36,8 @@
     "/src"
   ],
   "scripts": {
-    "bpf-sdk:install": "run-s bpf-sdk:clean bpf-sdk:fetch bpf-sdk:extract bpf-sdk:remove-symlinks bpf-sdk:clean",
-    "bpf-sdk:extract": "rimraf bpf-sdk; tar jxvf bpf-sdk.tar.bz2",
-    "bpf-sdk:fetch": "curl http://solana-sdk.s3.amazonaws.com/$npm_package_testnetDefaultChannel/bpf-sdk.tar.bz2 -o bpf-sdk.tar.bz2",
+    "bpf-sdk:install": "bin/bpf-sdk-install.sh",
     "bpf-sdk:remove-symlinks": "find bpf-sdk -type l -print -exec cp {} {}.tmp \\; -exec mv {}.tmp {} \\;",
-    "bpf-sdk:clean": "rimraf bpf-sdk.tar.bz2",
     "build": "cross-env NODE_ENV=production rollup -c",
     "clean": "rimraf ./coverage ./lib",
     "codecov": "set -ex; npm run test:cover; cat ./coverage/lcov.info | codecov",
@@ -58,7 +56,7 @@
     "localnet:up": "bin/localnet.sh up $npm_package_testnetDefaultChannel",
     "localnet:update": "bin/localnet.sh update $npm_package_testnetDefaultChannel",
     "ok": "run-s --serial lint flow test doc",
-    "prepare": "run-s clean bpf-sdk:install build",
+    "prepare": "run-s clean bpf-sdk:install bpf-sdk:remove-symlinks build",
     "pretty": "prettier --write '{,{examples,src,test}/**/}*.js'",
     "re": "semantic-release --repository-url git@github.com:solana-labs/solana-web3.js.git",
     "test": "cross-env NODE_ENV=test jest --useStderr",


### PR DESCRIPTION
@jackcmay, once this lands from tic-tac-toe we'll be able to run `solana-bpf-sdk-install` to refresh the bpf-sdk without having to ship a new solana-web3.js