### PR TITLE
feat: return null when account info not found

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -163,11 +163,11 @@ declare module '@solana/web3.js' {
     getAccountInfoAndContext(
       publicKey: PublicKey,
       commitment?: Commitment,
-    ): Promise<RpcResponseAndContext<AccountInfo>>;
+    ): Promise<RpcResponseAndContext<AccountInfo | null>>;
     getAccountInfo(
       publicKey: PublicKey,
       commitment?: Commitment,
-    ): Promise<AccountInfo>;
+    ): Promise<AccountInfo | null>;
     getProgramAccounts(
       programId: PublicKey,
       commitment?: Commitment,

--- a/module.flow.js
+++ b/module.flow.js
@@ -176,11 +176,11 @@ declare module '@solana/web3.js' {
     getAccountInfoAndContext(
       publicKey: PublicKey,
       commitment: ?Commitment,
-    ): Promise<RpcResponseAndContext<AccountInfo>>;
+    ): Promise<RpcResponseAndContext<AccountInfo | null>>;
     getAccountInfo(
       publicKey: PublicKey,
       commitment: ?Commitment,
-    ): Promise<AccountInfo>;
+    ): Promise<AccountInfo | null>;
     getProgramAccounts(
       programId: PublicKey,
       commitment: ?Commitment,

--- a/test/nonce.test.js
+++ b/test/nonce.test.js
@@ -129,6 +129,10 @@ test('create and query nonce account', async () => {
     nonceAccount.publicKey,
     'recent',
   );
+  if (nonceAccountData === null) {
+    expect(nonceAccountData).not.toBeNull();
+    return;
+  }
   expect(nonceAccountData.authorizedPubkey).toEqual(from.publicKey);
   expect(bs58.decode(nonceAccountData.nonce).length).toBeGreaterThan(30);
 });

--- a/test/system-program.test.js
+++ b/test/system-program.test.js
@@ -224,7 +224,17 @@ test('live Nonce actions', async () => {
   expect(nonceBalance).toEqual(minimumAmount);
 
   const nonceQuery1 = await connection.getNonce(nonceAccount.publicKey);
+  if (nonceQuery1 === null) {
+    expect(nonceQuery1).not.toBeNull();
+    return;
+  }
+
   const nonceQuery2 = await connection.getNonce(nonceAccount.publicKey);
+  if (nonceQuery2 === null) {
+    expect(nonceQuery2).not.toBeNull();
+    return;
+  }
+
   expect(nonceQuery1.nonce).toEqual(nonceQuery2.nonce);
 
   // Wait for blockhash to advance
@@ -238,6 +248,10 @@ test('live Nonce actions', async () => {
   );
   await sendAndConfirmRecentTransaction(connection, advanceNonce, from);
   const nonceQuery3 = await connection.getNonce(nonceAccount.publicKey);
+  if (nonceQuery3 === null) {
+    expect(nonceQuery3).not.toBeNull();
+    return;
+  }
   expect(nonceQuery1.nonce).not.toEqual(nonceQuery3.nonce);
   const nonce = nonceQuery3.nonce;
 


### PR DESCRIPTION
Related to: https://github.com/solana-labs/solana-web3.js/issues/779

#### Problem
Many of our APIs return null if a queried object is not found. This makes it easy to distinguish between a network errors and missing objects. However, `getAccountInfo` and `getNonce` throw an error if they do not find results and forces users to parse error messages (not fun) to distinguish the two cases.

#### Changes
Change `getAccountInfo` and `getNonce` return types to `<T | null>`