### PR TITLE
fix: race condition in rpc subscribe

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1367,7 +1367,7 @@ export class Connection {
   /**
    * @private
    */
-  async _updateSubscriptions() {
+  _updateSubscriptions() {
     const accountKeys = Object.keys(this._accountChangeSubscriptions).map(
       Number,
     );
@@ -1404,23 +1404,23 @@ export class Connection {
     }
 
     for (let id of accountKeys) {
-      const sub: AccountSubscriptionInfo = this._accountChangeSubscriptions[id];
-      await this._subscribe(sub, 'accountSubscribe', [sub.publicKey]);
+      const sub = this._accountChangeSubscriptions[id];
+      this._subscribe(sub, 'accountSubscribe', [sub.publicKey]);
     }
 
     for (let id of programKeys) {
       const sub = this._programAccountChangeSubscriptions[id];
-      await this._subscribe(sub, 'programSubscribe', [sub.programId]);
+      this._subscribe(sub, 'programSubscribe', [sub.programId]);
     }
 
     for (let id of slotKeys) {
       const sub = this._slotSubscriptions[id];
-      await this._subscribe(sub, 'slotSubscribe', []);
+      this._subscribe(sub, 'slotSubscribe', []);
     }
 
     for (let id of signatureKeys) {
       const sub = this._signatureSubscriptions[id];
-      await this._subscribe(sub, 'signatureSubscribe', [sub.signature]);
+      this._subscribe(sub, 'signatureSubscribe', [sub.signature]);
     }
   }
 


### PR DESCRIPTION
#### Problem
`updateSubscriptions` was await-ing while iterating over keys to subscribe to. If a key is removed before being subscribed, an error will be thrown. This situation is admittedly a bit unlikely to happen in practice, but feels worthy of fixing anyways

#### Changes
* Synchronously subscribe to keys