### PR TITLE
Expose `getTotalSupply` RPC method

### DIFF
--- a/module.flow.js
+++ b/module.flow.js
@@ -93,6 +93,7 @@ declare module '@solana/web3.js' {
       signature: TransactionSignature,
     ): Promise<SignatureSuccess | TransactionError | null>;
     getTransactionCount(): Promise<number>;
+    getTotalSupply(): Promise<number>;
     getRecentBlockhash(): Promise<[Blockhash, FeeCalculator]>;
     requestAirdrop(
       to: PublicKey,

--- a/src/connection.js
+++ b/src/connection.js
@@ -215,6 +215,11 @@ const GetSignatureStatusRpcResult = jsonRpcResult(
 const GetTransactionCountRpcResult = jsonRpcResult('number');
 
 /**
+ * Expected JSON RPC response for the "getTotalSupply" message
+ */
+const GetTotalSupplyRpcResult = jsonRpcResult('number');
+
+/**
  * Expected JSON RPC response for the "getRecentBlockhash" message
  */
 const GetRecentBlockhash = jsonRpcResult([
@@ -517,6 +522,19 @@ export class Connection {
   async getTransactionCount(): Promise<number> {
     const unsafeRes = await this._rpcRequest('getTransactionCount', []);
     const res = GetTransactionCountRpcResult(unsafeRes);
+    if (res.error) {
+      throw new Error(res.error.message);
+    }
+    assert(typeof res.result !== 'undefined');
+    return Number(res.result);
+  }
+
+  /**
+   * Fetch the current total currency supply of the cluster
+   */
+  async getTotalSupply(): Promise<number> {
+    const unsafeRes = await this._rpcRequest('getTotalSupply', []);
+    const res = GetTotalSupplyRpcResult(unsafeRes);
     if (res.error) {
       throw new Error(res.error.message);
     }

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -199,6 +199,25 @@ test('get transaction count', async () => {
   expect(count).toBeGreaterThanOrEqual(0);
 });
 
+test('get total supply', async () => {
+  const connection = new Connection(url);
+
+  mockRpc.push([
+    url,
+    {
+      method: 'getTotalSupply',
+      params: [],
+    },
+    {
+      error: null,
+      result: 1000000,
+    },
+  ]);
+
+  const count = await connection.getTotalSupply();
+  expect(count).toBeGreaterThanOrEqual(0);
+});
+
 test('get recent blockhash', async () => {
   const connection = new Connection(url);
 


### PR DESCRIPTION
Follow on to https://github.com/solana-labs/solana/pull/4774/

I *think* I hit all of the spots.  Tests pass anyway

I did have to remove `--serial` from https://github.com/solana-labs/solana-web3.js/blob/master/package.json#L58 to get `npm run ok` to not complain about thinking it's an invalid option.  I couldn't find any documentation for that flag, but the scripts seemed to run sequentially.