### PR TITLE
feat: use new getSignatureStatuses endpoint and naming

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -196,7 +196,7 @@ declare module '@solana/web3.js' {
       signature: TransactionSignature,
       commitment?: Commitment,
     ): Promise<RpcResponseAndContext<SignatureStatus | null>>;
-    getSignatureStatusBatch(
+    getSignatureStatuses(
       signatures: Array<TransactionSignature>,
       commitment?: Commitment,
     ): Promise<RpcResponseAndContext<Array<SignatureStatus | null>>>;

--- a/module.flow.js
+++ b/module.flow.js
@@ -209,7 +209,7 @@ declare module '@solana/web3.js' {
       signature: TransactionSignature,
       commitment: ?Commitment,
     ): Promise<RpcResponseAndContext<SignatureStatus | null>>;
-    getSignatureStatusBatch(
+    getSignatureStatuses(
       signatures: Array<TransactionSignature>,
       commitment: ?Commitment,
     ): Promise<RpcResponseAndContext<Array<SignatureStatus | null>>>;

--- a/src/connection.js
+++ b/src/connection.js
@@ -477,9 +477,9 @@ const GetVoteAccounts = jsonRpcResult(
 );
 
 /**
- * Expected JSON RPC response for the "getSignatureStatus" message
+ * Expected JSON RPC response for the "getSignatureStatuses" message
  */
-const GetSignatureStatusRpcResult = jsonRpcResultAndContext(
+const GetSignatureStatusesRpcResult = jsonRpcResultAndContext(
   struct.array([
     struct.union([
       'null',
@@ -1036,7 +1036,7 @@ export class Connection {
     signature: TransactionSignature,
     commitment: ?Commitment,
   ): Promise<RpcResponseAndContext<SignatureStatus | null>> {
-    const {context, value} = await this.getSignatureStatusBatch(
+    const {context, value} = await this.getSignatureStatuses(
       [signature],
       commitment,
     );
@@ -1047,13 +1047,13 @@ export class Connection {
   /**
    * Fetch the current status of a signature
    */
-  async getSignatureStatusBatch(
+  async getSignatureStatuses(
     signatures: Array<TransactionSignature>,
     commitment: ?Commitment,
   ): Promise<RpcResponseAndContext<Array<SignatureStatus | null>>> {
     const args = this._argsWithCommitment([signatures], commitment);
-    const unsafeRes = await this._rpcRequest('getSignatureStatus', args);
-    const res = GetSignatureStatusRpcResult(unsafeRes);
+    const unsafeRes = await this._rpcRequest('getSignatureStatuses', args);
+    const res = GetSignatureStatusesRpcResult(unsafeRes);
     if (res.error) {
       throw new Error(res.error.message);
     }

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -98,7 +98,7 @@ test('get program accounts', async () => {
   mockRpc.push([
     url,
     {
-      method: 'getSignatureStatus',
+      method: 'getSignatureStatuses',
       params: [
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
@@ -142,7 +142,7 @@ test('get program accounts', async () => {
   mockRpc.push([
     url,
     {
-      method: 'getSignatureStatus',
+      method: 'getSignatureStatuses',
       params: [
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
@@ -496,7 +496,7 @@ test('confirm transaction - error', async () => {
   mockRpc.push([
     url,
     {
-      method: 'getSignatureStatus',
+      method: 'getSignatureStatuses',
       params: [[badTransactionSignature]],
     },
     errorResponse,
@@ -887,7 +887,7 @@ test('request airdrop - max commitment', async () => {
   mockRpc.push([
     url,
     {
-      method: 'getSignatureStatus',
+      method: 'getSignatureStatuses',
       params: [
         [
           '1WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
@@ -1081,7 +1081,7 @@ test('transaction', async () => {
   mockRpc.push([
     url,
     {
-      method: 'getSignatureStatus',
+      method: 'getSignatureStatuses',
       params: [
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
@@ -1127,7 +1127,7 @@ test('transaction', async () => {
   mockRpc.push([
     url,
     {
-      method: 'getSignatureStatus',
+      method: 'getSignatureStatuses',
       params: [
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
@@ -1155,7 +1155,7 @@ test('transaction', async () => {
   ]);
 
   const responses = (
-    await connection.getSignatureStatusBatch([signature, unprocessedSignature])
+    await connection.getSignatureStatuses([signature, unprocessedSignature])
   ).value;
   expect(responses.length).toEqual(2);
 

--- a/test/transaction-payer.test.js
+++ b/test/transaction-payer.test.js
@@ -146,7 +146,7 @@ test('transaction-payer', async () => {
   mockRpc.push([
     url,
     {
-      method: 'getSignatureStatus',
+      method: 'getSignatureStatuses',
       params: [
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',


### PR DESCRIPTION
#### Problem
We moved the recent API changes for `getSignatureStatus` over to `getSignatureStatuses`

#### Changes
* rename `Connection.getSignatureStatusBatch` to `Connection.getSignatureStatuses`
* switch rpc method name from `getSignatureStatus` to `getSignatureStatuses`

Waiting on edge docker image for https://github.com/solana-labs/solana/pull/9228
