### PR TITLE
fix: budget program examples

### DIFF
--- a/examples/budget-common.js
+++ b/examples/budget-common.js
@@ -1,0 +1,67 @@
+/* eslint-disable import/no-commonjs */
+
+/*
+  Common code for the budget program examples
+*/
+
+function getTransactionFee(connection) {
+  return connection.getRecentBlockhash().then(response => {
+    return response[1];
+  });
+}
+
+function showBalance(connection, account1, account2, contractState) {
+  console.log(`\n== Account State`);
+  return Promise.all([
+    connection.getBalance(account1.publicKey),
+    connection.getBalance(account2.publicKey),
+    connection.getBalance(contractState.publicKey),
+  ]).then(([fromBalance, toBalance, contractStateBalance]) => {
+    console.log(
+      `Account1:       ${account1.publicKey} has a balance of ${fromBalance}`,
+    );
+    console.log(
+      `Account2:       ${account2.publicKey} has a balance of ${toBalance}`,
+    );
+    console.log(
+      `Contract State: ${contractState.publicKey} has a balance of ${contractStateBalance}`,
+    );
+  });
+}
+
+function confirmTransaction(connection, signature) {
+  console.log('Confirming transaction:', signature);
+  return connection.getSignatureStatus(signature).then(confirmation => {
+    if (confirmation && 'Ok' in confirmation) {
+      console.log('Transaction confirmed');
+    } else if (confirmation) {
+      throw new Error(
+        `Transaction was not confirmed (${JSON.stringify(confirmation.Err)})`,
+      );
+    } else {
+      throw new Error(`Transaction was not confirmed (${confirmation})`);
+    }
+  });
+}
+
+function airDrop(connection, account, feeCalculator) {
+  const airdrop = 100 + 5 * feeCalculator.targetLamportsPerSignature;
+  console.log(`\n== Requesting airdrop of ${airdrop} to ${account.publicKey}`);
+  return connection
+    .requestAirdrop(account.publicKey, airdrop)
+    .then(signature => confirmTransaction(connection, signature));
+}
+
+function sleep(millis) {
+  return new Promise(resolve => {
+    setTimeout(resolve, millis);
+  });
+}
+
+module.exports = {
+  airDrop,
+  confirmTransaction,
+  getTransactionFee,
+  showBalance,
+  sleep,
+};

--- a/examples/budget-timestamp.js
+++ b/examples/budget-timestamp.js
@@ -1,9 +1,12 @@
+/* eslint-disable import/no-commonjs */
+
 /*
   Example of using the Budget program to perform a time-lock payment of 50
   lamports from account1 to account2.
 */
 
-//eslint-disable-next-line import/no-commonjs
+const common = require('./budget-common');
+
 const solanaWeb3 = require('..');
 //const solanaWeb3 = require('@solana/web3.js');
 
@@ -14,93 +17,61 @@ const contractState = new solanaWeb3.Account();
 let url;
 url = 'http://localhost:8899';
 const connection = new solanaWeb3.Connection(url, 'recent');
+const getTransactionFee = () => common.getTransactionFee(connection);
+const showBalance = () =>
+  common.showBalance(connection, account1, account2, contractState);
+const confirmTransaction = signature =>
+  common.confirmTransaction(connection, signature);
+const airDrop = feeCalculator =>
+  common.airDrop(connection, account1, feeCalculator);
 
-function showBalance() {
-  console.log(`\n== Account State`);
-  return Promise.all([
-    connection.getBalance(account1.publicKey),
-    connection.getBalance(account2.publicKey),
-    connection.getBalance(contractState.publicKey),
-  ]).then(([fromBalance, toBalance, contractStateBalance]) => {
-    console.log(
-      `Account1:       ${account1.publicKey} has a balance of ${fromBalance}`,
-    );
-    console.log(
-      `Account2:       ${account2.publicKey} has a balance of ${toBalance}`,
-    );
-    console.log(
-      `Contract State: ${contractState.publicKey} has a balance of ${contractStateBalance}`,
-    );
-  });
-}
-
-function confirmTransaction(signature) {
-  console.log('Confirming transaction:', signature);
-  return connection.getSignatureStatus(signature).then(confirmation => {
-    if (confirmation && 'Ok' in confirmation) {
-      console.log('Transaction confirmed');
-    } else if (confirmation) {
-      throw new Error(
-        `Transaction was not confirmed (${JSON.stringify(confirmation.Err)})`,
-      );
-    } else {
-      throw new Error(`Transaction was not confirmed (${confirmation})`);
-    }
-  });
-}
-
-function airDrop() {
-  console.log(`\n== Requesting airdrop of 100000 to ${account1.publicKey}`);
-  return connection
-    .requestAirdrop(account1.publicKey, 100000)
-    .then(confirmTransaction);
-}
-
-showBalance()
-  .then(airDrop)
-  .then(showBalance)
-  .then(() => {
-    console.log(`\n== Initializing contract`);
-    const transaction = solanaWeb3.BudgetProgram.pay(
-      account1.publicKey,
-      contractState.publicKey,
-      account2.publicKey,
-      50,
-      solanaWeb3.BudgetProgram.timestampCondition(
+getTransactionFee().then(feeCalculator => {
+  airDrop(feeCalculator)
+    .then(showBalance)
+    .then(() => {
+      console.log(`\n== Initializing contract`);
+      const transaction = solanaWeb3.BudgetProgram.pay(
         account1.publicKey,
+        contractState.publicKey,
+        account2.publicKey,
+        50,
+        solanaWeb3.BudgetProgram.timestampCondition(
+          account1.publicKey,
+          new Date('2050'),
+        ),
+      );
+      return solanaWeb3.sendAndConfirmTransaction(
+        connection,
+        transaction,
+        account1,
+        contractState,
+      );
+    })
+    .then(confirmTransaction)
+    .then(showBalance)
+    .then(() => {
+      console.log(`\n== Witness contract`);
+      const transaction = solanaWeb3.BudgetProgram.applyTimestamp(
+        account1.publicKey,
+        contractState.publicKey,
+        account2.publicKey,
         new Date('2050'),
-      ),
-    );
-    return solanaWeb3.sendAndConfirmTransaction(
-      connection,
-      transaction,
-      account1,
-      contractState,
-    );
-  })
-  .then(confirmTransaction)
-  .then(showBalance)
-  .then(() => {
-    console.log(`\n== Witness contract`);
-    const transaction = solanaWeb3.BudgetProgram.applyTimestamp(
-      account1.publicKey,
-      contractState.publicKey,
-      account2.publicKey,
-      new Date('2050'),
-    );
-    return solanaWeb3.sendAndConfirmTransaction(
-      connection,
-      transaction,
-      account1,
-    );
-  })
-  .then(confirmTransaction)
-  .then(showBalance)
+      );
+      return solanaWeb3.sendAndConfirmTransaction(
+        connection,
+        transaction,
+        account1,
+        contractState,
+      );
+    })
+    .then(confirmTransaction)
+    .then(showBalance)
 
-  .then(() => {
-    console.log('\nDone');
-  })
+    .then(() => {
+      console.log('\nDone');
+    })
 
-  .catch(err => {
-    console.log(err);
-  });
+    .catch(err => {
+      console.log(err);
+    });
+});

--- a/examples/budget-two-approvers.js
+++ b/examples/budget-two-approvers.js
@@ -1,8 +1,11 @@
+/* eslint-disable import/no-commonjs */
+
 /*
   Example of using the Budget program to perform a payment authorized by two parties
 */
 
-//eslint-disable-next-line import/no-commonjs
+const common = require('./budget-common');
+
 const solanaWeb3 = require('..');
 //const solanaWeb3 = require('@solana/web3.js');
 
@@ -17,58 +20,16 @@ let url;
 url = 'http://localhost:8899';
 //url = 'http://testnet.solana.com:8899';
 const connection = new solanaWeb3.Connection(url, 'recent');
-
-function getTransactionFee() {
-  return connection.getRecentBlockhash().then(response => {
-    return response[1];
-  });
-}
-
-function showBalance() {
-  console.log(`\n== Account State`);
-  return Promise.all([
-    connection.getBalance(account1.publicKey),
-    connection.getBalance(account2.publicKey),
-    connection.getBalance(contractState.publicKey),
-  ]).then(([fromBalance, toBalance, contractStateBalance]) => {
-    console.log(
-      `Account1:       ${account1.publicKey} has a balance of ${fromBalance}`,
-    );
-    console.log(
-      `Account2:       ${account2.publicKey} has a balance of ${toBalance}`,
-    );
-    console.log(
-      `Contract State: ${contractState.publicKey} has a balance of ${contractStateBalance}`,
-    );
-  });
-}
-
-function confirmTransaction(signature) {
-  console.log('Confirming transaction:', signature);
-  return connection.getSignatureStatus(signature).then(confirmation => {
-    if (confirmation && 'Ok' in confirmation) {
-      console.log('Transaction confirmed');
-    } else if (confirmation) {
-      throw new Error(
-        `Transaction was not confirmed (${JSON.stringify(confirmation.Err)})`,
-      );
-    } else {
-      throw new Error(`Transaction was not confirmed (${confirmation})`);
-    }
-  });
-}
-
-function airDrop(feeCalculator) {
-  const airdrop = 100 + 5 * feeCalculator.targetLamportsPerSignature;
-  console.log(`\n== Requesting airdrop of ${airdrop} to ${account1.publicKey}`);
-  return connection
-    .requestAirdrop(account1.publicKey, airdrop)
-    .then(confirmTransaction);
-}
+const getTransactionFee = () => common.getTransactionFee(connection);
+const showBalance = () =>
+  common.showBalance(connection, account1, account2, contractState);
+const confirmTransaction = signature =>
+  common.confirmTransaction(connection, signature);
+const airDrop = feeCalculator =>
+  common.airDrop(connection, account1, feeCalculator);
 
 getTransactionFee().then(feeCalculator => {
-  showBalance()
-    .then(airDrop(feeCalculator))
+  airDrop(feeCalculator)
     .then(() => {
       console.log(`\n== Move 1 lamport to approver1`);
       const transaction = solanaWeb3.SystemProgram.transfer(

--- a/src/budget-program.js
+++ b/src/budget-program.js
@@ -351,7 +351,7 @@ export class BudgetProgram {
       keys: [
         {pubkey: from, isSigner: true, isWritable: true},
         {pubkey: program, isSigner: false, isWritable: true},
-        {pubkey: to, isSigner: false, isWritable: false},
+        {pubkey: to, isSigner: false, isWritable: true},
       ],
       programId: this.programId,
       data,


### PR DESCRIPTION
* Calculate fees for budget-timestamp (it was failing due to insufficient funds)
* Share code between budget examples
* Make `to` writable in applyTimestamp to fix:
```
== Witness contract
Error: Transaction 4e8vERadgTyTRpXGBy31q97n32F2i8uLWbkEsUnX7eE2TBaoaVggatko2FMUwToPsGUQiV2yeksvAqXSVQJCtKoE failed ({"Err":{"InstructionError":[0,"ReadonlyLamportChange"]}})
```