### PR TITLE
Update connection.ts

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -666,6 +666,11 @@ export type CompiledInnerInstruction = {
   instructions: CompiledInstruction[];
 };
 
+
+export type Status = {
+  Ok: string
+}
+
 /**
  * Metadata for a confirmed transaction on the ledger
  */
@@ -686,6 +691,8 @@ export type ConfirmedTransactionMeta = {
   postTokenBalances?: Array<TokenBalance> | null;
   /** The error result of transaction processing */
   err: TransactionError | null;
+  /** The status result of transaction
+  status: Status | null;
 };
 
 /**


### PR DESCRIPTION
connection.getTransaction() returns TransactionResponse which has properties such as slot, meta, blocktime, transaction. The meta property in turn returns ConfirmedTransactionMeta but the property status is missing from the type definition of ConfirmedTransactionMeta.

![image](https://user-images.githubusercontent.com/63198200/166673881-8195e958-fc3b-4305-a3e3-8b3ee5caa446.png)



# This repo is a mirror of https://github.com/solana-labs/solana/tree/master/web3.js

Please make changes directly to the main Solana repo: https://github.com/solana-labs/solana


