### PR TITLE
fix: add transaction instruction data-parsing functionality for system-instructions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export {BudgetProgram} from './budget-program';
 export {Connection} from './connection';
 export {Loader} from './loader';
 export {PublicKey} from './publickey';
-export {SystemProgram} from './system-program';
+export {SystemInstruction, SystemProgram} from './system-program';
 export {Token, TokenAmount} from './token-program';
 export {Transaction, TransactionInstruction} from './transaction';
 export {VALIDATOR_INFO_KEY, ValidatorInfo} from './validator-info';

--- a/src/system-program.js
+++ b/src/system-program.js
@@ -2,9 +2,154 @@
 
 import * as BufferLayout from 'buffer-layout';
 
-import {Transaction} from './transaction';
+import {Transaction, TransactionInstruction} from './transaction';
 import {PublicKey} from './publickey';
 import * as Layout from './layout';
+import type {TransactionInstructionCtorFields} from './transaction';
+
+/**
+ * System Instruction class
+ */
+export class SystemInstruction extends TransactionInstruction {
+  /**
+   * Type of SystemInstruction
+   */
+  type: SystemInstructionType;
+
+  constructor(
+    opts?: TransactionInstructionCtorFields,
+    type?: SystemInstructionType,
+  ) {
+    if (
+      opts &&
+      opts.programId &&
+      !opts.programId.equals(SystemProgram.programId)
+    ) {
+      throw new Error('programId incorrect; not a SystemInstruction');
+    }
+    super(opts);
+    if (type) {
+      this.type = type;
+    }
+  }
+
+  static from(instruction: TransactionInstruction): SystemInstruction {
+    if (!instruction.programId.equals(SystemProgram.programId)) {
+      throw new Error('programId incorrect; not SystemProgram');
+    }
+
+    const instructionTypeLayout = BufferLayout.u32('instruction');
+    const typeIndex = instructionTypeLayout.decode(instruction.data);
+    let type;
+    for (const t in SystemInstructionEnum) {
+      if (SystemInstructionEnum[t].index == typeIndex) {
+        type = SystemInstructionEnum[t];
+      }
+    }
+    if (!type) {
+      throw new Error('Instruction type incorrect; not a SystemInstruction');
+    }
+    return new SystemInstruction(
+      {
+        keys: instruction.keys,
+        programId: instruction.programId,
+        data: instruction.data,
+      },
+      type,
+    );
+  }
+
+  /**
+   * The `from` public key of the instruction;
+   * returns null if SystemInstructionType does not support this field
+   */
+  get From(): PublicKey | null {
+    if (
+      this.type == SystemInstructionEnum.CREATE ||
+      this.type == SystemInstructionEnum.TRANSFER
+    ) {
+      return this.keys[0].pubkey;
+    }
+    return null;
+  }
+
+  /**
+   * The `to` public key of the instruction;
+   * returns null if SystemInstructionType does not support this field
+   */
+  get To(): PublicKey | null {
+    if (
+      this.type == SystemInstructionEnum.CREATE ||
+      this.type == SystemInstructionEnum.TRANSFER
+    ) {
+      return this.keys[1].pubkey;
+    }
+    return null;
+  }
+
+  /**
+   * The `amount` or `lamports` of the instruction;
+   * returns null if SystemInstructionType does not support this field
+   */
+  get Amount(): number | null {
+    const data = this.type.layout.decode(this.data);
+    if (this.type == SystemInstructionEnum.TRANSFER) {
+      return data.amount;
+    } else if (this.type == SystemInstructionEnum.CREATE) {
+      return data.lamports;
+    }
+    return null;
+  }
+}
+
+/**
+ * @typedef {Object} SystemInstructionType
+ * @property (index} The System Instruction index (from solana-sdk)
+ * @property (BufferLayout} The BufferLayout to use to build data
+ */
+type SystemInstructionType = {|
+  index: number,
+  layout: typeof BufferLayout,
+|};
+
+/**
+ * An enumeration of valid SystemInstructionTypes
+ */
+const SystemInstructionEnum = Object.freeze({
+  CREATE: {
+    index: 0,
+    layout: BufferLayout.struct([
+      BufferLayout.u32('instruction'),
+      BufferLayout.ns64('lamports'),
+      BufferLayout.ns64('space'),
+      Layout.publicKey('programId'),
+    ]),
+  },
+  ASSIGN: {
+    index: 1,
+    layout: BufferLayout.struct([
+      BufferLayout.u32('instruction'),
+      Layout.publicKey('programId'),
+    ]),
+  },
+  TRANSFER: {
+    index: 2,
+    layout: BufferLayout.struct([
+      BufferLayout.u32('instruction'),
+      BufferLayout.ns64('amount'),
+    ]),
+  },
+});
+
+/**
+ * Populate a buffer of instruction data using the SystemInstructionType
+ */
+function encodeData(type: SystemInstructionType, fields: Object): Buffer {
+  const data = Buffer.alloc(type.layout.span);
+  const layoutFields = Object.assign({instruction: type.index}, fields);
+  type.layout.encode(layoutFields, data);
+  return data;
+}
 
 /**
  * Factory class for transactions to interact with the System program
@@ -29,23 +174,12 @@ export class SystemProgram {
     space: number,
     programId: PublicKey,
   ): Transaction {
-    const dataLayout = BufferLayout.struct([
-      BufferLayout.u32('instruction'),
-      BufferLayout.ns64('lamports'),
-      BufferLayout.ns64('space'),
-      Layout.publicKey('programId'),
-    ]);
-
-    const data = Buffer.alloc(dataLayout.span);
-    dataLayout.encode(
-      {
-        instruction: 0, // Create Account instruction
-        lamports,
-        space,
-        programId: programId.toBuffer(),
-      },
-      data,
-    );
+    const type = SystemInstructionEnum.CREATE;
+    const data = encodeData(type, {
+      lamports,
+      space,
+      programId: programId.toBuffer(),
+    });
 
     return new Transaction().add({
       keys: [
@@ -61,19 +195,8 @@ export class SystemProgram {
    * Generate a Transaction that transfers lamports from one account to another
    */
   static transfer(from: PublicKey, to: PublicKey, amount: number): Transaction {
-    const dataLayout = BufferLayout.struct([
-      BufferLayout.u32('instruction'),
-      BufferLayout.ns64('amount'),
-    ]);
-
-    const data = Buffer.alloc(dataLayout.span);
-    dataLayout.encode(
-      {
-        instruction: 2, // Move instruction
-        amount,
-      },
-      data,
-    );
+    const type = SystemInstructionEnum.TRANSFER;
+    const data = encodeData(type, {amount});
 
     return new Transaction().add({
       keys: [
@@ -89,19 +212,8 @@ export class SystemProgram {
    * Generate a Transaction that assigns an account to a program
    */
   static assign(from: PublicKey, programId: PublicKey): Transaction {
-    const dataLayout = BufferLayout.struct([
-      BufferLayout.u32('instruction'),
-      Layout.publicKey('programId'),
-    ]);
-
-    const data = Buffer.alloc(dataLayout.span);
-    dataLayout.encode(
-      {
-        instruction: 1, // Assign instruction
-        programId: programId.toBuffer(),
-      },
-      data,
-    );
+    const type = SystemInstructionEnum.ASSIGN;
+    const data = encodeData(type, {programId: programId.toBuffer()});
 
     return new Transaction().add({
       keys: [{pubkey: from, isSigner: true, isDebitable: true}],

--- a/src/system-program.js
+++ b/src/system-program.js
@@ -41,9 +41,9 @@ export class SystemInstruction extends TransactionInstruction {
     const instructionTypeLayout = BufferLayout.u32('instruction');
     const typeIndex = instructionTypeLayout.decode(instruction.data);
     let type;
-    for (const t in SystemInstructionEnum) {
-      if (SystemInstructionEnum[t].index == typeIndex) {
-        type = SystemInstructionEnum[t];
+    for (const t in SystemInstructionLayout) {
+      if (SystemInstructionLayout[t].index == typeIndex) {
+        type = SystemInstructionLayout[t];
       }
     }
     if (!type) {
@@ -63,10 +63,10 @@ export class SystemInstruction extends TransactionInstruction {
    * The `from` public key of the instruction;
    * returns null if SystemInstructionType does not support this field
    */
-  get From(): PublicKey | null {
+  get fromPublicKey(): PublicKey | null {
     if (
-      this.type == SystemInstructionEnum.CREATE ||
-      this.type == SystemInstructionEnum.TRANSFER
+      this.type == SystemInstructionLayout.Create ||
+      this.type == SystemInstructionLayout.Transfer
     ) {
       return this.keys[0].pubkey;
     }
@@ -77,10 +77,10 @@ export class SystemInstruction extends TransactionInstruction {
    * The `to` public key of the instruction;
    * returns null if SystemInstructionType does not support this field
    */
-  get To(): PublicKey | null {
+  get toPublicKey(): PublicKey | null {
     if (
-      this.type == SystemInstructionEnum.CREATE ||
-      this.type == SystemInstructionEnum.TRANSFER
+      this.type == SystemInstructionLayout.Create ||
+      this.type == SystemInstructionLayout.Transfer
     ) {
       return this.keys[1].pubkey;
     }
@@ -91,11 +91,11 @@ export class SystemInstruction extends TransactionInstruction {
    * The `amount` or `lamports` of the instruction;
    * returns null if SystemInstructionType does not support this field
    */
-  get Amount(): number | null {
+  get amount(): number | null {
     const data = this.type.layout.decode(this.data);
-    if (this.type == SystemInstructionEnum.TRANSFER) {
+    if (this.type == SystemInstructionLayout.Transfer) {
       return data.amount;
-    } else if (this.type == SystemInstructionEnum.CREATE) {
+    } else if (this.type == SystemInstructionLayout.Create) {
       return data.lamports;
     }
     return null;
@@ -115,8 +115,8 @@ type SystemInstructionType = {|
 /**
  * An enumeration of valid SystemInstructionTypes
  */
-const SystemInstructionEnum = Object.freeze({
-  CREATE: {
+const SystemInstructionLayout = Object.freeze({
+  Create: {
     index: 0,
     layout: BufferLayout.struct([
       BufferLayout.u32('instruction'),
@@ -125,14 +125,14 @@ const SystemInstructionEnum = Object.freeze({
       Layout.publicKey('programId'),
     ]),
   },
-  ASSIGN: {
+  Assign: {
     index: 1,
     layout: BufferLayout.struct([
       BufferLayout.u32('instruction'),
       Layout.publicKey('programId'),
     ]),
   },
-  TRANSFER: {
+  Transfer: {
     index: 2,
     layout: BufferLayout.struct([
       BufferLayout.u32('instruction'),
@@ -174,7 +174,7 @@ export class SystemProgram {
     space: number,
     programId: PublicKey,
   ): Transaction {
-    const type = SystemInstructionEnum.CREATE;
+    const type = SystemInstructionLayout.Create;
     const data = encodeData(type, {
       lamports,
       space,
@@ -195,7 +195,7 @@ export class SystemProgram {
    * Generate a Transaction that transfers lamports from one account to another
    */
   static transfer(from: PublicKey, to: PublicKey, amount: number): Transaction {
-    const type = SystemInstructionEnum.TRANSFER;
+    const type = SystemInstructionLayout.Transfer;
     const data = encodeData(type, {amount});
 
     return new Transaction().add({
@@ -212,7 +212,7 @@ export class SystemProgram {
    * Generate a Transaction that assigns an account to a program
    */
   static assign(from: PublicKey, programId: PublicKey): Transaction {
-    const type = SystemInstructionEnum.ASSIGN;
+    const type = SystemInstructionLayout.Assign;
     const data = encodeData(type, {programId: programId.toBuffer()});
 
     return new Transaction().add({

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -40,7 +40,7 @@ export const PACKET_DATA_SIZE = 1280 - 40 - 8;
  * @property {?PublicKey} programId
  * @property {?Buffer} data
  */
-type TransactionInstructionCtorFields = {|
+export type TransactionInstructionCtorFields = {|
   keys?: Array<{pubkey: PublicKey, isSigner: boolean, isDebitable: boolean}>,
   programId?: PublicKey,
   data?: Buffer,

--- a/test/system-program.test.js
+++ b/test/system-program.test.js
@@ -67,9 +67,9 @@ test('SystemInstruction create', () => {
   const transaction = new Transaction({recentBlockhash}).add(create);
 
   const systemInstruction = SystemInstruction.from(transaction.instructions[0]);
-  expect(systemInstruction.From).toEqual(from.publicKey);
-  expect(systemInstruction.To).toEqual(to.publicKey);
-  expect(systemInstruction.Amount).toEqual(amount);
+  expect(systemInstruction.fromPublicKey).toEqual(from.publicKey);
+  expect(systemInstruction.toPublicKey).toEqual(to.publicKey);
+  expect(systemInstruction.amount).toEqual(amount);
   expect(systemInstruction.programId).toEqual(SystemProgram.programId);
 });
 
@@ -83,9 +83,9 @@ test('SystemInstruction transfer', () => {
   transaction.sign(from);
 
   const systemInstruction = SystemInstruction.from(transaction.instructions[0]);
-  expect(systemInstruction.From).toEqual(from.publicKey);
-  expect(systemInstruction.To).toEqual(to.publicKey);
-  expect(systemInstruction.Amount).toEqual(amount);
+  expect(systemInstruction.fromPublicKey).toEqual(from.publicKey);
+  expect(systemInstruction.toPublicKey).toEqual(to.publicKey);
+  expect(systemInstruction.amount).toEqual(amount);
   expect(systemInstruction.programId).toEqual(SystemProgram.programId);
 });
 
@@ -98,9 +98,9 @@ test('SystemInstruction assign', () => {
   transaction.sign(from);
 
   const systemInstruction = SystemInstruction.from(transaction.instructions[0]);
-  expect(systemInstruction.From).toBeNull();
-  expect(systemInstruction.To).toBeNull();
-  expect(systemInstruction.Amount).toBeNull();
+  expect(systemInstruction.fromPublicKey).toBeNull();
+  expect(systemInstruction.toPublicKey).toBeNull();
+  expect(systemInstruction.amount).toBeNull();
   expect(systemInstruction.programId).toEqual(SystemProgram.programId);
 });
 


### PR DESCRIPTION
cc: @sunnygleason 
Feedback definitely wanted, if there's a more elegant way to do this.