### PR TITLE
chore: get `semantic-release` not to try to bump the version of private workspace package references

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 auto-install-peers=true
+workspaces-update=false


### PR DESCRIPTION
Related: https://github.com/dhoulb/multi-semantic-release/issues/129#issuecomment-1250013235