### PR TITLE
fix: use parent packages channel

### DIFF
--- a/bin/localnet.sh
+++ b/bin/localnet.sh
@@ -5,11 +5,12 @@ channel=$(
   cd "$(dirname "$0")";
   node -p '
     let p = [
+      "../../package.json",
       "../lib/node_modules/@solana/web3.js/package.json",
       "../@solana/web3.js/package.json",
       "../package.json"
     ].find(require("fs").existsSync);
-    if (!p) throw new Error("Unable to locate solana-web3.js directory");
+    if (!p) throw new Error("Unable to locate package.json");
     require(p)["testnetDefaultChannel"]
   '
 )


### PR DESCRIPTION
First check the parent's package.json for which channel to use for localnet