### PR TITLE
chore: build dependent packages when typechecking and testing tree-shakeability

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -50,7 +50,7 @@
             "outputs": []
         },
         "test:typecheck": {
-            "dependsOn": ["compile:js", "compile:typedefs"],
+            "dependsOn": ["^compile:typedefs"],
             "inputs": ["tsconfig.*", "src/**", "test/**"],
             "outputs": []
         },
@@ -63,15 +63,15 @@
             "outputs": []
         },
         "test:treeshakability:browser": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["^compile:js"],
             "outputs": []
         },
         "test:treeshakability:native": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["^compile:js"],
             "outputs": []
         },
         "test:treeshakability:node": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["^compile:js"],
             "outputs": []
         }
     },


### PR DESCRIPTION
## Summary

Now that packages are starting to depend upon one another, we have to enforce that dependencies get built _first_ before typechecking or testing a given library for tree-shakability, since the dependencies will play a role in those outcomes.

## Test Plan

CI run.
