### PR TITLE
[experimental] Remove the concept of the transport from the types of the RPC

### DIFF
--- a/packages/rpc-core/src/rpc.ts
+++ b/packages/rpc-core/src/rpc.ts
@@ -1,21 +1,31 @@
 import { IJsonRpcTransport } from '@solana/rpc-transport';
 import { JsonRpcApi } from './types/jsonRpcApi';
 
-export const rpc = /* #__PURE__ */ new Proxy<JsonRpcApi>({} as JsonRpcApi, {
+type RpcCore = {
+    [TMethodName in keyof JsonRpcApi]: (
+        transport: IJsonRpcTransport,
+        ...params: Parameters<JsonRpcApi[TMethodName]>
+    ) => ReturnType<JsonRpcApi[TMethodName]>;
+};
+
+export const rpc = /* #__PURE__ */ new Proxy<RpcCore>({} as RpcCore, {
     defineProperty() {
         return false;
     },
     deleteProperty() {
         return false;
     },
-    get<TMethodName extends keyof JsonRpcApi>(target: JsonRpcApi, p: TMethodName) {
+    get<TMethodName extends keyof JsonRpcApi>(target: RpcCore, p: TMethodName) {
         if (target[p] == null) {
             const method = p.toString();
-            target[p] = async function (transport: IJsonRpcTransport, ...params: Parameters<JsonRpcApi[TMethodName]>) {
+            target[p] = async function (transport, ...params) {
                 const normalizedParams = params.length ? params : undefined;
-                const result = await transport.send(method, normalizedParams);
+                const result = await transport.send<
+                    Parameters<JsonRpcApi[TMethodName]> | undefined,
+                    ReturnType<RpcCore[TMethodName]>
+                >(method, normalizedParams);
                 return result;
-            } as unknown as JsonRpcApi[TMethodName];
+            } as RpcCore[TMethodName];
         }
         return target[p];
     },

--- a/packages/rpc-core/src/types/jsonRpcApi.d.ts
+++ b/packages/rpc-core/src/types/jsonRpcApi.d.ts
@@ -2,4 +2,4 @@ import { GetAccountInfoApi } from './rpc-methods/getAccountInfo';
 import { GetBlockHeightApi } from './rpc-methods/getBlockHeight';
 import { GetBlocksApi } from './rpc-methods/getBlocks';
 
-declare interface JsonRpcApi extends GetAccountInfoApi, GetBlockHeightApi, GetBlocksApi {}
+export interface JsonRpcApi extends GetAccountInfoApi, GetBlockHeightApi, GetBlocksApi {}

--- a/packages/rpc-core/src/types/rpc-methods/getAccountInfo.d.ts
+++ b/packages/rpc-core/src/types/rpc-methods/getAccountInfo.d.ts
@@ -1,5 +1,4 @@
 import { Base58EncodedAddress } from '@solana/keys';
-import { IJsonRPCTransport } from '../../rpc';
 
 type Base64EncodedBytes = string & { readonly __base64EncodedBytes: unique symbol };
 type Base64EncodedZStdCompressedBytes = string & { readonly __base64EncodedZStdCompressedBytes: unique symbol };
@@ -59,12 +58,11 @@ type GetAccountInfoApiBase64EncodingCommonConfig = readonly {
     dataSlice?: DataSlice;
 };
 
-declare interface GetAccountInfoApi {
+export interface GetAccountInfoApi {
     /**
      * Returns all information associated with the account of provided public key
      */
     getAccountInfo(
-        transport: IJsonRPCTransport,
         address: Base58EncodedAddress,
         config?: readonly {
             encoding: 'base64';
@@ -73,7 +71,6 @@ declare interface GetAccountInfoApi {
             GetAccountInfoApiBase64EncodingCommonConfig
     ): Promise<GetAccountInfoApiResponseBase & GetAccountInfoApiResponseWithEncodedData>;
     getAccountInfo(
-        transport: IJsonRPCTransport,
         address: Base58EncodedAddress,
         config?: readonly {
             encoding: 'base64+zstd';
@@ -82,7 +79,6 @@ declare interface GetAccountInfoApi {
             GetAccountInfoApiBase64EncodingCommonConfig
     ): Promise<GetAccountInfoApiResponseBase & GetAccountInfoApiResponseWithEncodedZStdCompressedData>;
     getAccountInfo(
-        transport: IJsonRPCTransport,
         address: Base58EncodedAddress,
         config?: readonly {
             encoding: 'jsonParsed';

--- a/packages/rpc-core/src/types/rpc-methods/getBlockHeight.d.ts
+++ b/packages/rpc-core/src/types/rpc-methods/getBlockHeight.d.ts
@@ -1,15 +1,12 @@
-import { IJsonRpcTransport } from '@solana/rpc-transport';
-
 type GetBlockHeightApiResponse =
     // TODO(solana-labs/solana/issues/30341) Represent as bigint
     number;
 
-declare interface GetBlockHeightApi {
+export interface GetBlockHeightApi {
     /**
      * Returns the current block height of the node
      */
     getBlockHeight(
-        transport: IJsonRpcTransport,
         config?: readonly {
             // Defaults to `finalized`
             commitment?: Commitment;

--- a/packages/rpc-core/src/types/rpc-methods/getBlocks.d.ts
+++ b/packages/rpc-core/src/types/rpc-methods/getBlocks.d.ts
@@ -1,13 +1,10 @@
-import { IJsonRpcTransport } from '@solana/rpc-transport';
-
 type GetBlocksApiResponse = Slot[];
 
-declare interface GetBlocksApi {
+export interface GetBlocksApi {
     /**
      * Returns a list of confirmed blocks between two slots
      */
     getBlocks(
-        transport: IJsonRpcTransport,
         startSlot: Slot,
         endSlotInclusive?: Slot,
         config?: readonly {


### PR DESCRIPTION
# Summary

@joncinque pointed out in #1190 that the Typescript types of `@solana/rpc-core` relied on a cast through `unknown` to work. The more I thought about it the more I realized that the `transport` shouldn't form part of the typespec for the RPC.

In this PR we remove it from the source types, and map it back in where it's needed in the implementation..
