### PR TITLE
feat: getEpochInfo rpc

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -71,7 +71,7 @@ type VoteAccountStatus = {
  * (see https://docs.solana.com/book/v/master/implemented-proposals/ed_overview)
  *
  * @typedef {Object} Inflation
- * @property {number} foundation 
+ * @property {number} foundation
  * @property {number} foundation_term
  * @property {number} initial
  * @property {number} storage
@@ -88,9 +88,26 @@ const GetInflationResult = struct({
 });
 
 /**
+ * EpochInfo parameters
+ * (see https://docs.solana.com/book/v/master/terminology#epoch)
+ *
+ * @typedef {Object} EpochInfo
+ * @property {number} epoch
+ * @property {number} slotIndex
+ * @property {number} slotsInEpoch
+ * @property {number} absoluteSlot
+ */
+const GetEpochInfoResult = struct({
+  epoch: 'number',
+  slotIndex: 'number',
+  slotsInEpoch: 'number',
+  absoluteSlot: 'number',
+});
+
+/**
  * EpochSchedule parameters
  * (see https://docs.solana.com/book/v/master/terminology#epoch)
- * 
+ *
  * @typedef {Object} EpochSchedule
  * @property {number} slots_per_epoch
  * @property {number} leader_schedule_slot_offset
@@ -146,6 +163,16 @@ const GetInflationRpcResult = struct({
   id: 'string',
   error: 'any?',
   result: GetInflationResult,
+});
+
+/**
+ * Expected JSON RPC response for the "getEpochInfo" message
+ */
+const GetEpochInfoRpcResult = struct({
+  jsonrpc: struct.literal('2.0'),
+  id: 'string',
+  error: 'any?',
+  result: GetEpochInfoResult,
 });
 
 /**
@@ -716,6 +743,19 @@ export class Connection {
     }
     assert(typeof res.result !== 'undefined');
     return GetInflationResult(res.result);
+  }
+
+  /**
+   * Fetch the Epoch Info parameters
+   */
+  async getEpochInfo(): Promise<GetEpochInfoRpcResult> {
+    const unsafeRes = await this._rpcRequest('getEpochInfo', []);
+    const res = GetEpochInfoRpcResult(unsafeRes);
+    if (res.error) {
+      throw new Error(res.error.message);
+    }
+    assert(typeof res.result !== 'undefined');
+    return GetEpochInfoResult(res.result);
   }
 
   /**

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -170,6 +170,34 @@ test('get inflation', async () => {
   }
 });
 
+test('get epoch info', async () => {
+  const connection = new Connection(url);
+
+  mockRpc.push([
+    url,
+    {
+      method: 'getEpochInfo',
+      params: [],
+    },
+    {
+      error: null,
+      result: {
+        epoch: 1,
+        slotIndex: 1,
+        slotsInEpoch: 8192,
+        absoluteSlot: 1,
+      },
+    },
+  ]);
+
+  const epochInfo = await connection.getEpochInfo();
+
+  for (const key of ['epoch', 'slotIndex', 'slotsInEpoch', 'absoluteSlot']) {
+    expect(epochInfo).toHaveProperty(key);
+    expect(epochInfo[key]).toBeGreaterThan(0);
+  }
+});
+
 test('get epoch schedule', async () => {
   const connection = new Connection(url);
 


### PR DESCRIPTION
PROBLEM:

* we need current epoch for computing uptime in network explorer 🕚 

SOLUTION:

* add the already-existing getEpochInfo() call to the JS library 🔨 

OPEN QUESTION (assume it's ok):

* the existing RPC has camel-case response keys instead of underscore-separated, is that ok? (I figure now's not a good time to break/fix that) 🌊 

