### PR TITLE
Allow external signing of `Transaction`s

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -403,6 +403,7 @@ declare module '@solana/web3.js' {
         Transaction | TransactionInstruction | TransactionInstructionCtorFields
       >
     ): Transaction;
+    signData: Buffer;
     sign(...signers: Array<Account>): void;
     signPartial(...partialSigners: Array<PublicKey | Account>): void;
     addSigner(signer: Account): void;

--- a/module.d.ts
+++ b/module.d.ts
@@ -406,6 +406,7 @@ declare module '@solana/web3.js' {
     signData: Buffer;
     sign(...signers: Array<Account>): void;
     signPartial(...partialSigners: Array<PublicKey | Account>): void;
+    addSignature(pubkey: PublicKey, signature: Buffer): void;
     addSigner(signer: Account): void;
     verifySignatures(): boolean;
     serialize(): Buffer;

--- a/module.d.ts
+++ b/module.d.ts
@@ -403,7 +403,7 @@ declare module '@solana/web3.js' {
         Transaction | TransactionInstruction | TransactionInstructionCtorFields
       >
     ): Transaction;
-    signData: Buffer;
+    serializeMessage(): Buffer;
     sign(...signers: Array<Account>): void;
     signPartial(...partialSigners: Array<PublicKey | Account>): void;
     addSignature(pubkey: PublicKey, signature: Buffer): void;

--- a/module.flow.js
+++ b/module.flow.js
@@ -411,7 +411,7 @@ declare module '@solana/web3.js' {
         Transaction | TransactionInstruction | TransactionInstructionCtorFields,
       >
     ): Transaction;
-    signData: Buffer;
+    serializeMessage(): Buffer;
     sign(...signers: Array<Account>): void;
     signPartial(...partialSigners: Array<PublicKey | Account>): void;
     addSigner(signer: Account): void;

--- a/module.flow.js
+++ b/module.flow.js
@@ -411,6 +411,7 @@ declare module '@solana/web3.js' {
         Transaction | TransactionInstruction | TransactionInstructionCtorFields,
       >
     ): Transaction;
+    signData: Buffer;
     sign(...signers: Array<Account>): void;
     signPartial(...partialSigners: Array<PublicKey | Account>): void;
     addSigner(signer: Account): void;

--- a/module.flow.js
+++ b/module.flow.js
@@ -415,6 +415,7 @@ declare module '@solana/web3.js' {
     sign(...signers: Array<Account>): void;
     signPartial(...partialSigners: Array<PublicKey | Account>): void;
     addSigner(signer: Account): void;
+    addSignature(pubkey: PublicKey, signature: Buffer): void;
     verifySignatures(): boolean;
     serialize(): Buffer;
   }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -398,16 +398,24 @@ export class Transaction {
    * `signPartial`
    */
   addSigner(signer: Account) {
-    const index = this.signatures.findIndex(sigpair =>
-      signer.publicKey.equals(sigpair.publicKey),
-    );
-    if (index < 0) {
-      throw new Error(`Unknown signer: ${signer.publicKey.toString()}`);
-    }
-
     const signData = this.signData;
     const signature = nacl.sign.detached(signData, signer.secretKey);
+    this.addSignature(signer.publicKey, signature);
+  }
+
+  /**
+   * Add an externally created signature to a transaction
+   */
+  addSignature(pubkey: PublicKey, signature: Buffer) {
     invariant(signature.length === 64);
+
+    const index = this.signatures.findIndex(sigpair =>
+      pubkey.equals(sigpair.publicKey),
+    );
+    if (index < 0) {
+      throw new Error(`Unknown signer: ${pubkey.toString()}`);
+    }
+
     this.signatures[index].signature = Buffer.from(signature);
   }
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -182,7 +182,7 @@ export class Transaction {
   /**
    * Get a buffer of the Transaction data that need to be covered by signatures
    */
-  get signData(): Buffer {
+  serializeMessage(): Buffer {
     const {nonceInfo} = this;
     if (nonceInfo && this.instructions[0] != nonceInfo.nonceInstruction) {
       this.recentBlockhash = nonceInfo.nonce;
@@ -377,7 +377,7 @@ export class Transaction {
       },
     );
     this.signatures = signatures;
-    const signData = this.signData;
+    const signData = this.serializeMessage();
 
     partialSigners.forEach((accountOrPublicKey, index) => {
       if (accountOrPublicKey instanceof PublicKey) {
@@ -398,7 +398,7 @@ export class Transaction {
    * `signPartial`
    */
   addSigner(signer: Account) {
-    const signData = this.signData;
+    const signData = this.serializeMessage();
     const signature = nacl.sign.detached(signData, signer.secretKey);
     this.addSignature(signer.publicKey, signature);
   }
@@ -424,7 +424,7 @@ export class Transaction {
    */
   verifySignatures(): boolean {
     let verified = true;
-    const signData = this.signData;
+    const signData = this.serializeMessage();
     for (const {signature, publicKey} of this.signatures) {
       if (
         !nacl.sign.detached.verify(signData, signature, publicKey.toBuffer())
@@ -446,7 +446,7 @@ export class Transaction {
       throw new Error('Transaction has not been signed');
     }
 
-    const signData = this.signData;
+    const signData = this.serializeMessage();
     const signatureCount = [];
     shortvec.encodeLength(signatureCount, signatures.length);
     const transactionLength =

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -180,9 +180,9 @@ export class Transaction {
   }
 
   /**
-   * @private
+   * Get a buffer of the Transaction data that need to be covered by signatures
    */
-  _getSignData(): Buffer {
+  get signData(): Buffer {
     const {nonceInfo} = this;
     if (nonceInfo && this.instructions[0] != nonceInfo.nonceInstruction) {
       this.recentBlockhash = nonceInfo.nonce;
@@ -377,7 +377,7 @@ export class Transaction {
       },
     );
     this.signatures = signatures;
-    const signData = this._getSignData();
+    const signData = this.signData;
 
     partialSigners.forEach((accountOrPublicKey, index) => {
       if (accountOrPublicKey instanceof PublicKey) {
@@ -405,7 +405,7 @@ export class Transaction {
       throw new Error(`Unknown signer: ${signer.publicKey.toString()}`);
     }
 
-    const signData = this._getSignData();
+    const signData = this.signData;
     const signature = nacl.sign.detached(signData, signer.secretKey);
     invariant(signature.length === 64);
     this.signatures[index].signature = Buffer.from(signature);
@@ -416,7 +416,7 @@ export class Transaction {
    */
   verifySignatures(): boolean {
     let verified = true;
-    const signData = this._getSignData();
+    const signData = this.signData;
     for (const {signature, publicKey} of this.signatures) {
       if (
         !nacl.sign.detached.verify(signData, signature, publicKey.toBuffer())
@@ -438,7 +438,7 @@ export class Transaction {
       throw new Error('Transaction has not been signed');
     }
 
-    const signData = this._getSignData();
+    const signData = this.signData;
     const signatureCount = [];
     shortvec.encodeLength(signatureCount, signatures.length);
     const transactionLength =

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -439,3 +439,22 @@ test('serialize unsigned transaction', () => {
     expectedTransaction,
   );
 });
+
+test('get sign data for transaction', () => {
+  const from_keypair = nacl.sign.keyPair.fromSeed(
+    Uint8Array.from(Array(32).fill(1)),
+  );
+  const from = new Account(Buffer.from(from_keypair.secretKey));
+  const to = new PublicKey(2);
+  const recentBlockhash = new PublicKey(3).toBuffer();
+  var tx = SystemProgram.transfer({
+    fromPubkey: from.publicKey,
+    toPubkey: to,
+    lamports: 42,
+  });
+  tx.recentBlockhash = bs58.encode(recentBlockhash);
+  const tx_bytes = tx.signData;
+  const signature = nacl.sign.detached(tx_bytes, from.secretKey);
+  tx.addSignature(from.publicKey, signature);
+  expect(tx.verifySignatures()).toBe(true);
+});

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -453,7 +453,7 @@ test('get sign data for transaction', () => {
     lamports: 42,
   });
   tx.recentBlockhash = bs58.encode(recentBlockhash);
-  const tx_bytes = tx.signData;
+  const tx_bytes = tx.serializeMessage();
   const signature = nacl.sign.detached(tx_bytes, from.secretKey);
   tx.addSignature(from.publicKey, signature);
   expect(tx.verifySignatures()).toBe(true);


### PR DESCRIPTION
#### Problem

The `Transaction` type assumes it will handle creating all signatures and as a result keeps many of the facilities to do so private.  This makes it more involved than it needs to be to sign `Transactions` externally, such as with a Ledger wallet

#### Changes

Expose `Transaction._getSignData()` as `Transaction.signData`
Add a helper for adding externally created `PublicKey`/`Signature` pairs to `Transaction`s
Test!

Fixes: https://github.com/solana-labs/solana-web3.js/issues/570