### PR TITLE
[experimental] Type the RPC API with `bigint` at the edge

### DIFF
--- a/packages/fetch-impl-browser/package.json
+++ b/packages/fetch-impl-browser/package.json
@@ -42,7 +42,7 @@
         "@solana/eslint-config-solana": "^0.0.4",
         "@swc/core": "^1.3.18",
         "@swc/jest": "^0.2.23",
-        "@types/jest": "^29.2.3",
+        "@types/jest": "^29.5.0",
         "@types/node-fetch": "2",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
         "@typescript-eslint/parser": "^5.43.0",

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -62,7 +62,7 @@
         "@solana/eslint-config-solana": "^0.0.4",
         "@swc/core": "^1.3.18",
         "@swc/jest": "^0.2.23",
-        "@types/jest": "^29.2.3",
+        "@types/jest": "^29.5.0",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
         "@typescript-eslint/parser": "^5.43.0",
         "agadoo": "^2.0.0",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -66,7 +66,7 @@
         "@solana/eslint-config-solana": "^0.0.4",
         "@swc/core": "^1.3.18",
         "@swc/jest": "^0.2.23",
-        "@types/jest": "^29.2.3",
+        "@types/jest": "^29.5.0",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
         "@typescript-eslint/parser": "^5.43.0",
         "agadoo": "^2.0.0",

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -66,7 +66,7 @@
         "@solana/eslint-config-solana": "^0.0.4",
         "@swc/core": "^1.3.18",
         "@swc/jest": "^0.2.23",
-        "@types/jest": "^29.2.3",
+        "@types/jest": "^29.5.0",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
         "@typescript-eslint/parser": "^5.43.0",
         "agadoo": "^2.0.0",

--- a/packages/rpc-core/src/__tests__/rpc-test.ts
+++ b/packages/rpc-core/src/__tests__/rpc-test.ts
@@ -15,7 +15,7 @@ describe('rpc', () => {
         });
     });
     describe('a method call with params', () => {
-        const params = [1, undefined, { commitment: 'finalized' }] as const;
+        const params = [1n, undefined, { commitment: 'finalized' }] as const;
         beforeEach(async () => {
             await rpc.getBlocks(transport, ...params);
         });

--- a/packages/rpc-core/src/types/rpc-methods/common.d.ts
+++ b/packages/rpc-core/src/types/rpc-methods/common.d.ts
@@ -6,6 +6,9 @@ declare type DataSlice = readonly {
     length: number;
 };
 
-declare type Slot =
-    // TODO(solana-labs/solana/issues/30341) Represent as bigint
-    number;
+declare type Slot = U64UnsafeBeyond2Pow53Minus1;
+
+// FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
+// truncated or rounded because of a downcast to JavaScript `number` between your calling code and
+// the JSON-RPC transport.
+declare type U64UnsafeBeyond2Pow53Minus1 = bigint;

--- a/packages/rpc-core/src/types/rpc-methods/getAccountInfo.d.ts
+++ b/packages/rpc-core/src/types/rpc-methods/getAccountInfo.d.ts
@@ -12,10 +12,10 @@ type GetAccountInfoApiResponseBase = Readonly<{
     }>;
     value: Readonly<{
         executable: boolean;
-        lamports: number; // TODO(solana-labs/solana/issues/30341) Represent as bigint
+        lamports: U64UnsafeBeyond2Pow53Minus1;
         owner: Base64EncodedAddress;
-        rentEpoch: number; // TODO(solana-labs/solana/issues/30341) Represent as bigint
-        space: number; // TODO(solana-labs/solana/issues/30341) Represent as bigint
+        rentEpoch: U64UnsafeBeyond2Pow53Minus1;
+        space: U64UnsafeBeyond2Pow53Minus1;
     }> | null;
 }>;
 
@@ -38,7 +38,7 @@ type GetAccountInfoApiResponseWithJsonData = Readonly<{
                   // Name of the program that owns this account.
                   program: string;
                   parsed: unknown;
-                  space: number; // TODO(solana-labs/solana/issues/30341) Represent as bigint
+                  space: U64UnsafeBeyond2Pow53Minus1;
               }>
             // If `jsonParsed` encoding is requested but a parser cannot be found for the given
             // account the `data` field falls back to `base64`.

--- a/packages/rpc-core/src/types/rpc-methods/getBlockHeight.d.ts
+++ b/packages/rpc-core/src/types/rpc-methods/getBlockHeight.d.ts
@@ -1,6 +1,4 @@
-type GetBlockHeightApiResponse =
-    // TODO(solana-labs/solana/issues/30341) Represent as bigint
-    number;
+type GetBlockHeightApiResponse = U64UnsafeBeyond2Pow53Minus1;
 
 export interface GetBlockHeightApi {
     /**

--- a/packages/rpc-transport/package.json
+++ b/packages/rpc-transport/package.json
@@ -60,7 +60,7 @@
         "@solana/eslint-config-solana": "^0.0.4",
         "@swc/core": "^1.3.18",
         "@swc/jest": "^0.2.23",
-        "@types/jest": "^29.2.3",
+        "@types/jest": "^29.5.0",
         "@types/node-fetch": "2",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
         "@typescript-eslint/parser": "^5.43.0",

--- a/packages/rpc-transport/src/__tests__/params-patcher-test.ts
+++ b/packages/rpc-transport/src/__tests__/params-patcher-test.ts
@@ -1,0 +1,46 @@
+import { patchParamsForSolanaLabsRpc } from '../params-patcher';
+
+describe('patchParamsForSolanaLabsRpc', () => {
+    [10, '10', null, undefined, Symbol()].forEach(input => {
+        describe(`given \`${String(input)}\` (${typeof input}) as input`, () => {
+            it('returns the value as-is', () => {
+                expect(patchParamsForSolanaLabsRpc(input)).toBe(input);
+            });
+        });
+    });
+    describe('given a `bigint` as input', () => {
+        const input = 10n;
+        it('casts the input to a `number`', () => {
+            expect(patchParamsForSolanaLabsRpc(input)).toBe(Number(input));
+        });
+    });
+    describe('given a `bigint` two larger than `Number.MAX_SAFE_INTEGER` as input', () => {
+        const input = BigInt(Number.MAX_SAFE_INTEGER) + 2n; // 9007199254740993
+        it('casts the input to a `number`', () => {
+            expect(input - BigInt(patchParamsForSolanaLabsRpc(input)))
+                // Incorrectly rounds to 9007199254740992, leaving a difference of 1.
+                .toBe(1n);
+        });
+    });
+    describe('given an array as input', () => {
+        const input = [10n, 10, '10', ['10', [10, 10n], 10n]] as const;
+        it('casts the bigints in the array to a `number`, recursively', () => {
+            expect(patchParamsForSolanaLabsRpc(input)).toStrictEqual([
+                Number(input[0]),
+                input[1],
+                input[2],
+                [input[3][0], [input[3][1][0], Number(input[3][1][0])], Number(input[3][2])],
+            ]);
+        });
+    });
+    describe('given an object as input', () => {
+        const input = { a: 10n, b: 10, c: { c1: '10', c2: 10n } } as const;
+        it('casts the bigints in the array to a `number`, recursively', () => {
+            expect(patchParamsForSolanaLabsRpc(input)).toStrictEqual({
+                a: Number(input.a),
+                b: input.b,
+                c: { c1: input.c.c1, c2: Number(input.c.c2) },
+            });
+        });
+    });
+});

--- a/packages/rpc-transport/src/json-rpc-transport.ts
+++ b/packages/rpc-transport/src/json-rpc-transport.ts
@@ -2,6 +2,7 @@ import { IJsonRpcTransport } from '.';
 import { makeHttpRequest } from './http-request';
 import { SolanaJsonRpcError } from './json-rpc-errors';
 import { createJsonRpcMessage } from './json-rpc-message';
+import { patchParamsForSolanaLabsRpc } from './params-patcher';
 
 type Config = Readonly<{
     url: string;
@@ -14,7 +15,8 @@ type JsonRpcResponse<TResponse> = Readonly<
 export function createJsonRpcTransport({ url }: Config): IJsonRpcTransport {
     return {
         async send<TParams, TResponse>(method: string, params: TParams): Promise<TResponse> {
-            const jsonRpcMessage = createJsonRpcMessage(method, params);
+            const patchedParams = patchParamsForSolanaLabsRpc(params);
+            const jsonRpcMessage = createJsonRpcMessage(method, patchedParams);
             const response = await makeHttpRequest<JsonRpcResponse<TResponse>>({
                 payload: jsonRpcMessage,
                 url,

--- a/packages/rpc-transport/src/params-patcher.ts
+++ b/packages/rpc-transport/src/params-patcher.ts
@@ -1,0 +1,26 @@
+type Patched<T> = T extends object ? { [Property in keyof T]: Patched<T[Property]> } : T extends bigint ? number : T;
+
+// FIXME(https://github.com/microsoft/TypeScript/issues/33014)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TypescriptBug33014 = any;
+
+export function patchParamsForSolanaLabsRpc<T>(params: T): Patched<T> {
+    if (Array.isArray(params)) {
+        return params.map(patchParamsForSolanaLabsRpc) as TypescriptBug33014;
+    } else if (typeof params === 'object' && params !== null) {
+        const out = {} as TypescriptBug33014;
+        for (const propName in params) {
+            if (Object.prototype.hasOwnProperty.call(params, propName)) {
+                out[propName] = patchParamsForSolanaLabsRpc(params[propName]);
+            }
+        }
+        return out as TypescriptBug33014;
+    } else if (typeof params === 'bigint') {
+        // TODO(solana-labs/solana/issues/30341) Create a data type to represent u64 in the Solana
+        // JSON RPC implementation so that we can throw away this entire patcher instead of unsafely
+        // downcasting `bigints` to `numbers`.
+        return Number(params) as TypescriptBug33014;
+    } else {
+        return params as TypescriptBug33014;
+    }
+}

--- a/packages/test-config/jest-unit.config.common.ts
+++ b/packages/test-config/jest-unit.config.common.ts
@@ -7,7 +7,7 @@ const config: Partial<Config.InitialProjectOptions> = {
     },
     restoreMocks: true,
     roots: ['<rootDir>/src/'],
-    setupFiles: [path.resolve(__dirname, 'setup-fetch-mock.ts')],
+    setupFilesAfterEnv: [path.resolve(__dirname, 'setup-fetch-mock.ts')],
     transform: {
         '^.+\\.(ts|js)$': [
             '@swc/jest',

--- a/packages/test-config/package.json
+++ b/packages/test-config/package.json
@@ -20,7 +20,8 @@
         "jest-watch-typeahead": "^2.2.2"
     },
     "devDependencies": {
-        "@jest/types": "^29.4.2",
+        "@jest/types": "^29.5.0",
+        "@types/jest": "^29.5.0",
         "jest": "^29.5.0",
         "jest-fetch-mock": "^3.0.3",
         "tsconfig": "workspace:*"

--- a/packages/test-config/setup-fetch-mock.ts
+++ b/packages/test-config/setup-fetch-mock.ts
@@ -1,2 +1,11 @@
-import { enableFetchMocks } from 'jest-fetch-mock';
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
+
+beforeEach(() => {
+    fetchMock.doMock();
+});
+
+afterEach(() => {
+    fetchMock.resetMocks();
+    fetchMock.dontMock();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
       '@solana/eslint-config-solana': ^0.0.4
       '@swc/core': ^1.3.18
       '@swc/jest': ^0.2.23
-      '@types/jest': ^29.2.3
+      '@types/jest': ^29.5.0
       '@types/node-fetch': '2'
       '@typescript-eslint/eslint-plugin': ^5.43.0
       '@typescript-eslint/parser': ^5.43.0
@@ -59,7 +59,7 @@ importers:
       '@solana/eslint-config-solana': 0.0.4_bndcpr3wuk7rnye42pksdqhqci
       '@swc/core': 1.3.32
       '@swc/jest': 0.2.24_@swc+core@1.3.32
-      '@types/jest': 29.4.0
+      '@types/jest': 29.5.0
       '@types/node-fetch': 2.6.1
       '@typescript-eslint/eslint-plugin': 5.53.0_ny4s7qc6yg74faf3d6xty2ofzy
       '@typescript-eslint/parser': 5.53.0_7kw3g6rralp5ps6mg3uyzz6azm
@@ -87,7 +87,7 @@ importers:
       '@solana/eslint-config-solana': ^0.0.4
       '@swc/core': ^1.3.18
       '@swc/jest': ^0.2.23
-      '@types/jest': ^29.2.3
+      '@types/jest': ^29.5.0
       '@typescript-eslint/eslint-plugin': ^5.43.0
       '@typescript-eslint/parser': ^5.43.0
       agadoo: ^2.0.0
@@ -115,7 +115,7 @@ importers:
       '@solana/eslint-config-solana': 0.0.4_bndcpr3wuk7rnye42pksdqhqci
       '@swc/core': 1.3.32
       '@swc/jest': 0.2.24_@swc+core@1.3.32
-      '@types/jest': 29.4.0
+      '@types/jest': 29.5.0
       '@typescript-eslint/eslint-plugin': 5.53.0_ny4s7qc6yg74faf3d6xty2ofzy
       '@typescript-eslint/parser': 5.53.0_7kw3g6rralp5ps6mg3uyzz6azm
       agadoo: 2.0.0
@@ -143,7 +143,7 @@ importers:
       '@solana/keys': workspace:*
       '@swc/core': ^1.3.18
       '@swc/jest': ^0.2.23
-      '@types/jest': ^29.2.3
+      '@types/jest': ^29.5.0
       '@typescript-eslint/eslint-plugin': ^5.43.0
       '@typescript-eslint/parser': ^5.43.0
       agadoo: ^2.0.0
@@ -170,7 +170,7 @@ importers:
       '@solana/eslint-config-solana': 0.0.4_yqlmaiolblqnwnl2yjrnoa7ify
       '@swc/core': 1.3.32
       '@swc/jest': 0.2.24_@swc+core@1.3.32
-      '@types/jest': 29.4.0
+      '@types/jest': 29.5.0
       '@typescript-eslint/eslint-plugin': 5.50.0_rsaczafy73x3xqauzesvzbsgzy
       '@typescript-eslint/parser': 5.49.0_zkdaqh7it7uc4cvz2haft7rc6u
       agadoo: 2.0.0
@@ -346,7 +346,7 @@ importers:
       '@solana/rpc-transport': workspace:*
       '@swc/core': ^1.3.18
       '@swc/jest': ^0.2.23
-      '@types/jest': ^29.2.3
+      '@types/jest': ^29.5.0
       '@typescript-eslint/eslint-plugin': ^5.43.0
       '@typescript-eslint/parser': ^5.43.0
       agadoo: ^2.0.0
@@ -374,7 +374,7 @@ importers:
       '@solana/eslint-config-solana': 0.0.4_bndcpr3wuk7rnye42pksdqhqci
       '@swc/core': 1.3.32
       '@swc/jest': 0.2.24_@swc+core@1.3.32
-      '@types/jest': 29.4.0
+      '@types/jest': 29.5.0
       '@typescript-eslint/eslint-plugin': 5.53.0_ny4s7qc6yg74faf3d6xty2ofzy
       '@typescript-eslint/parser': 5.53.0_7kw3g6rralp5ps6mg3uyzz6azm
       agadoo: 2.0.0
@@ -402,7 +402,7 @@ importers:
       '@solana/fetch-impl-browser': workspace:*
       '@swc/core': ^1.3.18
       '@swc/jest': ^0.2.23
-      '@types/jest': ^29.2.3
+      '@types/jest': ^29.5.0
       '@types/node-fetch': '2'
       '@typescript-eslint/eslint-plugin': ^5.43.0
       '@typescript-eslint/parser': ^5.43.0
@@ -433,7 +433,7 @@ importers:
       '@solana/eslint-config-solana': 0.0.4_bndcpr3wuk7rnye42pksdqhqci
       '@swc/core': 1.3.32
       '@swc/jest': 0.2.24_@swc+core@1.3.32
-      '@types/jest': 29.4.0
+      '@types/jest': 29.5.0
       '@types/node-fetch': 2.6.1
       '@typescript-eslint/eslint-plugin': 5.53.0_ny4s7qc6yg74faf3d6xty2ofzy
       '@typescript-eslint/parser': 5.53.0_7kw3g6rralp5ps6mg3uyzz6azm
@@ -459,7 +459,8 @@ importers:
 
   packages/test-config:
     specifiers:
-      '@jest/types': ^29.4.2
+      '@jest/types': ^29.5.0
+      '@types/jest': ^29.5.0
       jest: ^29.5.0
       jest-environment-jsdom: ^29.5.0
       jest-fetch-mock: ^3.0.3
@@ -477,7 +478,8 @@ importers:
       jest-watch-select-projects: 2.0.0
       jest-watch-typeahead: 2.2.2_jest@29.5.0
     devDependencies:
-      '@jest/types': 29.4.2
+      '@jest/types': 29.5.0
+      '@types/jest': 29.5.0
       jest: 29.5.0
       jest-fetch-mock: 3.0.3
       tsconfig: link:../tsconfig
@@ -2191,13 +2193,6 @@ packages:
       '@types/node': 18.11.17
       jest-mock: 29.5.0
 
-  /@jest/expect-utils/29.4.2:
-    resolution: {integrity: sha512-Dd3ilDJpBnqa0GiPN7QrudVs0cczMMHtehSo2CSTjm3zdHx0RcpmhFNVEltuEFeqfLIyWKFI224FsMSQ/nsJQA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      jest-get-type: 29.4.3
-    dev: true
-
   /@jest/expect-utils/29.5.0:
     resolution: {integrity: sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2289,13 +2284,6 @@ packages:
       v8-to-istanbul: 9.0.1
     transitivePeerDependencies:
       - supports-color
-
-  /@jest/schemas/29.4.2:
-    resolution: {integrity: sha512-ZrGzGfh31NtdVH8tn0mgJw4khQuNHiKqdzJAFbCaERbyCP9tHlxWuL/mnMu8P7e/+k4puWjI1NOzi/sFsjce/g==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.25.21
-    dev: true
 
   /@jest/schemas/29.4.3:
     resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
@@ -2399,18 +2387,6 @@ packages:
       '@types/node': 18.11.17
       '@types/yargs': 16.0.5
       chalk: 4.1.2
-
-  /@jest/types/29.4.2:
-    resolution: {integrity: sha512-CKlngyGP0fwlgC1BRUtPZSiWLBhyS9dKwKmyGxk8Z6M82LBEGB2aLQSg+U1MyLsU+M7UjnlLllBM2BLWKVm/Uw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.4.2
-      '@types/istanbul-lib-coverage': 2.0.4
-      '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.11.17
-      '@types/yargs': 17.0.22
-      chalk: 4.1.2
-    dev: true
 
   /@jest/types/29.5.0:
     resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
@@ -3243,11 +3219,11 @@ packages:
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
 
-  /@types/jest/29.4.0:
-    resolution: {integrity: sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==}
+  /@types/jest/29.5.0:
+    resolution: {integrity: sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==}
     dependencies:
-      expect: 29.4.2
-      pretty-format: 29.4.2
+      expect: 29.5.0
+      pretty-format: 29.5.0
     dev: true
 
   /@types/jsdom/20.0.1:
@@ -5939,17 +5915,6 @@ packages:
       jest-matcher-utils: 27.5.1
       jest-message-util: 27.5.1
 
-  /expect/29.4.2:
-    resolution: {integrity: sha512-+JHYg9O3hd3RlICG90OPVjRkPBoiUH7PxvDVMnRiaq1g6JUgZStX514erMl0v2Dc5SkfVbm7ztqbd6qHHPn+mQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/expect-utils': 29.4.2
-      jest-get-type: 29.4.2
-      jest-matcher-utils: 29.4.2
-      jest-message-util: 29.4.2
-      jest-util: 29.4.2
-    dev: true
-
   /expect/29.5.0:
     resolution: {integrity: sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7320,11 +7285,6 @@ packages:
     resolution: {integrity: sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  /jest-get-type/29.4.2:
-    resolution: {integrity: sha512-vERN30V5i2N6lqlFu4ljdTqQAgrkTFMC9xaIIfOPYBw04pufjXRty5RuXBiB1d72tGbURa/UgoiHB90ruOSivg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
-
   /jest-get-type/29.4.3:
     resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7389,16 +7349,6 @@ packages:
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
 
-  /jest-matcher-utils/29.4.2:
-    resolution: {integrity: sha512-EZaAQy2je6Uqkrm6frnxBIdaWtSYFoR8SVb2sNLAtldswlR/29JAgx+hy67llT3+hXBaLB0zAm5UfeqerioZyg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      chalk: 4.1.2
-      jest-diff: 29.5.0
-      jest-get-type: 29.4.3
-      pretty-format: 29.5.0
-    dev: true
-
   /jest-matcher-utils/29.5.0:
     resolution: {integrity: sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7421,21 +7371,6 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       stack-utils: 2.0.6
-
-  /jest-message-util/29.4.2:
-    resolution: {integrity: sha512-SElcuN4s6PNKpOEtTInjOAA8QvItu0iugkXqhYyguRvQoXapg5gN+9RQxLAkakChZA7Y26j6yUCsFWN+hlKD6g==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@jest/types': 29.5.0
-      '@types/stack-utils': 2.0.1
-      chalk: 4.1.2
-      graceful-fs: 4.2.10
-      micromatch: 4.0.5
-      pretty-format: 29.5.0
-      slash: 3.0.0
-      stack-utils: 2.0.6
-    dev: true
 
   /jest-message-util/29.5.0:
     resolution: {integrity: sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==}
@@ -7800,18 +7735,6 @@ packages:
       ci-info: 3.7.1
       graceful-fs: 4.2.10
       picomatch: 2.3.1
-
-  /jest-util/29.4.2:
-    resolution: {integrity: sha512-wKnm6XpJgzMUSRFB7YF48CuwdzuDIHenVuoIb1PLuJ6F+uErZsuDkU+EiExkChf6473XcawBrSfDSnXl+/YG4g==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/types': 29.5.0
-      '@types/node': 18.11.17
-      chalk: 4.1.2
-      ci-info: 3.7.1
-      graceful-fs: 4.2.10
-      picomatch: 2.3.1
-    dev: true
 
   /jest-util/29.5.0:
     resolution: {integrity: sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==}
@@ -9278,15 +9201,6 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-
-  /pretty-format/29.4.2:
-    resolution: {integrity: sha512-qKlHR8yFVCbcEWba0H0TOC8dnLlO4vPlyEjRPw31FZ2Rupy9nLa8ZLbYny8gWEl8CkEhJqAE6IzdNELTBVcBEg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.4.2
-      ansi-styles: 5.2.0
-      react-is: 18.2.0
-    dev: true
 
   /pretty-format/29.5.0:
     resolution: {integrity: sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==}


### PR DESCRIPTION
[experimental] Type the RPC API with `bigint` at the edge
## Summary

The _correct_ thing to do is be to use `bigint` wherever the Solana JSON RPC specfies `u64`. This PR endeavours to do that.

*Note*: This isn't _actually_ safe, Because of an error in the design of the RPC. See #1204 for more information.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1205).
* #1210
* __->__ #1205
* #1204
* #1209