### PR TITLE
fix: update accounts to readonly/writable

### DIFF
--- a/module.flow.js
+++ b/module.flow.js
@@ -214,13 +214,13 @@ declare module '@solana/web3.js' {
   declare export type TransactionSignature = string;
 
   declare type TransactionInstructionCtorFields = {|
-    keys: ?Array<{pubkey: PublicKey, isSigner: boolean, isDebitable: boolean}>,
+    keys: ?Array<{pubkey: PublicKey, isSigner: boolean, isWritable: boolean}>,
     programId?: PublicKey,
     data?: Buffer,
   |};
 
   declare export class TransactionInstruction {
-    keys: Array<{pubkey: PublicKey, isSigner: boolean, isDebitable: boolean}>;
+    keys: Array<{pubkey: PublicKey, isSigner: boolean, isWritable: boolean}>;
     programId: PublicKey;
     data: Buffer;
 

--- a/src/budget-program.js
+++ b/src/budget-program.js
@@ -201,8 +201,8 @@ export class BudgetProgram {
 
         return transaction.add({
           keys: [
-            {pubkey: to, isSigner: false, isDebitable: false},
-            {pubkey: program, isSigner: false, isDebitable: true},
+            {pubkey: to, isSigner: false, isWritable: true},
+            {pubkey: program, isSigner: false, isWritable: true},
           ],
           programId: this.programId,
           data: trimmedData,
@@ -236,7 +236,7 @@ export class BudgetProgram {
         );
 
         return transaction.add({
-          keys: [{pubkey: program, isSigner: false, isDebitable: true}],
+          keys: [{pubkey: program, isSigner: false, isWritable: true}],
           programId: this.programId,
           data: trimmedData,
         });
@@ -269,7 +269,7 @@ export class BudgetProgram {
         );
 
         return transaction.add({
-          keys: [{pubkey: program, isSigner: false, isDebitable: true}],
+          keys: [{pubkey: program, isSigner: false, isWritable: true}],
           programId: this.programId,
           data: trimmedData,
         });
@@ -325,7 +325,7 @@ export class BudgetProgram {
     );
 
     return transaction.add({
-      keys: [{pubkey: program, isSigner: false, isDebitable: true}],
+      keys: [{pubkey: program, isSigner: false, isWritable: true}],
       programId: this.programId,
       data: trimmedData,
     });
@@ -349,9 +349,9 @@ export class BudgetProgram {
 
     return new Transaction().add({
       keys: [
-        {pubkey: from, isSigner: true, isDebitable: true},
-        {pubkey: program, isSigner: false, isDebitable: true},
-        {pubkey: to, isSigner: false, isDebitable: false},
+        {pubkey: from, isSigner: true, isWritable: true},
+        {pubkey: program, isSigner: false, isWritable: true},
+        {pubkey: to, isSigner: false, isWritable: false},
       ],
       programId: this.programId,
       data,
@@ -379,9 +379,9 @@ export class BudgetProgram {
 
     return new Transaction().add({
       keys: [
-        {pubkey: from, isSigner: true, isDebitable: true},
-        {pubkey: program, isSigner: false, isDebitable: true},
-        {pubkey: to, isSigner: false, isDebitable: false},
+        {pubkey: from, isSigner: true, isWritable: true},
+        {pubkey: program, isSigner: false, isWritable: true},
+        {pubkey: to, isSigner: false, isWritable: true},
       ],
       programId: this.programId,
       data,

--- a/src/loader.js
+++ b/src/loader.js
@@ -97,7 +97,7 @@ export class Loader {
       );
 
       const transaction = new Transaction().add({
-        keys: [{pubkey: program.publicKey, isSigner: true, isDebitable: true}],
+        keys: [{pubkey: program.publicKey, isSigner: true, isWritable: true}],
         programId,
         data,
       });
@@ -137,8 +137,8 @@ export class Loader {
 
       const transaction = new Transaction().add({
         keys: [
-          {pubkey: program.publicKey, isSigner: true, isDebitable: true},
-          {pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isDebitable: false},
+          {pubkey: program.publicKey, isSigner: true, isWritable: true},
+          {pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false},
         ],
         programId,
         data,

--- a/src/system-program.js
+++ b/src/system-program.js
@@ -183,8 +183,8 @@ export class SystemProgram {
 
     return new Transaction().add({
       keys: [
-        {pubkey: from, isSigner: true, isDebitable: true},
-        {pubkey: newAccount, isSigner: false, isDebitable: true},
+        {pubkey: from, isSigner: true, isWritable: true},
+        {pubkey: newAccount, isSigner: false, isWritable: true},
       ],
       programId: SystemProgram.programId,
       data,
@@ -200,10 +200,8 @@ export class SystemProgram {
 
     return new Transaction().add({
       keys: [
-        {pubkey: from, isSigner: true, isDebitable: true},
-        // TEMP FIX: a better proposed solution is here:
-        // https://github.com/solana-labs/solana-web3.js/issues/542
-        {pubkey: to, isSigner: false, isDebitable: true},
+        {pubkey: from, isSigner: true, isWritable: true},
+        {pubkey: to, isSigner: false, isWritable: true},
       ],
       programId: SystemProgram.programId,
       data,
@@ -218,7 +216,7 @@ export class SystemProgram {
     const data = encodeData(type, {programId: programId.toBuffer()});
 
     return new Transaction().add({
-      keys: [{pubkey: from, isSigner: true, isDebitable: true}],
+      keys: [{pubkey: from, isSigner: true, isWritable: true}],
       programId: SystemProgram.programId,
       data,
     });

--- a/test/bpf-loader.test.js
+++ b/test/bpf-loader.test.js
@@ -36,7 +36,7 @@ test('load BPF C program', async () => {
 
   const programId = await BpfLoader.load(connection, from, data);
   const transaction = new Transaction().add({
-    keys: [{pubkey: from.publicKey, isSigner: true, isDebitable: true}],
+    keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
     programId,
   });
   await sendAndConfirmTransaction(connection, transaction, from);
@@ -61,7 +61,7 @@ test('load BPF Rust program', async () => {
 
   const programId = await BpfLoader.load(connection, from, data);
   const transaction = new Transaction().add({
-    keys: [{pubkey: from.publicKey, isSigner: true, isDebitable: true}],
+    keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
     programId,
   });
   await sendAndConfirmTransaction(connection, transaction, from);

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -681,11 +681,6 @@ test('transaction', async () => {
       result: 31,
     },
   ]);
-  if (!mockRpcEnabled) {
-    // Credit-only account credits are committed at the end of every slot;
-    // this sleep is to ensure a full slot has elapsed
-    await sleep((1000 * DEFAULT_TICKS_PER_SLOT) / NUM_TICKS_PER_SECOND);
-  }
   expect(await connection.getBalance(accountTo.publicKey)).toBe(31);
 });
 

--- a/test/system-program.test.js
+++ b/test/system-program.test.js
@@ -111,8 +111,8 @@ test('non-SystemInstruction error', () => {
 
   const badProgramId = {
     keys: [
-      {pubkey: from.publicKey, isSigner: true, isDebitable: true},
-      {pubkey: to.publicKey, isSigner: false, isDebitable: false},
+      {pubkey: from.publicKey, isSigner: true, isWritable: true},
+      {pubkey: to.publicKey, isSigner: false, isWritable: true},
     ],
     programId: BudgetProgram.programId,
     data: Buffer.from([2, 0, 0, 0]),


### PR DESCRIPTION
Solana upstream no longer uses credit-only/credit-debit, but readonly/writable.
Update solana-web3 terminology, and (more importantly) make sure transaction account metadata is correct.

Closes #542 