### PR TITLE
feat: add getSignatureConfirmation endpoint

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -46,7 +46,12 @@ declare module '@solana/web3.js' {
 
   export type Commitment = 'max' | 'recent';
 
-  export type SignatureStatusResult = SignatureSuccess | TransactionError;
+  export type SignatureStatus = SignatureSuccess | TransactionError;
+
+  export type SignatureConfirmation = {
+    status: SignatureSuccess;
+    confirmations: number;
+  };
 
   export type BlockhashAndFeeCalculator = {
     blockhash: Blockhash;
@@ -83,7 +88,7 @@ declare module '@solana/web3.js' {
         fee: number;
         preBalances: Array<number>;
         postBalances: Array<number>;
-        status?: SignatureStatusResult;
+        status?: SignatureStatus;
       };
     }>;
   };
@@ -116,7 +121,7 @@ declare module '@solana/web3.js' {
   ) => void;
   export type SlotChangeCallback = (slotInfo: SlotInfo) => void;
   export type SignatureResultCallback = (
-    signatureResult: SignatureStatusResult,
+    signatureStatus: SignatureStatus,
   ) => void;
 
   export type SignatureSuccess = {
@@ -183,7 +188,11 @@ declare module '@solana/web3.js' {
     getSignatureStatus(
       signature: TransactionSignature,
       commitment?: Commitment,
-    ): Promise<SignatureSuccess | TransactionError | null>;
+    ): Promise<SignatureStatus | null>;
+    getSignatureConfirmation(
+      signature: TransactionSignature,
+      commitment?: Commitment,
+    ): Promise<SignatureConfirmation | null>;
     getTransactionCount(commitment?: Commitment): Promise<number>;
     getTotalSupply(commitment?: Commitment): Promise<number>;
     getVersion(): Promise<Version>;

--- a/module.flow.js
+++ b/module.flow.js
@@ -59,9 +59,12 @@ declare module '@solana/web3.js' {
 
   declare export type Commitment = 'max' | 'recent';
 
-  declare export type SignatureStatusResult =
-    | SignatureSuccess
-    | TransactionError;
+  declare export type SignatureStatus = SignatureSuccess | TransactionError;
+
+  declare export type SignatureConfirmation = {
+    status: SignatureSuccess,
+    confirmations: number,
+  };
 
   declare export type BlockhashAndFeeCalculator = {
     blockhash: Blockhash,
@@ -98,7 +101,7 @@ declare module '@solana/web3.js' {
         fee: number,
         preBalances: Array<number>,
         postBalances: Array<number>,
-        status: ?SignatureStatusResult,
+        status: ?SignatureStatus,
       },
     }>,
   };
@@ -131,7 +134,7 @@ declare module '@solana/web3.js' {
   ) => void;
   declare type SlotChangeCallback = (slotInfo: SlotInfo) => void;
   declare type SignatureResultCallback = (
-    signatureResult: SignatureStatusResult,
+    signatureStatus: SignatureStatus,
   ) => void;
 
   declare export type SignatureSuccess = {|
@@ -198,7 +201,11 @@ declare module '@solana/web3.js' {
     getSignatureStatus(
       signature: TransactionSignature,
       commitment: ?Commitment,
-    ): Promise<SignatureSuccess | TransactionError | null>;
+    ): Promise<SignatureStatus | null>;
+    getSignatureConfirmation(
+      signature: TransactionSignature,
+      commitment: ?Commitment,
+    ): Promise<SignatureConfirmation | null>;
     getTransactionCount(commitment: ?Commitment): Promise<number>;
     getTotalSupply(commitment: ?Commitment): Promise<number>;
     getVersion(): Promise<Version>;


### PR DESCRIPTION
#### Problem
* getSignatureConfirmation RPC method is missing from the SDK

#### Changes
* Rename `SignatureStatusResult` type to `SignatureStatus` since it conflicted with the struct def of the same name
* Add `getSignatureConfirmation` method to `Connection`