### PR TITLE
test: repair the type of the Jest project configs

### DIFF
--- a/packages/test-config/jest-lint.config.ts
+++ b/packages/test-config/jest-lint.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from 'jest';
 
-const config: Config = {
+const config: NonNullable<Config['projects']>[number] = {
     displayName: 'ESLint',
     runner: 'eslint',
     testMatch: ['<rootDir>src/**/*.ts'],

--- a/packages/test-config/jest-prettier.config.ts
+++ b/packages/test-config/jest-prettier.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from 'jest';
 
-const config: Config = {
+const config: NonNullable<Config['projects']>[number] = {
     displayName: 'Prettier',
     moduleFileExtensions: ['js', 'ts', 'json', 'md'],
     runner: 'prettier',

--- a/packages/test-config/jest-unit.config.browser.ts
+++ b/packages/test-config/jest-unit.config.browser.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'jest';
 import commonConfig from './jest-unit.config.common';
 
-const config: Config = {
+const config: NonNullable<Config['projects']>[number] = {
     ...commonConfig,
     displayName: 'Unit Test (Browser)',
     globals: {

--- a/packages/test-config/jest-unit.config.common.ts
+++ b/packages/test-config/jest-unit.config.common.ts
@@ -1,6 +1,6 @@
 import type { Config } from 'jest';
 
-const config: Config = {
+const config: NonNullable<Config['projects']>[number] = {
     globals: {
         __DEV__: false,
     },

--- a/packages/test-config/jest-unit.config.node.ts
+++ b/packages/test-config/jest-unit.config.node.ts
@@ -1,7 +1,7 @@
 import { Config } from 'jest';
 import commonConfig from './jest-unit.config.common';
 
-const config: Config = {
+const config: NonNullable<Config['projects']>[number] = {
     ...commonConfig,
     displayName: 'Unit Test (Node)',
     globals: {


### PR DESCRIPTION
This will prevent me from continually adding properties to these configs that actually belong in the root config.