### PR TITLE
fix: locale independent sort

### DIFF
--- a/packages/library-legacy/src/transaction/legacy.ts
+++ b/packages/library-legacy/src/transaction/legacy.ts
@@ -457,7 +457,17 @@ export class Transaction {
         return x.isWritable ? -1 : 1;
       }
       // Otherwise, sort by pubkey, stringwise.
-      return x.pubkey.toBase58().localeCompare(y.pubkey.toBase58());
+      const options = {
+        localeMatcher: 'best fit',
+        usage: 'sort',
+        sensitivity: 'variant',
+        ignorePunctuation: false,
+        numeric: false,
+        caseFirst: 'lower',
+      };
+      return x.pubkey
+        .toBase58()
+        .localeCompare(y.pubkey.toBase58(), 'en', options);
     });
 
     // Move fee payer to the front


### PR DESCRIPTION
### Problem

Need deterministic pubkey sorting that is not dependent on browser locale

### Summary of Changes
Supply the default options listed on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator) and specify a static locale (`'en'`).

Fixes #1094.