### PR TITLE
Refine stacktrace attribution of errors thrown from middleware

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -760,7 +760,9 @@ function createRpcClient(
     agentManager = new AgentManager(useHttps);
   }
 
-  let fetchWithMiddleware: (url: string, options: any) => Promise<Response>;
+  let fetchWithMiddleware:
+    | ((url: string, options: any) => Promise<Response>)
+    | undefined;
 
   if (fetchMiddleware) {
     fetchWithMiddleware = (url: string, options: any) => {
@@ -1972,7 +1974,7 @@ export type HttpHeaders = {[header: string]: string};
 export type FetchMiddleware = (
   url: string,
   options: any,
-  fetch: Function,
+  fetch: (modifiedUrl: string, modifiedOptions: any) => void,
 ) => void;
 
 /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -765,16 +765,19 @@ function createRpcClient(
     | undefined;
 
   if (fetchMiddleware) {
-    fetchWithMiddleware = (url: string, options: any) => {
-      return new Promise<Response>((resolve, reject) => {
-        fetchMiddleware(url, options, async (url: string, options: any) => {
+    fetchWithMiddleware = async (url: string, options: any) => {
+      const modifiedFetchArgs = await new Promise<[string, any]>(
+        (resolve, reject) => {
           try {
-            resolve(await fetch(url, options));
+            fetchMiddleware(url, options, (modifiedUrl, modifiedOptions) =>
+              resolve([modifiedUrl, modifiedOptions]),
+            );
           } catch (error) {
             reject(error);
           }
-        });
-      });
+        },
+      );
+      return await fetch(...modifiedFetchArgs);
     };
   }
 


### PR DESCRIPTION
This is a minor tweak to the way that middleware is applied. It will make it possible to tell the difference between an error that was thrown because `fetch()` experienced a fatal error, or because the middleware _itself_ fataled.

Previously, an error that originated from `fetch()` itself – and not from the middleware – would have a stacktrace that looks like this.

```
TypeError: Cannot use 'in' operator to search for 'signal' in Oh noes.
at new Request (node_modules/cross-fetch/node_modules/node-fetch/lib/index.js:1219:16)
at /Users/sluscher/Documents/Programming/solana-web3.js/node_modules/cross-fetch/node_modules/node-fetch/lib/index.js:1409:19
at new Promise (<anonymous>)
at fetch (node_modules/cross-fetch/node_modules/node-fetch/lib/index.js:1407:9)
at fetch (node_modules/cross-fetch/dist/node-ponyfill.js:10:20)
at /Users/sluscher/Documents/Programming/solana-web3.js/src/connection.ts:770:27
at fetchMiddleware (test/connection.test.ts:151:9)   <-- notice how the middleware is implicated here
at /Users/sluscher/Documents/Programming/solana-web3.js/src/connection.ts:768:9
at new Promise (<anonymous>)
at fetchWithMiddleware (src/connection.ts:767:14)
```

After this change, the same fatal would produce this stacktrace.

```
TypeError: Cannot use 'in' operator to search for 'signal' in Oh noes.
at new Request (node_modules/cross-fetch/node_modules/node-fetch/lib/index.js:1219:16)
at /Users/sluscher/Documents/Programming/solana-web3.js/node_modules/cross-fetch/node_modules/node-fetch/lib/index.js:1409:19
at new Promise (<anonymous>)
at fetch (node_modules/cross-fetch/node_modules/node-fetch/lib/index.js:1407:9)
at fetch (node_modules/cross-fetch/dist/node-ponyfill.js:10:20)
at fetchWithMiddleware (src/connection.ts:780:20)
```

Hopefully, this will save someone time in the future. Instead of going on a wild goose chase through various middleware, they'll head straight to the line where `fetch()` is called to see what went wrong.