### PR TITLE
feat: update getSignatureStatus methods

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -48,6 +48,10 @@ declare module '@solana/web3.js' {
 
   export type Commitment = 'max' | 'recent';
 
+  export type SignatureStatusConfig = {
+    searchTransactionHistory: boolean;
+  };
+
   export type SignatureStatus = {
     slot: number;
     err: TransactionError | null;
@@ -160,6 +164,7 @@ declare module '@solana/web3.js' {
 
   export class Connection {
     constructor(endpoint: string, commitment?: Commitment);
+    commitment?: Commitment;
     getAccountInfoAndContext(
       publicKey: PublicKey,
       commitment?: Commitment,
@@ -192,11 +197,11 @@ declare module '@solana/web3.js' {
     getSlotLeader(commitment?: Commitment): Promise<string>;
     getSignatureStatus(
       signature: TransactionSignature,
-      commitment?: Commitment,
+      config?: SignatureStatusConfig,
     ): Promise<RpcResponseAndContext<SignatureStatus | null>>;
     getSignatureStatuses(
       signatures: Array<TransactionSignature>,
-      commitment?: Commitment,
+      config?: SignatureStatusConfig,
     ): Promise<RpcResponseAndContext<Array<SignatureStatus | null>>>;
     getTransactionCount(commitment?: Commitment): Promise<number>;
     getTotalSupply(commitment?: Commitment): Promise<number>;

--- a/module.flow.js
+++ b/module.flow.js
@@ -61,6 +61,10 @@ declare module '@solana/web3.js' {
 
   declare export type Commitment = 'max' | 'recent';
 
+  declare export type SignatureStatusConfig = {
+    searchTransactionHistory: boolean,
+  };
+
   declare export type SignatureStatus = {
     slot: number,
     err: TransactionError | null,
@@ -173,6 +177,7 @@ declare module '@solana/web3.js' {
 
   declare export class Connection {
     constructor(endpoint: string, commitment: ?Commitment): Connection;
+    commitment: ?Commitment;
     getAccountInfoAndContext(
       publicKey: PublicKey,
       commitment: ?Commitment,
@@ -205,11 +210,11 @@ declare module '@solana/web3.js' {
     getSlotLeader(commitment: ?Commitment): Promise<string>;
     getSignatureStatus(
       signature: TransactionSignature,
-      commitment: ?Commitment,
+      config: ?SignatureStatusConfig,
     ): Promise<RpcResponseAndContext<SignatureStatus | null>>;
     getSignatureStatuses(
       signatures: Array<TransactionSignature>,
-      commitment: ?Commitment,
+      config: ?SignatureStatusConfig,
     ): Promise<RpcResponseAndContext<Array<SignatureStatus | null>>>;
     getTransactionCount(commitment: ?Commitment): Promise<number>;
     getTotalSupply(commitment: ?Commitment): Promise<number>;

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -109,7 +109,6 @@ test('get program accounts', async () => {
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
         ],
-        {commitment: 'recent'},
       ],
     },
     {
@@ -154,7 +153,6 @@ test('get program accounts', async () => {
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
         ],
-        {commitment: 'recent'},
       ],
     },
     {
@@ -905,7 +903,6 @@ test('request airdrop - max commitment', async () => {
         [
           '1WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
         ],
-        {commitment: 'recent'},
       ],
     },
     {
@@ -926,7 +923,7 @@ test('request airdrop - max commitment', async () => {
     },
   ]);
 
-  const {value} = await connection.getSignatureStatus(signature, 'recent');
+  const {value} = await connection.getSignatureStatus(signature);
   if (value === null) {
     expect(value).not.toBeNull();
     return;
@@ -1050,7 +1047,6 @@ test('transaction failure', async () => {
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
         ],
-        {commitment: 'recent'},
       ],
     },
     {
@@ -1249,7 +1245,6 @@ test('transaction', async () => {
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
         ],
-        {commitment: 'recent'},
       ],
     },
     {
@@ -1297,7 +1292,6 @@ test('transaction', async () => {
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
           unprocessedSignature,
         ],
-        {commitment: 'recent'},
       ],
     },
     {

--- a/test/transaction-payer.test.js
+++ b/test/transaction-payer.test.js
@@ -151,7 +151,6 @@ test('transaction-payer', async () => {
         [
           '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
         ],
-        {commitment: 'recent'},
       ],
     },
     {


### PR DESCRIPTION
https://github.com/solana-labs/solana/pull/9314 has removed `commitment` from the config and introduced `searchTransactionHistory` to the config for the `getSignatureStatuses` RPC endpoint and this PR addresses that API change.