### PR TITLE
fix: Expose getProgramAccounts RPC method

### DIFF
--- a/module.flow.js
+++ b/module.flow.js
@@ -87,6 +87,9 @@ declare module '@solana/web3.js' {
   declare export class Connection {
     constructor(endpoint: string): Connection;
     getAccountInfo(publicKey: PublicKey): Promise<AccountInfo>;
+    getProgramAccounts(
+      programId: PublicKey,
+    ): Promise<Array<[PublicKey, AccountInfo]>>;
     getBalance(publicKey: PublicKey): Promise<number>;
     getClusterNodes(): Promise<Array<ContactInfo>>;
     getEpochVoteAccounts(): Promise<Array<VoteAccountInfo>>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6561,7 +6561,7 @@
       "dependencies": {
         "marked": {
           "version": "0.3.19",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
           "dev": true
         },
@@ -6825,7 +6825,7 @@
         },
         "marked": {
           "version": "0.3.19",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
           "dev": true
         },
@@ -13022,7 +13022,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -17988,7 +17988,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "localnet:logs": "bin/localnet.sh logs -f",
     "localnet:up": "bin/localnet.sh up $npm_package_testnetDefaultChannel",
     "localnet:update": "bin/localnet.sh update $npm_package_testnetDefaultChannel",
-    "ok": "run-s --serial lint flow test doc",
+    "ok": "run-s lint flow test doc",
     "prepare": "run-s clean bpf-sdk:install bpf-sdk:remove-symlinks build",
     "pretty": "prettier --write '{,{examples,src,test}/**/}*.js'",
     "re": "semantic-release --repository-url git@github.com:solana-labs/solana-web3.js.git",


### PR DESCRIPTION
Depends on https://github.com/solana-labs/solana/pull/4876
(CI will also fail until #385 lands)

I went ahead and removed `--serial` from https://github.com/solana-labs/solana-web3.js/blob/master/package.json#L58 to run `npm run ok` (see #370 )