### PR TITLE
chore: build typedefs for all packages before typechecking

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
             "outputs": ["dist/**", "lib/**"]
         },
         "compile:typedefs": {
-            "dependsOn": ["clean", "compile:js"],
+            "dependsOn": ["clean", "compile:js", "^compile:typedefs"],
             "inputs": ["rollup.config.types.js", "tsconfig.*", "src/**"],
             "outputs": ["declarations/**", "dist/**/*.d.ts", "lib/**/*.d.ts"]
         },
@@ -50,7 +50,7 @@
             "outputs": []
         },
         "test:typecheck": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["compile:js", "compile:typedefs"],
             "inputs": ["tsconfig.*", "src/**", "test/**"],
             "outputs": []
         },


### PR DESCRIPTION
chore: build typedefs for all packages before typechecking
## Summary
Sometimes package A depends on package B, and needs to read its typedefs to be able to typecheck _itself_. This implies that typedefs need to be built _before_ typechecking. This PR adds `compile:typedefs` as a dependency of `test:typecheck`.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1202).
* #1201
* #1200
* __->__ #1202