### PR TITLE
Absolute path for web3 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ console.log(solanaWeb3);
 
 Example scripts for the web3.js repo and native programs:
 
-- [Web3 Examples](./examples)
+- [Web3 Examples](https://github.com/solana-labs/solana-web3.js/tree/master/examples)
 
 Example scripts for the Solana Program Library:
 


### PR DESCRIPTION
The relative path causes a broken link on the github pages for https://solana-labs.github.io/solana-web3.js/. 

It currently points to https://solana-labs.github.io/solana-web3.js/examples, which DNE.

# This repo is a mirror of https://github.com/solana-labs/solana/tree/master/web3.js

Please make changes directly to the main Solana repo: https://github.com/solana-labs/solana
