### PR TITLE
Remove Support for Deprecated Commitment Levels

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -438,11 +438,6 @@ export type Commitment =
   | 'processed'
   | 'confirmed'
   | 'finalized'
-  | 'recent' // Deprecated as of v1.5.5
-  | 'single' // Deprecated as of v1.5.5
-  | 'singleGossip' // Deprecated as of v1.5.5
-  | 'root' // Deprecated as of v1.5.5
-  | 'max'; // Deprecated as of v1.5.5
 
 /**
  * A subset of Commitment levels, which are at least optimistically confirmed


### PR DESCRIPTION
Hi! Ajay from Alchemy here - wanted to flag that proposed removal of these commitment is essential as they have been deprecated over [1.5 years ago](https://github.com/solana-labs/solana-web3.js/releases?page=12). This affects us as a Solana RPC Provider as we to unnecessarily support these deprecated commitment levels. We want to help steer the ecosystem towards the newer commitment levels, and this is part of that goal. Let us know how else we can help!

`feat`