### PR TITLE
Add new commitment levels and update tx confirmation apis

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -46,7 +46,7 @@ declare module '@solana/web3.js' {
     value: T;
   };
 
-  export type Commitment = 'max' | 'recent';
+  export type Commitment = 'max' | 'recent' | 'root' | 'single';
 
   export type SignatureStatusConfig = {
     searchTransactionHistory: boolean;

--- a/module.d.ts
+++ b/module.d.ts
@@ -210,14 +210,10 @@ declare module '@solana/web3.js' {
       endSlot: number,
     ): Promise<Array<TransactionSignature>>;
     getVoteAccounts(commitment?: Commitment): Promise<VoteAccountStatus>;
-    confirmTransactionAndContext(
-      signature: TransactionSignature,
-      commitment?: Commitment,
-    ): Promise<RpcResponseAndContext<boolean>>;
     confirmTransaction(
       signature: TransactionSignature,
-      commitment?: Commitment,
-    ): Promise<boolean>;
+      confirmations?: number,
+    ): Promise<RpcResponseAndContext<SignatureStatus | null>>;
     getSlot(commitment?: Commitment): Promise<number>;
     getSlotLeader(commitment?: Commitment): Promise<string>;
     getSignatureStatus(
@@ -247,7 +243,7 @@ declare module '@solana/web3.js' {
     ): Promise<TransactionSignature>;
     sendTransaction(
       transaction: Transaction,
-      ...signers: Array<Account>
+      signers: Array<Account>,
     ): Promise<TransactionSignature>;
     sendEncodedTransaction(
       encodedTransaction: string,
@@ -769,20 +765,15 @@ declare module '@solana/web3.js' {
   export function sendAndConfirmTransaction(
     connection: Connection,
     transaction: Transaction,
-    ...signers: Array<Account>
-  ): Promise<TransactionSignature>;
-
-  export function sendAndConfirmRecentTransaction(
-    connection: Connection,
-    transaction: Transaction,
-    ...signers: Array<Account>
+    signers: Array<Account>,
+    confirmations?: number,
   ): Promise<TransactionSignature>;
 
   // === src/util/send-and-confirm-raw-transaction.js ===
   export function sendAndConfirmRawTransaction(
     connection: Connection,
     wireTransaction: Buffer,
-    commitment?: Commitment,
+    confirmations?: number,
   ): Promise<TransactionSignature>;
 
   // === src/util/cluster.js ===

--- a/module.flow.js
+++ b/module.flow.js
@@ -223,14 +223,10 @@ declare module '@solana/web3.js' {
       endSlot: number,
     ): Promise<Array<TransactionSignature>>;
     getVoteAccounts(commitment: ?Commitment): Promise<VoteAccountStatus>;
-    confirmTransactionAndContext(
-      signature: TransactionSignature,
-      commitment: ?Commitment,
-    ): Promise<RpcResponseAndContext<boolean>>;
     confirmTransaction(
       signature: TransactionSignature,
-      commitment: ?Commitment,
-    ): Promise<boolean>;
+      confirmations: ?number,
+    ): Promise<RpcResponseAndContext<SignatureStatus | null>>;
     getSlot(commitment: ?Commitment): Promise<number>;
     getSlotLeader(commitment: ?Commitment): Promise<string>;
     getSignatureStatus(
@@ -260,7 +256,7 @@ declare module '@solana/web3.js' {
     ): Promise<TransactionSignature>;
     sendTransaction(
       transaction: Transaction,
-      ...signers: Array<Account>
+      signers: Array<Account>,
     ): Promise<TransactionSignature>;
     sendEncodedTransaction(
       encodedTransaction: string,
@@ -784,20 +780,15 @@ declare module '@solana/web3.js' {
   declare export function sendAndConfirmTransaction(
     connection: Connection,
     transaction: Transaction,
-    ...signers: Array<Account>
-  ): Promise<TransactionSignature>;
-
-  declare export function sendAndConfirmRecentTransaction(
-    connection: Connection,
-    transaction: Transaction,
-    ...signers: Array<Account>
+    signers: Array<Account>,
+    confirmations: ?number,
   ): Promise<TransactionSignature>;
 
   // === src/util/send-and-confirm-raw-transaction.js ===
   declare export function sendAndConfirmRawTransaction(
     connection: Connection,
     wireTransaction: Buffer,
-    commitment: ?Commitment,
+    confirmations: ?number,
   ): Promise<TransactionSignature>;
 
   // === src/util/cluster.js ===

--- a/module.flow.js
+++ b/module.flow.js
@@ -59,7 +59,7 @@ declare module '@solana/web3.js' {
     value: T,
   };
 
-  declare export type Commitment = 'max' | 'recent';
+  declare export type Commitment = 'max' | 'recent' | 'root' | 'single';
 
   declare export type SignatureStatusConfig = {
     searchTransactionHistory: boolean,

--- a/src/connection.js
+++ b/src/connection.js
@@ -89,12 +89,16 @@ function notificationResultAndContext(resultDescription: any) {
 
 /**
  * The level of commitment desired when querying state
- *   'max':    Query the most recent block which has reached max voter lockout
- *   'recent': Query the most recent block
+ * <pre>
+ *   'max':    Query the most recent block which has been finalized by the cluster
+ *   'recent': Query the most recent block which has reached 1 confirmation by the connected node
+ *   'root':   Query the most recent block which has been rooted by the connected node
+ *   'single': Query the most recent block which has reached 1 confirmation by the cluster
+ * </pre>
  *
- * @typedef {'max' | 'recent'} Commitment
+ * @typedef {'max' | 'recent' | 'root' | 'single'} Commitment
  */
-export type Commitment = 'max' | 'recent';
+export type Commitment = 'max' | 'recent' | 'root' | 'single';
 
 /**
  * Configuration object for changing query behavior

--- a/src/index.js
+++ b/src/index.js
@@ -30,10 +30,7 @@ export {
   SYSVAR_REWARDS_PUBKEY,
   SYSVAR_STAKE_HISTORY_PUBKEY,
 } from './sysvar';
-export {
-  sendAndConfirmTransaction,
-  sendAndConfirmRecentTransaction,
-} from './util/send-and-confirm-transaction';
+export {sendAndConfirmTransaction} from './util/send-and-confirm-transaction';
 export {sendAndConfirmRawTransaction} from './util/send-and-confirm-raw-transaction';
 export {clusterApiUrl} from './util/cluster';
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -65,7 +65,12 @@ export class Loader {
         space: data.length,
         programId,
       });
-      await sendAndConfirmTransaction(connection, transaction, payer, program);
+      await sendAndConfirmTransaction(
+        connection,
+        transaction,
+        [payer, program],
+        1,
+      );
     }
 
     const dataLayout = BufferLayout.struct([
@@ -102,7 +107,7 @@ export class Loader {
         data,
       });
       transactions.push(
-        sendAndConfirmTransaction(connection, transaction, payer, program),
+        sendAndConfirmTransaction(connection, transaction, [payer, program], 1),
       );
 
       // Delay ~1 tick between write transactions in an attempt to reduce AccountInUse errors
@@ -143,7 +148,12 @@ export class Loader {
         programId,
         data,
       });
-      await sendAndConfirmTransaction(connection, transaction, payer, program);
+      await sendAndConfirmTransaction(
+        connection,
+        transaction,
+        [payer, program],
+        1,
+      );
     }
     return program.publicKey;
   }

--- a/src/util/send-and-confirm-raw-transaction.js
+++ b/src/util/send-and-confirm-raw-transaction.js
@@ -1,54 +1,34 @@
 // @flow
 
 import {Connection} from '../connection';
-import type {Commitment} from '../connection';
-import {sleep} from './sleep';
 import type {TransactionSignature} from '../transaction';
-import {DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND} from '../timing';
 
 /**
- * Sign, send and confirm a raw transaction
+ * Send and confirm a raw transaction
  */
 export async function sendAndConfirmRawTransaction(
   connection: Connection,
   rawTransaction: Buffer,
-  commitment: ?Commitment,
+  confirmations: ?number,
 ): Promise<TransactionSignature> {
   const start = Date.now();
-  const statusCommitment = commitment || connection.commitment || 'max';
-  let signature = await connection.sendRawTransaction(rawTransaction);
+  const signature = await connection.sendRawTransaction(rawTransaction);
+  const status = (await connection.confirmTransaction(signature, confirmations))
+    .value;
 
-  // Wait up to a couple slots for a confirmation
-  let status = null;
-  let statusRetries = 6;
-  for (;;) {
-    status = (await connection.getSignatureStatus(signature)).value;
-    if (status) {
-      if (statusCommitment === 'max' && status.confirmations === null) {
-        break;
-      } else if (statusCommitment === 'recent') {
-        break;
-      }
-    }
-
-    // Sleep for approximately half a slot
-    await sleep((500 * DEFAULT_TICKS_PER_SLOT) / NUM_TICKS_PER_SECOND);
-
-    if (--statusRetries <= 0) {
-      const duration = (Date.now() - start) / 1000;
+  if (status) {
+    if (status.err) {
       throw new Error(
-        `Raw Transaction '${signature}' was not confirmed in ${duration.toFixed(
-          2,
-        )} seconds (${JSON.stringify(status)})`,
+        `Raw transaction ${signature} failed (${JSON.stringify(status)})`,
       );
     }
-  }
-
-  if (status && !status.err) {
     return signature;
   }
 
+  const duration = (Date.now() - start) / 1000;
   throw new Error(
-    `Raw transaction ${signature} failed (${JSON.stringify(status)})`,
+    `Raw transaction '${signature}' was not confirmed in ${duration.toFixed(
+      2,
+    )} seconds`,
   );
 }

--- a/src/util/send-and-confirm-transaction.js
+++ b/src/util/send-and-confirm-transaction.js
@@ -1,111 +1,52 @@
 // @flow
 
-import invariant from 'assert';
-
 import {Connection} from '../connection';
-import type {Commitment} from '../connection';
 import {Transaction} from '../transaction';
 import {sleep} from './sleep';
 import type {Account} from '../account';
 import type {TransactionSignature} from '../transaction';
-import {DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND} from '../timing';
-
-const MS_PER_SECOND = 1000;
-const MS_PER_SLOT =
-  (DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND) * MS_PER_SECOND;
 
 const NUM_SEND_RETRIES = 10;
-const NUM_STATUS_RETRIES = 10;
 
 /**
- * Sign, send and confirm a transaction with recent commitment level
- */
-export async function sendAndConfirmRecentTransaction(
-  connection: Connection,
-  transaction: Transaction,
-  ...signers: Array<Account>
-): Promise<TransactionSignature> {
-  return await _sendAndConfirmTransaction(
-    connection,
-    transaction,
-    signers,
-    'recent',
-  );
-}
-
-/**
- * Sign, send and confirm a transaction
+ * Sign, send and confirm a transaction.
+ *
+ * If `confirmations` count is not specified, wait for transaction to be finalized.
  */
 export async function sendAndConfirmTransaction(
   connection: Connection,
   transaction: Transaction,
-  ...signers: Array<Account>
-): Promise<TransactionSignature> {
-  return await _sendAndConfirmTransaction(connection, transaction, signers);
-}
-
-async function _sendAndConfirmTransaction(
-  connection: Connection,
-  transaction: Transaction,
   signers: Array<Account>,
-  commitment: ?Commitment,
+  confirmations: ?number,
 ): Promise<TransactionSignature> {
-  const statusCommitment = commitment || connection.commitment || 'max';
-
+  const start = Date.now();
   let sendRetries = NUM_SEND_RETRIES;
-  let signature;
 
   for (;;) {
-    const start = Date.now();
-    signature = await connection.sendTransaction(transaction, ...signers);
-
-    // Wait up to a couple slots for a confirmation
-    let status = null;
-    let statusRetries = NUM_STATUS_RETRIES;
-    for (;;) {
-      status = (await connection.getSignatureStatus(signature)).value;
-      if (status) {
-        // Recieved a status, if not an error wait for confirmation
-        statusRetries = NUM_STATUS_RETRIES;
-        if (
-          status.err ||
-          status.confirmations === null ||
-          (statusCommitment === 'recent' && status.confirmations >= 1)
-        ) {
-          break;
-        }
-      }
-
-      if (--statusRetries <= 0) {
-        break;
-      }
-      // Sleep for approximately half a slot
-      await sleep(MS_PER_SLOT / 2);
-    }
+    const signature = await connection.sendTransaction(transaction, signers);
+    const status = (
+      await connection.confirmTransaction(signature, confirmations)
+    ).value;
 
     if (status) {
-      if (!status.err) {
-        break;
-      } else if (!('AccountInUse' in status.err)) {
+      if (status.err) {
         throw new Error(
           `Transaction ${signature} failed (${JSON.stringify(status)})`,
         );
       }
+      return signature;
     }
 
-    if (--sendRetries <= 0) {
-      const duration = (Date.now() - start) / 1000;
-      throw new Error(
-        `Transaction '${signature}' was not confirmed in ${duration.toFixed(
-          2,
-        )} seconds (${JSON.stringify(status)})`,
-      );
-    }
+    if (--sendRetries <= 0) break;
 
     // Retry in 0..100ms to try to avoid another AccountInUse collision
     await sleep(Math.random() * 100);
   }
 
-  invariant(signature !== undefined);
-  return signature;
+  const duration = (Date.now() - start) / 1000;
+  throw new Error(
+    `Transaction was not confirmed in ${duration.toFixed(
+      2,
+    )} seconds (${JSON.stringify(status)})`,
+  );
 }

--- a/test/bpf-loader.test.js
+++ b/test/bpf-loader.test.js
@@ -44,7 +44,7 @@ test('load BPF C program', async () => {
     keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
     programId,
   });
-  await sendAndConfirmTransaction(connection, transaction, from);
+  await sendAndConfirmTransaction(connection, transaction, [from], 1);
 });
 
 test('load BPF Rust program', async () => {
@@ -73,5 +73,5 @@ test('load BPF Rust program', async () => {
     keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
     programId,
   });
-  await sendAndConfirmTransaction(connection, transaction, from);
+  await sendAndConfirmTransaction(connection, transaction, [from], 1);
 });

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1031,12 +1031,15 @@ test('get confirmed block', async () => {
 
 test('get recent blockhash', async () => {
   const connection = new Connection(url);
+  for (const commitment of ['max', 'recent', 'root', 'single']) {
+    mockGetRecentBlockhash(commitment);
 
-  mockGetRecentBlockhash();
-
-  const {blockhash, feeCalculator} = await connection.getRecentBlockhash();
-  expect(blockhash.length).toBeGreaterThanOrEqual(43);
-  expect(feeCalculator.lamportsPerSignature).toBeGreaterThanOrEqual(0);
+    const {blockhash, feeCalculator} = await connection.getRecentBlockhash(
+      commitment,
+    );
+    expect(blockhash.length).toBeGreaterThanOrEqual(43);
+    expect(feeCalculator.lamportsPerSignature).toBeGreaterThanOrEqual(0);
+  }
 });
 
 test('get block time', async () => {

--- a/test/nonce.test.js
+++ b/test/nonce.test.js
@@ -103,7 +103,7 @@ test('create and query nonce account', async () => {
     authorizedPubkey: from.publicKey,
     lamports: minimumAmount,
   });
-  await connection.sendTransaction(transaction, from, nonceAccount);
+  await connection.sendTransaction(transaction, [from, nonceAccount]);
 
   mockRpc.push([
     url,
@@ -222,7 +222,7 @@ test('create and query nonce account with seed', async () => {
     authorizedPubkey: from.publicKey,
     lamports: minimumAmount,
   });
-  await connection.sendTransaction(transaction, from);
+  await connection.sendTransaction(transaction, [from]);
 
   mockRpc.push([
     url,

--- a/test/system-program.test.js
+++ b/test/system-program.test.js
@@ -8,7 +8,7 @@ import {
   SystemProgram,
   Transaction,
   TransactionInstruction,
-  sendAndConfirmRecentTransaction,
+  sendAndConfirmTransaction,
   LAMPORTS_PER_SOL,
 } from '../src';
 import {NONCE_ACCOUNT_LENGTH} from '../src/nonce-account';
@@ -293,11 +293,11 @@ test('live Nonce actions', async () => {
     authorizedPubkey: from.publicKey,
     lamports: minimumAmount,
   });
-  await sendAndConfirmRecentTransaction(
+  await sendAndConfirmTransaction(
     connection,
     createNonceAccount,
-    from,
-    nonceAccount,
+    [from, nonceAccount],
+    0,
   );
   const nonceBalance = await connection.getBalance(nonceAccount.publicKey);
   expect(nonceBalance).toEqual(minimumAmount);
@@ -325,7 +325,7 @@ test('live Nonce actions', async () => {
       authorizedPubkey: from.publicKey,
     }),
   );
-  await sendAndConfirmRecentTransaction(connection, advanceNonce, from);
+  await sendAndConfirmTransaction(connection, advanceNonce, [from], 0);
   const nonceQuery3 = await connection.getNonce(nonceAccount.publicKey);
   if (nonceQuery3 === null) {
     expect(nonceQuery3).not.toBeNull();
@@ -344,7 +344,7 @@ test('live Nonce actions', async () => {
       newAuthorizedPubkey: newAuthority.publicKey,
     }),
   );
-  await sendAndConfirmRecentTransaction(connection, authorizeNonce, from);
+  await sendAndConfirmTransaction(connection, authorizeNonce, [from], 0);
 
   let transfer = SystemProgram.transfer({
     fromPubkey: from.publicKey,
@@ -359,11 +359,11 @@ test('live Nonce actions', async () => {
     }),
   };
 
-  await sendAndConfirmRecentTransaction(
+  await sendAndConfirmTransaction(
     connection,
     transfer,
-    from,
-    newAuthority,
+    [from, newAuthority],
+    0,
   );
   const toBalance = await connection.getBalance(to.publicKey);
   expect(toBalance).toEqual(minimumAmount);
@@ -380,11 +380,7 @@ test('live Nonce actions', async () => {
       toPubkey: withdrawAccount.publicKey,
     }),
   );
-  await sendAndConfirmRecentTransaction(
-    connection,
-    withdrawNonce,
-    newAuthority,
-  );
+  await sendAndConfirmTransaction(connection, withdrawNonce, [newAuthority], 0);
   expect(await connection.getBalance(nonceAccount.publicKey)).toEqual(0);
   const withdrawBalance = await connection.getBalance(
     withdrawAccount.publicKey,


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/solana-web3.js/issues/792
Fixes: https://github.com/solana-labs/solana-web3.js/issues/793
Fixes: https://github.com/solana-labs/solana-web3.js/issues/892

#### Problem
RPC has new commitment levels and the behaviour of the `getSignatureStatuses` endpoint has shifted to represent cluster confirmations rather than the incorrect notion of node votes as "confirmations".

#### Changes
This felt like a good time to clean up our apis around transaction confirmation
* Removed `Connection.confirmTransactionAndContext` API
* Updated `Connection.confirmTransaction` to poll the `getSignatureStatuses` RPC API until a specified confirmation count has been reached or the transaction fails
* Added `confirmations` param to both `sendAndConfirmTransaction` and `sendAndConfirmRawTransaction` to allow waiting for a particular number of confirmations (or finalization in the default case)
* Removed the `sendAndConfirmRecentTransaction` API since it's ripe for misuse. Its behaviour can be achieved by passing `0` confirmations to `sendAndConfirmTransaction`. 
* Removed the `AccountInUse` error check from `sendAndConfirmTransaction` since that error never gets committed to the status cache
* In order to allow passing a `confirmations` param to `sendAndConfirmTransaction` I changed the `...signers` varargs-style param to a single array param and updated `Connection.sendTransaction` to have a consistent API.