### PR TITLE
chore: update `node-fetch` to 2.6.7

### DIFF
--- a/packages/library-legacy/package.json
+++ b/packages/library-legacy/package.json
@@ -68,7 +68,7 @@
     "buffer": "6.0.1",
     "fast-stable-stringify": "^1.0.0",
     "jayson": "^3.4.4",
-    "node-fetch": "2",
+    "node-fetch": "^2.6.7",
     "rpc-websockets": "^7.5.0",
     "superstruct": "^0.14.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
       mockttp: ^3.6.2
       mz: ^2.7.0
       node-abort-controller: ^3.0.1
-      node-fetch: '2'
+      node-fetch: ^2.6.7
       nyc: ^15.1.0
       prettier: ^2.3.0
       rimraf: 4.1.2


### PR DESCRIPTION
To address https://github.com/solana-labs/solana-web3.js/security/dependabot/64