### PR TITLE
chore: mock `fetch` in tests

### DIFF
--- a/packages/build-scripts/tsup.config.browser.ts
+++ b/packages/build-scripts/tsup.config.browser.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'tsup';
+import { getBaseConfig } from './getBaseConfig';
+
+export default defineConfig(options => [...getBaseConfig('browser', ['cjs', 'esm'], options)]);

--- a/packages/test-config/jest-unit.config.common.ts
+++ b/packages/test-config/jest-unit.config.common.ts
@@ -1,4 +1,5 @@
 import { Config } from '@jest/types';
+import path from 'path';
 
 const config: Partial<Config.InitialProjectOptions> = {
     globals: {
@@ -6,6 +7,7 @@ const config: Partial<Config.InitialProjectOptions> = {
     },
     restoreMocks: true,
     roots: ['<rootDir>/src/'],
+    setupFiles: [path.resolve(__dirname, 'setup-fetch-mock.ts')],
     transform: {
         '^.+\\.(ts|js)$': [
             '@swc/jest',

--- a/packages/test-config/package.json
+++ b/packages/test-config/package.json
@@ -12,6 +12,7 @@
     "peerDependencies": {
         "jest": "^29.4.2",
         "jest-environment-jsdom": "^29.4.2",
+        "jest-fetch-mock": "^3.0.3",
         "jest-runner-eslint": "^1.1.0",
         "jest-runner-prettier": "^1.0.0",
         "jest-watch-master": "^1.0.0",
@@ -21,6 +22,7 @@
     "devDependencies": {
         "@jest/types": "^29.4.2",
         "jest": "^29.4.2",
+        "jest-fetch-mock": "^3.0.3",
         "tsconfig": "workspace:*"
     }
 }

--- a/packages/test-config/setup-fetch-mock.ts
+++ b/packages/test-config/setup-fetch-mock.ts
@@ -1,0 +1,2 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
+enableFetchMocks();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,6 +399,7 @@ importers:
       '@jest/types': ^29.4.2
       jest: ^29.4.2
       jest-environment-jsdom: ^29.4.2
+      jest-fetch-mock: ^3.0.3
       jest-runner-eslint: ^1.1.0
       jest-runner-prettier: ^1.0.0
       jest-watch-master: ^1.0.0
@@ -415,6 +416,7 @@ importers:
     devDependencies:
       '@jest/types': 29.4.2
       jest: 29.4.2
+      jest-fetch-mock: 3.0.3
       tsconfig: link:../tsconfig
 
   packages/tsconfig:
@@ -7203,6 +7205,15 @@ packages:
       jest-mock: 29.4.2
       jest-util: 29.4.2
 
+  /jest-fetch-mock/3.0.3:
+    resolution: {integrity: sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==}
+    dependencies:
+      cross-fetch: 3.1.5
+      promise-polyfill: 8.3.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
   /jest-get-type/27.5.1:
     resolution: {integrity: sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -9117,6 +9128,10 @@ packages:
 
   /process-nextick-args/2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+    dev: true
+
+  /promise-polyfill/8.3.0:
+    resolution: {integrity: sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==}
     dev: true
 
   /prompts/2.4.2:


### PR DESCRIPTION
chore: mock `fetch` in tests
Summary: `jsdom` does not supply a polyfill for `fetch`; we have to do it ourselves

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1192).
* #1194
* #1193
* __->__ #1192