### PR TITLE
fix: add balances fields to GetConfirmedBlockRpcResult

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -490,6 +490,8 @@ export const GetConfirmedBlockRpcResult = jsonRpcResult(
           struct({
             status: SignatureStatusResult,
             fee: 'number',
+            preBalances: struct.list(['number']),
+            postBalances: struct.list(['number']),
           }),
         ]),
       ]),


### PR DESCRIPTION
Fixes up CI failures: https://travis-ci.org/solana-labs/solana-web3.js/jobs/628935451