### PR TITLE
fix: use the jsonrpc framework reconnect interval

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1043,8 +1043,10 @@ export class Connection {
     // 1000 means _rpcWebSocket.close() was called explicitly
     if (code !== 1000) {
       console.log('ws close:', code, message);
+    } else {
+      // Only after an explicit close do we need to explicitly connect again
+      this._rpcWebSocketConnected = false;
     }
-    this._rpcWebSocketConnected = false;
   }
 
   /**


### PR DESCRIPTION
We shouldn't mark the rpc client as disconnected when it isn't explicitly closed. The rpc client framework will automatically reconnect according to a configurable interval (default 1s)