### PR TITLE
feat: add support for more system instructions

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -578,17 +578,6 @@ declare module '@solana/web3.js' {
     programId: PublicKey;
   };
 
-  export type TransferParams = {
-    fromPubkey: PublicKey;
-    toPubkey: PublicKey;
-    lamports: number;
-  };
-
-  export type AssignParams = {
-    fromPubkey: PublicKey;
-    programId: PublicKey;
-  };
-
   export type CreateAccountWithSeedParams = {
     fromPubkey: PublicKey;
     newAccountPubkey: PublicKey;
@@ -597,6 +586,37 @@ declare module '@solana/web3.js' {
     lamports: number;
     space: number;
     programId: PublicKey;
+  };
+
+  export type AllocateParams = {
+    accountPubkey: PublicKey;
+    space: number;
+  };
+
+  export type AllocateWithSeedParams = {
+    accountPubkey: PublicKey;
+    basePubkey: PublicKey;
+    seed: string;
+    space: number;
+    programId: PublicKey;
+  };
+
+  export type AssignParams = {
+    accountPubkey: PublicKey;
+    programId: PublicKey;
+  };
+
+  export type AssignWithSeedParams = {
+    accountPubkey: PublicKey;
+    basePubkey: PublicKey;
+    seed: string;
+    programId: PublicKey;
+  };
+
+  export type TransferParams = {
+    fromPubkey: PublicKey;
+    toPubkey: PublicKey;
+    lamports: number;
   };
 
   export type CreateNonceAccountParams = {
@@ -642,11 +662,14 @@ declare module '@solana/web3.js' {
     static programId: PublicKey;
 
     static createAccount(params: CreateAccountParams): Transaction;
-    static transfer(params: TransferParams): Transaction;
-    static assign(params: AssignParams): Transaction;
     static createAccountWithSeed(
       params: CreateAccountWithSeedParams,
     ): Transaction;
+    static allocate(
+      params: AllocateParams | AllocateWithSeedParams,
+    ): Transaction;
+    static assign(params: AssignParams | AssignWithSeedParams): Transaction;
+    static transfer(params: TransferParams): Transaction;
     static createNonceAccount(
       params: CreateNonceAccountParams | CreateNonceAccountWithSeedParams,
     ): Transaction;
@@ -657,9 +680,12 @@ declare module '@solana/web3.js' {
 
   export type SystemInstructionType =
     | 'Create'
-    | 'Assign'
-    | 'Transfer'
     | 'CreateWithSeed'
+    | 'Allocate'
+    | 'AllocateWithSeed'
+    | 'Assign'
+    | 'AssignWithSeed'
+    | 'Transfer'
     | 'AdvanceNonceAccount'
     | 'WithdrawNonceAccount'
     | 'InitializeNonceAccount'
@@ -676,11 +702,18 @@ declare module '@solana/web3.js' {
     static decodeCreateAccount(
       instruction: TransactionInstruction,
     ): CreateAccountParams;
-    static decodeTransfer(instruction: TransactionInstruction): TransferParams;
-    static decodeAssign(instruction: TransactionInstruction): AssignParams;
     static decodeCreateWithSeed(
       instruction: TransactionInstruction,
     ): CreateAccountWithSeedParams;
+    static decodeAllocate(instruction: TransactionInstruction): AllocateParams;
+    static decodeAllocateWithSeed(
+      instruction: TransactionInstruction,
+    ): AllocateWithSeedParams;
+    static decodeAssign(instruction: TransactionInstruction): AssignParams;
+    static decodeAssignWithSeed(
+      instruction: TransactionInstruction,
+    ): AssignWithSeedParams;
+    static decodeTransfer(instruction: TransactionInstruction): TransferParams;
     static decodeNonceInitialize(
       instruction: TransactionInstruction,
     ): InitializeNonceParams;

--- a/module.flow.js
+++ b/module.flow.js
@@ -593,17 +593,6 @@ declare module '@solana/web3.js' {
     programId: PublicKey,
   |};
 
-  declare export type TransferParams = {|
-    fromPubkey: PublicKey,
-    toPubkey: PublicKey,
-    lamports: number,
-  |};
-
-  declare export type AssignParams = {|
-    fromPubkey: PublicKey,
-    programId: PublicKey,
-  |};
-
   declare export type CreateAccountWithSeedParams = {|
     fromPubkey: PublicKey,
     newAccountPubkey: PublicKey,
@@ -612,6 +601,37 @@ declare module '@solana/web3.js' {
     lamports: number,
     space: number,
     programId: PublicKey,
+  |};
+
+  declare export type AllocateParams = {|
+    accountPubkey: PublicKey,
+    space: number,
+  |};
+
+  declare export type AllocateWithSeedParams = {|
+    accountPubkey: PublicKey,
+    basePubkey: PublicKey,
+    seed: string,
+    space: number,
+    programId: PublicKey,
+  |};
+
+  declare export type AssignParams = {|
+    accountPubkey: PublicKey,
+    programId: PublicKey,
+  |};
+
+  declare export type AssignWithSeedParams = {|
+    accountPubkey: PublicKey,
+    basePubkey: PublicKey,
+    seed: string,
+    programId: PublicKey,
+  |};
+
+  declare export type TransferParams = {|
+    fromPubkey: PublicKey,
+    toPubkey: PublicKey,
+    lamports: number,
   |};
 
   declare export type CreateNonceAccountParams = {|
@@ -657,11 +677,14 @@ declare module '@solana/web3.js' {
     static programId: PublicKey;
 
     static createAccount(params: CreateAccountParams): Transaction;
-    static transfer(params: TransferParams): Transaction;
-    static assign(params: AssignParams): Transaction;
     static createAccountWithSeed(
       params: CreateAccountWithSeedParams,
     ): Transaction;
+    static allocate(
+      params: AllocateParams | AllocateWithSeedParams,
+    ): Transaction;
+    static assign(params: AssignParams | AssignWithSeedParams): Transaction;
+    static transfer(params: TransferParams): Transaction;
     static createNonceAccount(
       params: CreateNonceAccountParams | CreateNonceAccountWithSeedParams,
     ): Transaction;
@@ -672,9 +695,12 @@ declare module '@solana/web3.js' {
 
   declare export type SystemInstructionType =
     | 'Create'
-    | 'Assign'
-    | 'Transfer'
     | 'CreateWithSeed'
+    | 'Allocate'
+    | 'AllocateWithSeed'
+    | 'Assign'
+    | 'AssignWithSeed'
+    | 'Transfer'
     | 'AdvanceNonceAccount'
     | 'WithdrawNonceAccount'
     | 'InitializeNonceAccount'
@@ -691,11 +717,18 @@ declare module '@solana/web3.js' {
     static decodeCreateAccount(
       instruction: TransactionInstruction,
     ): CreateAccountParams;
-    static decodeTransfer(instruction: TransactionInstruction): TransferParams;
-    static decodeAssign(instruction: TransactionInstruction): AssignParams;
     static decodeCreateWithSeed(
       instruction: TransactionInstruction,
     ): CreateAccountWithSeedParams;
+    static decodeAllocate(instruction: TransactionInstruction): AllocateParams;
+    static decodeAllocateWithSeed(
+      instruction: TransactionInstruction,
+    ): AllocateWithSeedParams;
+    static decodeAssign(instruction: TransactionInstruction): AssignParams;
+    static decodeAssignWithSeed(
+      instruction: TransactionInstruction,
+    ): AssignWithSeedParams;
+    static decodeTransfer(instruction: TransactionInstruction): TransferParams;
     static decodeNonceInitialize(
       instruction: TransactionInstruction,
     ): InitializeNonceParams;

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -132,7 +132,7 @@ test('get program accounts', async () => {
     },
   ]);
   let transaction = SystemProgram.assign({
-    fromPubkey: account0.publicKey,
+    accountPubkey: account0.publicKey,
     programId: programId.publicKey,
   });
   await sendAndConfirmTransaction(connection, transaction, account0);
@@ -176,7 +176,7 @@ test('get program accounts', async () => {
     },
   ]);
   transaction = SystemProgram.assign({
-    fromPubkey: account1.publicKey,
+    accountPubkey: account1.publicKey,
     programId: programId.publicKey,
   });
 

--- a/test/system-program.test.js
+++ b/test/system-program.test.js
@@ -49,15 +49,57 @@ test('transfer', () => {
   expect(params).toEqual(SystemInstruction.decodeTransfer(systemInstruction));
 });
 
+test('allocate', () => {
+  const params = {
+    accountPubkey: new Account().publicKey,
+    space: 42,
+  };
+  const transaction = SystemProgram.allocate(params);
+  expect(transaction.instructions).toHaveLength(1);
+  const [systemInstruction] = transaction.instructions;
+  expect(params).toEqual(SystemInstruction.decodeAllocate(systemInstruction));
+});
+
+test('allocateWithSeed', () => {
+  const params = {
+    accountPubkey: new Account().publicKey,
+    basePubkey: new Account().publicKey,
+    seed: '你好',
+    space: 42,
+    programId: new Account().publicKey,
+  };
+  const transaction = SystemProgram.allocate(params);
+  expect(transaction.instructions).toHaveLength(1);
+  const [systemInstruction] = transaction.instructions;
+  expect(params).toEqual(
+    SystemInstruction.decodeAllocateWithSeed(systemInstruction),
+  );
+});
+
 test('assign', () => {
   const params = {
-    fromPubkey: new Account().publicKey,
+    accountPubkey: new Account().publicKey,
     programId: new Account().publicKey,
   };
   const transaction = SystemProgram.assign(params);
   expect(transaction.instructions).toHaveLength(1);
   const [systemInstruction] = transaction.instructions;
   expect(params).toEqual(SystemInstruction.decodeAssign(systemInstruction));
+});
+
+test('assignWithSeed', () => {
+  const params = {
+    accountPubkey: new Account().publicKey,
+    basePubkey: new Account().publicKey,
+    seed: '你好',
+    programId: new Account().publicKey,
+  };
+  const transaction = SystemProgram.assign(params);
+  expect(transaction.instructions).toHaveLength(1);
+  const [systemInstruction] = transaction.instructions;
+  expect(params).toEqual(
+    SystemInstruction.decodeAssignWithSeed(systemInstruction),
+  );
 });
 
 test('createAccountWithSeed', () => {


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/solana-web3.js/issues/866

#### Changes
* Adds support for creating and decoding the following instruction types:
    - Allocate
    - AllocateWithSeed
    - AssignWithSeed
* Renamed the assign param from `fromPubkey` to `accountPubkey`