### PR TITLE
add getRecentPrioritizationFee API

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2126,6 +2126,18 @@ const SignatureStatusResponse = pick({
 });
 
 /**
+ * Expected JSON RPC response for the "getRecentPrioritizationFees" message
+ */
+const GetRecentPrioritizationFees = jsonRpcResult(
+  array(
+    pick({
+      slot: number(),
+      prioritizationFee: number(),
+    }),
+  ),
+);
+
+/**
  * Expected JSON RPC response for the "getSignatureStatuses" message
  */
 const GetSignatureStatusesRpcResult = jsonRpcResultAndContext(
@@ -2882,6 +2894,16 @@ export type TransactionConfirmationStatus =
   | 'processed'
   | 'confirmed'
   | 'finalized';
+
+/**
+ * PrioritizationFee
+ */
+export type PrioritizationFee = {
+  /** when the transaction was processed */
+  slot: number;
+  /**  minimum prioritization fees from recent blocks */
+  prioritizationFee: number;
+};
 
 /**
  * Signature status
@@ -4086,6 +4108,27 @@ export class Connection {
       abortConfirmation();
     }
     return result;
+  }
+
+  /**
+   * Fetch the recent prioritization fees
+   */
+  async getRecentPrioritizationFees(
+    pubkeys?: Array<String>,
+  ): Promise<Array<PrioritizationFee>> {
+    const params: any[] = pubkeys ? [pubkeys] : [];
+    const unsafeRes = await this._rpcRequest(
+      'getRecentPrioritizationFees',
+      params,
+    );
+    const res = create(unsafeRes, GetRecentPrioritizationFees);
+    if ('error' in res) {
+      throw new SolanaJSONRPCError(
+        res.error,
+        'failed to get recent prioritization fees',
+      );
+    }
+    return res.result;
   }
 
   /**

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -987,6 +987,27 @@ describe('Connection', function () {
     expect(slotLeaders[0]).to.be.instanceOf(PublicKey);
   });
 
+  it('get recent prioritization fee', async () => {
+    if (mockServer) {
+      const pubkey = Keypair.generate().publicKey;
+      await mockRpcResponse({
+        method: 'getRecentPrioritizationFees',
+        params: [[pubkey.toString()]],
+        value: [
+          {prioritizationFee: 12, slot: 89335},
+          {prioritizationFee: 0, slot: 89332},
+        ],
+      });
+
+      const recentPrioritizationFee =
+        await connection.getRecentPrioritizationFees([pubkey.toString()]);
+      expect(recentPrioritizationFee).to.eql([
+        {prioritizationFee: 12, slot: 89335},
+        {prioritizationFee: 0, slot: 89332},
+      ]);
+    }
+  });
+
   it('get cluster nodes', async () => {
     await mockRpcResponse({
       method: 'getClusterNodes',


### PR DESCRIPTION
#### Problem
no method in web3.js to call ```getRecentPrioritizationFee```


#### Summary of Changes
added a new method ```getRecentPrioritizationFee``` in ```connection.ts``` 


Fixes #1095