### PR TITLE
fix: loader report minimum number of signatures required

### DIFF
--- a/src/bpf-loader.js
+++ b/src/bpf-loader.js
@@ -17,6 +17,16 @@ export class BpfLoader {
   }
 
   /**
+   * Minimum number of signatures required to load a program not including
+   * retries
+   *
+   * Can be used to calculate transaction fees
+   */
+  static getMinNumSignatures(dataLength: number): number {
+    return Loader.getMinNumSignatures(dataLength);
+  }
+
+  /**
    * Load a BPF program
    *
    * @param connection The connection to use

--- a/src/loader.js
+++ b/src/loader.js
@@ -29,6 +29,16 @@ export class Loader {
   }
 
   /**
+   * Minimum number of signatures required to load a program not including
+   * retries
+   *
+   * Can be used to calculate transaction fees
+   */
+  static getMinNumSignatures(dataLength: number): number {
+    return Math.ceil(dataLength / Loader.chunkSize);
+  }
+
+  /**
    * Loads a generic program
    *
    * @param connection The connection to use


### PR DESCRIPTION
Clients have no way of determining how many lamports will be required to upload a program.  

The loader doesn't know for sure due to retries, but can at least provide an estimate of the minimum number of signatures required given how many signatures it needs per transaction and how many chunks it plans to send.  The client can then use the `feeCalculator` to calculate the total fees.