### PR TITLE
Safeguard for executing withdraws that will clean out a vote account

### DIFF
--- a/test/vote-program.test.ts
+++ b/test/vote-program.test.ts
@@ -165,9 +165,25 @@ describe('VoteProgram', () => {
         minimumAmount + 10 * LAMPORTS_PER_SOL,
       );
 
-      // Withdraw from Vote account
+      // Withdraw from Vote account with invalid amount (clear all funds)
       let recipient = Keypair.generate();
       let withdraw = VoteProgram.withdraw({
+        votePubkey: newVoteAccount.publicKey,
+        authorizedWithdrawerPubkey: authorized.publicKey,
+        lamports: minimumAmount + 10 * LAMPORTS_PER_SOL,
+        toPubkey: recipient.publicKey,
+      });
+      await expect(
+        sendAndConfirmTransaction(connection, withdraw, [authorized], {
+          preflightCommitment: 'confirmed',
+        }),
+      ).to.be.rejectedWith(
+        Error,
+        `Withdraw transaction failed, vote account balance after withdrawal will be smaller than minimum balance required for rent.`,
+      );
+
+      // Withdraw from Vote account
+      withdraw = VoteProgram.withdraw({
         votePubkey: newVoteAccount.publicKey,
         authorizedWithdrawerPubkey: authorized.publicKey,
         lamports: LAMPORTS_PER_SOL,


### PR DESCRIPTION
In our time working with the solana validator we've run into an issue where we try to withdraw rewards, but the withdraw results in a balance which is lower than the  minimum requirement for rent.  Thus causing our vote account to be closed.

I've added a check for VoteProgram 'withdraw' transaction instructions in the `sendAndConfirmTransaction` function which will throw an exception in this case.
