### PR TITLE
Vote Account fixes

### DIFF
--- a/src/vote-account.js
+++ b/src/vote-account.js
@@ -28,6 +28,10 @@ export type EpochCredits = {|
  * @private
  */
 const VoteAccountLayout = BufferLayout.struct([
+  Layout.publicKey('nodePubkey'),
+  Layout.publicKey('authorizedVoterPubkey'),
+  Layout.publicKey('authorizedWithdrawerPubkey'),
+  BufferLayout.u8('commission'),
   BufferLayout.nu64(), // votes.length
   BufferLayout.seq(
     BufferLayout.struct([
@@ -37,9 +41,6 @@ const VoteAccountLayout = BufferLayout.struct([
     BufferLayout.offset(BufferLayout.u32(), -8),
     'votes',
   ),
-  Layout.publicKey('nodePubkey'),
-  Layout.publicKey('authorizedVoterPubkey'),
-  BufferLayout.u8('commission'),
   BufferLayout.u8('rootSlotValid'),
   BufferLayout.nu64('rootSlot'),
   BufferLayout.nu64('epoch'),
@@ -61,10 +62,11 @@ const VoteAccountLayout = BufferLayout.struct([
  * VoteAccount class
  */
 export class VoteAccount {
-  votes: Array<Lockout>;
   nodePubkey: PublicKey;
   authorizedVoterPubkey: PublicKey;
+  authorizedWithdrawerPubkey: PublicKey;
   commission: number;
+  votes: Array<Lockout>;
   rootSlot: number | null;
   epoch: number;
   credits: number;
@@ -81,6 +83,9 @@ export class VoteAccount {
     const va = VoteAccountLayout.decode(buffer, 0);
     va.nodePubkey = new PublicKey(va.nodePubkey);
     va.authorizedVoterPubkey = new PublicKey(va.authorizedVoterPubkey);
+    va.authorizedWithdrawerPubkey = new PublicKey(
+      va.authorizedWithdrawerPubkey,
+    );
     if (!va.rootSlotValid) {
       va.rootSlot = null;
     }

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -255,7 +255,9 @@ test('getVoteAccounts', async () => {
 
   const connection = new Connection(url);
   const voteAccounts = await connection.getVoteAccounts();
-  expect(voteAccounts.current.length).toBeGreaterThan(0);
+  expect(
+    voteAccounts.current.concat(voteAccounts.delinquent).length,
+  ).toBeGreaterThan(0);
 });
 
 test('confirm transaction - error', async () => {


### PR DESCRIPTION
Updates VoteAccount class and layout to match https://github.com/solana-labs/solana/pull/6072
Also fixes live test; localnet node does not appear to be voting, and so shows up on the `delinquent` list of vote accounts. This might indicate an issue upstream, but I don't think this test needs to depend on that.

Fixes #490 