### PR TITLE
Broken Web3 Examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ console.log(solanaWeb3);
 
 Example scripts for the web3.js repo and native programs:
 
-- [Web3 Examples](./examples)
+- [Web3 Examples](https://github.com/solana-labs/solana-program-library/tree/master/examples)
 
 Example scripts for the Solana Program Library:
 


### PR DESCRIPTION
The Web3 Examples link was broken in the published documentation under https://solana-labs.github.io/solana-web3.js/

![image](https://user-images.githubusercontent.com/2914096/138934510-80274f78-7782-4918-9ca0-c823e3a7e290.png)

Using an absoute URL, like in the case of the "Token Program Examples" should fix the issue.

# This repo is a mirror of https://github.com/solana-labs/solana/tree/master/web3.js

Please make changes directly to the main Solana repo: https://github.com/solana-labs/solana
