### PR TITLE
feat: expose instruction types and refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,12 +8,14 @@ module.exports = {
     'eslint:recommended',
     'plugin:import/errors',
     'plugin:import/warnings',
+    'plugin:flowtype/recommended',
   ],
   parser: 'babel-eslint',
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 8,
   },
+  plugins: ['flowtype'],
   rules: {
     'no-trailing-spaces': ['error'],
     'import/first': ['error'],
@@ -45,6 +47,7 @@ module.exports = {
     ],
     'require-await': ['error'],
     semi: ['error', 'always'],
+    'flowtype/generic-spacing': [0],
   },
 
   // Used to lint the TypeScript type declaration file

--- a/module.d.ts
+++ b/module.d.ts
@@ -233,73 +233,6 @@ declare module '@solana/web3.js' {
     ): Promise<number>;
   }
 
-  // === src/stake-program.js ===
-  export type StakeAuthorizationType = {
-    index: number;
-  };
-
-  export class Authorized {
-    staker: PublicKey;
-    withdrawer: PublicKey;
-    constructor(staker: PublicKey, withdrawer: PublicKey);
-  }
-
-  export class Lockup {
-    unixTimestamp: number;
-    epoch: number;
-    custodian: PublicKey;
-
-    constructor(unixTimestamp: number, epoch: number, custodian: PublicKey);
-  }
-
-  export class StakeProgram {
-    static programId: PublicKey;
-    static space: number;
-
-    static createAccount(
-      from: PublicKey,
-      stakeAccount: PublicKey,
-      authorized: Authorized,
-      lockup: Lockup,
-      lamports: number,
-    ): Transaction;
-    static createAccountWithSeed(
-      from: PublicKey,
-      stakeAccount: PublicKey,
-      seed: string,
-      authorized: Authorized,
-      lockup: Lockup,
-      lamports: number,
-    ): Transaction;
-    static delegate(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      votePubkey: PublicKey,
-    ): Transaction;
-    static authorize(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      newAuthorized: PublicKey,
-      stakeAuthorizationType: StakeAuthorizationType,
-    ): Transaction;
-    static split(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      lamports: number,
-      splitStakePubkey: PublicKey,
-    ): Transaction;
-    static withdraw(
-      stakeAccount: PublicKey,
-      withdrawerPubkey: PublicKey,
-      to: PublicKey,
-      lamports: number,
-    ): Transaction;
-    static deactivate(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-    ): Transaction;
-  }
-
   // === src/validator-info.js ===
   export const VALIDATOR_INFO_KEY: PublicKey;
   export type Info = {
@@ -421,6 +354,97 @@ declare module '@solana/web3.js' {
     serialize(): Buffer;
   }
 
+  // === src/stake-program.js ===
+  export type StakeAuthorizationType = {
+    index: number;
+  };
+
+  export class Authorized {
+    staker: PublicKey;
+    withdrawer: PublicKey;
+    constructor(staker: PublicKey, withdrawer: PublicKey);
+  }
+
+  export class Lockup {
+    unixTimestamp: number;
+    epoch: number;
+    custodian: PublicKey;
+
+    constructor(unixTimestamp: number, epoch: number, custodian: PublicKey);
+  }
+
+  export class StakeProgram {
+    static programId: PublicKey;
+    static space: number;
+
+    static createAccount(
+      from: PublicKey,
+      stakeAccount: PublicKey,
+      authorized: Authorized,
+      lockup: Lockup,
+      lamports: number,
+    ): Transaction;
+    static createAccountWithSeed(
+      from: PublicKey,
+      stakeAccount: PublicKey,
+      seed: string,
+      authorized: Authorized,
+      lockup: Lockup,
+      lamports: number,
+    ): Transaction;
+    static delegate(
+      stakeAccount: PublicKey,
+      authorizedPubkey: PublicKey,
+      votePubkey: PublicKey,
+    ): Transaction;
+    static authorize(
+      stakeAccount: PublicKey,
+      authorizedPubkey: PublicKey,
+      newAuthorized: PublicKey,
+      stakeAuthorizationType: StakeAuthorizationType,
+    ): Transaction;
+    static split(
+      stakeAccount: PublicKey,
+      authorizedPubkey: PublicKey,
+      lamports: number,
+      splitStakePubkey: PublicKey,
+    ): Transaction;
+    static withdraw(
+      stakeAccount: PublicKey,
+      withdrawerPubkey: PublicKey,
+      to: PublicKey,
+      lamports: number,
+    ): Transaction;
+    static deactivate(
+      stakeAccount: PublicKey,
+      authorizedPubkey: PublicKey,
+    ): Transaction;
+  }
+
+  export type StakeInstructionType =
+    | 'Initialize'
+    | 'Authorize'
+    | 'Delegate'
+    | 'Split'
+    | 'Withdraw'
+    | 'Deactivate';
+
+  export const STAKE_INSTRUCTION_LAYOUTS: {
+    [StakeInstructionType]: InstructionType;
+  };
+
+  export class StakeInstruction extends TransactionInstruction {
+    type: StakeInstructionType;
+    stakePublicKey: PublicKey | null;
+    authorizedPublicKey: PublicKey | null;
+
+    constructor(
+      opts?: TransactionInstructionCtorFields,
+      type: StakeInstructionType,
+    );
+    static from(instruction: TransactionInstruction): StakeInstruction;
+  }
+
   // === src/system-program.js ===
   export class SystemProgram {
     static programId: PublicKey;
@@ -471,15 +495,29 @@ declare module '@solana/web3.js' {
     ): Transaction;
   }
 
+  export type SystemInstructionType =
+    | 'Create'
+    | 'Assign'
+    | 'Transfer'
+    | 'CreateWithSeed'
+    | 'AdvanceNonceAccount'
+    | 'WithdrawNonceAccount'
+    | 'InitializeNonceAccount'
+    | 'AuthorizeNonceAccount';
+
+  export const SYSTEM_INSTRUCTION_LAYOUTS: {
+    [SystemInstructionType]: InstructionType;
+  };
+
   export class SystemInstruction extends TransactionInstruction {
-    type: InstructionType;
+    type: SystemInstructionType;
     fromPublicKey: PublicKey | null;
     toPublicKey: PublicKey | null;
     amount: number | null;
 
     constructor(
       opts?: TransactionInstructionCtorFields,
-      type?: InstructionType,
+      type: SystemInstructionType,
     );
     static from(instruction: TransactionInstruction): SystemInstruction;
   }

--- a/module.flow.js
+++ b/module.flow.js
@@ -318,6 +318,30 @@ declare module '@solana/web3.js' {
     ): Transaction;
   }
 
+  declare export type StakeInstructionType =
+    | 'Initialize'
+    | 'Authorize'
+    | 'Delegate'
+    | 'Split'
+    | 'Withdraw'
+    | 'Deactivate';
+
+  declare export var STAKE_INSTRUCTION_LAYOUTS: {
+    [StakeInstructionType]: InstructionType,
+  };
+
+  declare export class StakeInstruction extends TransactionInstruction {
+    type: StakeInstructionType;
+    stakePublicKey: PublicKey | null;
+    authorizedPublicKey: PublicKey | null;
+
+    constructor(
+      opts?: TransactionInstructionCtorFields,
+      type: StakeInstructionType,
+    ): StakeInstruction;
+    static from(instruction: TransactionInstruction): StakeInstruction;
+  }
+
   // === src/system-program.js ===
   declare export class SystemProgram {
     static programId: PublicKey;
@@ -368,15 +392,29 @@ declare module '@solana/web3.js' {
     ): Transaction;
   }
 
+  declare export type SystemInstructionType =
+    | 'Create'
+    | 'Assign'
+    | 'Transfer'
+    | 'CreateWithSeed'
+    | 'AdvanceNonceAccount'
+    | 'WithdrawNonceAccount'
+    | 'InitializeNonceAccount'
+    | 'AuthorizeNonceAccount';
+
+  declare export var SYSTEM_INSTRUCTION_LAYOUTS: {
+    [SystemInstructionType]: InstructionType,
+  };
+
   declare export class SystemInstruction extends TransactionInstruction {
-    type: InstructionType;
+    type: SystemInstructionType;
     fromPublicKey: PublicKey | null;
     toPublicKey: PublicKey | null;
     amount: number | null;
 
     constructor(
       opts?: TransactionInstructionCtorFields,
-      type?: InstructionType,
+      type: SystemInstructionType,
     ): SystemInstruction;
     static from(instruction: TransactionInstruction): SystemInstruction;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9550,6 +9550,15 @@
         "pkg-dir": "^2.0.0"
       }
     },
+    "eslint-plugin-flowtype": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.6.0.tgz",
+      "integrity": "sha512-W5hLjpFfZyZsXfo5anlu7HM970JBDqbEshAJUkeczP6BFCIfJXuiIBQXyberLRtOStT0OGPF8efeTbxlHk4LpQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "esdoc-standard-plugin": "^1.0.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-flowtype": "^4.6.0",
     "eslint-plugin-import": "2.20.1",
     "eslint-plugin-jest": "22.19.0",
     "eslint-plugin-prettier": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "solana-bpf-sdk-install": "bin/bpf-sdk-install.sh",
     "solana-localnet": "bin/localnet.sh"
   },
-  "testnetDefaultChannel": "edge",
+  "testnetDefaultChannel": "beta",
   "files": [
     "/bin",
     "/doc",

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export {
   Lockup,
   StakeAuthorizationLayout,
   StakeInstruction,
-  StakeInstructionLayout,
+  STAKE_INSTRUCTION_LAYOUTS,
   StakeProgram,
 } from './stake-program';
 export {SystemInstruction, SystemProgram} from './system-program';

--- a/src/stake-program.js
+++ b/src/stake-program.js
@@ -107,12 +107,12 @@ export class StakeInstruction extends TransactionInstruction {
    */
   get stakePublicKey(): PublicKey | null {
     switch (this.type) {
-      case STAKE_INSTRUCTION_LAYOUTS.Initialize:
-      case STAKE_INSTRUCTION_LAYOUTS.Delegate:
-      case STAKE_INSTRUCTION_LAYOUTS.Authorize:
-      case STAKE_INSTRUCTION_LAYOUTS.Split:
-      case STAKE_INSTRUCTION_LAYOUTS.Withdraw:
-      case STAKE_INSTRUCTION_LAYOUTS.Deactivate:
+      case 'Initialize':
+      case 'Delegate':
+      case 'Authorize':
+      case 'Split':
+      case 'Withdraw':
+      case 'Deactivate':
         return this.keys[0].pubkey;
       default:
         return null;
@@ -126,16 +126,16 @@ export class StakeInstruction extends TransactionInstruction {
    */
   get authorizedPublicKey(): PublicKey | null {
     switch (this.type) {
-      case STAKE_INSTRUCTION_LAYOUTS.Delegate:
+      case 'Delegate':
         return this.keys[5].pubkey;
-      case STAKE_INSTRUCTION_LAYOUTS.Authorize:
+      case 'Authorize':
         return this.keys[2].pubkey;
-      case STAKE_INSTRUCTION_LAYOUTS.Split:
+      case 'Split':
         return this.keys[2].pubkey;
-      case STAKE_INSTRUCTION_LAYOUTS.Withdraw:
+      case 'Withdraw':
         return this.keys[4].pubkey;
-      case STAKE_INSTRUCTION_LAYOUTS.Deactivate:
-        return this.keys[0].pubkey;
+      case 'Deactivate':
+        return this.keys[2].pubkey;
       default:
         return null;
     }

--- a/test/__mocks__/rpc-websockets.js
+++ b/test/__mocks__/rpc-websockets.js
@@ -1,3 +1,5 @@
+// @flow
+
 import {Client as RpcWebSocketClient} from 'rpc-websockets';
 
 // Define TEST_LIVE in the environment to test against the real full node

--- a/test/__mocks__/rpc-websockets.js
+++ b/test/__mocks__/rpc-websockets.js
@@ -1,6 +1,10 @@
 // @flow
 
-import {Client as RpcWebSocketClient} from 'rpc-websockets';
+import {
+  Client as RpcWebSocketClient,
+  NodeWebSocketTypeOptions,
+  IWSClientAdditionalOptions,
+} from 'rpc-websockets';
 
 // Define TEST_LIVE in the environment to test against the real full node
 // identified by `url` instead of using the mock
@@ -11,7 +15,10 @@ let mockNotice = true;
 export class Client {
   client: RpcWebSocketClient;
 
-  constructor(url, options) {
+  constructor(
+    url: string,
+    options: NodeWebSocketTypeOptions & IWSClientAdditionalOptions,
+  ) {
     //console.log('MockClient', url, options);
     if (!mockRpcEnabled) {
       if (mockNotice) {

--- a/test/stake-program.test.js
+++ b/test/stake-program.test.js
@@ -49,6 +49,8 @@ test('createAccountWithSeed', () => {
     SystemProgram.programId,
   );
   expect(transaction.instructions[1].programId).toEqual(StakeProgram.programId);
+  const stakeInstruction = StakeInstruction.from(transaction.instructions[1]);
+  expect(stakeInstruction.stakePublicKey).toEqual(newAccountPubkey);
   // TODO: Validate transaction contents more
 });
 
@@ -71,6 +73,12 @@ test('createAccount', () => {
     SystemProgram.programId,
   );
   expect(transaction.instructions[1].programId).toEqual(StakeProgram.programId);
+  const stakeInstruction = StakeInstruction.from(transaction.instructions[1]);
+  expect(stakeInstruction.stakePublicKey).toEqual(newAccount.publicKey);
+
+  expect(() => {
+    StakeInstruction.from(transaction.instructions[0]);
+  }).toThrow();
   // TODO: Validate transaction contents more
 });
 
@@ -88,6 +96,9 @@ test('delegate', () => {
 
   expect(transaction.keys).toHaveLength(6);
   expect(transaction.programId).toEqual(StakeProgram.programId);
+  const stakeInstruction = StakeInstruction.from(transaction.instructions[0]);
+  expect(stakeInstruction.stakePublicKey).toEqual(stake.publicKey);
+  expect(stakeInstruction.authorizedPublicKey).toEqual(authorized.publicKey);
   // TODO: Validate transaction contents more
 });
 
@@ -107,6 +118,9 @@ test('authorize', () => {
 
   expect(transaction.keys).toHaveLength(3);
   expect(transaction.programId).toEqual(StakeProgram.programId);
+  const stakeInstruction = StakeInstruction.from(transaction.instructions[0]);
+  expect(stakeInstruction.stakePublicKey).toEqual(stake.publicKey);
+  expect(stakeInstruction.authorizedPublicKey).toEqual(authorized.publicKey);
   // TODO: Validate transaction contents more
 });
 
@@ -128,6 +142,9 @@ test('split', () => {
     SystemProgram.programId,
   );
   expect(transaction.instructions[1].programId).toEqual(StakeProgram.programId);
+  const stakeInstruction = StakeInstruction.from(transaction.instructions[1]);
+  expect(stakeInstruction.stakePublicKey).toEqual(stake.publicKey);
+  expect(stakeInstruction.authorizedPublicKey).toEqual(authorized.publicKey);
   // TODO: Validate transaction contents more
 });
 
@@ -146,6 +163,9 @@ test('withdraw', () => {
 
   expect(transaction.keys).toHaveLength(5);
   expect(transaction.programId).toEqual(StakeProgram.programId);
+  const stakeInstruction = StakeInstruction.from(transaction.instructions[0]);
+  expect(stakeInstruction.stakePublicKey).toEqual(stake.publicKey);
+  expect(stakeInstruction.authorizedPublicKey).toEqual(withdrawer.publicKey);
   // TODO: Validate transaction contents more
 });
 
@@ -158,6 +178,9 @@ test('deactivate', () => {
 
   expect(transaction.keys).toHaveLength(3);
   expect(transaction.programId).toEqual(StakeProgram.programId);
+  const stakeInstruction = StakeInstruction.from(transaction.instructions[0]);
+  expect(stakeInstruction.stakePublicKey).toEqual(stake.publicKey);
+  expect(stakeInstruction.authorizedPublicKey).toEqual(authorized.publicKey);
   // TODO: Validate transaction contents more
 });
 

--- a/test/stake-program.test.js
+++ b/test/stake-program.test.js
@@ -10,7 +10,6 @@ import {
   LAMPORTS_PER_SOL,
   StakeAuthorizationLayout,
   StakeInstruction,
-  StakeInstructionLayout,
   StakeProgram,
   SystemInstruction,
   SystemProgram,
@@ -197,7 +196,7 @@ test('StakeInstructions', () => {
   const stakeInstruction = StakeInstruction.from(
     createWithSeedTransaction.instructions[1],
   );
-  expect(stakeInstruction.type).toEqual(StakeInstructionLayout.Initialize);
+  expect(stakeInstruction.type).toEqual('Initialize');
 
   expect(() => {
     StakeInstruction.from(createWithSeedTransaction.instructions[0]);
@@ -216,9 +215,7 @@ test('StakeInstructions', () => {
   const anotherStakeInstruction = StakeInstruction.from(
     delegateTransaction.instructions[0],
   );
-  expect(anotherStakeInstruction.type).toEqual(
-    StakeInstructionLayout.DelegateStake,
-  );
+  expect(anotherStakeInstruction.type).toEqual('Delegate');
 });
 
 test('live staking actions', async () => {

--- a/test/system-program.test.js
+++ b/test/system-program.test.js
@@ -249,7 +249,7 @@ test('non-SystemInstruction error', () => {
     data: Buffer.from([2, 0, 0, 0]),
   };
   expect(() => {
-    new SystemInstruction(badProgramId);
+    new SystemInstruction(badProgramId, 'Create');
   }).toThrow();
 
   const amount = 123;


### PR DESCRIPTION
#### Problems
* StakeInstruction is not exposed in type definitions
* Instruction layouts are not exposed in type definitions
* Instruction types are not exposed in type definitions
* No dev friendly way to get a human readable name of an instruction type
* It's not safe to pull out particular account keys from stake instructions (stake key, authorized key, etc)

#### Changes
* Fix flow type linting
* Exposed above types in definitions
* Refactored system and stake instruction classes to expose instruction type names
* Added nullable getter methods for pulling out the stake and authorized pubkeys from a stake instruction (similar to how we handle system instructions)