### PR TITLE
fix: remove grant/grant_term from inflation

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -82,8 +82,6 @@ type VoteAccountStatus = {
 const GetInflationResult = struct({
   foundation: 'number',
   foundation_term: 'number',
-  grant: 'number',
-  grant_term: 'number',
   initial: 'number',
   storage: 'number',
   taper: 'number',

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -142,8 +142,6 @@ test('get inflation', async () => {
       result: {
         foundation: 0.05,
         foundation_term: 7.0,
-        grant: 0.05,
-        grant_term: 7.0,
         initial: 0.15,
         storage: 0.1,
         taper: 0.15,
@@ -153,9 +151,18 @@ test('get inflation', async () => {
   ]);
 
   const inflation = await connection.getInflation();
-  expect(inflation.initial).toBeGreaterThan(0);
-  expect(inflation.storage).toBeGreaterThan(0);
-  expect(inflation.terminal).toBeGreaterThan(0);
+
+  for (const key of [
+    'initial',
+    'terminal',
+    'taper',
+    'foundation',
+    'foundation_term',
+    'storage',
+  ]) {
+    expect(inflation).toHaveProperty(key);
+    expect(inflation[key]).toBeGreaterThan(0);
+  }
 });
 
 test('get slot', async () => {


### PR DESCRIPTION
Problem:

* grant/grant_term were removed from RPC by https://github.com/solana-labs/solana/pull/5936

Solution:

* update web3js to not include those attributes
* extend tests so we could have caught this pre-release w/ integration tests
