### PR TITLE
fix: Add epoch_credits value to getVoteAccounts RPC call

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -95,6 +95,7 @@ type ContactInfo = {
  * @property {string} nodePubkey Identity public key of the node voting with this account
  * @property {number} activatedStake The stake, in lamports, delegated to this vote account and activated
  * @property {boolean} epochVoteAccount Whether the vote account is staked for this epoch
+ * @property {Array<Array<number>>} epochCredits Recent epoch voting credit history for this voter
  * @property {number} commission A percentage (0-100) of rewards payout owed to the voter
  * @property {number} lastVote Most recent slot voted on by this vote account
  */
@@ -103,6 +104,7 @@ type VoteAccountInfo = {
   nodePubkey: string,
   activatedStake: number,
   epochVoteAccount: boolean,
+  epochCredits: Array<[number, number, number]>,
   commission: number,
   lastVote: number,
 };
@@ -397,6 +399,9 @@ const GetVoteAccounts = jsonRpcResult(
         nodePubkey: 'string',
         activatedStake: 'number',
         epochVoteAccount: 'boolean',
+        epochCredits: struct.union(['null', struct.list([
+          struct.tuple(['number', 'number', 'number']),
+        ])]),
         commission: 'number',
         lastVote: 'number',
         rootSlot: 'number?',
@@ -408,6 +413,9 @@ const GetVoteAccounts = jsonRpcResult(
         nodePubkey: 'string',
         activatedStake: 'number',
         epochVoteAccount: 'boolean',
+        epochCredits: struct.union(['null', struct.list([
+          struct.tuple(['number', 'number', 'number']),
+        ])]),
         commission: 'number',
         lastVote: 'number',
         rootSlot: 'number?',


### PR DESCRIPTION
#### Problem
`epoch_credits` was recently added to the `getVoteAccounts` RPC endpoint but the SDK does not expect it.

#### Changes
* Add an optional `epoch_credits` value to `getVoteAccounts`