### PR TITLE
Declare System Program ID in base58

### DIFF
--- a/src/system-program.js
+++ b/src/system-program.js
@@ -433,9 +433,7 @@ export class SystemProgram {
    * Public key that identifies the System program
    */
   static get programId(): PublicKey {
-    return new PublicKey(
-      '0x000000000000000000000000000000000000000000000000000000000000000',
-    );
+    return new PublicKey('11111111111111111111111111111111');
   }
 
   /**


### PR DESCRIPTION
For consistency with all of the others, and because it has tripped up partner developers 