### PR TITLE
feat: remove commitment param from requestAirdrop method

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -281,7 +281,6 @@ declare module '@solana/web3.js' {
     requestAirdrop(
       to: PublicKey,
       amount: number,
-      commitment?: Commitment,
     ): Promise<TransactionSignature>;
     sendTransaction(
       transaction: Transaction,

--- a/module.flow.js
+++ b/module.flow.js
@@ -294,7 +294,6 @@ declare module '@solana/web3.js' {
     requestAirdrop(
       to: PublicKey,
       amount: number,
-      commitment: ?Commitment,
     ): Promise<TransactionSignature>;
     sendTransaction(
       transaction: Transaction,

--- a/src/connection.js
+++ b/src/connection.js
@@ -1703,10 +1703,11 @@ export class Connection {
   async requestAirdrop(
     to: PublicKey,
     amount: number,
-    commitment: ?Commitment,
   ): Promise<TransactionSignature> {
-    const args = this._argsWithCommitment([to.toBase58(), amount], commitment);
-    const unsafeRes = await this._rpcRequest('requestAirdrop', args);
+    const unsafeRes = await this._rpcRequest('requestAirdrop', [
+      to.toBase58(),
+      amount,
+    ]);
     const res = RequestAirdropRpcResult(unsafeRes);
     if (res.error) {
       throw new Error(

--- a/test/nonce.test.js
+++ b/test/nonce.test.js
@@ -49,11 +49,7 @@ test('create and query nonce account', async () => {
     url,
     {
       method: 'requestAirdrop',
-      params: [
-        from.publicKey.toBase58(),
-        minimumAmount * 2,
-        {commitment: 'recent'},
-      ],
+      params: [from.publicKey.toBase58(), minimumAmount * 2],
     },
     {
       error: null,
@@ -168,11 +164,7 @@ test('create and query nonce account with seed', async () => {
     url,
     {
       method: 'requestAirdrop',
-      params: [
-        from.publicKey.toBase58(),
-        minimumAmount * 2,
-        {commitment: 'recent'},
-      ],
+      params: [from.publicKey.toBase58(), minimumAmount * 2],
     },
     {
       error: null,

--- a/test/transaction-payer.test.js
+++ b/test/transaction-payer.test.js
@@ -36,11 +36,7 @@ test('transaction-payer', async () => {
     url,
     {
       method: 'requestAirdrop',
-      params: [
-        accountPayer.publicKey.toBase58(),
-        LAMPORTS_PER_SOL,
-        {commitment: 'recent'},
-      ],
+      params: [accountPayer.publicKey.toBase58(), LAMPORTS_PER_SOL],
     },
     {
       error: null,
@@ -54,11 +50,7 @@ test('transaction-payer', async () => {
     url,
     {
       method: 'requestAirdrop',
-      params: [
-        accountFrom.publicKey.toBase58(),
-        minimumAmount + 12,
-        {commitment: 'recent'},
-      ],
+      params: [accountFrom.publicKey.toBase58(), minimumAmount + 12],
     },
     {
       error: null,
@@ -72,11 +64,7 @@ test('transaction-payer', async () => {
     url,
     {
       method: 'requestAirdrop',
-      params: [
-        accountTo.publicKey.toBase58(),
-        minimumAmount + 21,
-        {commitment: 'recent'},
-      ],
+      params: [accountTo.publicKey.toBase58(), minimumAmount + 21],
     },
     {
       error: null,


### PR DESCRIPTION
#### Problem
The `requestAirdrop` method on the RPC API service used to wait until a status was available at the specified `commitment` level before returning a response. But after https://github.com/solana-labs/solana/pull/10446, it only uses the `commitment` param to determine which blockhash to use for the airdrop transaction.

There's no reason I can think of that a developer would want to use a more recent blockhash so I think it's best to remove this parameter from the `Connection.requestAirdrop` API to avoid confusion and encourage best practices.

#### Changes
- Remove `commitment` param from `requestAirdop`
- Fix failing CI