### PR TITLE
fix: Fix transaction live test for credit-only accounts

### DIFF
--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -480,6 +480,11 @@ test('transaction', async () => {
       result: 31,
     },
   ]);
+  if (!mockRpcEnabled) {
+    // Credit-only account credits are committed at the end of every slot;
+    // this sleep is to ensure a full slot has elapsed
+    await sleep((1000 * DEFAULT_TICKS_PER_SLOT) / NUM_TICKS_PER_SECOND);
+  }
   expect(await connection.getBalance(accountTo.publicKey)).toBe(31);
 });
 


### PR DESCRIPTION
CI tests have been failing since credit-only accounts landed on solana (https://github.com/solana-labs/solana/pull/4691), as system transfer credits only get committed on slot boundary