### PR TITLE
[experimental] A handler you can supply to transports in the event of integer overflows

### DIFF
--- a/packages/rpc-transport/src/__tests__/json-rpc-transport-test.ts
+++ b/packages/rpc-transport/src/__tests__/json-rpc-transport-test.ts
@@ -23,4 +23,70 @@ describe('JSON-RPC 2.0 transport', () => {
         await expect(sendPromise).rejects.toThrow(/o no/);
         await expect(sendPromise).rejects.toMatchObject({ code: 123, data: 'abc' });
     });
+    // FIXME(solana-labs/solana/issues/30341) The JSON RPC was designed to communicate JavaScript
+    // `Numbers` over the wire, which puts values over `Number.MAX_SAFE_INTEGER` at risk of rounding
+    // errors. This test exercises the warning handler for such integer overflows.
+    describe('with respect to possible integer overflows', () => {
+        let onIntegerOverflow: jest.Mock;
+        let transport: IJsonRpcTransport;
+        beforeEach(() => {
+            onIntegerOverflow = jest.fn();
+        });
+        describe('given a transport configured without an `onIntegerOverflow` function', () => {
+            beforeEach(() => {
+                transport = createJsonRpcTransport({ url: 'fake://url' });
+            });
+            it('does not call `onIntegerOverflow` when passed a value above `Number.MAX_SAFE_INTEGER`', async () => {
+                expect.assertions(2);
+                fetchMock.once(JSON.stringify({ result: 123 }));
+                const result = await transport.send('someMethod', BigInt(Number.MAX_SAFE_INTEGER) + 1n);
+                expect(onIntegerOverflow).not.toHaveBeenCalled();
+                expect(result).toBe(123);
+            });
+        });
+        describe('given a transport configured with an `onIntegerOverflow` function', () => {
+            beforeEach(() => {
+                transport = createJsonRpcTransport({ onIntegerOverflow, url: 'fake://url' });
+            });
+            it('calls `onIntegerOverflow` when passed a value above `Number.MAX_SAFE_INTEGER`', async () => {
+                expect.assertions(2);
+                fetchMock.once(JSON.stringify({ result: 123 }));
+                const result = await transport.send('someMethod', BigInt(Number.MAX_SAFE_INTEGER) + 1n);
+                expect(onIntegerOverflow).toHaveBeenCalledWith('someMethod', [], BigInt(Number.MAX_SAFE_INTEGER) + 1n);
+                expect(result).toBe(123);
+            });
+            it('calls `onIntegerOverflow` when passed a nested array having a value above `Number.MAX_SAFE_INTEGER`', async () => {
+                expect.assertions(2);
+                fetchMock.once(JSON.stringify({ result: 123 }));
+                const result = await transport.send('someMethod', [1, 2, [3, BigInt(Number.MAX_SAFE_INTEGER) + 1n]]);
+                expect(onIntegerOverflow).toHaveBeenCalledWith(
+                    'someMethod',
+                    [2, 1], // Equivalent to `params[2][1]`.
+                    BigInt(Number.MAX_SAFE_INTEGER) + 1n
+                );
+                expect(result).toBe(123);
+            });
+            it('calls `onIntegerOverflow` when passed a nested object having a value above `Number.MAX_SAFE_INTEGER`', async () => {
+                expect.assertions(2);
+                fetchMock.once(JSON.stringify({ result: 123 }));
+                const result = await transport.send('someMethod', {
+                    a: 1,
+                    b: { b1: 2, b2: BigInt(Number.MAX_SAFE_INTEGER) + 1n },
+                });
+                expect(onIntegerOverflow).toHaveBeenCalledWith(
+                    'someMethod',
+                    ['b', 'b2'], // Equivalent to `params.b.b2`.
+                    BigInt(Number.MAX_SAFE_INTEGER) + 1n
+                );
+                expect(result).toBe(123);
+            });
+            it('does not call `onIntegerOverflow` when passed `Number.MAX_SAFE_INTEGER`', async () => {
+                expect.assertions(2);
+                fetchMock.once(JSON.stringify({ result: 123 }));
+                const result = await transport.send('someMethod', BigInt(Number.MAX_SAFE_INTEGER));
+                expect(onIntegerOverflow).not.toHaveBeenCalled();
+                expect(result).toBe(123);
+            });
+        });
+    });
 });

--- a/packages/rpc-transport/src/json-rpc-transport.ts
+++ b/packages/rpc-transport/src/json-rpc-transport.ts
@@ -5,6 +5,7 @@ import { createJsonRpcMessage } from './json-rpc-message';
 import { patchParamsForSolanaLabsRpc } from './params-patcher';
 
 type Config = Readonly<{
+    onIntegerOverflow?: (method: string, keyPath: (number | string)[], value: bigint) => void;
     url: string;
 }>;
 
@@ -12,10 +13,17 @@ type JsonRpcResponse<TResponse> = Readonly<
     { result: TResponse } | { error: { code: number; message: string; data?: unknown } }
 >;
 
-export function createJsonRpcTransport({ url }: Config): IJsonRpcTransport {
+export function createJsonRpcTransport({ onIntegerOverflow, url }: Config): IJsonRpcTransport {
     return {
         async send<TParams, TResponse>(method: string, params: TParams): Promise<TResponse> {
-            const patchedParams = patchParamsForSolanaLabsRpc(params);
+            const patchedParams = patchParamsForSolanaLabsRpc(
+                params,
+                onIntegerOverflow
+                    ? (keyPath, value) => {
+                          onIntegerOverflow(method, keyPath, value);
+                      }
+                    : undefined
+            );
             const jsonRpcMessage = createJsonRpcMessage(method, patchedParams);
             const response = await makeHttpRequest<JsonRpcResponse<TResponse>>({
                 payload: jsonRpcMessage,

--- a/packages/rpc-transport/src/params-patcher.ts
+++ b/packages/rpc-transport/src/params-patcher.ts
@@ -1,26 +1,36 @@
+type IntegerOverflowHandler = (keyPath: KeyPath, value: bigint) => void;
+type KeyPath = (number | string)[];
 type Patched<T> = T extends object ? { [Property in keyof T]: Patched<T[Property]> } : T extends bigint ? number : T;
-
 // FIXME(https://github.com/microsoft/TypeScript/issues/33014)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TypescriptBug33014 = any;
 
-export function patchParamsForSolanaLabsRpc<T>(params: T): Patched<T> {
-    if (Array.isArray(params)) {
-        return params.map(patchParamsForSolanaLabsRpc) as TypescriptBug33014;
-    } else if (typeof params === 'object' && params !== null) {
+function visitNode<T>(value: T, keyPath: KeyPath, onIntegerOverflow?: IntegerOverflowHandler): Patched<T> {
+    if (Array.isArray(value)) {
+        return value.map((element, ii) =>
+            visitNode(element, [...keyPath, ii], onIntegerOverflow)
+        ) as TypescriptBug33014;
+    } else if (typeof value === 'object' && value !== null) {
         const out = {} as TypescriptBug33014;
-        for (const propName in params) {
-            if (Object.prototype.hasOwnProperty.call(params, propName)) {
-                out[propName] = patchParamsForSolanaLabsRpc(params[propName]);
+        for (const propName in value) {
+            if (Object.prototype.hasOwnProperty.call(value, propName)) {
+                out[propName] = visitNode(value[propName], [...keyPath, propName], onIntegerOverflow);
             }
         }
         return out as TypescriptBug33014;
-    } else if (typeof params === 'bigint') {
-        // TODO(solana-labs/solana/issues/30341) Create a data type to represent u64 in the Solana
+    } else if (typeof value === 'bigint') {
+        // FIXME(solana-labs/solana/issues/30341) Create a data type to represent u64 in the Solana
         // JSON RPC implementation so that we can throw away this entire patcher instead of unsafely
         // downcasting `bigints` to `numbers`.
-        return Number(params) as TypescriptBug33014;
+        if (onIntegerOverflow && value > Number.MAX_SAFE_INTEGER) {
+            onIntegerOverflow(keyPath, value);
+        }
+        return Number(value) as TypescriptBug33014;
     } else {
-        return params as TypescriptBug33014;
+        return value as TypescriptBug33014;
     }
+}
+
+export function patchParamsForSolanaLabsRpc<T>(params: T, onIntegerOverflow?: IntegerOverflowHandler): Patched<T> {
+    return visitNode(params, [], onIntegerOverflow);
 }


### PR DESCRIPTION
[experimental] A handler you can supply to transports in the event of integer overflows
## Summary

The JSON RPC was designed to communicate JavaScript `Numbers` over the wire, which puts values over `Number.MAX_SAFE_INTEGER` at risk of rounding errors. In this PR we add a hook that fires in the event of such an overflow. Implementers of that hook can decide to do whatever they want: throw, warn, or allow.
## Test Plan

```shell
pnpm test:unit:browser
pnpm test:unit:node
```
