### PR TITLE
feat: specify program account when using bpf loader

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -651,6 +651,7 @@ declare module '@solana/web3.js' {
     static load(
       connection: Connection,
       payer: Account,
+      program: Account,
       elfBytes: Buffer | Uint8Array | Array<number>,
     ): Promise<PublicKey>;
   }

--- a/module.flow.js
+++ b/module.flow.js
@@ -662,6 +662,7 @@ declare module '@solana/web3.js' {
     static load(
       connection: Connection,
       payer: Account,
+      program: Account,
       elfBytes: Buffer | Uint8Array | Array<number>,
     ): Promise<PublicKey>;
   }

--- a/src/bpf-loader.js
+++ b/src/bpf-loader.js
@@ -30,15 +30,16 @@ export class BpfLoader {
    * Load a BPF program
    *
    * @param connection The connection to use
-   * @param owner User account to load the program into
+   * @param payer Account that will pay program loading fees
+   * @param program Account to load the program into
    * @param elfBytes The entire ELF containing the BPF program
    */
   static load(
     connection: Connection,
     payer: Account,
+    program: Account,
     elf: Buffer | Uint8Array | Array<number>,
   ): Promise<PublicKey> {
-    const program = new Account();
     return Loader.load(connection, payer, program, BpfLoader.programId, elf);
   }
 }

--- a/test/bpf-loader.test.js
+++ b/test/bpf-loader.test.js
@@ -7,6 +7,7 @@ import {
   BpfLoader,
   Transaction,
   sendAndConfirmTransaction,
+  Account,
 } from '../src';
 import {mockRpcEnabled} from './__mocks__/node-fetch';
 import {url} from './url';
@@ -37,7 +38,8 @@ test('load BPF C program', async () => {
   );
   const from = await newAccountWithLamports(connection, fees + balanceNeeded);
 
-  const programId = await BpfLoader.load(connection, from, data);
+  const program = new Account();
+  const programId = await BpfLoader.load(connection, from, program, data);
   const transaction = new Transaction().add({
     keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
     programId,
@@ -65,7 +67,8 @@ test('load BPF Rust program', async () => {
   );
   const from = await newAccountWithLamports(connection, fees + balanceNeeded);
 
-  const programId = await BpfLoader.load(connection, from, data);
+  const program = new Account();
+  const programId = await BpfLoader.load(connection, from, program, data);
   const transaction = new Transaction().add({
     keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
     programId,


### PR DESCRIPTION
#### Problem
It's not possible to load a program into a particular account

#### Changes
* Add `program: Account` param to the `BpfLoader.load(..)` method