### PR TITLE
feat: make Transaction.populate method public and tweak MessageArgs

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -423,7 +423,7 @@ declare module '@solana/web3.js' {
 
   export type MessageArgs = {
     header: MessageHeader;
-    accountKeys: PublicKey[];
+    accountKeys: string[];
     recentBlockhash: Blockhash;
     instructions: CompiledInstruction[];
   };
@@ -487,6 +487,7 @@ declare module '@solana/web3.js' {
 
     constructor(opts?: TransactionCtorFields);
     static from(buffer: Buffer | Uint8Array | Array<number>): Transaction;
+    static populate(message: Message, signatures: Array<string>): Transaction;
     add(
       ...items: Array<
         Transaction | TransactionInstruction | TransactionInstructionCtorFields

--- a/module.flow.js
+++ b/module.flow.js
@@ -433,7 +433,7 @@ declare module '@solana/web3.js' {
 
   declare export type MessageArgs = {
     header: MessageHeader,
-    accountKeys: PublicKey[],
+    accountKeys: string[],
     recentBlockhash: Blockhash,
     instructions: CompiledInstruction[],
   };
@@ -499,6 +499,7 @@ declare module '@solana/web3.js' {
 
     constructor(opts?: TransactionCtorFields): Transaction;
     static from(buffer: Buffer | Uint8Array | Array<number>): Transaction;
+    static populate(message: Message, signatures: Array<string>): Transaction;
     add(
       ...items: Array<
         Transaction | TransactionInstruction | TransactionInstructionCtorFields,

--- a/src/connection.js
+++ b/src/connection.js
@@ -12,6 +12,7 @@ import {NonceAccount} from './nonce-account';
 import {PublicKey} from './publickey';
 import {DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND} from './timing';
 import {Transaction} from './transaction';
+import {Message} from './message';
 import {sleep} from './util/sleep';
 import {toBuffer} from './util/to-buffer';
 import type {Blockhash} from './blockhash';
@@ -1578,27 +1579,26 @@ export class Connection {
    */
   async getConfirmedBlock(slot: number): Promise<ConfirmedBlock> {
     const unsafeRes = await this._rpcRequest('getConfirmedBlock', [slot]);
-    const result = GetConfirmedBlockRpcResult(unsafeRes);
-    if (result.error) {
+    const {result, error} = GetConfirmedBlockRpcResult(unsafeRes);
+    if (error) {
       throw new Error('failed to get confirmed block: ' + result.error.message);
     }
-    assert(typeof result.result !== 'undefined');
-    if (!result.result) {
+    assert(typeof result !== 'undefined');
+    if (!result) {
       throw new Error('Confirmed block ' + slot + ' not found');
     }
     return {
-      blockhash: new PublicKey(result.result.blockhash).toString(),
-      previousBlockhash: new PublicKey(
-        result.result.previousBlockhash,
-      ).toString(),
-      parentSlot: result.result.parentSlot,
-      transactions: result.result.transactions.map(result => {
+      blockhash: new PublicKey(result.blockhash).toString(),
+      previousBlockhash: new PublicKey(result.previousBlockhash).toString(),
+      parentSlot: result.parentSlot,
+      transactions: result.transactions.map(result => {
+        const {message, signatures} = result.transaction;
         return {
-          transaction: Transaction.fromRpcResult(result.transaction),
+          transaction: Transaction.populate(new Message(message), signatures),
           meta: result.meta,
         };
       }),
-      rewards: result.result.rewards || [],
+      rewards: result.rewards || [],
     };
   }
 
@@ -1620,9 +1620,10 @@ export class Connection {
       return result;
     }
 
+    const {message, signatures} = result.transaction;
     return {
       slot: result.slot,
-      transaction: Transaction.fromRpcResult(result.transaction),
+      transaction: Transaction.populate(new Message(message), signatures),
       meta: result.meta,
     };
   }

--- a/src/message.js
+++ b/src/message.js
@@ -42,13 +42,13 @@ export type CompiledInstruction = {
  *
  * @typedef {Object} MessageArgs
  * @property {MessageHeader} header The message header, identifying signed and read-only `accountKeys`
- * @property {PublicKey[]} accounts All the account keys used by this transaction
+ * @property {string[]} accounts All the account keys used by this transaction
  * @property {Blockhash} recentBlockhash The hash of a recent ledger block
  * @property {CompiledInstruction[]} instructions Instructions that will be executed in sequence and committed in one atomic transaction if all succeed.
  */
 type MessageArgs = {
   header: MessageHeader,
-  accountKeys: PublicKey[],
+  accountKeys: string[],
   recentBlockhash: Blockhash,
   instructions: CompiledInstruction[],
 };
@@ -64,7 +64,7 @@ export class Message {
 
   constructor(args: MessageArgs) {
     this.header = args.header;
-    this.accountKeys = args.accountKeys;
+    this.accountKeys = args.accountKeys.map(account => new PublicKey(account));
     this.recentBlockhash = args.recentBlockhash;
     this.instructions = args.instructions;
   }

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -7,6 +7,7 @@ import {PublicKey} from '../src/publickey';
 import {Transaction} from '../src/transaction';
 import {StakeProgram} from '../src/stake-program';
 import {SystemProgram} from '../src/system-program';
+import {Message} from '../src/message';
 
 test('signPartial', () => {
   const account1 = new Account();
@@ -159,38 +160,37 @@ test('parse wire format and serialize', () => {
   expect(wireTransaction).toEqual(expectedTransaction.serialize());
 });
 
-test('transaction from rpc result', () => {
+test('populate transaction', () => {
   const recentBlockhash = new PublicKey(1).toString();
-  const rpcResult = {
-    message: {
-      accountKeys: [
-        new PublicKey(1).toString(),
-        new PublicKey(2).toString(),
-        new PublicKey(3).toString(),
-        new PublicKey(4).toString(),
-        new PublicKey(5).toString(),
-      ],
-      header: {
-        num_ReadonlySignedAccounts: 0,
-        numReadonlyUnsignedAccounts: 3,
-        numRequiredSignatures: 2,
-      },
-      instructions: [
-        {
-          accounts: [1, 2, 3],
-          data: bs58.encode(Buffer.alloc(5).fill(9)),
-          programIdIndex: 4,
-        },
-      ],
-      recentBlockhash,
-    },
-    signatures: [
-      bs58.encode(Buffer.alloc(64).fill(1)),
-      bs58.encode(Buffer.alloc(64).fill(2)),
+  const message = {
+    accountKeys: [
+      new PublicKey(1).toString(),
+      new PublicKey(2).toString(),
+      new PublicKey(3).toString(),
+      new PublicKey(4).toString(),
+      new PublicKey(5).toString(),
     ],
+    header: {
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 3,
+      numRequiredSignatures: 2,
+    },
+    instructions: [
+      {
+        accounts: [1, 2, 3],
+        data: bs58.encode(Buffer.alloc(5).fill(9)),
+        programIdIndex: 4,
+      },
+    ],
+    recentBlockhash,
   };
 
-  const transaction = Transaction.fromRpcResult(rpcResult);
+  const signatures = [
+    bs58.encode(Buffer.alloc(64).fill(1)),
+    bs58.encode(Buffer.alloc(64).fill(2)),
+  ];
+
+  const transaction = Transaction.populate(new Message(message), signatures);
   expect(transaction.instructions.length).toEqual(1);
   expect(transaction.signatures.length).toEqual(2);
   expect(transaction.recentBlockhash).toEqual(recentBlockhash);


### PR DESCRIPTION
#### Problem
No method in transaction type definitions for constructing a transaction from an RPC response. 

#### Changes
- Tweaked `MessageArgs` type (used to construct `Message`) in order to remove `fromRpcResult` method
- Removed `Transaction.fromRpcResult`
- Made `Transaction.populate` method public