### PR TITLE
fix: remove references to decommissioned testnets

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "solana-bpf-sdk-install": "bin/bpf-sdk-install.sh",
     "solana-localnet": "bin/localnet.sh"
   },
-  "testnetDefaultChannel": "edge",
+  "testnetDefaultChannel": "stable",
   "files": [
     "/bin",
     "/doc",

--- a/src/util/testnet.js
+++ b/src/util/testnet.js
@@ -7,13 +7,9 @@ import {testnetDefaultChannel} from '../../package.json';
  */
 const endpoint = {
   http: {
-    edge: 'http://edge.testnet.solana.com:8899',
-    beta: 'http://beta.testnet.solana.com:8899',
     stable: 'http://testnet.solana.com:8899',
   },
   https: {
-    edge: 'https://edge.testnet.solana.com:8443',
-    beta: 'https://beta.testnet.solana.com:8443',
     stable: 'https://testnet.solana.com:8443',
   },
 };

--- a/test/testnet.test.js
+++ b/test/testnet.test.js
@@ -7,17 +7,17 @@ test('invalid', () => {
   }).toThrow();
 });
 
-test('edge', () => {
-  expect(testnetChannelEndpoint('edge')).toEqual(
-    'https://edge.testnet.solana.com:8443',
+test('stable', () => {
+  expect(testnetChannelEndpoint('stable')).toEqual(
+    'https://testnet.solana.com:8443',
   );
 
-  expect(testnetChannelEndpoint('edge', true)).toEqual(
-    'https://edge.testnet.solana.com:8443',
+  expect(testnetChannelEndpoint('stable', true)).toEqual(
+    'https://testnet.solana.com:8443',
   );
 
-  expect(testnetChannelEndpoint('edge', false)).toEqual(
-    'http://edge.testnet.solana.com:8899',
+  expect(testnetChannelEndpoint('stable', false)).toEqual(
+    'http://testnet.solana.com:8899',
   );
 });
 

--- a/test/url.js
+++ b/test/url.js
@@ -5,14 +5,5 @@
  */
 
 export const url = 'http://localhost:8899/';
-
-/*
-export const url = 'https://edge.testnet.solana.com:8443/';
-export const url = 'https://beta.testnet.solana.com:8443/';
-export const url = 'https://testnet.solana.com:8443/';
-*/
-/*
-export const url = 'http://edge.testnet.solana.com:8899/';
-export const url = 'http://beta.testnet.solana.com:8899/';
-export const url = 'http://testnet.solana.com:8899/';
-*/
+// export const url = 'https://testnet.solana.com:8443/';
+// export const url = 'http://testnet.solana.com:8899/';


### PR DESCRIPTION
#### Problem
The edge and beta testnets have been turned off but the sdk still references them. Removing them will cause an error to be thrown in the testnet utility method

This also impacts the `bpf-sdk-install` and `localnet` binaries. They read `"testnetDefaultChannel"` to determine which sdk and docker image to install/download/run. But both work fine with "stable" as the new default.