### PR TITLE
fix: reject base58 public keys that are too short

### DIFF
--- a/src/publickey.js
+++ b/src/publickey.js
@@ -19,7 +19,11 @@ export class PublicKey {
         this._bn = new BN(value.substring(2), 16);
       } else {
         // assume base 58 encoding by default
-        this._bn = new BN(bs58.decode(value));
+        const decoded = bs58.decode(value);
+        if (decoded.length != 32) {
+          throw new Error(`Invalid public key input`);
+        }
+        this._bn = new BN(decoded);
       }
     } else {
       this._bn = new BN(value);

--- a/test/publickey.test.js
+++ b/test/publickey.test.js
@@ -51,6 +51,10 @@ test('invalid', () => {
       '135693854574979916511997248057056142015550763280047535983739356259273198796800000',
     );
   }).toThrow();
+
+  expect(() => {
+    new PublicKey('12345');
+  }).toThrow();
 });
 
 test('equals', () => {
@@ -170,6 +174,14 @@ test('toBuffer', () => {
   );
   expect(key2.toBuffer()).toHaveLength(32);
   expect(key2.toBase58()).toBe('11111111111111111111111111111111');
+
+  const key3 = new PublicKey(0);
+  expect(key3.toBuffer()).toHaveLength(32);
+  expect(key3.toBase58()).toBe('11111111111111111111111111111111');
+
+  const key4 = new PublicKey('0x0');
+  expect(key4.toBuffer()).toHaveLength(32);
+  expect(key4.toBase58()).toBe('11111111111111111111111111111111');
 });
 
 test('equals (II)', () => {


### PR DESCRIPTION
If a public key is created with a base58 string, there is no expectation of zero padding if it is too short and so we should throw an error.