### PR TITLE
feat: add root and single commitment levels

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -46,7 +46,7 @@ declare module '@solana/web3.js' {
     value: T;
   };
 
-  export type Commitment = 'max' | 'recent';
+  export type Commitment = 'max' | 'recent' | 'root' | 'single';
 
   export type SignatureStatusConfig = {
     searchTransactionHistory: boolean;

--- a/module.flow.js
+++ b/module.flow.js
@@ -59,7 +59,7 @@ declare module '@solana/web3.js' {
     value: T,
   };
 
-  declare export type Commitment = 'max' | 'recent';
+  declare export type Commitment = 'max' | 'recent' | 'root' | 'single';
 
   declare export type SignatureStatusConfig = {
     searchTransactionHistory: boolean,

--- a/src/connection.js
+++ b/src/connection.js
@@ -89,12 +89,16 @@ function notificationResultAndContext(resultDescription: any) {
 
 /**
  * The level of commitment desired when querying state
- *   'max':    Query the most recent block which has reached max voter lockout
- *   'recent': Query the most recent block
+ * <pre>
+ *   'max':    Query the most recent block which has been finalized by the cluster
+ *   'recent': Query the most recent block which has reached 1 confirmation by the connected node
+ *   'root':   Query the most recent block which has been rooted by the connected node
+ *   'single': Query the most recent block which has reached 1 confirmation by the cluster
+ * </pre>
  *
- * @typedef {'max' | 'recent'} Commitment
+ * @typedef {'max' | 'recent' | 'root' | 'single'} Commitment
  */
-export type Commitment = 'max' | 'recent';
+export type Commitment = 'max' | 'recent' | 'root' | 'single';
 
 /**
  * Configuration object for changing query behavior

--- a/src/util/send-and-confirm-transaction.js
+++ b/src/util/send-and-confirm-transaction.js
@@ -65,12 +65,13 @@ async function _sendAndConfirmTransaction(
     for (;;) {
       status = (await connection.getSignatureStatus(signature)).value;
       if (status) {
-        // Recieved a status, if not an error wait for confirmation
+        // Received a status, if not an error wait for confirmation
         statusRetries = NUM_STATUS_RETRIES;
         if (
           status.err ||
           status.confirmations === null ||
-          (statusCommitment === 'recent' && status.confirmations >= 1)
+          ((statusCommitment === 'recent' || statusCommitment === 'single') &&
+            status.confirmations >= 1)
         ) {
           break;
         }

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1031,12 +1031,15 @@ test('get confirmed block', async () => {
 
 test('get recent blockhash', async () => {
   const connection = new Connection(url);
+  for (const commitment of ['max', 'recent', 'root', 'single']) {
+    mockGetRecentBlockhash(commitment);
 
-  mockGetRecentBlockhash();
-
-  const {blockhash, feeCalculator} = await connection.getRecentBlockhash();
-  expect(blockhash.length).toBeGreaterThanOrEqual(43);
-  expect(feeCalculator.lamportsPerSignature).toBeGreaterThanOrEqual(0);
+    const {blockhash, feeCalculator} = await connection.getRecentBlockhash(
+      commitment,
+    );
+    expect(blockhash.length).toBeGreaterThanOrEqual(43);
+    expect(feeCalculator.lamportsPerSignature).toBeGreaterThanOrEqual(0);
+  }
 });
 
 test('getVersion', async () => {


### PR DESCRIPTION
#### Problem
`root` and `single` commitment levels are not supported.

---
Unfortunately `sendAndConfirmTransaction` and `sendAndConfirmRawTransaction` are currently incorrect (before and after this change) and are not fixable without RPC changes.

This is because `getSignatureStatuses` does not accept a commitment level param and always returns the confirmation count as seen by the connected node. It doesn't support fetching confirmation count as seen by the _cluster_. This broke when we separated the notion of `root` and `max` commitment level and is also an issue for accurately returning status for `single` commitment. Issue here: https://github.com/solana-labs/solana/issues/10108