### PR TITLE
Using signersOrOptions for VersionedTransaction

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -5696,7 +5696,7 @@ export class Connection {
       }
 
       const wireTransaction = transaction.serialize();
-      return await this.sendRawTransaction(wireTransaction, options);
+      return await this.sendRawTransaction(wireTransaction, signersOrOptions);
     }
 
     if (signersOrOptions === undefined || !Array.isArray(signersOrOptions)) {


### PR DESCRIPTION
For `VersionedTransaction`, the method `sendTransaction` currently passes to `sendRawTransaction` the third parameter `options`, which is always undefined – `SendOptions` is defined as the the second parameter `signersOrOptions` for `VersionedTransaction`.

This PR changes the parameter of `sendRawTransaction` to `signersOrOptions` instead of `options` when handling `VersionedTransaction`.