### PR TITLE
implement getMultipleTransactions for connection

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3305,6 +3305,34 @@ export class Connection {
   }
 
   /**
+   * Fetch transaction details for a batch of confirmed transactions.
+   * Similar to {@link getParsedTransactions} but they aren't parsed.
+   */
+  async getMultipleTransactions(
+    signatures: TransactionSignature[],
+    commitment?: Finality,
+  ): Promise<(ParsedConfirmedTransaction | null)[]> {
+    const batch = signatures.map(signature => {
+      const args = this._buildArgsAtLeastConfirmed([signature], commitment);
+      return {
+        methodName: 'getTransaction',
+        args,
+      };
+    });
+
+    const unsafeRes = await this._rpcBatchRequest(batch);
+    const res = unsafeRes.map((unsafeRes: any) => {
+      const res = create(unsafeRes, GetTransactionRpcResult);
+      if ('error' in res) {
+        throw new Error('failed to get transactions: ' + res.error.message);
+      }
+      return res.result;
+    });
+
+    return res;
+  }
+
+  /**
    * Fetch a list of Transactions and transaction statuses from the cluster
    * for a confirmed block.
    *

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3311,7 +3311,7 @@ export class Connection {
   async getMultipleTransactions(
     signatures: TransactionSignature[],
     commitment?: Finality,
-  ): Promise<(ParsedConfirmedTransaction | null)[]> {
+  ): Promise<(TransactionResponse | null)[]> {
     const batch = signatures.map(signature => {
       const args = this._buildArgsAtLeastConfirmed([signature], commitment);
       return {


### PR DESCRIPTION
currently `getParsedConfirmedTransactions` is the only fcn which lets you retrieve multiple txs in a single call, however the `ParsedTransactionWithMeta` structure is different from a `TransactionResponse` structure

this pull implements `getMultipleTransactions` which returns multiple `TransactionResponse`s in a single RPC call 