### PR TITLE
Add import documentation to `sign()`

### DIFF
--- a/packages/library-legacy/src/transaction/versioned.ts
+++ b/packages/library-legacy/src/transaction/versioned.ts
@@ -90,6 +90,10 @@ export class VersionedTransaction {
     return new VersionedTransaction(message, signatures);
   }
 
+  /**
+   * NOTE: When the `sign()` method is called, all previously added transaction
+   * signatures will be fully replaced with new signatures created from the provided Signers.
+   */
   sign(signers: Array<Signer>) {
     const messageData = this.message.serialize();
     const signerPubkeys = this.message.staticAccountKeys.slice(


### PR DESCRIPTION
This seems like a pretty important thing to know about the new `sign` method and is only mentioned as a footnote on another random solana page unrelated to the web3.js docs.