### PR TITLE
Allow for custom recentBlockhash to be supplied

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3879,6 +3879,22 @@ export class Connection {
   ): Promise<TransactionSignature> {
     if (transaction.nonceInfo) {
       transaction.sign(...signers);
+    } else if (transaction.recentBlockhash) {
+      let disableCache = this._disableBlockhashCaching;
+      for (;;) {
+        transaction.sign(...signers);
+        if (!transaction.signature) {
+          throw new Error('!signature'); // should never happen
+        }
+
+        const signature = transaction.signature.toString('base64');
+        if (!this._blockhashInfo.transactionSignatures.includes(signature)) {
+          this._blockhashInfo.transactionSignatures.push(signature);
+          break;
+        } else {
+          disableCache = true;
+        }
+      }
     } else {
       let disableCache = this._disableBlockhashCaching;
       for (;;) {


### PR DESCRIPTION
This enables us to supply a custom recentBlockhash. The use-case is for a transaction to be able to be re-broadcasted with the same blockhash when it is dropped from the mempool.

One question along this PR: Why do we use for(;;) = while(true) in this piece of code? In the end this only checks for one signature doesn't it?