### PR TITLE
feat: slot change callback (provides real-time fork information)

### DIFF
--- a/module.flow.js
+++ b/module.flow.js
@@ -75,7 +75,9 @@ declare module '@solana/web3.js' {
     blockhash: Blockhash,
     previousBlockhash: Blockhash,
     parentSlot: number,
-    transactions: Array<[Transaction, SignatureSuccess | TransactionError | null]>,
+    transactions: Array<
+      [Transaction, SignatureSuccess | TransactionError | null],
+    >,
   };
 
   declare export type KeyedAccountInfo = {
@@ -94,10 +96,17 @@ declare module '@solana/web3.js' {
     commission: number,
   };
 
+  declare export type SlotInfo = {
+    parent: 'number',
+    slot: 'number',
+    root: 'number',
+  };
+
   declare type AccountChangeCallback = (accountInfo: AccountInfo) => void;
   declare type ProgramAccountChangeCallback = (
     keyedAccountInfo: KeyedAccountInfo,
   ) => void;
+  declare type SlotChangeCallback = (slotInfo: SlotInfo) => void;
 
   declare export type SignatureSuccess = {|
     Ok: null,
@@ -189,6 +198,7 @@ declare module '@solana/web3.js' {
       programId: PublicKey,
       callback: ProgramAccountChangeCallback,
     ): number;
+    onSlotChange(callback: SlotChangeCallback): number;
     removeProgramAccountChangeListener(id: number): Promise<void>;
     validatorExit(): Promise<boolean>;
   }

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -927,3 +927,39 @@ test('program account change notification', async () => {
 
   await connection.removeProgramAccountChangeListener(subscriptionId);
 });
+
+test('slot notification', async () => {
+  if (mockRpcEnabled) {
+    console.log('non-live test skipped');
+    return;
+  }
+
+  const connection = new Connection(url, 'recent');
+
+  // let notified = false;
+  const subscriptionId = connection.onSlotChange(slotInfo => {
+    expect(slotInfo.parent).toBeDefined();
+    expect(slotInfo.slot).toBeDefined();
+    expect(slotInfo.root).toBeDefined();
+    expect(slotInfo.slot).toBeGreaterThan(slotInfo.parent);
+    expect(slotInfo.slot).toBeGreaterThanOrEqual(slotInfo.root);
+    // notified = true;
+  });
+
+  //
+  // FIXME: enable this check when slotNotification is live
+  //
+  // // Wait for mockCallback to receive a call
+  // let i = 0;
+  // while (!notified) {
+  //   //for (;;) {
+  //   if (++i === 30) {
+  //     throw new Error('Slot change notification not observed');
+  //   }
+  //   // Sleep for a 1/4 of a slot, notifications only occur after a block is
+  //   // processed
+  //   await sleep((250 * DEFAULT_TICKS_PER_SLOT) / NUM_TICKS_PER_SECOND);
+  // }
+
+  await connection.removeSlotChangeListener(subscriptionId);
+});


### PR DESCRIPTION
PROBLEM:

* clients would like realtime slot notifications (e.g. for fork visualization)
* see solana-labs/solana#7114 for latest problem description

SOLUTION:

* hook up the websocket slot notification API

