### PR TITLE
test: extend timeout for ‘get leader schedule’ test

### DIFF
--- a/packages/library-legacy/package.json
+++ b/packages/library-legacy/package.json
@@ -47,7 +47,7 @@
     "test:lint": "eslint src/ test/ --ext .js,.ts",
     "test:lint:fix": "eslint src/ test/ --fix --ext .js,.ts",
     "test:live": "TEST_LIVE=1 pnpm run test:unit:node",
-    "test:live-with-test-validator": "start-server-and-test '$HOME/.local/share/solana/install/active_release/bin/solana-test-validator --reset --quiet' http://localhost:8899/health test:live",
+    "test:live-with-test-validator": "start-server-and-test '$HOME/.local/share/solana/install/active_release/bin/solana-test-validator --reset --quiet' http://127.0.0.1:8899/health test:live",
     "test:prettier": "prettier --check '{,{src,test}/**/}*.{j,t}s'",
     "test:prettier:fix": "prettier --write '{,{src,test}/**/}*.{j,t}s'",
     "test:typecheck": "tsc --noEmit",

--- a/packages/library-legacy/test/connection.test.ts
+++ b/packages/library-legacy/test/connection.test.ts
@@ -939,7 +939,7 @@ describe('Connection', function () {
       expect(Array.isArray(slots)).to.be.true;
       expect(slots.length).to.be.at.least(4);
     }
-  });
+  }).timeout(30 * 1000);
 
   it('get slot', async () => {
     await mockRpcResponse({

--- a/packages/library-legacy/test/url.ts
+++ b/packages/library-legacy/test/url.ts
@@ -12,12 +12,12 @@ declare var process: {
 };
 
 export const url = process.env.TEST_LIVE
-  ? 'http://localhost:8899/'
-  : 'http://localhost:9999/';
+  ? 'http://127.0.0.1:8899/'
+  : 'http://127.0.0.1:9999/';
 
 export const wsUrl = process.env.TEST_LIVE
-  ? 'ws://localhost:8900/'
-  : 'ws://localhost:9999/';
+  ? 'ws://127.0.0.1:8900/'
+  : 'ws://127.0.0.1:9999/';
 
 export const nodeVersion = Number(process.version.split('.')[0]);
 

--- a/packages/library-legacy/test/websocket.test.ts
+++ b/packages/library-legacy/test/websocket.test.ts
@@ -76,7 +76,7 @@ if (process.env.TEST_LIVE) {
     });
 
     it('connect by websocket endpoint from options', async () => {
-      let connection = new Connection('http://localhost', {
+      let connection = new Connection('http://127.0.0.1', {
         wsEndpoint: wsUrl,
       });
 

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
             "outputs": ["dist/**", "lib/**"]
         },
         "compile:typedefs": {
-            "dependsOn": ["clean", "compile:js"],
+            "dependsOn": ["clean", "compile:js", "^compile:typedefs"],
             "inputs": ["rollup.config.types.js", "tsconfig.*", "src/**"],
             "outputs": ["declarations/**", "dist/**/*.d.ts", "lib/**/*.d.ts"]
         },
@@ -50,7 +50,7 @@
             "outputs": []
         },
         "test:typecheck": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["compile:js", "compile:typedefs"],
             "inputs": ["tsconfig.*", "src/**", "test/**"],
             "outputs": []
         },


### PR DESCRIPTION
test: extend timeout for ‘get leader schedule’ test
## Summary
This test seems to timeout a lot in CI these days. Let's try extending the timeout.

## Test Plan
```shell
pnpm test:live-with-test-validator
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1201).
* __->__ #1201
* #1200
* #1202