### PR TITLE
feat: add API for decoding stake instructions

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -369,52 +369,74 @@ declare module '@solana/web3.js' {
     constructor(unixTimestamp: number, epoch: number, custodian: PublicKey);
   }
 
+  export type CreateStakeAccountParams = {
+    fromPubkey: PublicKey;
+    stakePubkey: PublicKey;
+    authorized: Authorized;
+    lockup: Lockup;
+    lamports: number;
+  };
+
+  export type CreateStakeAccountWithSeedParams = {
+    fromPubkey: PublicKey;
+    stakePubkey: PublicKey;
+    basePubkey: PublicKey;
+    seed: string;
+    authorized: Authorized;
+    lockup: Lockup;
+    lamports: number;
+  };
+
+  export type InitializeStakeParams = {
+    stakePubkey: PublicKey;
+    authorized: Authorized;
+    lockup: Lockup;
+  };
+
+  export type DelegateStakeParams = {
+    stakePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+    votePubkey: PublicKey;
+  };
+
+  export type AuthorizeStakeParams = {
+    stakePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+    newAuthorizedPubkey: PublicKey;
+    stakeAuthorizationType: StakeAuthorizationType;
+  };
+
+  export type SplitStakeParams = {
+    stakePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+    splitStakePubkey: PublicKey;
+    lamports: number;
+  };
+
+  export type WithdrawStakeParams = {
+    stakePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+    toPubkey: PublicKey;
+    lamports: number;
+  };
+
+  export type DeactivateStakeParams = {
+    stakePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+  };
+
   export class StakeProgram {
     static programId: PublicKey;
     static space: number;
-
-    static createAccount(
-      from: PublicKey,
-      stakeAccount: PublicKey,
-      authorized: Authorized,
-      lockup: Lockup,
-      lamports: number,
-    ): Transaction;
+    static createAccount(params: CreateStakeAccountParams): Transaction;
     static createAccountWithSeed(
-      from: PublicKey,
-      stakeAccount: PublicKey,
-      seed: string,
-      authorized: Authorized,
-      lockup: Lockup,
-      lamports: number,
+      params: CreateStakeAccountWithSeedParams,
     ): Transaction;
-    static delegate(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      votePubkey: PublicKey,
-    ): Transaction;
-    static authorize(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      newAuthorized: PublicKey,
-      stakeAuthorizationType: StakeAuthorizationType,
-    ): Transaction;
-    static split(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      lamports: number,
-      splitStakePubkey: PublicKey,
-    ): Transaction;
-    static withdraw(
-      stakeAccount: PublicKey,
-      withdrawerPubkey: PublicKey,
-      to: PublicKey,
-      lamports: number,
-    ): Transaction;
-    static deactivate(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-    ): Transaction;
+    static delegate(params: DelegateStakeParams): Transaction;
+    static authorize(params: AuthorizeStakeParams): Transaction;
+    static split(params: SplitStakeParams): Transaction;
+    static withdraw(params: WithdrawStakeParams): Transaction;
+    static deactivate(params: DeactivateStakeParams): Transaction;
   }
 
   export type StakeInstructionType =
@@ -429,16 +451,26 @@ declare module '@solana/web3.js' {
     [type in StakeInstructionType]: InstructionType;
   };
 
-  export class StakeInstruction extends TransactionInstruction {
-    type: StakeInstructionType;
-    stakePublicKey: PublicKey | null;
-    authorizedPublicKey: PublicKey | null;
-
-    constructor(
-      opts: TransactionInstructionCtorFields,
-      type: StakeInstructionType,
-    );
-    static from(instruction: TransactionInstruction): StakeInstruction;
+  export class StakeInstruction {
+    static decodeInstructionType(
+      instruction: TransactionInstruction,
+    ): StakeInstructionType;
+    static decodeInitialize(
+      instruction: TransactionInstruction,
+    ): InitializeStakeParams;
+    static decodeDelegate(
+      instruction: TransactionInstruction,
+    ): DelegateStakeParams;
+    static decodeAuthorize(
+      instruction: TransactionInstruction,
+    ): AuthorizeStakeParams;
+    static decodeSplit(instruction: TransactionInstruction): SplitStakeParams;
+    static decodeWithdraw(
+      instruction: TransactionInstruction,
+    ): WithdrawStakeParams;
+    static decodeDeactivate(
+      instruction: TransactionInstruction,
+    ): DeactivateStakeParams;
   }
 
   // === src/system-program.js ===

--- a/module.flow.js
+++ b/module.flow.js
@@ -266,52 +266,74 @@ declare module '@solana/web3.js' {
     ): Lockup;
   }
 
+  declare export type CreateStakeAccountParams = {|
+    fromPubkey: PublicKey,
+    stakePubkey: PublicKey,
+    authorized: Authorized,
+    lockup: Lockup,
+    lamports: number,
+  |};
+
+  declare export type CreateStakeAccountWithSeedParams = {|
+    fromPubkey: PublicKey,
+    stakePubkey: PublicKey,
+    basePubkey: PublicKey,
+    seed: string,
+    authorized: Authorized,
+    lockup: Lockup,
+    lamports: number,
+  |};
+
+  declare export type InitializeStakeParams = {|
+    stakePubkey: PublicKey,
+    authorized: Authorized,
+    lockup: Lockup,
+  |};
+
+  declare export type DelegateStakeParams = {|
+    stakePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+    votePubkey: PublicKey,
+  |};
+
+  declare export type AuthorizeStakeParams = {|
+    stakePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+    newAuthorizedPubkey: PublicKey,
+    stakeAuthorizationType: StakeAuthorizationType,
+  |};
+
+  declare export type SplitStakeParams = {|
+    stakePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+    splitStakePubkey: PublicKey,
+    lamports: number,
+  |};
+
+  declare export type WithdrawStakeParams = {|
+    stakePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+    toPubkey: PublicKey,
+    lamports: number,
+  |};
+
+  declare export type DeactivateStakeParams = {|
+    stakePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+  |};
+
   declare export class StakeProgram {
     static programId: PublicKey;
     static space: number;
-
-    static createAccount(
-      from: PublicKey,
-      stakeAccount: PublicKey,
-      authorized: Authorized,
-      lockup: Lockup,
-      lamports: number,
-    ): Transaction;
+    static createAccount(params: CreateStakeAccountParams): Transaction;
     static createAccountWithSeed(
-      from: PublicKey,
-      stakeAccount: PublicKey,
-      seed: string,
-      authorized: Authorized,
-      lockup: Lockup,
-      lamports: number,
+      params: CreateStakeAccountWithSeedParams,
     ): Transaction;
-    static delegate(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      votePubkey: PublicKey,
-    ): Transaction;
-    static authorize(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      newAuthorized: PublicKey,
-      stakeAuthorizationType: StakeAuthorizationType,
-    ): Transaction;
-    static split(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      lamports: number,
-      splitStakePubkey: PublicKey,
-    ): Transaction;
-    static withdraw(
-      stakeAccount: PublicKey,
-      withdrawerPubkey: PublicKey,
-      to: PublicKey,
-      lamports: number,
-    ): Transaction;
-    static deactivate(
-      stakeAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-    ): Transaction;
+    static delegate(params: DelegateStakeParams): Transaction;
+    static authorize(params: AuthorizeStakeParams): Transaction;
+    static split(params: SplitStakeParams): Transaction;
+    static withdraw(params: WithdrawStakeParams): Transaction;
+    static deactivate(params: DeactivateStakeParams): Transaction;
   }
 
   declare export type StakeInstructionType =
@@ -326,16 +348,26 @@ declare module '@solana/web3.js' {
     [StakeInstructionType]: InstructionType,
   };
 
-  declare export class StakeInstruction extends TransactionInstruction {
-    type: StakeInstructionType;
-    stakePublicKey: PublicKey | null;
-    authorizedPublicKey: PublicKey | null;
-
-    constructor(
-      opts?: TransactionInstructionCtorFields,
-      type: StakeInstructionType,
-    ): StakeInstruction;
-    static from(instruction: TransactionInstruction): StakeInstruction;
+  declare export class StakeInstruction {
+    static decodeInstructionType(
+      instruction: TransactionInstruction,
+    ): StakeInstructionType;
+    static decodeInitialize(
+      instruction: TransactionInstruction,
+    ): InitializeStakeParams;
+    static decodeDelegate(
+      instruction: TransactionInstruction,
+    ): DelegateStakeParams;
+    static decodeAuthorize(
+      instruction: TransactionInstruction,
+    ): AuthorizeStakeParams;
+    static decodeSplit(instruction: TransactionInstruction): SplitStakeParams;
+    static decodeWithdraw(
+      instruction: TransactionInstruction,
+    ): WithdrawStakeParams;
+    static decodeDeactivate(
+      instruction: TransactionInstruction,
+    ): DeactivateStakeParams;
   }
 
   // === src/system-program.js ===

--- a/src/instruction.js
+++ b/src/instruction.js
@@ -25,3 +25,23 @@ export function encodeData(type: InstructionType, fields: Object): Buffer {
   type.layout.encode(layoutFields, data);
   return data;
 }
+
+/**
+ * Decode instruction data buffer using an InstructionType
+ */
+export function decodeData(type: InstructionType, buffer: Buffer): Object {
+  let data;
+  try {
+    data = type.layout.decode(buffer);
+  } catch (err) {
+    throw new Error('invalid instruction; ' + err);
+  }
+
+  if (data.instruction !== type.index) {
+    throw new Error(
+      `invalid instruction; instruction index mismatch ${data.instruction} != ${type.index}`,
+    );
+  }
+
+  return data;
+}

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -112,11 +112,11 @@ test('use nonce', () => {
   const stakeAccount = new Account();
   const voteAccount = new Account();
   const stakeTransaction = new Transaction({nonceInfo}).add(
-    StakeProgram.delegate(
-      stakeAccount.publicKey,
-      account1.publicKey,
-      voteAccount.publicKey,
-    ),
+    StakeProgram.delegate({
+      stakePubkey: stakeAccount.publicKey,
+      authorizedPubkey: account1.publicKey,
+      votePubkey: voteAccount.publicKey,
+    }),
   );
   stakeTransaction.sign(account1);
 


### PR DESCRIPTION
#### Problem
* The sdk doesn't provide a way to decode stake instruction data
* Stake instruction API methods have lots of parameters and can be easily misused

#### Changes
* Remove `StakeInstruction.from` method in favor of `StakeInstruction.decode...` methods.
* Refactor `StakeProgram` methods to accept a typed param object rather than a list of params
* Add methods to decode stake instructions into the typed param objects they were created with