### PR TITLE
feat: add API for decoding system instructions

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -475,6 +475,65 @@ declare module '@solana/web3.js' {
   }
 
   // === src/system-program.js ===
+  export type CreateAccountParams = {
+    fromPubkey: PublicKey;
+    newAccountPubkey: PublicKey;
+    lamports: number;
+    space: number;
+    programId: PublicKey;
+  };
+
+  export type TransferParams = {
+    fromPubkey: PublicKey;
+    toPubkey: PublicKey;
+    lamports: number;
+  };
+
+  export type AssignParams = {
+    fromPubkey: PublicKey;
+    programId: PublicKey;
+  };
+
+  export type CreateAccountWithSeedParams = {
+    fromPubkey: PublicKey;
+    newAccountPubkey: PublicKey;
+    basePubkey: PublicKey;
+    seed: string;
+    lamports: number;
+    space: number;
+    programId: PublicKey;
+  };
+
+  export type CreateNonceAccountParams = {
+    fromPubkey: PublicKey;
+    noncePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+    lamports: number;
+  };
+
+  export type InitializeNonceParams = {
+    noncePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+  };
+
+  export type AdvanceNonceParams = {
+    noncePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+  };
+
+  export type WithdrawNonceParams = {
+    noncePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+    toPubkey: PublicKey;
+    lamports: number;
+  };
+
+  export type AuthorizeNonceParams = {
+    noncePubkey: PublicKey;
+    authorizedPubkey: PublicKey;
+    newAuthorizedPubkey: PublicKey;
+  };
+
   export class SystemProgram {
     static programId: PublicKey;
     static nonceSpace: number;
@@ -538,17 +597,30 @@ declare module '@solana/web3.js' {
     [type in SystemInstructionType]: InstructionType;
   };
 
-  export class SystemInstruction extends TransactionInstruction {
-    type: SystemInstructionType;
-    fromPublicKey: PublicKey | null;
-    toPublicKey: PublicKey | null;
-    amount: number | null;
-
-    constructor(
-      opts: TransactionInstructionCtorFields,
-      type: SystemInstructionType,
-    );
-    static from(instruction: TransactionInstruction): SystemInstruction;
+  export class SystemInstruction {
+    static decodeInstructionType(
+      instruction: TransactionInstruction,
+    ): SystemInstructionType;
+    static decodeCreateAccount(
+      instruction: TransactionInstruction,
+    ): CreateAccountParams;
+    static decodeTransfer(instruction: TransactionInstruction): TransferParams;
+    static decodeAssign(instruction: TransactionInstruction): AssignParams;
+    static decodeCreateWithSeed(
+      instruction: TransactionInstruction,
+    ): CreateAccountWithSeedParams;
+    static decodeNonceInitialize(
+      instruction: TransactionInstruction,
+    ): InitializeNonceParams;
+    static decodeNonceAdvance(
+      instruction: TransactionInstruction,
+    ): AdvanceNonceParams;
+    static decodeNonceWithdraw(
+      instruction: TransactionInstruction,
+    ): WithdrawNonceParams;
+    static decodeNonceAuthorize(
+      instruction: TransactionInstruction,
+    ): AuthorizeNonceParams;
   }
 
   // === src/loader.js ===

--- a/module.flow.js
+++ b/module.flow.js
@@ -371,53 +371,79 @@ declare module '@solana/web3.js' {
   }
 
   // === src/system-program.js ===
+  declare export type CreateAccountParams = {|
+    fromPubkey: PublicKey,
+    newAccountPubkey: PublicKey,
+    lamports: number,
+    space: number,
+    programId: PublicKey,
+  |};
+
+  declare export type TransferParams = {|
+    fromPubkey: PublicKey,
+    toPubkey: PublicKey,
+    lamports: number,
+  |};
+
+  declare export type AssignParams = {|
+    fromPubkey: PublicKey,
+    programId: PublicKey,
+  |};
+
+  declare export type CreateAccountWithSeedParams = {|
+    fromPubkey: PublicKey,
+    newAccountPubkey: PublicKey,
+    basePubkey: PublicKey,
+    seed: string,
+    lamports: number,
+    space: number,
+    programId: PublicKey,
+  |};
+
+  declare export type CreateNonceAccountParams = {|
+    fromPubkey: PublicKey,
+    noncePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+    lamports: number,
+  |};
+
+  declare export type InitializeNonceParams = {|
+    noncePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+  |};
+
+  declare export type AdvanceNonceParams = {|
+    noncePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+  |};
+
+  declare export type WithdrawNonceParams = {|
+    noncePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+    toPubkey: PublicKey,
+    lamports: number,
+  |};
+
+  declare export type AuthorizeNonceParams = {|
+    noncePubkey: PublicKey,
+    authorizedPubkey: PublicKey,
+    newAuthorizedPubkey: PublicKey,
+  |};
+
   declare export class SystemProgram {
     static programId: PublicKey;
     static nonceSpace: number;
 
-    static createAccount(
-      from: PublicKey,
-      newAccount: PublicKey,
-      lamports: number,
-      space: number,
-      programId: PublicKey,
-    ): Transaction;
-    static transfer(
-      from: PublicKey,
-      to: PublicKey,
-      amount: number,
-    ): Transaction;
-    static assign(from: PublicKey, programId: PublicKey): Transaction;
+    static createAccount(params: CreateAccountParams): Transaction;
+    static transfer(params: TransferParams): Transaction;
+    static assign(params: AssignParams): Transaction;
     static createAccountWithSeed(
-      from: PublicKey,
-      newAccount: PublicKey,
-      base: PublicKey,
-      seed: string,
-      lamports: number,
-      space: number,
-      programId: PublicKey,
+      params: CreateAccountWithSeedParams,
     ): Transaction;
-    static createNonceAccount(
-      from: PublicKey,
-      nonceAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      lamports: number,
-    ): Transaction;
-    static nonceAdvance(
-      nonceAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-    ): TransactionInstruction;
-    static nonceWithdraw(
-      nonceAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      to: PublicKey,
-      lamports: number,
-    ): Transaction;
-    static nonceAuthorize(
-      nonceAccount: PublicKey,
-      authorizedPubkey: PublicKey,
-      newAuthorized: PublicKey,
-    ): Transaction;
+    static createNonceAccount(params: CreateNonceAccountParams): Transaction;
+    static nonceAdvance(params: AdvanceNonceParams): TransactionInstruction;
+    static nonceWithdraw(params: WithdrawNonceParams): Transaction;
+    static nonceAuthorize(params: AuthorizeNonceParams): Transaction;
   }
 
   declare export type SystemInstructionType =
@@ -434,17 +460,27 @@ declare module '@solana/web3.js' {
     [SystemInstructionType]: InstructionType,
   };
 
-  declare export class SystemInstruction extends TransactionInstruction {
-    type: SystemInstructionType;
-    fromPublicKey: PublicKey | null;
-    toPublicKey: PublicKey | null;
-    amount: number | null;
-
-    constructor(
-      opts?: TransactionInstructionCtorFields,
-      type: SystemInstructionType,
-    ): SystemInstruction;
-    static from(instruction: TransactionInstruction): SystemInstruction;
+  declare export class SystemInstruction {
+    static decodeCreateAccount(
+      instruction: TransactionInstruction,
+    ): CreateAccountParams;
+    static decodeTransfer(instruction: TransactionInstruction): TransferParams;
+    static decodeAssign(instruction: TransactionInstruction): AssignParams;
+    static decodeCreateWithSeed(
+      instruction: TransactionInstruction,
+    ): CreateAccountWithSeedParams;
+    static decodeNonceInitialize(
+      instruction: TransactionInstruction,
+    ): InitializeNonceParams;
+    static decodeNonceAdvance(
+      instruction: TransactionInstruction,
+    ): AdvanceNonceParams;
+    static decodeNonceWithdraw(
+      instruction: TransactionInstruction,
+    ): WithdrawNonceParams;
+    static decodeNonceAuthorize(
+      instruction: TransactionInstruction,
+    ): AuthorizeNonceParams;
   }
 
   // === src/validator-info.js ===

--- a/src/budget-program.js
+++ b/src/budget-program.js
@@ -191,13 +191,13 @@ export class BudgetProgram {
         }
         const trimmedData = data.slice(0, pos);
 
-        const transaction = SystemProgram.createAccount(
-          from,
-          program,
-          amount,
-          trimmedData.length,
-          this.programId,
-        );
+        const transaction = SystemProgram.createAccount({
+          fromPubkey: from,
+          newAccountPubkey: program,
+          lamports: amount,
+          space: trimmedData.length,
+          programId: this.programId,
+        });
 
         return transaction.add({
           keys: [
@@ -227,13 +227,13 @@ export class BudgetProgram {
         }
         const trimmedData = data.slice(0, pos);
 
-        const transaction = SystemProgram.createAccount(
-          from,
-          program,
-          amount,
-          trimmedData.length,
-          this.programId,
-        );
+        const transaction = SystemProgram.createAccount({
+          fromPubkey: from,
+          newAccountPubkey: program,
+          lamports: amount,
+          space: trimmedData.length,
+          programId: this.programId,
+        });
 
         return transaction.add({
           keys: [{pubkey: program, isSigner: false, isWritable: true}],
@@ -260,13 +260,13 @@ export class BudgetProgram {
         }
         const trimmedData = data.slice(0, pos);
 
-        const transaction = SystemProgram.createAccount(
-          from,
-          program,
-          amount,
-          trimmedData.length,
-          this.programId,
-        );
+        const transaction = SystemProgram.createAccount({
+          fromPubkey: from,
+          newAccountPubkey: program,
+          lamports: amount,
+          space: trimmedData.length,
+          programId: this.programId,
+        });
 
         return transaction.add({
           keys: [{pubkey: program, isSigner: false, isWritable: true}],
@@ -316,13 +316,13 @@ export class BudgetProgram {
 
     const trimmedData = data.slice(0, pos);
 
-    const transaction = SystemProgram.createAccount(
-      from,
-      program,
-      amount,
-      trimmedData.length,
-      this.programId,
-    );
+    const transaction = SystemProgram.createAccount({
+      fromPubkey: from,
+      newAccountPubkey: program,
+      lamports: amount,
+      space: trimmedData.length,
+      programId: this.programId,
+    });
 
     return transaction.add({
       keys: [{pubkey: program, isSigner: false, isWritable: true}],

--- a/src/loader.js
+++ b/src/loader.js
@@ -58,13 +58,13 @@ export class Loader {
       const balanceNeeded = await connection.getMinimumBalanceForRentExemption(
         data.length,
       );
-      const transaction = SystemProgram.createAccount(
-        payer.publicKey,
-        program.publicKey,
-        balanceNeeded > 0 ? balanceNeeded : 1,
-        data.length,
+      const transaction = SystemProgram.createAccount({
+        fromPubkey: payer.publicKey,
+        newAccountPubkey: program.publicKey,
+        lamports: balanceNeeded > 0 ? balanceNeeded : 1,
+        space: data.length,
         programId,
-      );
+      });
       await sendAndConfirmTransaction(connection, transaction, payer, program);
     }
 

--- a/src/stake-program.js
+++ b/src/stake-program.js
@@ -463,15 +463,15 @@ export class StakeProgram {
   static createAccountWithSeed(
     params: CreateStakeAccountWithSeedParams,
   ): Transaction {
-    let transaction = SystemProgram.createAccountWithSeed(
-      params.fromPubkey,
-      params.stakePubkey,
-      params.basePubkey,
-      params.seed,
-      params.lamports,
-      this.space,
-      this.programId,
-    );
+    let transaction = SystemProgram.createAccountWithSeed({
+      fromPubkey: params.fromPubkey,
+      newAccountPubkey: params.stakePubkey,
+      basePubkey: params.basePubkey,
+      seed: params.seed,
+      lamports: params.lamports,
+      space: this.space,
+      programId: this.programId,
+    });
 
     const {stakePubkey, authorized, lockup} = params;
     return transaction.add(this.initialize({stakePubkey, authorized, lockup}));
@@ -481,13 +481,13 @@ export class StakeProgram {
    * Generate a Transaction that creates a new Stake account
    */
   static createAccount(params: CreateStakeAccountParams): Transaction {
-    let transaction = SystemProgram.createAccount(
-      params.fromPubkey,
-      params.stakePubkey,
-      params.lamports,
-      this.space,
-      this.programId,
-    );
+    let transaction = SystemProgram.createAccount({
+      fromPubkey: params.fromPubkey,
+      newAccountPubkey: params.stakePubkey,
+      lamports: params.lamports,
+      space: this.space,
+      programId: this.programId,
+    });
 
     const {stakePubkey, authorized, lockup} = params;
     return transaction.add(this.initialize({stakePubkey, authorized, lockup}));
@@ -557,13 +557,13 @@ export class StakeProgram {
   static split(params: SplitStakeParams): Transaction {
     const {stakePubkey, authorizedPubkey, splitStakePubkey, lamports} = params;
 
-    let transaction = SystemProgram.createAccount(
-      stakePubkey,
-      splitStakePubkey,
-      0,
-      this.space,
-      this.programId,
-    );
+    let transaction = SystemProgram.createAccount({
+      fromPubkey: stakePubkey,
+      newAccountPubkey: splitStakePubkey,
+      lamports: 0,
+      space: this.space,
+      programId: this.programId,
+    });
     transaction.instructions[0].keys[0].isSigner = false;
     const type = STAKE_INSTRUCTION_LAYOUTS.Split;
     const data = encodeData(type, {lamports});

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -109,10 +109,10 @@ test('get program accounts', async () => {
       result: {Ok: null},
     },
   ]);
-  let transaction = SystemProgram.assign(
-    account0.publicKey,
-    programId.publicKey,
-  );
+  let transaction = SystemProgram.assign({
+    fromPubkey: account0.publicKey,
+    programId: programId.publicKey,
+  });
   await sendAndConfirmTransaction(connection, transaction, account0);
 
   mockRpc.push([
@@ -140,7 +140,11 @@ test('get program accounts', async () => {
       result: {Ok: null},
     },
   ]);
-  transaction = SystemProgram.assign(account1.publicKey, programId.publicKey);
+  transaction = SystemProgram.assign({
+    fromPubkey: account1.publicKey,
+    programId: programId.publicKey,
+  });
+
   await sendAndConfirmTransaction(connection, transaction, account1);
 
   mockGetRecentBlockhash('recent');
@@ -651,14 +655,16 @@ test('get confirmed block', async () => {
     url,
     {
       method: 'getConfirmedBlock',
-      params: [10000],
+      params: [Number.MAX_SAFE_INTEGER],
     },
     {
       error: null,
       result: null,
     },
   ]);
-  await expect(connection.getConfirmedBlock(10000)).rejects.toThrow();
+  await expect(
+    connection.getConfirmedBlock(Number.MAX_SAFE_INTEGER),
+  ).rejects.toThrow();
 });
 
 test('get recent blockhash', async () => {
@@ -962,11 +968,11 @@ test('transaction', async () => {
     },
   ]);
 
-  const transaction = SystemProgram.transfer(
-    accountFrom.publicKey,
-    accountTo.publicKey,
-    10,
-  );
+  const transaction = SystemProgram.transfer({
+    fromPubkey: accountFrom.publicKey,
+    toPubkey: accountTo.publicKey,
+    lamports: 10,
+  });
   const signature = await connection.sendTransaction(transaction, accountFrom);
 
   mockRpc.push([
@@ -1088,12 +1094,16 @@ test('multi-instruction transaction', async () => {
 
   // 1. Move(accountFrom, accountTo)
   // 2. Move(accountTo, accountFrom)
-  const transaction = SystemProgram.transfer(
-    accountFrom.publicKey,
-    accountTo.publicKey,
-    100,
-  ).add(
-    SystemProgram.transfer(accountTo.publicKey, accountFrom.publicKey, 100),
+  const transaction = SystemProgram.transfer({
+    fromPubkey: accountFrom.publicKey,
+    toPubkey: accountTo.publicKey,
+    lamports: 100,
+  }).add(
+    SystemProgram.transfer({
+      fromPubkey: accountTo.publicKey,
+      toPubkey: accountFrom.publicKey,
+      lamports: 100,
+    }),
   );
   const signature = await connection.sendTransaction(
     transaction,
@@ -1149,11 +1159,11 @@ test('account change notification', async () => {
 
   await connection.requestAirdrop(owner.publicKey, LAMPORTS_PER_SOL);
   try {
-    let transaction = SystemProgram.transfer(
-      owner.publicKey,
-      programAccount.publicKey,
-      balanceNeeded,
-    );
+    let transaction = SystemProgram.transfer({
+      fromPubkey: owner.publicKey,
+      toPubkey: programAccount.publicKey,
+      lamports: balanceNeeded,
+    });
     await sendAndConfirmTransaction(connection, transaction, owner);
   } catch (err) {
     await connection.removeAccountChangeListener(subscriptionId);
@@ -1213,11 +1223,11 @@ test('program account change notification', async () => {
 
   await connection.requestAirdrop(owner.publicKey, LAMPORTS_PER_SOL);
   try {
-    let transaction = SystemProgram.transfer(
-      owner.publicKey,
-      programAccount.publicKey,
-      balanceNeeded,
-    );
+    let transaction = SystemProgram.transfer({
+      fromPubkey: owner.publicKey,
+      toPubkey: programAccount.publicKey,
+      lamports: balanceNeeded,
+    });
     await sendAndConfirmTransaction(connection, transaction, owner);
   } catch (err) {
     await connection.removeProgramAccountChangeListener(subscriptionId);

--- a/test/get-confirmed-block.test.js
+++ b/test/get-confirmed-block.test.js
@@ -11,19 +11,19 @@ test('verify getConfirmedBlock', () => {
   const recentBlockhash = account1.publicKey.toBase58(); // Fake recentBlockhash
 
   // Create a couple signed transactions
-  const transfer0 = SystemProgram.transfer(
-    account0.publicKey,
-    account1.publicKey,
-    123,
-  );
+  const transfer0 = SystemProgram.transfer({
+    fromPubkey: account0.publicKey,
+    toPubkey: account1.publicKey,
+    lamports: 123,
+  });
 
   const transaction0 = new Transaction({recentBlockhash}).add(transfer0);
   transaction0.sign(account0);
-  const transfer1 = SystemProgram.transfer(
-    account2.publicKey,
-    account3.publicKey,
-    456,
-  );
+  const transfer1 = SystemProgram.transfer({
+    fromPubkey: account2.publicKey,
+    toPubkey: account3.publicKey,
+    lamports: 456,
+  });
 
   let transaction1 = new Transaction({recentBlockhash}).add(transfer1);
   transaction1.sign(account2);

--- a/test/nonce.test.js
+++ b/test/nonce.test.js
@@ -86,12 +86,12 @@ test('create and query nonce account', async () => {
     },
   ]);
 
-  const transaction = SystemProgram.createNonceAccount(
-    from.publicKey,
-    nonceAccount.publicKey,
-    from.publicKey,
-    minimumAmount,
-  );
+  const transaction = SystemProgram.createNonceAccount({
+    fromPubkey: from.publicKey,
+    noncePubkey: nonceAccount.publicKey,
+    authorizedPubkey: from.publicKey,
+    lamports: minimumAmount,
+  });
   await connection.sendTransaction(transaction, from, nonceAccount);
 
   const expectedData = Buffer.alloc(68);

--- a/test/transaction-payer.test.js
+++ b/test/transaction-payer.test.js
@@ -100,11 +100,11 @@ test('transaction-payer', async () => {
     },
   ]);
 
-  const transaction = SystemProgram.transfer(
-    accountFrom.publicKey,
-    accountTo.publicKey,
-    10,
-  );
+  const transaction = SystemProgram.transfer({
+    fromPubkey: accountFrom.publicKey,
+    toPubkey: accountTo.publicKey,
+    lamports: 10,
+  });
 
   const signature = await connection.sendTransaction(
     transaction,

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -12,11 +12,11 @@ test('signPartial', () => {
   const account1 = new Account();
   const account2 = new Account();
   const recentBlockhash = account1.publicKey.toBase58(); // Fake recentBlockhash
-  const transfer = SystemProgram.transfer(
-    account1.publicKey,
-    account2.publicKey,
-    123,
-  );
+  const transfer = SystemProgram.transfer({
+    fromPubkey: account1.publicKey,
+    toPubkey: account2.publicKey,
+    lamports: 123,
+  });
 
   const transaction = new Transaction({recentBlockhash}).add(transfer);
   transaction.sign(account1, account2);
@@ -33,16 +33,16 @@ test('transfer signatures', () => {
   const account1 = new Account();
   const account2 = new Account();
   const recentBlockhash = account1.publicKey.toBase58(); // Fake recentBlockhash
-  const transfer1 = SystemProgram.transfer(
-    account1.publicKey,
-    account2.publicKey,
-    123,
-  );
-  const transfer2 = SystemProgram.transfer(
-    account2.publicKey,
-    account1.publicKey,
-    123,
-  );
+  const transfer1 = SystemProgram.transfer({
+    fromPubkey: account1.publicKey,
+    toPubkey: account2.publicKey,
+    lamports: 123,
+  });
+  const transfer2 = SystemProgram.transfer({
+    fromPubkey: account2.publicKey,
+    toPubkey: account1.publicKey,
+    lamports: 123,
+  });
 
   const orgTransaction = new Transaction({recentBlockhash}).add(
     transfer1,
@@ -62,16 +62,16 @@ test('dedup signatures', () => {
   const account1 = new Account();
   const account2 = new Account();
   const recentBlockhash = account1.publicKey.toBase58(); // Fake recentBlockhash
-  const transfer1 = SystemProgram.transfer(
-    account1.publicKey,
-    account2.publicKey,
-    123,
-  );
-  const transfer2 = SystemProgram.transfer(
-    account1.publicKey,
-    account2.publicKey,
-    123,
-  );
+  const transfer1 = SystemProgram.transfer({
+    fromPubkey: account1.publicKey,
+    toPubkey: account2.publicKey,
+    lamports: 123,
+  });
+  const transfer2 = SystemProgram.transfer({
+    fromPubkey: account1.publicKey,
+    toPubkey: account2.publicKey,
+    lamports: 123,
+  });
 
   const orgTransaction = new Transaction({recentBlockhash}).add(
     transfer1,
@@ -88,14 +88,18 @@ test('use nonce', () => {
 
   const nonceInfo = {
     nonce,
-    nonceInstruction: SystemProgram.nonceAdvance(
-      nonceAccount.publicKey,
-      account1.publicKey,
-    ),
+    nonceInstruction: SystemProgram.nonceAdvance({
+      noncePubkey: nonceAccount.publicKey,
+      authorizedPubkey: account1.publicKey,
+    }),
   };
 
   const transferTransaction = new Transaction({nonceInfo}).add(
-    SystemProgram.transfer(account1.publicKey, account2.publicKey, 123),
+    SystemProgram.transfer({
+      fromPubkey: account1.publicKey,
+      toPubkey: account2.publicKey,
+      lamports: 123,
+    }),
   );
   transferTransaction.sign(account1);
 
@@ -137,7 +141,11 @@ test('parse wire format and serialize', () => {
   const recipient = new PublicKey(
     'J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i99',
   ); // Arbitrary known public key
-  const transfer = SystemProgram.transfer(sender.publicKey, recipient, 49);
+  const transfer = SystemProgram.transfer({
+    fromPubkey: sender.publicKey,
+    toPubkey: recipient,
+    lamports: 49,
+  });
   const expectedTransaction = new Transaction({recentBlockhash}).add(transfer);
   expectedTransaction.sign(sender);
 
@@ -198,7 +206,11 @@ test('serialize unsigned transaction', () => {
   const recipient = new PublicKey(
     'J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i99',
   ); // Arbitrary known public key
-  const transfer = SystemProgram.transfer(sender.publicKey, recipient, 49);
+  const transfer = SystemProgram.transfer({
+    fromPubkey: sender.publicKey,
+    toPubkey: recipient,
+    lamports: 49,
+  });
   const expectedTransaction = new Transaction({recentBlockhash}).add(transfer);
 
   const wireTransactionArray = [


### PR DESCRIPTION
#### Problem
* The sdk doesn't provide a way to decode the finer details of system instruction data (especially nonce instructions)
* System instruction API methods have lots of parameters and can be easily misused

#### Changes
* Remove `SystemInstruction.from` method in favor of `SystemInstruction.decode`... methods.
* Refactor `SystemProgram` methods to accept a typed param object rather than a list of params
* Add methods to decode system instructions into the typed param objects they were created with
* Add more tests for peace of mind (and @CriesofCarrots's peace of mind!)
