### PR TITLE
fix: use max confirmed blockhash for recent blockhash

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1696,7 +1696,7 @@ export class Connection {
         let attempts = 0;
         const startTime = Date.now();
         for (;;) {
-          const {blockhash} = await this.getRecentBlockhash();
+          const {blockhash} = await this.getRecentBlockhash('max');
 
           if (this._blockhashInfo.recentBlockhash != blockhash) {
             this._blockhashInfo = {


### PR DESCRIPTION
Now that RPC simulates transactions, it checks if transactions use a blockhash that has reached max confirmations. This ensures we use a blockhash that won't get rejected by the simulation check and helps avoid using a fork as a recent blockhash