### PR TITLE
Add stake program

### DIFF
--- a/flow-typed/hasha.js
+++ b/flow-typed/hasha.js
@@ -1,0 +1,4 @@
+declare module 'hasha' {
+  // TODO: Fill in types
+  declare module.exports: any;
+}

--- a/module.flow.js
+++ b/module.flow.js
@@ -203,9 +203,6 @@ declare module '@solana/web3.js' {
     validatorExit(): Promise<boolean>;
   }
 
-  // === src/config-program.js ===
-  declare export var CONFIG_PROGRAM_ID;
-
   // === src/stake-program.js ===
   declare export class StakeProgram {
     static programId: PublicKey;

--- a/module.flow.js
+++ b/module.flow.js
@@ -203,6 +203,62 @@ declare module '@solana/web3.js' {
     validatorExit(): Promise<boolean>;
   }
 
+  // === src/config-program.js ===
+  declare export var CONFIG_PROGRAM_ID;
+
+  // === src/stake-program.js ===
+  declare export class StakeProgram {
+    static programId: PublicKey;
+    static space: number;
+
+    static createAccount(
+      from: PublicKey,
+      stakeAccount: PublicKey,
+      authorized: Authorized,
+      lockup: Lockup,
+      lamports: number,
+    ): Transaction;
+    static createAccountWithSeed(
+      from: PublicKey,
+      stakeAccount: PublicKey,
+      seed: string,
+      authorized: Authorized,
+      lockup: Lockup,
+      lamports: number,
+    ): Transaction;
+    static delegate(
+      stakeAccount: PublicKey,
+      authorizedPubkey: PublicKey,
+      votePubkey: PublicKey,
+    ): Transaction;
+    static authorize(
+      stakeAccount: PublicKey,
+      authorizedPubkey: PublicKey,
+      newAuthorized: PublicKey,
+      stakeAuthorizationType: StakeAuthorizationType,
+    ): Transaction;
+    static redeemVoteCredits(
+      stakeAccount: PublicKey,
+      votePubkey: PublicKey,
+    ): Transaction;
+    static split(
+      stakeAccount: PublicKey,
+      authorizedPubkey: PublicKey,
+      lamports: number,
+      splitStakePubkey: PublicKey,
+    ): Transaction;
+    static withdraw(
+      stakeAccount: PublicKey,
+      withdrawerPubkey: PublicKey,
+      to: PublicKey,
+      lamports: number,
+    ): Transaction;
+    static deactivate(
+      stakeAccount: PublicKey,
+      authorizedPubkey: PublicKey,
+    ): Transaction;
+  }
+
   // === src/system-program.js ===
   declare export class SystemProgram {
     static programId: PublicKey;
@@ -248,11 +304,14 @@ declare module '@solana/web3.js' {
     static fromConfigData(buffer: Buffer): ?ValidatorInfo;
   }
 
-  // === src/sysvar-rent.js ===
+  // === src/sysvar.js ===
+  declare export var SYSVAR_CLOCK_PUBKEY;
   declare export var SYSVAR_RENT_PUBKEY;
+  declare export var SYSVAR_REWARDS_PUBKEY;
+  declare export var SYSVAR_STAKE_HISTORY_PUBKEY;
 
   // === src/vote-account.js ===
-  declare export var VOTE_ACCOUNT_KEY;
+  declare export var VOTE_PROGRAM_ID;
   declare export type Lockout = {|
     slot: number,
     confirmationCount: number,
@@ -276,6 +335,17 @@ declare module '@solana/web3.js' {
     epochCredits: Array<EpochCredits>;
     static fromAccountData(buffer: Buffer): VoteAccount;
   }
+
+  // === src/instruction.js ===
+  declare export type InstructionType = {|
+    index: number,
+    layout: typeof BufferLayout,
+  |};
+
+  declare export function encodeData(
+    type: InstructionType,
+    fields: Object,
+  ): Buffer;
 
   // === src/transaction.js ===
   declare export type TransactionSignature = string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9692,6 +9692,27 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hasha": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
+      "integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+        }
+      }
+    },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "bs58": "^4.0.1",
     "buffer-layout": "^1.2.0",
     "esdoc-inject-style-plugin": "^1.0.0",
+    "hasha": "^5.1.0",
     "jayson": "^3.0.1",
     "mz": "^2.7.0",
     "node-fetch": "^2.2.0",

--- a/src/config-program.js
+++ b/src/config-program.js
@@ -1,6 +1,0 @@
-// @flow
-import {PublicKey} from './publickey';
-
-export const CONFIG_PROGRAM_ID = new PublicKey(
-  'Config1111111111111111111111111111111111111',
-);

--- a/src/config-program.js
+++ b/src/config-program.js
@@ -1,0 +1,6 @@
+// @flow
+import {PublicKey} from './publickey';
+
+export const CONFIG_PROGRAM_ID = new PublicKey(
+  'Config1111111111111111111111111111111111111',
+);

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,14 @@ export {CONFIG_PROGRAM_ID} from './config-program';
 export {Connection} from './connection';
 export {Loader} from './loader';
 export {PublicKey} from './publickey';
-export {StakeInstruction, StakeProgram} from './stake-program';
+export {
+  Authorized,
+  Lockup,
+  StakeAuthorizationLayout,
+  StakeInstruction,
+  StakeInstructionLayout,
+  StakeProgram,
+} from './stake-program';
 export {SystemInstruction, SystemProgram} from './system-program';
 export {Transaction, TransactionInstruction} from './transaction';
 export {VALIDATOR_INFO_KEY, ValidatorInfo} from './validator-info';

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,11 @@
 export {Account} from './account';
 export {BpfLoader} from './bpf-loader';
 export {BudgetProgram} from './budget-program';
-export {CONFIG_PROGRAM_ID} from './config-program';
 export {Connection} from './connection';
 export {Loader} from './loader';
 export {PublicKey} from './publickey';
 export {
+  STAKE_CONFIG_ID,
   Authorized,
   Lockup,
   StakeAuthorizationLayout,

--- a/src/index.js
+++ b/src/index.js
@@ -2,21 +2,26 @@
 export {Account} from './account';
 export {BpfLoader} from './bpf-loader';
 export {BudgetProgram} from './budget-program';
+export {CONFIG_PROGRAM_ID} from './config-program';
 export {Connection} from './connection';
 export {Loader} from './loader';
 export {PublicKey} from './publickey';
+export {StakeInstruction, StakeProgram} from './stake-program';
 export {SystemInstruction, SystemProgram} from './system-program';
 export {Transaction, TransactionInstruction} from './transaction';
 export {VALIDATOR_INFO_KEY, ValidatorInfo} from './validator-info';
-export {VOTE_ACCOUNT_KEY, VoteAccount} from './vote-account';
-export {SYSVAR_RENT_PUBKEY} from './sysvar-rent';
+export {VOTE_PROGRAM_ID, VoteAccount} from './vote-account';
+export {
+  SYSVAR_CLOCK_PUBKEY,
+  SYSVAR_RENT_PUBKEY,
+  SYSVAR_REWARDS_PUBKEY,
+  SYSVAR_STAKE_HISTORY_PUBKEY,
+} from './sysvar';
 export {
   sendAndConfirmTransaction,
   sendAndConfirmRecentTransaction,
 } from './util/send-and-confirm-transaction';
-export {
-  sendAndConfirmRawTransaction,
-} from './util/send-and-confirm-raw-transaction';
+export {sendAndConfirmRawTransaction} from './util/send-and-confirm-raw-transaction';
 export {testnetChannelEndpoint} from './util/testnet';
 
 // There are 1-billion lamports in one SOL

--- a/src/instruction.js
+++ b/src/instruction.js
@@ -1,0 +1,27 @@
+// @flow
+
+import * as BufferLayout from 'buffer-layout';
+
+import * as Layout from './layout';
+
+/**
+ * @typedef {Object} InstructionType
+ * @property (index} The Instruction index (from solana upstream program)
+ * @property (BufferLayout} The BufferLayout to use to build data
+ */
+export type InstructionType = {|
+  index: number,
+  layout: typeof BufferLayout,
+|};
+
+/**
+ * Populate a buffer of instruction data using an InstructionType
+ */
+export function encodeData(type: InstructionType, fields: Object): Buffer {
+  const allocLength =
+    type.layout.span >= 0 ? type.layout.span : Layout.getAlloc(type, fields);
+  const data = Buffer.alloc(allocLength);
+  const layoutFields = Object.assign({instruction: type.index}, fields);
+  type.layout.encode(layoutFields, data);
+  return data;
+}

--- a/src/layout.js
+++ b/src/layout.js
@@ -69,7 +69,11 @@ export const authorized = (property: string = 'authorized') => {
  */
 export const lockup = (property: string = 'lockup') => {
   return BufferLayout.struct(
-    [BufferLayout.ns64('epoch'), publicKey('custodian')],
+    [
+      BufferLayout.ns64('unixTimestamp'),
+      BufferLayout.ns64('epoch'),
+      publicKey('custodian'),
+    ],
     property,
   );
 };

--- a/src/layout.js
+++ b/src/layout.js
@@ -54,6 +54,26 @@ export const rustString = (property: string = 'string') => {
   return rsl;
 };
 
+/**
+ * Layout for an Authorized object
+ */
+export const authorized = (property: string = 'authorized') => {
+  return BufferLayout.struct(
+    [publicKey('staker'), publicKey('withdrawer')],
+    property,
+  );
+};
+
+/**
+ * Layout for a Lockup object
+ */
+export const lockup = (property: string = 'lockup') => {
+  return BufferLayout.struct(
+    [BufferLayout.ns64('epoch'), publicKey('custodian')],
+    property,
+  );
+};
+
 export function getAlloc(type: Object, fields: Object): number {
   let alloc = 0;
   type.layout.fields.forEach(item => {

--- a/src/loader.js
+++ b/src/loader.js
@@ -6,7 +6,7 @@ import {Account} from './account';
 import {PublicKey} from './publickey';
 import {NUM_TICKS_PER_SECOND} from './timing';
 import {Transaction, PACKET_DATA_SIZE} from './transaction';
-import {SYSVAR_RENT_PUBKEY} from './sysvar-rent';
+import {SYSVAR_RENT_PUBKEY} from './sysvar';
 import {sendAndConfirmTransaction} from './util/send-and-confirm-transaction';
 import {sleep} from './util/sleep';
 import type {Connection} from './connection';

--- a/src/publickey.js
+++ b/src/publickey.js
@@ -80,8 +80,16 @@ export class PublicKey {
   /**
    * Derive a public key from another key, a seed, and a programId.
    */
-  static createWithSeed(fromPublicKey: PublicKey, seed: string, programId: PublicKey): PublicKey {
-    const buffer = Buffer.concat([fromPublicKey.toBuffer(), Buffer.from(seed), programId.toBuffer()])
+  static createWithSeed(
+    fromPublicKey: PublicKey,
+    seed: string,
+    programId: PublicKey,
+  ): PublicKey {
+    const buffer = Buffer.concat([
+      fromPublicKey.toBuffer(),
+      Buffer.from(seed),
+      programId.toBuffer(),
+    ]);
     const hash = hasha(buffer, {algorithm: 'sha256'});
     return new PublicKey('0x' + hash);
   }

--- a/src/publickey.js
+++ b/src/publickey.js
@@ -2,6 +2,7 @@
 
 import BN from 'bn.js';
 import bs58 from 'bs58';
+import hasha from 'hasha';
 
 /**
  * A public key
@@ -74,5 +75,14 @@ export class PublicKey {
    */
   toString(): string {
     return this.toBase58();
+  }
+
+  /**
+   * Derive a public key from another key, a seed, and a programId.
+   */
+  static createWithSeed(fromPublicKey: PublicKey, seed: string, programId: PublicKey): PublicKey {
+    const buffer = Buffer.concat([fromPublicKey.toBuffer(), Buffer.from(seed), programId.toBuffer()])
+    const hash = hasha(buffer, {algorithm: 'sha256'});
+    return new PublicKey('0x' + hash);
   }
 }

--- a/src/stake-program.js
+++ b/src/stake-program.js
@@ -1,0 +1,395 @@
+// @flow
+
+import * as BufferLayout from 'buffer-layout';
+import hasha from 'hasha';
+
+import {CONFIG_PROGRAM_ID} from './config-program';
+import {encodeData} from './instruction';
+import type {InstructionType} from './instruction';
+import * as Layout from './layout';
+import {PublicKey} from './publickey';
+import {SystemProgram} from './system-program';
+import {
+  SYSVAR_CLOCK_PUBKEY,
+  SYSVAR_RENT_PUBKEY,
+  SYSVAR_REWARDS_PUBKEY,
+  SYSVAR_STAKE_HISTORY_PUBKEY,
+} from './sysvar';
+import {Transaction, TransactionInstruction} from './transaction';
+import type {TransactionInstructionCtorFields} from './transaction';
+
+export class Authorized {
+  staker: PublicKey;
+  withdrawer: PublicKey;
+
+  /**
+   * Create a new Authorized object
+   */
+  constructor(staker: PublicKey, withdrawer: PublicKey) {
+    this.staker = staker;
+    this.withdrawer = withdrawer;
+  }
+}
+
+export class Lockup {
+  epoch: number;
+  custodian: PublicKey;
+
+  /**
+   * Create a new Authorized object
+   */
+  constructor(epoch: number, custodian: PublicKey) {
+    this.epoch = epoch;
+    this.custodian = custodian;
+  }
+}
+
+/**
+ * Stake Instruction class
+ */
+export class StakeInstruction extends TransactionInstruction {
+  /**
+   * Type of StakeInstruction
+   */
+  type: InstructionType;
+}
+
+/**
+ * An enumeration of valid StakeInstructionTypes
+ */
+const StakeInstructionLayout = Object.freeze({
+  Initialize: {
+    index: 0,
+    layout: BufferLayout.struct([
+      BufferLayout.u32('instruction'),
+      Layout.authorized(),
+      Layout.lockup(),
+    ]),
+  },
+  Authorize: {
+    index: 1,
+    layout: BufferLayout.struct([
+      BufferLayout.u32('instruction'),
+      Layout.publicKey('newAuthorized'),
+      BufferLayout.u32('stakeAuthorizationType'),
+    ]),
+  },
+  DelegateStake: {
+    index: 2,
+    layout: BufferLayout.struct([BufferLayout.u32('instruction')]),
+  },
+  RedeemVoteCredits: {
+    index: 3,
+    layout: BufferLayout.struct([BufferLayout.u32('instruction')]),
+  },
+  Split: {
+    index: 4,
+    layout: BufferLayout.struct([
+      BufferLayout.u32('instruction'),
+      BufferLayout.ns64('amount'),
+    ]),
+  },
+  Withdraw: {
+    index: 5,
+    layout: BufferLayout.struct([
+      BufferLayout.u32('instruction'),
+      BufferLayout.ns64('amount'),
+    ]),
+  },
+  Deactivate: {
+    index: 6,
+    layout: BufferLayout.struct([BufferLayout.u32('instruction')]),
+  },
+});
+
+/**
+ * @typedef {Object} StakeAuthorizationType
+ * @property (index} The Stake Authorization index (from solana-stake-program)
+ */
+export type StakeAuthorizationType = {|
+  index: number,
+|};
+
+/**
+ * An enumeration of valid StakeInstructionTypes
+ */
+export const StakeAuthorizationLayout = Object.freeze({
+  Staker: {
+    index: 0,
+  },
+  Withdrawer: {
+    index: 1,
+  },
+});
+
+class RewardsPoolPublicKey extends PublicKey {
+  static get rewardsPoolBaseId(): PublicKey {
+    return new PublicKey('StakeRewards1111111111111111111111111111111');
+  }
+
+  /**
+   * Generate Derive a public key from another key, a seed, and a programId.
+   */
+  static randomId(): PublicKey {
+    const randomInt = Math.floor(Math.random() * (256 - 1));
+    let pubkey = this.rewardsPoolBaseId;
+    for (let i = 0; i < randomInt; i++) {
+      const buffer = pubkey.toBuffer();
+      const hash = hasha(buffer, {algorithm: 'sha256'});
+      return new PublicKey('0x' + hash);
+    }
+    return pubkey;
+  }
+}
+
+/**
+ * Factory class for transactions to interact with the Stake program
+ */
+export class StakeProgram {
+  /**
+   * Public key that identifies the Stake program
+   */
+  static get programId(): PublicKey {
+    return new PublicKey('Stake11111111111111111111111111111111111111');
+  }
+
+  /**
+   * Max space of a Stake account
+   */
+  static get space(): number {
+    return 2000;
+  }
+
+  /**
+   * Generate an Initialize instruction to add to a Stake Create transaction
+   */
+  static initialize(
+    stakeAccount: PublicKey,
+    authorized: Authorized,
+    lockup: Lockup,
+  ): TransactionInstruction {
+    const type = StakeInstructionLayout.Initialize;
+    const data = encodeData(type, {
+      authorized,
+      lockup,
+    });
+    const instructionData = {
+      keys: [
+        {pubkey: stakeAccount, isSigner: false, isWritable: true},
+        {pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false},
+      ],
+      programId: this.programId,
+      data,
+    };
+    return new TransactionInstruction(instructionData);
+  }
+
+  /**
+   * Generate a Transaction that creates a new Stake account at
+   *   an address generated with `from`, a seed, and the Stake programId
+   */
+  static createAccountWithSeed(
+    from: PublicKey,
+    stakeAccount: PublicKey,
+    seed: string,
+    authorized: Authorized,
+    lockup: Lockup,
+    lamports: number,
+  ): Transaction {
+    let transaction = SystemProgram.createAccountWithSeed(
+      from,
+      stakeAccount,
+      seed,
+      lamports,
+      this.space,
+      this.programId,
+    );
+
+    return transaction.add(this.initialize(stakeAccount, authorized, lockup));
+  }
+
+  /**
+   * Generate a Transaction that creates a new Stake account
+   */
+  static createAccount(
+    from: PublicKey,
+    stakeAccount: PublicKey,
+    authorized: Authorized,
+    lockup: Lockup,
+    lamports: number,
+  ): Transaction {
+    let transaction = SystemProgram.createAccount(
+      from,
+      stakeAccount,
+      lamports,
+      this.space,
+      this.programId,
+    );
+
+    return transaction.add(this.initialize(stakeAccount, authorized, lockup));
+  }
+
+  /**
+   * Generate a Transaction that delegates Stake tokens to a validator
+   * Vote PublicKey. This transaction can also be used to redelegate Stake
+   * to a new validator Vote PublicKey.
+   */
+  static delegate(
+    stakeAccount: PublicKey,
+    authorizedPubkey: PublicKey,
+    votePubkey: PublicKey,
+  ): Transaction {
+    const type = StakeInstructionLayout.DelegateStake;
+    const data = encodeData(type);
+
+    return new Transaction().add({
+      keys: [
+        {pubkey: stakeAccount, isSigner: false, isWritable: true},
+        {pubkey: votePubkey, isSigner: false, isWritable: false},
+        {pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false},
+        {pubkey: CONFIG_PROGRAM_ID, isSigner: false, isWritable: false},
+        {pubkey: authorizedPubkey, isSigner: true, isWritable: false},
+      ],
+      programId: this.programId,
+      data,
+    });
+  }
+
+  /**
+   * Generate a Transaction that authorizes a new PublicKey as Staker
+   * or Withdrawer on the Stake account.
+   */
+  static authorize(
+    stakeAccount: PublicKey,
+    authorizedPubkey: PublicKey,
+    newAuthorized: PublicKey,
+    stakeAuthorizationType: StakeAuthorizationType,
+  ): Transaction {
+    const type = StakeInstructionLayout.Authorize;
+    const data = encodeData(type, {
+      newAuthorized,
+      stakeAuthorizationType: stakeAuthorizationType.index,
+    });
+
+    return new Transaction().add({
+      keys: [
+        {pubkey: stakeAccount, isSigner: false, isWritable: true},
+        {pubkey: authorizedPubkey, isSigner: true, isWritable: false},
+      ],
+      programId: this.programId,
+      data,
+    });
+  }
+
+  /**
+   * Generate a Transaction that authorizes a new PublicKey as Staker
+   * or Withdrawer on the Stake account.
+   */
+  static redeemVoteCredits(
+    stakeAccount: PublicKey,
+    votePubkey: PublicKey,
+  ): Transaction {
+    const type = StakeInstructionLayout.RedeemVoteCredits;
+    const data = encodeData(type);
+
+    return new Transaction().add({
+      keys: [
+        {pubkey: stakeAccount, isSigner: false, isWritable: true},
+        {pubkey: votePubkey, isSigner: false, isWritable: true},
+        {
+          pubkey: RewardsPoolPublicKey.randomId(),
+          isSigner: false,
+          isWritable: true,
+        },
+        {pubkey: SYSVAR_REWARDS_PUBKEY, isSigner: false, isWritable: false},
+        {
+          pubkey: SYSVAR_STAKE_HISTORY_PUBKEY,
+          isSigner: false,
+          isWritable: false,
+        },
+      ],
+      programId: this.programId,
+      data,
+    });
+  }
+
+  /**
+   * Generate a Transaction that splits Stake tokens into another stake account
+   */
+  static split(
+    stakeAccount: PublicKey,
+    authorizedPubkey: PublicKey,
+    lamports: number,
+    splitStakePubkey: PublicKey,
+  ): Transaction {
+    let transaction = SystemProgram.createAccount(
+      stakeAccount,
+      splitStakePubkey,
+      0,
+      this.space,
+      this.programId,
+    );
+    const type = StakeInstructionLayout.Split;
+    const data = encodeData(type, {lamports});
+
+    return transaction.add({
+      keys: [
+        {pubkey: stakeAccount, isSigner: false, isWritable: true},
+        {pubkey: splitStakePubkey, isSigner: false, isWritable: true},
+        {pubkey: authorizedPubkey, isSigner: true, isWritable: false},
+      ],
+      programId: this.programId,
+      data,
+    });
+  }
+
+  /**
+   * Generate a Transaction that withdraws deactivated Stake tokens.
+   */
+  static withdraw(
+    stakeAccount: PublicKey,
+    withdrawerPubkey: PublicKey,
+    to: PublicKey,
+    lamports: number,
+  ): Transaction {
+    const type = StakeInstructionLayout.Withdraw;
+    const data = encodeData(type, {lamports});
+
+    return new Transaction().add({
+      keys: [
+        {pubkey: stakeAccount, isSigner: false, isWritable: true},
+        {pubkey: to, isSigner: false, isWritable: true},
+        {pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false},
+        {
+          pubkey: SYSVAR_STAKE_HISTORY_PUBKEY,
+          isSigner: false,
+          isWritable: false,
+        },
+        {pubkey: withdrawerPubkey, isSigner: true, isWritable: false},
+      ],
+      programId: this.programId,
+      data,
+    });
+  }
+
+  /**
+   * Generate a Transaction that deactivates Stake tokens.
+   */
+  static deactivate(
+    stakeAccount: PublicKey,
+    authorizedPubkey: PublicKey,
+  ): Transaction {
+    const type = StakeInstructionLayout.Deactivate;
+    const data = encodeData(type);
+
+    return new Transaction().add({
+      keys: [
+        {pubkey: stakeAccount, isSigner: false, isWritable: true},
+        {pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false},
+        {pubkey: authorizedPubkey, isSigner: true, isWritable: false},
+      ],
+      programId: this.programId,
+      data,
+    });
+  }
+}

--- a/src/stake-program.js
+++ b/src/stake-program.js
@@ -243,6 +243,7 @@ export class StakeProgram {
   static createAccountWithSeed(
     from: PublicKey,
     stakeAccount: PublicKey,
+    base: PublicKey,
     seed: string,
     authorized: Authorized,
     lockup: Lockup,
@@ -251,6 +252,7 @@ export class StakeProgram {
     let transaction = SystemProgram.createAccountWithSeed(
       from,
       stakeAccount,
+      base,
       seed,
       lamports,
       this.space,

--- a/src/stake-program.js
+++ b/src/stake-program.js
@@ -52,6 +52,46 @@ export class StakeInstruction extends TransactionInstruction {
    * Type of StakeInstruction
    */
   type: InstructionType;
+
+  constructor(opts?: TransactionInstructionCtorFields, type?: InstructionType) {
+    if (
+      opts &&
+      opts.programId &&
+      !opts.programId.equals(StakeProgram.programId)
+    ) {
+      throw new Error('programId incorrect; not a StakeInstruction');
+    }
+    super(opts);
+    if (type) {
+      this.type = type;
+    }
+  }
+
+  static from(instruction: TransactionInstruction): StakeInstruction {
+    if (!instruction.programId.equals(StakeProgram.programId)) {
+      throw new Error('programId incorrect; not StakeProgram');
+    }
+
+    const instructionTypeLayout = BufferLayout.u32('instruction');
+    const typeIndex = instructionTypeLayout.decode(instruction.data);
+    let type;
+    for (const t in StakeInstructionLayout) {
+      if (StakeInstructionLayout[t].index == typeIndex) {
+        type = StakeInstructionLayout[t];
+      }
+    }
+    if (!type) {
+      throw new Error('Instruction type incorrect; not a StakeInstruction');
+    }
+    return new StakeInstruction(
+      {
+        keys: instruction.keys,
+        programId: instruction.programId,
+        data: instruction.data,
+      },
+      type,
+    );
+  }
 }
 
 /**

--- a/src/stake-program.js
+++ b/src/stake-program.js
@@ -328,6 +328,7 @@ export class StakeProgram {
     return new Transaction().add({
       keys: [
         {pubkey: stakeAccount, isSigner: false, isWritable: true},
+        {pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: true},
         {pubkey: authorizedPubkey, isSigner: true, isWritable: false},
       ],
       programId: this.programId,

--- a/src/stake-program.js
+++ b/src/stake-program.js
@@ -97,7 +97,7 @@ export class StakeInstruction extends TransactionInstruction {
 /**
  * An enumeration of valid StakeInstructionTypes
  */
-const StakeInstructionLayout = Object.freeze({
+export const StakeInstructionLayout = Object.freeze({
   Initialize: {
     index: 0,
     layout: BufferLayout.struct([
@@ -210,8 +210,14 @@ export class StakeProgram {
   ): TransactionInstruction {
     const type = StakeInstructionLayout.Initialize;
     const data = encodeData(type, {
-      authorized,
-      lockup,
+      authorized: {
+        staker: authorized.staker.toBuffer(),
+        withdrawer: authorized.withdrawer.toBuffer(),
+      },
+      lockup: {
+        epoch: lockup.epoch,
+        custodian: lockup.custodian.toBuffer(),
+      },
     });
     const instructionData = {
       keys: [
@@ -307,7 +313,7 @@ export class StakeProgram {
   ): Transaction {
     const type = StakeInstructionLayout.Authorize;
     const data = encodeData(type, {
-      newAuthorized,
+      newAuthorized: newAuthorized.toBuffer(),
       stakeAuthorizationType: stakeAuthorizationType.index,
     });
 

--- a/src/stake-program.js
+++ b/src/stake-program.js
@@ -381,6 +381,7 @@ export class StakeProgram {
       this.space,
       this.programId,
     );
+    transaction.instructions[0].keys[0].isSigner = false;
     const type = StakeInstructionLayout.Split;
     const data = encodeData(type, {lamports});
 

--- a/src/system-program.js
+++ b/src/system-program.js
@@ -2,9 +2,11 @@
 
 import * as BufferLayout from 'buffer-layout';
 
-import {Transaction, TransactionInstruction} from './transaction';
-import {PublicKey} from './publickey';
+import {encodeData} from './instruction';
+import type {InstructionType} from './instruction';
 import * as Layout from './layout';
+import {PublicKey} from './publickey';
+import {Transaction, TransactionInstruction} from './transaction';
 import type {TransactionInstructionCtorFields} from './transaction';
 
 /**
@@ -14,12 +16,9 @@ export class SystemInstruction extends TransactionInstruction {
   /**
    * Type of SystemInstruction
    */
-  type: SystemInstructionType;
+  type: InstructionType;
 
-  constructor(
-    opts?: TransactionInstructionCtorFields,
-    type?: SystemInstructionType,
-  ) {
+  constructor(opts?: TransactionInstructionCtorFields, type?: InstructionType) {
     if (
       opts &&
       opts.programId &&
@@ -108,16 +107,6 @@ export class SystemInstruction extends TransactionInstruction {
 }
 
 /**
- * @typedef {Object} SystemInstructionType
- * @property (index} The System Instruction index (from solana-sdk)
- * @property (BufferLayout} The BufferLayout to use to build data
- */
-type SystemInstructionType = {|
-  index: number,
-  layout: typeof BufferLayout,
-|};
-
-/**
  * An enumeration of valid SystemInstructionTypes
  */
 const SystemInstructionLayout = Object.freeze({
@@ -156,18 +145,6 @@ const SystemInstructionLayout = Object.freeze({
     ]),
   },
 });
-
-/**
- * Populate a buffer of instruction data using the SystemInstructionType
- */
-function encodeData(type: SystemInstructionType, fields: Object): Buffer {
-  const allocLength =
-    type.layout.span >= 0 ? type.layout.span : Layout.getAlloc(type, fields);
-  const data = Buffer.alloc(allocLength);
-  const layoutFields = Object.assign({instruction: type.index}, fields);
-  type.layout.encode(layoutFields, data);
-  return data;
-}
 
 /**
  * Factory class for transactions to interact with the System program

--- a/src/sysvar-rent.js
+++ b/src/sysvar-rent.js
@@ -1,6 +1,0 @@
-// @flow
-import {PublicKey} from './publickey';
-
-export const SYSVAR_RENT_PUBKEY = new PublicKey(
-  'SysvarRent111111111111111111111111111111111',
-);

--- a/src/sysvar.js
+++ b/src/sysvar.js
@@ -1,0 +1,18 @@
+// @flow
+import {PublicKey} from './publickey';
+
+export const SYSVAR_CLOCK_PUBKEY = new PublicKey(
+  'SysvarC1ock11111111111111111111111111111111',
+);
+
+export const SYSVAR_RENT_PUBKEY = new PublicKey(
+  'SysvarRent111111111111111111111111111111111',
+);
+
+export const SYSVAR_REWARDS_PUBKEY = new PublicKey(
+  'SysvarRewards111111111111111111111111111111',
+);
+
+export const SYSVAR_STAKE_HISTORY_PUBKEY = new PublicKey(
+  'SysvarStakeHistory1111111111111111111111111',
+);

--- a/src/vote-account.js
+++ b/src/vote-account.js
@@ -4,7 +4,7 @@ import * as BufferLayout from 'buffer-layout';
 import * as Layout from './layout';
 import {PublicKey} from './publickey';
 
-export const VOTE_ACCOUNT_KEY = new PublicKey(
+export const VOTE_PROGRAM_ID = new PublicKey(
   'Vote111111111111111111111111111111111111111',
 );
 

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -785,7 +785,9 @@ test('multi-instruction transaction', async () => {
   const connection = new Connection(url, 'recent');
 
   await connection.requestAirdrop(accountFrom.publicKey, LAMPORTS_PER_SOL);
-  expect(await connection.getBalance(accountFrom.publicKey)).toBe(LAMPORTS_PER_SOL);
+  expect(await connection.getBalance(accountFrom.publicKey)).toBe(
+    LAMPORTS_PER_SOL,
+  );
 
   await connection.requestAirdrop(accountTo.publicKey, 21);
   expect(await connection.getBalance(accountTo.publicKey)).toBe(21);

--- a/test/publickey.test.js
+++ b/test/publickey.test.js
@@ -259,7 +259,15 @@ test('createWithSeed', () => {
     0,
     0,
   ]);
-  const derivedKey = PublicKey.createWithSeed(defaultPublicKey, 'limber chicken: 4/45', defaultPublicKey);
+  const derivedKey = PublicKey.createWithSeed(
+    defaultPublicKey,
+    'limber chicken: 4/45',
+    defaultPublicKey,
+  );
 
-  expect(derivedKey.equals(new PublicKey('9h1HyLCW5dZnBVap8C5egQ9Z6pHyjsh5MNy83iPqqRuq'))).toBe(true);
+  expect(
+    derivedKey.equals(
+      new PublicKey('9h1HyLCW5dZnBVap8C5egQ9Z6pHyjsh5MNy83iPqqRuq'),
+    ),
+  ).toBe(true);
 });

--- a/test/publickey.test.js
+++ b/test/publickey.test.js
@@ -223,3 +223,43 @@ test('equals (II)', () => {
 
   expect(key1.equals(key2)).toBe(true);
 });
+
+test('createWithSeed', () => {
+  const defaultPublicKey = new PublicKey([
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  ]);
+  const derivedKey = PublicKey.createWithSeed(defaultPublicKey, 'limber chicken: 4/45', defaultPublicKey);
+
+  expect(derivedKey.equals(new PublicKey('9h1HyLCW5dZnBVap8C5egQ9Z6pHyjsh5MNy83iPqqRuq'))).toBe(true);
+});

--- a/test/stake-program.test.js
+++ b/test/stake-program.test.js
@@ -266,7 +266,7 @@ test('live staking actions', async () => {
     seed,
     new Authorized(authorized.publicKey, authorized.publicKey),
     new Lockup(0, 0, new PublicKey('0x00')),
-    2 * minimumAmount + 42,
+    3 * minimumAmount + 42,
   );
 
   await sendAndConfirmRecentTransaction(
@@ -275,7 +275,7 @@ test('live staking actions', async () => {
     from,
   );
   let originalStakeBalance = await connection.getBalance(newAccountPubkey);
-  expect(originalStakeBalance).toEqual(2 * minimumAmount + 42);
+  expect(originalStakeBalance).toEqual(3 * minimumAmount + 42);
 
   let delegation = StakeProgram.delegate(
     newAccountPubkey,
@@ -295,6 +295,21 @@ test('live staking actions', async () => {
   await expect(
     sendAndConfirmRecentTransaction(connection, withdraw, authorized),
   ).rejects.toThrow();
+
+  // Split stake
+  const newStake = new Account();
+  let split = StakeProgram.split(
+    newAccountPubkey,
+    authorized.publicKey,
+    minimumAmount + 20,
+    newStake.publicKey,
+  );
+  await sendAndConfirmRecentTransaction(
+    connection,
+    split,
+    authorized,
+    newStake,
+  );
 
   // Authorize to new account
   const newAuthorized = new Account();
@@ -344,7 +359,7 @@ test('live staking actions', async () => {
   );
   await sendAndConfirmRecentTransaction(connection, withdraw, newAuthorized);
   const balance = await connection.getBalance(newAccountPubkey);
-  expect(balance).toEqual(minimumAmount + 22);
+  expect(balance).toEqual(minimumAmount + 2);
   const recipientBalance = await connection.getBalance(recipient.publicKey);
   expect(recipientBalance).toEqual(minimumAmount + 20);
 });

--- a/test/stake-program.test.js
+++ b/test/stake-program.test.js
@@ -1,0 +1,222 @@
+// @flow
+
+import {
+  Account,
+  Authorized,
+  Lockup,
+  PublicKey,
+  StakeAuthorizationLayout,
+  StakeInstruction,
+  StakeInstructionLayout,
+  StakeProgram,
+  SystemInstruction,
+  SystemProgram,
+  Transaction,
+} from '../src';
+
+test('createAccountWithSeed', () => {
+  const from = new Account();
+  const seed = 'test string';
+  const newAccountPubkey = PublicKey.createWithSeed(
+    from.publicKey,
+    seed,
+    StakeProgram.programId,
+  );
+  const authorized = new Account();
+  let transaction;
+
+  transaction = StakeProgram.createAccountWithSeed(
+    from.publicKey,
+    newAccountPubkey,
+    seed,
+    new Authorized(authorized.publicKey, authorized.publicKey),
+    new Lockup(0, from.publicKey),
+    123,
+  );
+
+  expect(transaction.instructions).toHaveLength(2);
+  expect(transaction.instructions[0].programId).toEqual(
+    SystemProgram.programId,
+  );
+  expect(transaction.instructions[1].programId).toEqual(StakeProgram.programId);
+  // TODO: Validate transaction contents more
+});
+
+test('createAccount', () => {
+  const from = new Account();
+  const newAccount = new Account();
+  const authorized = new Account();
+  let transaction;
+
+  transaction = StakeProgram.createAccount(
+    from.publicKey,
+    newAccount.publicKey,
+    new Authorized(authorized.publicKey, authorized.publicKey),
+    new Lockup(0, from.publicKey),
+    123,
+  );
+
+  expect(transaction.instructions).toHaveLength(2);
+  expect(transaction.instructions[0].programId).toEqual(
+    SystemProgram.programId,
+  );
+  expect(transaction.instructions[1].programId).toEqual(StakeProgram.programId);
+  // TODO: Validate transaction contents more
+});
+
+test('delegate', () => {
+  const stake = new Account();
+  const authorized = new Account();
+  const vote = new Account();
+  let transaction;
+
+  transaction = StakeProgram.delegate(
+    stake.publicKey,
+    authorized.publicKey,
+    vote.publicKey,
+  );
+
+  expect(transaction.keys).toHaveLength(5);
+  expect(transaction.programId).toEqual(StakeProgram.programId);
+  // TODO: Validate transaction contents more
+});
+
+test('authorize', () => {
+  const stake = new Account();
+  const authorized = new Account();
+  const newAuthorized = new Account();
+  const type = StakeAuthorizationLayout.Staker;
+  let transaction;
+
+  transaction = StakeProgram.authorize(
+    stake.publicKey,
+    authorized.publicKey,
+    newAuthorized.publicKey,
+    type,
+  );
+
+  expect(transaction.keys).toHaveLength(2);
+  expect(transaction.programId).toEqual(StakeProgram.programId);
+  // TODO: Validate transaction contents more
+});
+
+test('redeemVoteCredits', () => {
+  const stake = new Account();
+  const vote = new Account();
+  let transaction;
+
+  transaction = StakeProgram.redeemVoteCredits(stake.publicKey, vote.publicKey);
+
+  expect(transaction.keys).toHaveLength(5);
+  expect(transaction.programId).toEqual(StakeProgram.programId);
+  // TODO: Validate transaction contents more
+});
+
+test('split', () => {
+  const stake = new Account();
+  const authorized = new Account();
+  const newStake = new Account();
+  let transaction;
+
+  transaction = StakeProgram.split(
+    stake.publicKey,
+    authorized.publicKey,
+    123,
+    newStake.publicKey,
+  );
+
+  expect(transaction.instructions).toHaveLength(2);
+  expect(transaction.instructions[0].programId).toEqual(
+    SystemProgram.programId,
+  );
+  expect(transaction.instructions[1].programId).toEqual(StakeProgram.programId);
+  // TODO: Validate transaction contents more
+});
+
+test('withdraw', () => {
+  const stake = new Account();
+  const withdrawer = new Account();
+  const to = new Account();
+  let transaction;
+
+  transaction = StakeProgram.withdraw(
+    stake.publicKey,
+    withdrawer.publicKey,
+    to.publicKey,
+    123,
+  );
+
+  expect(transaction.keys).toHaveLength(5);
+  expect(transaction.programId).toEqual(StakeProgram.programId);
+  // TODO: Validate transaction contents more
+});
+
+test('deactivate', () => {
+  const stake = new Account();
+  const authorized = new Account();
+  let transaction;
+
+  transaction = StakeProgram.deactivate(stake.publicKey, authorized.publicKey);
+
+  expect(transaction.keys).toHaveLength(3);
+  expect(transaction.programId).toEqual(StakeProgram.programId);
+  // TODO: Validate transaction contents more
+});
+
+test('StakeInstructions', () => {
+  const from = new Account();
+  const seed = 'test string';
+  const newAccountPubkey = PublicKey.createWithSeed(
+    from.publicKey,
+    seed,
+    StakeProgram.programId,
+  );
+  const authorized = new Account();
+  const amount = 123;
+  const recentBlockhash = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k'; // Arbitrary known recentBlockhash
+  const createWithSeed = StakeProgram.createAccountWithSeed(
+    from.publicKey,
+    newAccountPubkey,
+    seed,
+    new Authorized(authorized.publicKey, authorized.publicKey),
+    new Lockup(0, from.publicKey),
+    amount,
+  );
+  const createWithSeedTransaction = new Transaction({recentBlockhash}).add(
+    createWithSeed,
+  );
+
+  const systemInstruction = SystemInstruction.from(
+    createWithSeedTransaction.instructions[0],
+  );
+  expect(systemInstruction.fromPublicKey).toEqual(from.publicKey);
+  expect(systemInstruction.toPublicKey).toEqual(newAccountPubkey);
+  expect(systemInstruction.amount).toEqual(amount);
+  expect(systemInstruction.programId).toEqual(SystemProgram.programId);
+
+  const stakeInstruction = StakeInstruction.from(
+    createWithSeedTransaction.instructions[1],
+  );
+  expect(stakeInstruction.type).toEqual(StakeInstructionLayout.Initialize);
+
+  expect(() => {
+    StakeInstruction.from(createWithSeedTransaction.instructions[0]);
+  }).toThrow();
+
+  const stake = new Account();
+  const vote = new Account();
+  const delegate = StakeProgram.delegate(
+    stake.publicKey,
+    authorized.publicKey,
+    vote.publicKey,
+  );
+
+  const delegateTransaction = new Transaction({recentBlockhash}).add(delegate);
+
+  const anotherStakeInstruction = StakeInstruction.from(
+    delegateTransaction.instructions[0],
+  );
+  expect(anotherStakeInstruction.type).toEqual(
+    StakeInstructionLayout.DelegateStake,
+  );
+});

--- a/test/stake-program.test.js
+++ b/test/stake-program.test.js
@@ -106,7 +106,7 @@ test('authorize', () => {
     type,
   );
 
-  expect(transaction.keys).toHaveLength(2);
+  expect(transaction.keys).toHaveLength(3);
   expect(transaction.programId).toEqual(StakeProgram.programId);
   // TODO: Validate transaction contents more
 });

--- a/test/stake-program.test.js
+++ b/test/stake-program.test.js
@@ -38,6 +38,7 @@ test('createAccountWithSeed', () => {
   transaction = StakeProgram.createAccountWithSeed(
     from.publicKey,
     newAccountPubkey,
+    from.publicKey,
     seed,
     new Authorized(authorized.publicKey, authorized.publicKey),
     new Lockup(0, 0, from.publicKey),
@@ -187,6 +188,7 @@ test('StakeInstructions', () => {
   const createWithSeed = StakeProgram.createAccountWithSeed(
     from.publicKey,
     newAccountPubkey,
+    from.publicKey,
     seed,
     new Authorized(authorized.publicKey, authorized.publicKey),
     new Lockup(0, 0, from.publicKey),
@@ -244,8 +246,8 @@ test('live staking actions', async () => {
 
   const from = new Account();
   const authorized = new Account();
-  await connection.requestAirdrop(from.publicKey, LAMPORTS_PER_SOL);
-  await connection.requestAirdrop(authorized.publicKey, LAMPORTS_PER_SOL);
+  await connection.requestAirdrop(from.publicKey, 2 * LAMPORTS_PER_SOL);
+  await connection.requestAirdrop(authorized.publicKey, 2 * LAMPORTS_PER_SOL);
 
   const minimumAmount = await connection.getMinimumBalanceForRentExemption(
     StakeProgram.space,
@@ -263,6 +265,7 @@ test('live staking actions', async () => {
   let createAndInitializeWithSeed = StakeProgram.createAccountWithSeed(
     from.publicKey,
     newAccountPubkey,
+    from.publicKey,
     seed,
     new Authorized(authorized.publicKey, authorized.publicKey),
     new Lockup(0, 0, new PublicKey('0x00')),


### PR DESCRIPTION
@mvines , fyi, and one question:
I wrote `delegate`, `authorize`, `split`, `withdraw`, and `deactivate` on the assumption that the client would use a non-stake-account authorized keypair to sign/execute the transaction. This seems like the most common downstream use case to me, so it is a convenient short-cut. Should I rework now to offer something like the solana-stake-program's `with_signer()`?

- [x] I will add a live integration test to bump this up to ready-for-review.

Toward https://github.com/solana-labs/solana/issues/7583