### PR TITLE
Fix CI, add skipPreflight, update inflation api

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -271,6 +271,10 @@ declare module '@solana/web3.js' {
     getRecentBlockhashAndContext(
       commitment?: Commitment,
     ): Promise<RpcResponseAndContext<BlockhashAndFeeCalculator>>;
+    getFeeCalculatorForBlockhash(
+      blockhash: Blockhash,
+      commitment?: Commitment,
+    ): Promise<RpcResponseAndContext<FeeCalculator | null>>;
     getRecentBlockhash(
       commitment?: Commitment,
     ): Promise<BlockhashAndFeeCalculator>;

--- a/module.d.ts
+++ b/module.d.ts
@@ -41,12 +41,26 @@ declare module '@solana/web3.js' {
     slot: number;
   };
 
+  export type SendOptions = {
+    skipPreflight: boolean;
+  };
+
+  export type ConfirmOptions = {
+    confirmations: number;
+    skipPreflight: boolean;
+  };
+
   export type RpcResponseAndContext<T> = {
     context: Context;
     value: T;
   };
 
-  export type Commitment = 'max' | 'recent' | 'root' | 'single' | 'singleGossip';
+  export type Commitment =
+    | 'max'
+    | 'recent'
+    | 'root'
+    | 'single'
+    | 'singleGossip';
 
   export type LargestAccountsFilter = 'circulating' | 'nonCirculating';
 
@@ -269,12 +283,15 @@ declare module '@solana/web3.js' {
     sendTransaction(
       transaction: Transaction,
       signers: Array<Account>,
+      options?: SendOptions,
     ): Promise<TransactionSignature>;
     sendEncodedTransaction(
       encodedTransaction: string,
+      options?: SendOptions,
     ): Promise<TransactionSignature>;
     sendRawTransaction(
       wireTransaction: Buffer | Uint8Array | Array<number>,
+      options?: SendOptions,
     ): Promise<TransactionSignature>;
     onAccountChange(
       publickey: PublicKey,
@@ -794,14 +811,14 @@ declare module '@solana/web3.js' {
     connection: Connection,
     transaction: Transaction,
     signers: Array<Account>,
-    confirmations?: number,
+    options?: ConfirmOptions,
   ): Promise<TransactionSignature>;
 
   // === src/util/send-and-confirm-raw-transaction.js ===
   export function sendAndConfirmRawTransaction(
     connection: Connection,
     wireTransaction: Buffer,
-    confirmations?: number,
+    options?: ConfirmOptions,
   ): Promise<TransactionSignature>;
 
   // === src/util/cluster.js ===

--- a/module.d.ts
+++ b/module.d.ts
@@ -170,11 +170,10 @@ declare module '@solana/web3.js' {
     err: TransactionError | null;
   };
 
-  export type Inflation = {
+  export type InflationGovernor = {
     foundation: number;
     foundationTerm: number;
     initial: number;
-    storage: number;
     taper: number;
     terminal: number;
   };
@@ -266,7 +265,7 @@ declare module '@solana/web3.js' {
     getTransactionCount(commitment?: Commitment): Promise<number>;
     getTotalSupply(commitment?: Commitment): Promise<number>;
     getVersion(): Promise<Version>;
-    getInflation(commitment?: Commitment): Promise<Inflation>;
+    getInflationGovernor(commitment?: Commitment): Promise<InflationGovernor>;
     getEpochSchedule(): Promise<EpochSchedule>;
     getEpochInfo(commitment?: Commitment): Promise<EpochInfo>;
     getRecentBlockhashAndContext(

--- a/module.flow.js
+++ b/module.flow.js
@@ -54,12 +54,26 @@ declare module '@solana/web3.js' {
     slot: number,
   };
 
+  declare export type SendOptions = {
+    skipPreflight: boolean;
+  };
+
+  declare export type ConfirmOptions = {
+    confirmations: number;
+    skipPreflight: boolean;
+  };
+
   declare export type RpcResponseAndContext<T> = {
     context: Context,
     value: T,
   };
 
-  declare export type Commitment = 'max' | 'recent' | 'root' | 'single' | 'singleGossip';
+  declare export type Commitment =
+    | 'max'
+    | 'recent'
+    | 'root'
+    | 'single'
+    | 'singleGossip';
 
   declare export type LargestAccountsFilter = 'circulating' | 'nonCirculating';
 
@@ -282,12 +296,15 @@ declare module '@solana/web3.js' {
     sendTransaction(
       transaction: Transaction,
       signers: Array<Account>,
+      options?: SendOptions,
     ): Promise<TransactionSignature>;
     sendEncodedTransaction(
       encodedTransaction: string,
+      options?: SendOptions,
     ): Promise<TransactionSignature>;
     sendRawTransaction(
       wireTransaction: Buffer | Uint8Array | Array<number>,
+      options?: SendOptions,
     ): Promise<TransactionSignature>;
     onAccountChange(
       publickey: PublicKey,
@@ -809,14 +826,14 @@ declare module '@solana/web3.js' {
     connection: Connection,
     transaction: Transaction,
     signers: Array<Account>,
-    confirmations: ?number,
+    options: ?ConfirmOptions,
   ): Promise<TransactionSignature>;
 
   // === src/util/send-and-confirm-raw-transaction.js ===
   declare export function sendAndConfirmRawTransaction(
     connection: Connection,
     wireTransaction: Buffer,
-    confirmations: ?number,
+    options: ?ConfirmOptions,
   ): Promise<TransactionSignature>;
 
   // === src/util/cluster.js ===

--- a/module.flow.js
+++ b/module.flow.js
@@ -55,12 +55,12 @@ declare module '@solana/web3.js' {
   };
 
   declare export type SendOptions = {
-    skipPreflight: boolean;
+    skipPreflight: boolean,
   };
 
   declare export type ConfirmOptions = {
-    confirmations: number;
-    skipPreflight: boolean;
+    confirmations: number,
+    skipPreflight: boolean,
   };
 
   declare export type RpcResponseAndContext<T> = {
@@ -183,11 +183,10 @@ declare module '@solana/web3.js' {
     err: TransactionError | null,
   |};
 
-  declare export type Inflation = {
+  declare export type InflationGovernor = {
     foundation: number,
     foundationTerm: number,
     initial: number,
-    storage: number,
     taper: number,
     terminal: number,
   };
@@ -279,7 +278,7 @@ declare module '@solana/web3.js' {
     getTransactionCount(commitment: ?Commitment): Promise<number>;
     getTotalSupply(commitment: ?Commitment): Promise<number>;
     getVersion(): Promise<Version>;
-    getInflation(commitment: ?Commitment): Promise<Inflation>;
+    getInflationGovernor(commitment: ?Commitment): Promise<InflationGovernor>;
     getEpochSchedule(): Promise<EpochSchedule>;
     getEpochInfo(commitment: ?Commitment): Promise<EpochInfo>;
     getRecentBlockhashAndContext(

--- a/module.flow.js
+++ b/module.flow.js
@@ -284,6 +284,10 @@ declare module '@solana/web3.js' {
     getRecentBlockhashAndContext(
       commitment: ?Commitment,
     ): Promise<RpcResponseAndContext<BlockhashAndFeeCalculator>>;
+    getFeeCalculatorForBlockhash(
+      blockhash: Blockhash,
+      commitment: ?Commitment,
+    ): Promise<RpcResponseAndContext<FeeCalculator | null>>;
     getRecentBlockhash(
       commitment: ?Commitment,
     ): Promise<BlockhashAndFeeCalculator>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6288,24 +6288,24 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
-      "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.34.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^2.0.0"
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-scope": "^4.0.0"
       },
       "dependencies": {
-        "eslint-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
           "dev": true,
           "requires": {
-            "eslint-visitor-keys": "^1.1.0"
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         }
       }
@@ -6396,55 +6396,13 @@
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
-      "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.1",
-        "eslint-visitor-keys": "^1.1.0",
-        "glob": "^7.1.6",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
-        }
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
       }
     },
     "JSONStream": {
@@ -10633,12 +10591,12 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "23.13.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.13.2.tgz",
-      "integrity": "sha512-qZit+moTXTyZFNDqSIR88/L3rdBlTU7CuW6XmyErD2FfHEkdoLgThkRbiQjzgYnX6rfgLx3Ci4eJmF4Ui5v1Cw==",
+      "version": "22.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.19.0.tgz",
+      "integrity": "sha512-4zUc3rh36ds0SXdl2LywT4YWA3zRe8sfLhz8bPp8qQPIKvynTTkNGwmSCMpl5d9QiZE2JxSinGF+WD8yU+O0Lg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "^2.5.0"
+        "@typescript-eslint/experimental-utils": "^1.13.0"
       }
     },
     "eslint-plugin-prettier": {
@@ -15586,6 +15544,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
     "lodash.uniq": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11155,9 +11155,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.126.0.tgz",
-      "integrity": "sha512-91nCLt3B0drolW9bXmTssNxhshkkGDwokVyuquBA7TeHMCajbMNxm77JI0JydzHEv9xa6nMbBJXYyM6XW8Jzgg==",
+      "version": "0.125.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.125.1.tgz",
+      "integrity": "sha512-jEury9NTXylxQEOAXLWEE945BjBwYcMwwKVnb+5XORNwMQE7i5hQYF0ysYfsaaYOa7rW/U16rHBfwLuaZfWV7A==",
       "dev": true
     },
     "flow-typed": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-flowtype": "^4.6.0",
     "eslint-plugin-import": "2.20.2",
-    "eslint-plugin-jest": "23.13.2",
+    "eslint-plugin-jest": "22.19.0",
     "eslint-plugin-prettier": "^3.0.0",
     "flow-bin": "0.125.1",
     "flow-typed": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bpf-sdk:install": "npm run clean:fixtures; bin/bpf-sdk-install.sh .",
     "bpf-sdk:remove-symlinks": "find bpf-sdk -type l -print -exec cp {} {}.tmp \\; -exec mv {}.tmp {} \\;",
     "build": "cross-env NODE_ENV=production rollup -c",
-    "build:fixtures": "./test/fixtures/noop-c/build.sh; ./test/fixtures/noop-rust/build.sh",
+    "build:fixtures": "echo blah",
     "clean:fixtures": "examples/bpf-rust-noop/do.sh clean; make -C examples/bpf-c-noop clean ",
     "clean": "rimraf ./coverage ./lib",
     "codecov": "set -ex; npm run test:cover; cat ./coverage/lcov.info | codecov",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "eslint-plugin-import": "2.20.2",
     "eslint-plugin-jest": "23.13.2",
     "eslint-plugin-prettier": "^3.0.0",
-    "flow-bin": "0.126.0",
+    "flow-bin": "0.125.1",
     "flow-typed": "3.1.0",
     "fs-file-tree": "1.1.0",
     "jest": "26.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bpf-sdk:install": "npm run clean:fixtures; bin/bpf-sdk-install.sh .",
     "bpf-sdk:remove-symlinks": "find bpf-sdk -type l -print -exec cp {} {}.tmp \\; -exec mv {}.tmp {} \\;",
     "build": "cross-env NODE_ENV=production rollup -c",
-    "build:fixtures": "echo blah",
+    "build:fixtures": "./test/fixtures/noop-c/build.sh; ./test/fixtures/noop-rust/build.sh",
     "clean:fixtures": "examples/bpf-rust-noop/do.sh clean; make -C examples/bpf-c-noop clean ",
     "clean": "rimraf ./coverage ./lib",
     "codecov": "set -ex; npm run test:cover; cat ./coverage/lcov.info | codecov",

--- a/src/connection.js
+++ b/src/connection.js
@@ -212,28 +212,25 @@ type VoteAccountStatus = {
  * Network Inflation
  * (see https://docs.solana.com/implemented-proposals/ed_overview)
  *
- * @typedef {Object} Inflation
+ * @typedef {Object} InflationGovernor
  * @property {number} foundation
  * @property {number} foundation_term
  * @property {number} initial
- * @property {number} storage
  * @property {number} taper
  * @property {number} terminal
  */
-type Inflation = {
+type InflationGovernor = {
   foundation: number,
   foundationTerm: number,
   initial: number,
-  storage: number,
   taper: number,
   terminal: number,
 };
 
-const GetInflationResult = struct({
+const GetInflationGovernorResult = struct({
   foundation: 'number',
   foundationTerm: 'number',
   initial: 'number',
-  storage: 'number',
   taper: 'number',
   terminal: 'number',
 });
@@ -395,13 +392,13 @@ function createRpcRequest(url): RpcRequest {
 }
 
 /**
- * Expected JSON RPC response for the "getInflation" message
+ * Expected JSON RPC response for the "getInflationGovernor" message
  */
-const GetInflationRpcResult = struct({
+const GetInflationGovernorRpcResult = struct({
   jsonrpc: struct.literal('2.0'),
   id: 'string',
   error: 'any?',
-  result: GetInflationResult,
+  result: GetInflationGovernorResult,
 });
 
 /**
@@ -1425,17 +1422,19 @@ export class Connection {
   }
 
   /**
-   * Fetch the cluster Inflation parameters
+   * Fetch the cluster InflationGovernor parameters
    */
-  async getInflation(commitment: ?Commitment): Promise<Inflation> {
+  async getInflationGovernor(
+    commitment: ?Commitment,
+  ): Promise<InflationGovernor> {
     const args = this._argsWithCommitment([], commitment);
-    const unsafeRes = await this._rpcRequest('getInflation', args);
-    const res = GetInflationRpcResult(unsafeRes);
+    const unsafeRes = await this._rpcRequest('getInflationGovernor', args);
+    const res = GetInflationGovernorRpcResult(unsafeRes);
     if (res.error) {
       throw new Error('failed to get inflation: ' + res.error.message);
     }
     assert(typeof res.result !== 'undefined');
-    return GetInflationResult(res.result);
+    return GetInflationGovernorResult(res.result);
   }
 
   /**

--- a/src/loader.js
+++ b/src/loader.js
@@ -69,7 +69,10 @@ export class Loader {
         connection,
         transaction,
         [payer, program],
-        1,
+        {
+          confirmations: 1,
+          skipPreflight: true,
+        },
       );
     }
 
@@ -107,7 +110,10 @@ export class Loader {
         data,
       });
       transactions.push(
-        sendAndConfirmTransaction(connection, transaction, [payer, program], 1),
+        sendAndConfirmTransaction(connection, transaction, [payer, program], {
+          confirmations: 1,
+          skipPreflight: true,
+        }),
       );
 
       // Delay ~1 tick between write transactions in an attempt to reduce AccountInUse errors
@@ -152,7 +158,10 @@ export class Loader {
         connection,
         transaction,
         [payer, program],
-        1,
+        {
+          confirmations: 1,
+          skipPreflight: true,
+        },
       );
     }
   }

--- a/src/util/send-and-confirm-raw-transaction.js
+++ b/src/util/send-and-confirm-raw-transaction.js
@@ -2,6 +2,7 @@
 
 import {Connection} from '../connection';
 import type {TransactionSignature} from '../transaction';
+import type {ConfirmOptions} from '../connection';
 
 /**
  * Send and confirm a raw transaction
@@ -9,12 +10,19 @@ import type {TransactionSignature} from '../transaction';
 export async function sendAndConfirmRawTransaction(
   connection: Connection,
   rawTransaction: Buffer,
-  confirmations: ?number,
+  options?: ConfirmOptions,
 ): Promise<TransactionSignature> {
   const start = Date.now();
-  const signature = await connection.sendRawTransaction(rawTransaction);
-  const status = (await connection.confirmTransaction(signature, confirmations))
-    .value;
+  const signature = await connection.sendRawTransaction(
+    rawTransaction,
+    options,
+  );
+  const status = (
+    await connection.confirmTransaction(
+      signature,
+      options && options.confirmations,
+    )
+  ).value;
 
   if (status) {
     if (status.err) {

--- a/src/util/send-and-confirm-transaction.js
+++ b/src/util/send-and-confirm-transaction.js
@@ -4,6 +4,7 @@ import {Connection} from '../connection';
 import {Transaction} from '../transaction';
 import {sleep} from './sleep';
 import type {Account} from '../account';
+import type {ConfirmOptions} from '../connection';
 import type {TransactionSignature} from '../transaction';
 
 const NUM_SEND_RETRIES = 10;
@@ -17,15 +18,22 @@ export async function sendAndConfirmTransaction(
   connection: Connection,
   transaction: Transaction,
   signers: Array<Account>,
-  confirmations: ?number,
+  options?: ConfirmOptions,
 ): Promise<TransactionSignature> {
   const start = Date.now();
   let sendRetries = NUM_SEND_RETRIES;
 
   for (;;) {
-    const signature = await connection.sendTransaction(transaction, signers);
+    const signature = await connection.sendTransaction(
+      transaction,
+      signers,
+      options,
+    );
     const status = (
-      await connection.confirmTransaction(signature, confirmations)
+      await connection.confirmTransaction(
+        signature,
+        options && options.confirmations,
+      )
     ).value;
 
     if (status) {

--- a/test/bpf-loader.test.js
+++ b/test/bpf-loader.test.js
@@ -44,7 +44,10 @@ test('load BPF C program', async () => {
     keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
     programId: program.publicKey,
   });
-  await sendAndConfirmTransaction(connection, transaction, [from], 1);
+  await sendAndConfirmTransaction(connection, transaction, [from], {
+    confirmations: 1,
+    skipPreflight: true,
+  });
 });
 
 test('load BPF Rust program', async () => {
@@ -73,5 +76,8 @@ test('load BPF Rust program', async () => {
     keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
     programId: program.publicKey,
   });
-  await sendAndConfirmTransaction(connection, transaction, [from], 1);
+  await sendAndConfirmTransaction(connection, transaction, [from], {
+    confirmations: 1,
+    skipPreflight: true,
+  });
 });

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -324,7 +324,7 @@ test('get inflation', async () => {
   mockRpc.push([
     url,
     {
-      method: 'getInflation',
+      method: 'getInflationGovernor',
       params: [],
     },
     {
@@ -333,14 +333,13 @@ test('get inflation', async () => {
         foundation: 0.05,
         foundationTerm: 7.0,
         initial: 0.15,
-        storage: 0.1,
         taper: 0.15,
         terminal: 0.015,
       },
     },
   ]);
 
-  const inflation = await connection.getInflation();
+  const inflation = await connection.getInflationGovernor();
 
   for (const key of [
     'initial',
@@ -348,7 +347,6 @@ test('get inflation', async () => {
     'taper',
     'foundation',
     'foundationTerm',
-    'storage',
   ]) {
     expect(inflation).toHaveProperty(key);
     expect(inflation[key]).toBeGreaterThan(0);
@@ -1529,9 +1527,14 @@ test('transaction failure', async () => {
     newAccountPubkey: newAccount.publicKey,
     lamports: 1000,
     space: 0,
-    programId: SystemProgram.programId
+    programId: SystemProgram.programId,
   });
-  await sendAndConfirmTransaction(connection, transaction, [account, newAccount], {confirmations: 1, skipPreflight: true});
+  await sendAndConfirmTransaction(
+    connection,
+    transaction,
+    [account, newAccount],
+    {confirmations: 1, skipPreflight: true},
+  );
 
   mockRpc.push([
     url,
@@ -1551,9 +1554,13 @@ test('transaction failure', async () => {
     newAccountPubkey: newAccount.publicKey,
     lamports: 10,
     space: 0,
-    programId: SystemProgram.programId
+    programId: SystemProgram.programId,
   });
-  const signature = await connection.sendTransaction(transaction, [account, newAccount], {skipPreflight: true});
+  const signature = await connection.sendTransaction(
+    transaction,
+    [account, newAccount],
+    {skipPreflight: true},
+  );
 
   const expectedErr = {InstructionError: [0, {Custom: 0}]};
   mockRpc.push([
@@ -1738,9 +1745,11 @@ test('transaction', async () => {
     toPubkey: accountTo.publicKey,
     lamports: 10,
   });
-  const signature = await connection.sendTransaction(transaction, [
-    accountFrom,
-  ], {skipPreflight: true});
+  const signature = await connection.sendTransaction(
+    transaction,
+    [accountFrom],
+    {skipPreflight: true},
+  );
 
   mockRpc.push([
     url,
@@ -1942,10 +1951,11 @@ test('multi-instruction transaction', async () => {
       lamports: 100,
     }),
   );
-  const signature = await connection.sendTransaction(transaction, [
-    accountFrom,
-    accountTo,
-  ], {skipPreflight: true});
+  const signature = await connection.sendTransaction(
+    transaction,
+    [accountFrom, accountTo],
+    {skipPreflight: true},
+  );
 
   await connection.confirmTransaction(signature, 1);
 

--- a/test/nonce.test.js
+++ b/test/nonce.test.js
@@ -103,7 +103,9 @@ test('create and query nonce account', async () => {
     authorizedPubkey: from.publicKey,
     lamports: minimumAmount,
   });
-  await connection.sendTransaction(transaction, [from, nonceAccount], {skipPreflight: true});
+  await connection.sendTransaction(transaction, [from, nonceAccount], {
+    skipPreflight: true,
+  });
 
   mockRpc.push([
     url,

--- a/test/nonce.test.js
+++ b/test/nonce.test.js
@@ -84,7 +84,7 @@ test('create and query nonce account', async () => {
   const balance = await connection.getBalance(from.publicKey);
   expect(balance).toBe(minimumAmount * 2);
 
-  mockGetRecentBlockhash('recent');
+  mockGetRecentBlockhash('max');
   mockRpc.push([
     url,
     {
@@ -103,7 +103,7 @@ test('create and query nonce account', async () => {
     authorizedPubkey: from.publicKey,
     lamports: minimumAmount,
   });
-  await connection.sendTransaction(transaction, [from, nonceAccount]);
+  await connection.sendTransaction(transaction, [from, nonceAccount], {skipPreflight: true});
 
   mockRpc.push([
     url,
@@ -201,7 +201,7 @@ test('create and query nonce account with seed', async () => {
   const balance = await connection.getBalance(from.publicKey);
   expect(balance).toBe(minimumAmount * 2);
 
-  mockGetRecentBlockhash('recent');
+  mockGetRecentBlockhash('max');
   mockRpc.push([
     url,
     {
@@ -222,7 +222,7 @@ test('create and query nonce account with seed', async () => {
     authorizedPubkey: from.publicKey,
     lamports: minimumAmount,
   });
-  await connection.sendTransaction(transaction, [from]);
+  await connection.sendTransaction(transaction, [from], {skipPreflight: true});
 
   mockRpc.push([
     url,

--- a/test/stake-program.test.js
+++ b/test/stake-program.test.js
@@ -272,7 +272,7 @@ test('live staking actions', async () => {
       connection,
       createAndInitialize,
       [from, newStakeAccount],
-      0,
+      {confirmations: 0, skipPreflight: true},
     );
     expect(await connection.getBalance(newStakeAccount.publicKey)).toEqual(
       minimumAmount + 42,
@@ -283,7 +283,10 @@ test('live staking actions', async () => {
       authorizedPubkey: authorized.publicKey,
       votePubkey,
     });
-    await sendAndConfirmTransaction(connection, delegation, [authorized], 0);
+    await sendAndConfirmTransaction(connection, delegation, [authorized], {
+      confirmations: 0,
+      skipPreflight: true,
+    });
   }
 
   // Create Stake account with seed
@@ -308,7 +311,7 @@ test('live staking actions', async () => {
     connection,
     createAndInitializeWithSeed,
     [from],
-    0,
+    {confirmations: 0, skipPreflight: true},
   );
   let originalStakeBalance = await connection.getBalance(newAccountPubkey);
   expect(originalStakeBalance).toEqual(3 * minimumAmount + 42);
@@ -318,7 +321,10 @@ test('live staking actions', async () => {
     authorizedPubkey: authorized.publicKey,
     votePubkey,
   });
-  await sendAndConfirmTransaction(connection, delegation, [authorized], 0);
+  await sendAndConfirmTransaction(connection, delegation, [authorized], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
 
   // Test that withdraw fails before deactivation
   const recipient = new Account();
@@ -329,7 +335,10 @@ test('live staking actions', async () => {
     lamports: 1000,
   });
   await expect(
-    sendAndConfirmTransaction(connection, withdraw, [authorized], 0),
+    sendAndConfirmTransaction(connection, withdraw, [authorized], {
+      confirmations: 0,
+      skipPreflight: true,
+    }),
   ).rejects.toThrow();
 
   // Split stake
@@ -340,7 +349,10 @@ test('live staking actions', async () => {
     splitStakePubkey: newStake.publicKey,
     lamports: minimumAmount + 20,
   });
-  await sendAndConfirmTransaction(connection, split, [authorized, newStake], 0);
+  await sendAndConfirmTransaction(connection, split, [authorized, newStake], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
 
   // Authorize to new account
   const newAuthorized = new Account();
@@ -352,14 +364,20 @@ test('live staking actions', async () => {
     newAuthorizedPubkey: newAuthorized.publicKey,
     stakeAuthorizationType: StakeAuthorizationLayout.Withdrawer,
   });
-  await sendAndConfirmTransaction(connection, authorize, [authorized], 0);
+  await sendAndConfirmTransaction(connection, authorize, [authorized], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
   authorize = StakeProgram.authorize({
     stakePubkey: newAccountPubkey,
     authorizedPubkey: authorized.publicKey,
     newAuthorizedPubkey: newAuthorized.publicKey,
     stakeAuthorizationType: StakeAuthorizationLayout.Staker,
   });
-  await sendAndConfirmTransaction(connection, authorize, [authorized], 0);
+  await sendAndConfirmTransaction(connection, authorize, [authorized], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
 
   // Test old authorized can't deactivate
   let deactivateNotAuthorized = StakeProgram.deactivate({
@@ -371,7 +389,7 @@ test('live staking actions', async () => {
       connection,
       deactivateNotAuthorized,
       [authorized],
-      0,
+      {confirmations: 0, skipPreflight: true},
     ),
   ).rejects.toThrow();
 
@@ -380,7 +398,10 @@ test('live staking actions', async () => {
     stakePubkey: newAccountPubkey,
     authorizedPubkey: newAuthorized.publicKey,
   });
-  await sendAndConfirmTransaction(connection, deactivate, [newAuthorized], 0);
+  await sendAndConfirmTransaction(connection, deactivate, [newAuthorized], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
 
   // Test that withdraw succeeds after deactivation
   withdraw = StakeProgram.withdraw({
@@ -389,7 +410,10 @@ test('live staking actions', async () => {
     toPubkey: recipient.publicKey,
     lamports: minimumAmount + 20,
   });
-  await sendAndConfirmTransaction(connection, withdraw, [newAuthorized], 0);
+  await sendAndConfirmTransaction(connection, withdraw, [newAuthorized], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
   const balance = await connection.getBalance(newAccountPubkey);
   expect(balance).toEqual(minimumAmount + 2);
   const recipientBalance = await connection.getBalance(recipient.publicKey);

--- a/test/system-program.test.js
+++ b/test/system-program.test.js
@@ -297,7 +297,7 @@ test('live Nonce actions', async () => {
     connection,
     createNonceAccount,
     [from, nonceAccount],
-    0,
+    {confirmations: 0, skipPreflight: true},
   );
   const nonceBalance = await connection.getBalance(nonceAccount.publicKey);
   expect(nonceBalance).toEqual(minimumAmount);
@@ -325,7 +325,10 @@ test('live Nonce actions', async () => {
       authorizedPubkey: from.publicKey,
     }),
   );
-  await sendAndConfirmTransaction(connection, advanceNonce, [from], 0);
+  await sendAndConfirmTransaction(connection, advanceNonce, [from], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
   const nonceQuery3 = await connection.getNonce(nonceAccount.publicKey);
   if (nonceQuery3 === null) {
     expect(nonceQuery3).not.toBeNull();
@@ -344,7 +347,10 @@ test('live Nonce actions', async () => {
       newAuthorizedPubkey: newAuthority.publicKey,
     }),
   );
-  await sendAndConfirmTransaction(connection, authorizeNonce, [from], 0);
+  await sendAndConfirmTransaction(connection, authorizeNonce, [from], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
 
   let transfer = SystemProgram.transfer({
     fromPubkey: from.publicKey,
@@ -359,12 +365,10 @@ test('live Nonce actions', async () => {
     }),
   };
 
-  await sendAndConfirmTransaction(
-    connection,
-    transfer,
-    [from, newAuthority],
-    0,
-  );
+  await sendAndConfirmTransaction(connection, transfer, [from, newAuthority], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
   const toBalance = await connection.getBalance(to.publicKey);
   expect(toBalance).toEqual(minimumAmount);
 
@@ -380,7 +384,10 @@ test('live Nonce actions', async () => {
       toPubkey: withdrawAccount.publicKey,
     }),
   );
-  await sendAndConfirmTransaction(connection, withdrawNonce, [newAuthority], 0);
+  await sendAndConfirmTransaction(connection, withdrawNonce, [newAuthority], {
+    confirmations: 0,
+    skipPreflight: true,
+  });
   expect(await connection.getBalance(nonceAccount.publicKey)).toEqual(0);
   const withdrawBalance = await connection.getBalance(
     withdrawAccount.publicKey,

--- a/test/transaction-payer.test.js
+++ b/test/transaction-payer.test.js
@@ -86,7 +86,7 @@ test('transaction-payer', async () => {
   ]);
   await connection.requestAirdrop(accountTo.publicKey, minimumAmount + 21);
 
-  mockGetRecentBlockhash('recent');
+  mockGetRecentBlockhash('max');
   mockRpc.push([
     url,
     {
@@ -108,7 +108,7 @@ test('transaction-payer', async () => {
   const signature = await connection.sendTransaction(transaction, [
     accountPayer,
     accountFrom,
-  ]);
+  ], {skipPreflight: true});
 
   mockRpc.push([
     url,

--- a/test/transaction-payer.test.js
+++ b/test/transaction-payer.test.js
@@ -105,10 +105,11 @@ test('transaction-payer', async () => {
     lamports: 10,
   });
 
-  const signature = await connection.sendTransaction(transaction, [
-    accountPayer,
-    accountFrom,
-  ], {skipPreflight: true});
+  const signature = await connection.sendTransaction(
+    transaction,
+    [accountPayer, accountFrom],
+    {skipPreflight: true},
+  );
 
   mockRpc.push([
     url,


### PR DESCRIPTION
#### Changes
- Reverted 2 rogue dependabot commits that didn't pass CI but merged anyways
- Added `skipPreflight` option to transaction sending APIs
- Updated `getInflation` to `getInflationGovernor`
- Use max commitment blockhashes when sending transactions
- Added `getFeeCalculatorForBlockhash` method (needed for a test)