### PR TITLE
Update to borsh@0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ethersproject/sha2": "^5.5.0",
         "@solana/buffer-layout": "^3.0.0",
         "bn.js": "^5.0.0",
-        "borsh": "^0.4.0",
+        "borsh": "^0.7.0",
         "bs58": "^4.0.1",
         "buffer": "6.0.1",
         "cross-fetch": "^3.1.4",
@@ -3926,6 +3926,27 @@
         "tweetnacl": "^1.0.0"
       }
     },
+    "node_modules/@solana/web3.js/node_modules/@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/borsh": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
+      "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+      "dev": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "bn.js": "^5.0.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -5007,22 +5028,13 @@
       }
     },
     "node_modules/borsh": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
-      "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
       "dependencies": {
-        "@types/bn.js": "^4.11.5",
-        "bn.js": "^5.0.0",
+        "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
         "text-encoding-utf-8": "^1.0.2"
-      }
-    },
-    "node_modules/borsh/node_modules/@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/bottleneck": {
@@ -13811,11 +13823,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20790,6 +20797,29 @@
         "secp256k1": "^4.0.2",
         "superstruct": "^0.14.2",
         "tweetnacl": "^1.0.0"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "borsh": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
+          "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "bn.js": "^5.0.0",
+            "bs58": "^4.0.0",
+            "text-encoding-utf-8": "^1.0.2"
+          }
+        }
       }
     },
     "@tootallnate/once": {
@@ -21650,24 +21680,13 @@
       }
     },
     "borsh": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
-      "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
       "requires": {
-        "@types/bn.js": "^4.11.5",
-        "bn.js": "^5.0.0",
+        "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
         "text-encoding-utf-8": "^1.0.2"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-          "requires": {
-            "@types/node": "*"
-          }
-        }
       }
     },
     "bottleneck": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@ethersproject/sha2": "^5.5.0",
     "@solana/buffer-layout": "^3.0.0",
     "bn.js": "^5.0.0",
-    "borsh": "^0.4.0",
+    "borsh": "^0.7.0",
     "bs58": "^4.0.1",
     "buffer": "6.0.1",
     "cross-fetch": "^3.1.4",


### PR DESCRIPTION
Borsh < 0.7.0 uses 'global' which breaks if you integrate @solana/web3.js into a browser without the CommonJS rollup. Currently @solana/web3.js uses v0.4.0. This was fixed in v0.7.0 of 'borsh' and `npm run ok` passes.

https://github.com/near/borsh-js/commit/1eed6aebc0d951dc41a95696f277afc7b42cc4d4

https://github.com/near/borsh-js/pull/45/files

