### PR TITLE
feat: add getSignatureConfirmation endpoint

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -48,7 +48,10 @@ declare module '@solana/web3.js' {
 
   export type Commitment = 'max' | 'recent';
 
-  export type SignatureStatusResult = SignatureSuccess | TransactionError;
+  export type SignatureConfirmation = {
+    status: SignatureSuccess;
+    confirmations: number;
+  };
 
   export type SignatureStatus = {
     slot: number;
@@ -90,7 +93,7 @@ declare module '@solana/web3.js' {
         fee: number;
         preBalances: Array<number>;
         postBalances: Array<number>;
-        status?: SignatureStatusResult;
+        status: SignatureSuccess | TransactionError | null;
       };
     }>;
   };
@@ -127,7 +130,7 @@ declare module '@solana/web3.js' {
   ) => void;
   export type SlotChangeCallback = (slotInfo: SlotInfo) => void;
   export type SignatureResultCallback = (
-    signatureResult: SignatureStatusResult,
+    signatureResult: SignatureSuccess | TransactionError,
     context: Context,
   ) => void;
 
@@ -200,6 +203,10 @@ declare module '@solana/web3.js' {
       signatures: Array<TransactionSignature>,
       commitment?: Commitment,
     ): Promise<Array<SignatureStatus | null>>;
+    getSignatureConfirmation(
+      signature: TransactionSignature,
+      commitment?: Commitment,
+    ): Promise<SignatureConfirmation | null>;
     getTransactionCount(commitment?: Commitment): Promise<number>;
     getTotalSupply(commitment?: Commitment): Promise<number>;
     getVersion(): Promise<Version>;

--- a/module.flow.js
+++ b/module.flow.js
@@ -61,9 +61,10 @@ declare module '@solana/web3.js' {
 
   declare export type Commitment = 'max' | 'recent';
 
-  declare export type SignatureStatusResult =
-    | SignatureSuccess
-    | TransactionError;
+  declare export type SignatureConfirmation = {
+    confirmations: number,
+    status: SignatureSuccess | TransactionError,
+  };
 
   declare export type SignatureStatus = {
     slot: number,
@@ -105,7 +106,7 @@ declare module '@solana/web3.js' {
         fee: number,
         preBalances: Array<number>,
         postBalances: Array<number>,
-        status: ?SignatureStatusResult,
+        status: SignatureSuccess | TransactionError | null,
       },
     }>,
   };
@@ -142,7 +143,7 @@ declare module '@solana/web3.js' {
   ) => void;
   declare type SlotChangeCallback = (slotInfo: SlotInfo) => void;
   declare type SignatureResultCallback = (
-    signatureResult: SignatureStatusResult,
+    signatureResult: SignatureSuccess | TransactionError,
     context: Context,
   ) => void;
 
@@ -215,6 +216,10 @@ declare module '@solana/web3.js' {
       signatures: Array<TransactionSignature>,
       commitment: ?Commitment,
     ): Promise<Array<SignatureStatus | null>>;
+    getSignatureConfirmation(
+      signature: TransactionSignature,
+      commitment: ?Commitment,
+    ): Promise<SignatureConfirmation | null>;
     getTransactionCount(commitment: ?Commitment): Promise<number>;
     getTotalSupply(commitment: ?Commitment): Promise<number>;
     getVersion(): Promise<Version>;

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -493,6 +493,19 @@ test('confirm transaction - error', async () => {
   await expect(
     connection.getSignatureStatus(badTransactionSignature),
   ).rejects.toThrow(errorMessage);
+
+  mockRpc.push([
+    url,
+    {
+      method: 'getSignatureConfirmation',
+      params: [badTransactionSignature],
+    },
+    errorResponse,
+  ]);
+
+  await expect(
+    connection.getSignatureConfirmation(badTransactionSignature),
+  ).rejects.toThrow(errorMessage);
 });
 
 test('get transaction count', async () => {
@@ -1009,6 +1022,9 @@ test('transaction', async () => {
     },
   ]);
 
+  // Wait for one confirmation
+  await sleep(500);
+
   let i = 0;
   for (;;) {
     if (await connection.confirmTransaction(signature)) {
@@ -1083,6 +1099,34 @@ test('transaction', async () => {
   expect(responses.length).toEqual(2);
   expect(responses[0]).toEqual(response);
   expect(responses[1]).toBeNull();
+
+  mockRpc.push([
+    url,
+    {
+      method: 'getSignatureConfirmation',
+      params: [
+        '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
+        {commitment: 'recent'},
+      ],
+    },
+    {
+      error: null,
+      result: {
+        status: {Ok: null},
+        confirmations: 1,
+      },
+    },
+  ]);
+  const confirmation = await connection.getSignatureConfirmation(
+    signature,
+    'recent',
+  );
+  if (confirmation) {
+    expect(confirmation.confirmations).toBeGreaterThan(0);
+    expect(confirmation.status).toEqual({Ok: null});
+  } else {
+    expect(confirmation).not.toBeNull();
+  }
 
   mockRpc.push([
     url,


### PR DESCRIPTION
#### Problem
* getSignatureConfirmation RPC method is missing from the SDK

#### Changes
* Rename `SignatureStatusResult` type to `SignatureStatus` since it conflicted with the struct def of the same name
* Add `getSignatureConfirmation` method to `Connection`