### PR TITLE
feat: add optional rootSlot parameter

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -259,6 +259,7 @@ const GetVoteAccounts = jsonRpcResult(
         epochVoteAccount: 'boolean',
         commission: 'number',
         lastVote: 'number',
+        rootSlot: 'number?',
       }),
     ]),
     delinquent: struct.list([
@@ -269,6 +270,7 @@ const GetVoteAccounts = jsonRpcResult(
         epochVoteAccount: 'boolean',
         commission: 'number',
         lastVote: 'number',
+        rootSlot: 'number?',
       }),
     ]),
   }),


### PR DESCRIPTION
PROBLEM:

* the new `rootSlot` field is breaking stuff

SOLUTION:

* add an optional field definition until we figure out something like #527 
