### PR TITLE
fix: update rpc sendTransaction format

### DIFF
--- a/module.flow.js
+++ b/module.flow.js
@@ -194,6 +194,9 @@ declare module '@solana/web3.js' {
       transaction: Transaction,
       ...signers: Array<Account>
     ): Promise<TransactionSignature>;
+    sendEncodedTransaction(
+      encodedTransaction: string,
+    ): Promise<TransactionSignature>;
     sendRawTransaction(wireTransaction: Buffer): Promise<TransactionSignature>;
     onAccountChange(
       publickey: PublicKey,

--- a/src/connection.js
+++ b/src/connection.js
@@ -1220,8 +1220,20 @@ export class Connection {
   async sendRawTransaction(
     rawTransaction: Buffer,
   ): Promise<TransactionSignature> {
+    const encodedTransaction = bs58.encode(rawTransaction);
+    const result = await this.sendEncodedTransaction(encodedTransaction);
+    return result;
+  }
+
+  /**
+   * Send a transaction that has already been signed, serialized into the
+   * wire format, and encoded as a base58 string
+   */
+  async sendEncodedTransaction(
+    encodedTransaction: string,
+  ): Promise<TransactionSignature> {
     const unsafeRes = await this._rpcRequest('sendTransaction', [
-      [...rawTransaction],
+      encodedTransaction,
     ]);
     const res = SendTransactionRpcResult(unsafeRes);
     if (res.error) {


### PR DESCRIPTION
Encode raw transaction as base58 string. I also included a `Connection.sendEncodedTransaction()` method, as I thought it might be helpful for users.

CI depends on https://github.com/solana-labs/solana/pull/7913 in solana docker image