### PR TITLE
fix: remove return value from load, unnecessary

### DIFF
--- a/src/bpf-loader.js
+++ b/src/bpf-loader.js
@@ -39,7 +39,7 @@ export class BpfLoader {
     payer: Account,
     program: Account,
     elf: Buffer | Uint8Array | Array<number>,
-  ): Promise<PublicKey> {
+  ): Promise<void> {
     return Loader.load(connection, payer, program, BpfLoader.programId, elf);
   }
 }

--- a/src/loader.js
+++ b/src/loader.js
@@ -53,7 +53,7 @@ export class Loader {
     program: Account,
     programId: PublicKey,
     data: Buffer | Uint8Array | Array<number>,
-  ): Promise<PublicKey> {
+  ): Promise<void> {
     {
       const balanceNeeded = await connection.getMinimumBalanceForRentExemption(
         data.length,
@@ -145,6 +145,5 @@ export class Loader {
       });
       await sendAndConfirmTransaction(connection, transaction, payer, program);
     }
-    return program.publicKey;
   }
 }

--- a/test/bpf-loader.test.js
+++ b/test/bpf-loader.test.js
@@ -39,10 +39,10 @@ test('load BPF C program', async () => {
   const from = await newAccountWithLamports(connection, fees + balanceNeeded);
 
   const program = new Account();
-  const programId = await BpfLoader.load(connection, from, program, data);
+  await BpfLoader.load(connection, from, program, data);
   const transaction = new Transaction().add({
     keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
-    programId,
+    programId: program.publicKey,
   });
   await sendAndConfirmTransaction(connection, transaction, from);
 });
@@ -68,10 +68,10 @@ test('load BPF Rust program', async () => {
   const from = await newAccountWithLamports(connection, fees + balanceNeeded);
 
   const program = new Account();
-  const programId = await BpfLoader.load(connection, from, program, data);
+  await BpfLoader.load(connection, from, program, data);
   const transaction = new Transaction().add({
     keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
-    programId,
+    programId: program.publicKey,
   });
   await sendAndConfirmTransaction(connection, transaction, from);
 });


### PR DESCRIPTION
The program loader and BPF loader was recently modified to take a program account in which to load the module but still return's that accounts public key.  The return value is unnecessary since callers can use the `publicKey` member of `Account` directly.  Returning the public key may also be confusing as it might lead callers to think that the returned key represents something different than the key of the program account passed in.