### PR TITLE
chore: create a build config that _only_ makes a browser build

### DIFF
--- a/packages/build-scripts/tsup.config.browser.ts
+++ b/packages/build-scripts/tsup.config.browser.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'tsup';
+import { getBaseConfig } from './getBaseConfig';
+
+export default defineConfig(options => [...getBaseConfig('browser', ['cjs', 'esm'], options)]);


### PR DESCRIPTION
chore: create a build config that _only_ makes a browser build
Summary: We will need this to build browser-only forks of modules like `fetch-impl`.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1193).
* #1194
* __->__ #1193
* #1192