### PR TITLE
feat: add commitment param to JSON RPC API requests

### DIFF
--- a/examples/budget-timestamp.js
+++ b/examples/budget-timestamp.js
@@ -13,7 +13,7 @@ const contractState = new solanaWeb3.Account();
 
 let url;
 url = 'http://localhost:8899';
-const connection = new solanaWeb3.Connection(url);
+const connection = new solanaWeb3.Connection(url, 'recent');
 
 function showBalance() {
   console.log(`\n== Account State`);
@@ -50,9 +50,9 @@ function confirmTransaction(signature) {
 }
 
 function airDrop() {
-  console.log(`\n== Requesting airdrop of 100 to ${account1.publicKey}`);
+  console.log(`\n== Requesting airdrop of 100000 to ${account1.publicKey}`);
   return connection
-    .requestAirdrop(account1.publicKey, 100)
+    .requestAirdrop(account1.publicKey, 100000)
     .then(confirmTransaction);
 }
 

--- a/examples/budget-two-approvers.js
+++ b/examples/budget-two-approvers.js
@@ -16,7 +16,7 @@ const approver2 = new solanaWeb3.Account();
 let url;
 url = 'http://localhost:8899';
 //url = 'http://testnet.solana.com:8899';
-const connection = new solanaWeb3.Connection(url);
+const connection = new solanaWeb3.Connection(url, 'recent');
 
 function getTransactionFee() {
   return connection.getRecentBlockhash().then(response => {

--- a/examples/budget-two-approvers.js
+++ b/examples/budget-two-approvers.js
@@ -59,7 +59,7 @@ function confirmTransaction(signature) {
 }
 
 function airDrop(feeCalculator) {
-  const airdrop = 100 + 3 * feeCalculator.targetLamportsPerSignature;
+  const airdrop = 100 + 5 * feeCalculator.targetLamportsPerSignature;
   console.log(`\n== Requesting airdrop of ${airdrop} to ${account1.publicKey}`);
   return connection
     .requestAirdrop(account1.publicKey, airdrop)

--- a/module.flow.js
+++ b/module.flow.js
@@ -47,6 +47,10 @@ declare module '@solana/web3.js' {
   /* TODO */
 
   // === src/connection.js ===
+  declare export type MAX_COMMITMENT = 'max';
+  declare export type RECENT_COMMITMENT = 'recent';
+  declare export type Commitment = MAX_COMMITMENT | RECENT_COMMITMENT;
+
   declare export type AccountInfo = {
     executable: boolean,
     owner: PublicKey,
@@ -104,28 +108,39 @@ declare module '@solana/web3.js' {
   };
 
   declare export class Connection {
-    constructor(endpoint: string): Connection;
-    getAccountInfo(publicKey: PublicKey): Promise<AccountInfo>;
+    constructor(endpoint: string, commitment: ?Commitment): Connection;
+    getAccountInfo(
+      publicKey: PublicKey,
+      commitment: ?Commitment,
+    ): Promise<AccountInfo>;
     getProgramAccounts(
       programId: PublicKey,
+      commitment: ?Commitment,
     ): Promise<Array<[PublicKey, AccountInfo]>>;
-    getBalance(publicKey: PublicKey): Promise<number>;
+    getBalance(publicKey: PublicKey, commitment: ?Commitment): Promise<number>;
     getClusterNodes(): Promise<Array<ContactInfo>>;
-    getVoteAccounts(): Promise<VoteAccountStatus>;
-    confirmTransaction(signature: TransactionSignature): Promise<boolean>;
-    getSlot(): Promise<number>;
-    getSlotLeader(): Promise<string>;
+    getVoteAccounts(commitment: ?Commitment): Promise<VoteAccountStatus>;
+    confirmTransaction(
+      signature: TransactionSignature,
+      commitment: ?Commitment,
+    ): Promise<boolean>;
+    getSlot(commitment: ?Commitment): Promise<number>;
+    getSlotLeader(commitment: ?Commitment): Promise<string>;
     getSignatureStatus(
       signature: TransactionSignature,
+      commitment: ?Commitment,
     ): Promise<SignatureSuccess | TransactionError | null>;
-    getTransactionCount(): Promise<number>;
-    getTotalSupply(): Promise<number>;
-    getInflation(): Promise<Inflation>;
+    getTransactionCount(commitment: ?Commitment): Promise<number>;
+    getTotalSupply(commitment: ?Commitment): Promise<number>;
+    getInflation(commitment: ?Commitment): Promise<Inflation>;
     getEpochSchedule(): Promise<EpochSchedule>;
-    getRecentBlockhash(): Promise<[Blockhash, FeeCalculator]>;
+    getRecentBlockhash(
+      commitment: ?Commitment,
+    ): Promise<[Blockhash, FeeCalculator]>;
     requestAirdrop(
       to: PublicKey,
       amount: number,
+      commitment: ?Commitment,
     ): Promise<TransactionSignature>;
     sendTransaction(
       transaction: Transaction,
@@ -287,10 +302,17 @@ declare module '@solana/web3.js' {
     ...signers: Array<Account>
   ): Promise<TransactionSignature>;
 
+  declare export function sendAndConfirmRecentTransaction(
+    connection: Connection,
+    transaction: Transaction,
+    ...signers: Array<Account>
+  ): Promise<TransactionSignature>;
+
   // === src/util/send-and-confirm-raw-transaction.js ===
   declare export function sendAndConfirmRawTransaction(
     connection: Connection,
     wireTransaction: Buffer,
+    commitment: ?Commitment,
   ): Promise<TransactionSignature>;
 
   // === src/util/testnet.js ===

--- a/module.flow.js
+++ b/module.flow.js
@@ -47,9 +47,7 @@ declare module '@solana/web3.js' {
   /* TODO */
 
   // === src/connection.js ===
-  declare export type MAX_COMMITMENT = 'max';
-  declare export type RECENT_COMMITMENT = 'recent';
-  declare export type Commitment = MAX_COMMITMENT | RECENT_COMMITMENT;
+  declare export type Commitment = 'max' | 'recent';
 
   declare export type AccountInfo = {
     executable: boolean,

--- a/src/connection.js
+++ b/src/connection.js
@@ -20,16 +20,22 @@ type RpcRequest = (methodName: string, args: Array<any>) => any;
 
 /**
  * The node will query the most recent block which has reached max voter lockout
+ *
+ * @typedef {'max'} MAX_COMMITMENT
  */
 export type MAX_COMMITMENT = 'max';
 
 /**
  * The node will query its most recent block
+ *
+ * @typedef {'recent'} RECENT_COMMITMENT
  */
 export type RECENT_COMMITMENT = 'recent';
 
 /**
  * The level of commitment desired when querying state
+ *
+ * @typedef {MAX_COMMITMENT | RECENT_COMMITMENT} Commitment
  */
 export type Commitment = MAX_COMMITMENT | RECENT_COMMITMENT;
 
@@ -521,7 +527,7 @@ export class Connection {
    * Establish a JSON RPC connection
    *
    * @param endpoint URL to the fullnode JSON RPC endpoint
-   * @param commitment {Commitment} optional default commitment level
+   * @param commitment optional default commitment level
    */
   constructor(endpoint: string, commitment: ?Commitment) {
     let url = urlParse(endpoint);

--- a/src/connection.js
+++ b/src/connection.js
@@ -19,25 +19,13 @@ import type {TransactionSignature} from './transaction';
 type RpcRequest = (methodName: string, args: Array<any>) => any;
 
 /**
- * The node will query the most recent block which has reached max voter lockout
- *
- * @typedef {'max'} MAX_COMMITMENT
- */
-export type MAX_COMMITMENT = 'max';
-
-/**
- * The node will query its most recent block
- *
- * @typedef {'recent'} RECENT_COMMITMENT
- */
-export type RECENT_COMMITMENT = 'recent';
-
-/**
  * The level of commitment desired when querying state
+ *   'max':    Query the most recent block which has reached max voter lockout
+ *   'recent': Query the most recent block
  *
- * @typedef {MAX_COMMITMENT | RECENT_COMMITMENT} Commitment
+ * @typedef {'max' | 'recent'} Commitment
  */
-export type Commitment = MAX_COMMITMENT | RECENT_COMMITMENT;
+export type Commitment = 'max' | 'recent';
 
 /**
  * Information describing a cluster node

--- a/src/util/send-and-confirm-raw-transaction.js
+++ b/src/util/send-and-confirm-raw-transaction.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {Connection} from '../connection';
+import type {Commitment} from '../connection';
 import {sleep} from './sleep';
 import type {TransactionSignature} from '../transaction';
 import {DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND} from '../timing';
@@ -11,6 +12,7 @@ import {DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND} from '../timing';
 export async function sendAndConfirmRawTransaction(
   connection: Connection,
   rawTransaction: Buffer,
+  commitment: ?Commitment,
 ): Promise<TransactionSignature> {
   const start = Date.now();
   let signature = await connection.sendRawTransaction(rawTransaction);
@@ -19,7 +21,7 @@ export async function sendAndConfirmRawTransaction(
   let status = null;
   let statusRetries = 6;
   for (;;) {
-    status = await connection.getSignatureStatus(signature);
+    status = await connection.getSignatureStatus(signature, commitment);
     if (status) {
       break;
     }

--- a/test/bpf-loader.test.js
+++ b/test/bpf-loader.test.js
@@ -27,7 +27,7 @@ test('load BPF C program', async () => {
 
   const data = await fs.readFile('test/fixtures/noop-c/noop.so');
 
-  const connection = new Connection(url);
+  const connection = new Connection(url, 'recent');
   const [, feeCalculator] = await connection.getRecentBlockhash();
   const fees =
     feeCalculator.lamportsPerSignature *
@@ -52,7 +52,7 @@ test('load BPF Rust program', async () => {
     'test/fixtures/noop-rust/solana_bpf_rust_noop.so',
   );
 
-  const connection = new Connection(url);
+  const connection = new Connection(url, 'recent');
   const [, feeCalculator] = await connection.getRecentBlockhash();
   const fees =
     feeCalculator.lamportsPerSignature *

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -177,7 +177,7 @@ test('get epoch info', async () => {
     url,
     {
       method: 'getEpochInfo',
-      params: [{'commitment': 'recent'}],
+      params: [{commitment: 'recent'}],
     },
     {
       error: null,
@@ -795,11 +795,16 @@ test('account change notification', async () => {
   );
 
   await connection.requestAirdrop(owner.publicKey, SOL_LAMPORTS);
-  await Loader.load(connection, owner, programAccount, BpfLoader.programId, [
-    1,
-    2,
-    3,
-  ]);
+  try {
+    await Loader.load(connection, owner, programAccount, BpfLoader.programId, [
+      1,
+      2,
+      3,
+    ]);
+  } catch (err) {
+    await connection.removeAccountChangeListener(subscriptionId);
+    throw err;
+  }
 
   // Wait for mockCallback to receive a call
   let i = 0;
@@ -849,11 +854,16 @@ test('program account change notification', async () => {
   );
 
   await connection.requestAirdrop(owner.publicKey, SOL_LAMPORTS);
-  await Loader.load(connection, owner, programAccount, BpfLoader.programId, [
-    1,
-    2,
-    3,
-  ]);
+  try {
+    await Loader.load(connection, owner, programAccount, BpfLoader.programId, [
+      1,
+      2,
+      3,
+    ]);
+  } catch (err) {
+    await connection.removeProgramAccountChangeListener(subscriptionId);
+    throw err;
+  }
 
   // Wait for mockCallback to receive a call
   let i = 0;

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -171,18 +171,18 @@ test('get inflation', async () => {
 });
 
 test('get epoch info', async () => {
-  const connection = new Connection(url);
+  const connection = new Connection(url, 'recent');
 
   mockRpc.push([
     url,
     {
       method: 'getEpochInfo',
-      params: [],
+      params: [{'commitment': 'recent'}],
     },
     {
       error: null,
       result: {
-        epoch: 1,
+        epoch: 0,
         slotIndex: 1,
         slotsInEpoch: 8192,
         absoluteSlot: 1,
@@ -194,7 +194,7 @@ test('get epoch info', async () => {
 
   for (const key of ['epoch', 'slotIndex', 'slotsInEpoch', 'absoluteSlot']) {
     expect(epochInfo).toHaveProperty(key);
-    expect(epochInfo[key]).toBeGreaterThan(0);
+    expect(epochInfo[key]).toBeGreaterThanOrEqual(0);
   }
 });
 

--- a/test/mockrpc/get-recent-blockhash.js
+++ b/test/mockrpc/get-recent-blockhash.js
@@ -1,17 +1,22 @@
 // @flow
 
 import {Account} from '../../src';
+import type {Commitment} from '../../src/connection';
 import {url} from '../url';
 import {mockRpc} from '../__mocks__/node-fetch';
 
-export function mockGetRecentBlockhash() {
+export function mockGetRecentBlockhash(commitment: ?Commitment) {
   const recentBlockhash = new Account();
+  const params = [];
+  if (commitment) {
+    params.push({commitment});
+  }
 
   mockRpc.push([
     url,
     {
       method: 'getRecentBlockhash',
-      params: [],
+      params,
     },
     {
       error: null,

--- a/test/transaction-payer.test.js
+++ b/test/transaction-payer.test.js
@@ -14,13 +14,17 @@ test('transaction-payer', async () => {
   const accountPayer = new Account();
   const accountFrom = new Account();
   const accountTo = new Account();
-  const connection = new Connection(url);
+  const connection = new Connection(url, 'recent');
 
   mockRpc.push([
     url,
     {
       method: 'requestAirdrop',
-      params: [accountPayer.publicKey.toBase58(), SOL_LAMPORTS],
+      params: [
+        accountPayer.publicKey.toBase58(),
+        SOL_LAMPORTS,
+        {commitment: 'recent'},
+      ],
     },
     {
       error: null,
@@ -34,7 +38,7 @@ test('transaction-payer', async () => {
     url,
     {
       method: 'requestAirdrop',
-      params: [accountFrom.publicKey.toBase58(), 12],
+      params: [accountFrom.publicKey.toBase58(), 12, {commitment: 'recent'}],
     },
     {
       error: null,
@@ -48,7 +52,7 @@ test('transaction-payer', async () => {
     url,
     {
       method: 'requestAirdrop',
-      params: [accountTo.publicKey.toBase58(), 21],
+      params: [accountTo.publicKey.toBase58(), 21, {commitment: 'recent'}],
     },
     {
       error: null,
@@ -58,7 +62,7 @@ test('transaction-payer', async () => {
   ]);
   await connection.requestAirdrop(accountTo.publicKey, 21);
 
-  mockGetRecentBlockhash();
+  mockGetRecentBlockhash('recent');
   mockRpc.push([
     url,
     {
@@ -89,6 +93,7 @@ test('transaction-payer', async () => {
       method: 'confirmTransaction',
       params: [
         '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
+        {commitment: 'recent'},
       ],
     },
     {
@@ -114,6 +119,7 @@ test('transaction-payer', async () => {
       method: 'getSignatureStatus',
       params: [
         '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
+        {commitment: 'recent'},
       ],
     },
     {
@@ -129,7 +135,7 @@ test('transaction-payer', async () => {
     url,
     {
       method: 'getBalance',
-      params: [accountPayer.publicKey.toBase58()],
+      params: [accountPayer.publicKey.toBase58(), {commitment: 'recent'}],
     },
     {
       error: null,
@@ -148,7 +154,7 @@ test('transaction-payer', async () => {
     url,
     {
       method: 'getBalance',
-      params: [accountFrom.publicKey.toBase58()],
+      params: [accountFrom.publicKey.toBase58(), {commitment: 'recent'}],
     },
     {
       error: null,


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/solana-web3.js/issues/546

Other related changes:
* Allow specifying a default commitment level for a `Connection` instance
* Add new `sendAndConfirmRecentTransaction` convenience method
* Fix broken examples
* Fix live tests
* Add test for max commitment