### PR TITLE
feat: add commitment param to subscription apis

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -254,11 +254,13 @@ declare module '@solana/web3.js' {
     onAccountChange(
       publickey: PublicKey,
       callback: AccountChangeCallback,
+      commitment?: Commitment,
     ): number;
     removeAccountChangeListener(id: number): Promise<void>;
     onProgramAccountChange(
       programId: PublicKey,
       callback: ProgramAccountChangeCallback,
+      commitment?: Commitment,
     ): number;
     removeProgramAccountChangeListener(id: number): Promise<void>;
     onSlotChange(callback: SlotChangeCallback): number;
@@ -266,6 +268,7 @@ declare module '@solana/web3.js' {
     onSignature(
       signature: TransactionSignature,
       callback: SignatureResultCallback,
+      commitment?: Commitment,
     ): number;
     removeSignatureListener(id: number): Promise<void>;
     onRootChange(callback: RootChangeCallback): number;

--- a/module.flow.js
+++ b/module.flow.js
@@ -267,11 +267,13 @@ declare module '@solana/web3.js' {
     onAccountChange(
       publickey: PublicKey,
       callback: AccountChangeCallback,
+      commitment: ?Commitment,
     ): number;
     removeAccountChangeListener(id: number): Promise<void>;
     onProgramAccountChange(
       programId: PublicKey,
       callback: ProgramAccountChangeCallback,
+      commitment: ?Commitment,
     ): number;
     removeProgramAccountChangeListener(id: number): Promise<void>;
     onSlotChange(callback: SlotChangeCallback): number;
@@ -279,6 +281,7 @@ declare module '@solana/web3.js' {
     onSignature(
       signature: TransactionSignature,
       callback: SignatureResultCallback,
+      commitment: ?Commitment,
     ): number;
     removeSignatureListener(id: number): Promise<void>;
     onRootChange(callback: RootChangeCallback): number;

--- a/src/connection.js
+++ b/src/connection.js
@@ -726,6 +726,7 @@ type SubscriptionId = 'subscribing' | number;
 type AccountSubscriptionInfo = {
   publicKey: string, // PublicKey of the account as a base 58 string
   callback: AccountChangeCallback,
+  commitment: ?Commitment,
   subscriptionId: ?SubscriptionId, // null when there's no current server subscription id
 };
 
@@ -743,6 +744,7 @@ export type ProgramAccountChangeCallback = (
 type ProgramAccountSubscriptionInfo = {
   programId: string, // PublicKey of the program as a base 58 string
   callback: ProgramAccountChangeCallback,
+  commitment: ?Commitment,
   subscriptionId: ?SubscriptionId, // null when there's no current server subscription id
 };
 
@@ -773,6 +775,7 @@ export type SignatureResultCallback = (
 type SignatureSubscriptionInfo = {
   signature: TransactionSignature, // TransactionSignature as a base 58 string
   callback: SignatureResultCallback,
+  commitment: ?Commitment,
   subscriptionId: ?SubscriptionId, // null when there's no current server subscription id
 };
 
@@ -1704,12 +1707,20 @@ export class Connection {
 
     for (let id of accountKeys) {
       const sub = this._accountChangeSubscriptions[id];
-      this._subscribe(sub, 'accountSubscribe', [sub.publicKey]);
+      this._subscribe(
+        sub,
+        'accountSubscribe',
+        this._argsWithCommitment([sub.publicKey], sub.commitment),
+      );
     }
 
     for (let id of programKeys) {
       const sub = this._programAccountChangeSubscriptions[id];
-      this._subscribe(sub, 'programSubscribe', [sub.programId]);
+      this._subscribe(
+        sub,
+        'programSubscribe',
+        this._argsWithCommitment([sub.programId], sub.commitment),
+      );
     }
 
     for (let id of slotKeys) {
@@ -1719,7 +1730,11 @@ export class Connection {
 
     for (let id of signatureKeys) {
       const sub = this._signatureSubscriptions[id];
-      this._subscribe(sub, 'signatureSubscribe', [sub.signature]);
+      this._subscribe(
+        sub,
+        'signatureSubscribe',
+        this._argsWithCommitment([sub.signature], sub.commitment),
+      );
     }
 
     for (let id of rootKeys) {
@@ -1761,18 +1776,21 @@ export class Connection {
   /**
    * Register a callback to be invoked whenever the specified account changes
    *
-   * @param publickey Public key of the account to monitor
+   * @param publicKey Public key of the account to monitor
    * @param callback Function to invoke whenever the account is changed
+   * @param commitment Specify the commitment level account changes must reach before notification
    * @return subscription id
    */
   onAccountChange(
     publicKey: PublicKey,
     callback: AccountChangeCallback,
+    commitment: ?Commitment,
   ): number {
     const id = ++this._accountChangeSubscriptionCounter;
     this._accountChangeSubscriptions[id] = {
       publicKey: publicKey.toBase58(),
       callback,
+      commitment,
       subscriptionId: null,
     };
     this._updateSubscriptions();
@@ -1838,16 +1856,19 @@ export class Connection {
    *
    * @param programId Public key of the program to monitor
    * @param callback Function to invoke whenever the account is changed
+   * @param commitment Specify the commitment level account changes must reach before notification
    * @return subscription id
    */
   onProgramAccountChange(
     programId: PublicKey,
     callback: ProgramAccountChangeCallback,
+    commitment: ?Commitment,
   ): number {
     const id = ++this._programAccountChangeSubscriptionCounter;
     this._programAccountChangeSubscriptions[id] = {
       programId: programId.toBase58(),
       callback,
+      commitment,
       subscriptionId: null,
     };
     this._updateSubscriptions();
@@ -1962,16 +1983,19 @@ export class Connection {
    *
    * @param signature Transaction signature string in base 58
    * @param callback Function to invoke on signature notifications
+   * @param commitment Specify the commitment level signature must reach before notification
    * @return subscription id
    */
   onSignature(
     signature: TransactionSignature,
     callback: SignatureResultCallback,
+    commitment: ?Commitment,
   ): number {
     const id = ++this._signatureSubscriptionCounter;
     this._signatureSubscriptions[id] = {
       signature,
       callback,
+      commitment,
       subscriptionId: null,
     };
     this._updateSubscriptions();

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1821,6 +1821,7 @@ test('account change notification', async () => {
   const subscriptionId = connection.onAccountChange(
     programAccount.publicKey,
     mockCallback,
+    'recent',
   );
 
   const balanceNeeded = Math.max(


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/solana-web3.js/issues/904

#### Problem
RPC API supports commitment param but the sdk doesn't provide a way to pass it