### PR TITLE
[experimental] Invert the responsibilities of the transport and rpc

### DIFF
--- a/packages/rpc-transport/package.json
+++ b/packages/rpc-transport/package.json
@@ -41,7 +41,9 @@
         "test:treeshakability:browser": "agadoo dist/index.browser.js",
         "test:treeshakability:native": "agadoo dist/index.node.js",
         "test:treeshakability:node": "agadoo dist/index.native.js",
-        "test:typecheck": "tsc --noEmit"
+        "test:typecheck": "tsc --noEmit",
+        "test:unit:browser": "jest -c node_modules/test-config/jest-unit.config.browser.ts --rootDir . --silent",
+        "test:unit:node": "jest -c node_modules/test-config/jest-unit.config.node.ts --rootDir . --silent"
     },
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "license": "MIT",
@@ -94,6 +96,8 @@
     },
     "dependencies": {
         "@solana/fetch-impl-browser": "workspace:*",
+        "@solana/keys": "workspace:*",
+        "@solana/rpc-core": "workspace:*",
         "node-fetch": "^2.6.7"
     }
 }

--- a/packages/rpc-transport/src/__tests__/json-rpc-transport-test.ts
+++ b/packages/rpc-transport/src/__tests__/json-rpc-transport-test.ts
@@ -1,33 +1,104 @@
-import { IJsonRpcTransport } from '..';
 import { makeHttpRequest } from '../http-request';
 import { SolanaJsonRpcError } from '../json-rpc-errors';
+import { createJsonRpcMessage } from '../json-rpc-message';
+import { getNextMessageId } from '../json-rpc-message-id';
 import { createJsonRpcTransport } from '../json-rpc-transport';
+import { Transport } from '../json-rpc-transport-types';
 
 jest.mock('../http-request');
+jest.mock('../json-rpc-message-id');
+
+interface TestRpcApi {
+    someMethod(...args: unknown[]): unknown;
+    someOtherMethod(...args: unknown[]): unknown;
+}
 
 describe('JSON-RPC 2.0 transport', () => {
-    let transport: IJsonRpcTransport;
+    let transport: Transport<TestRpcApi>;
+    const url = 'fake://url';
     beforeEach(() => {
-        transport = createJsonRpcTransport({ url: 'fake://url' });
+        transport = createJsonRpcTransport<TestRpcApi>({ url });
         (makeHttpRequest as jest.Mock).mockImplementation(
             () =>
                 new Promise(_ => {
                     /* never resolve */
                 })
         );
+        let counter = 0;
+        (getNextMessageId as jest.Mock).mockImplementation(() => counter++);
+    });
+    it('sends a request to a JSON-RPC 2.0 endpoint', () => {
+        transport.someMethod(123).send();
+        expect(makeHttpRequest).toHaveBeenCalledWith({
+            payload: { ...createJsonRpcMessage('someMethod', [123]), id: expect.any(Number) },
+            url,
+        });
+    });
+    it('sends a batch of requests to a JSON-RPC 2.0 endpoint', () => {
+        transport.someMethod(123).someOtherMethod(456).sendBatch();
+        expect(makeHttpRequest).toHaveBeenCalledWith({
+            payload: [
+                { ...createJsonRpcMessage('someMethod', [123]), id: expect.any(Number) },
+                { ...createJsonRpcMessage('someOtherMethod', [456]), id: expect.any(Number) },
+            ],
+            url,
+        });
     });
     it('returns results from a JSON-RPC 2.0 endpoint', async () => {
         expect.assertions(1);
         (makeHttpRequest as jest.Mock).mockResolvedValueOnce({ result: 123 });
-        const result = await transport.send('someMethod', undefined);
+        const result = await transport.someMethod().send();
         expect(result).toBe(123);
+    });
+    it('returns a batch of results from a JSON-RPC 2.0 endpoint', async () => {
+        expect.assertions(2);
+        (makeHttpRequest as jest.Mock).mockResolvedValueOnce([{ result: 123 }, { result: 456 }]);
+        const [resultA, resultB] = await transport.someMethod().someOtherMethod().sendBatch();
+        expect(resultA).toBe(123);
+        expect(resultB).toBe(456);
+    });
+    it('reorders results of a batch from a JSON-RPC 2.0 endpoint in request order', async () => {
+        expect.assertions(3);
+        // Produce requests in order.
+        const startId = Date.now();
+        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId);
+        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId + 1);
+        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId + 2);
+        // Mock the responses being returned out of order.
+        (makeHttpRequest as jest.Mock).mockResolvedValueOnce([
+            { id: startId + 2, result: 789 },
+            { id: startId, result: 123 },
+            { id: startId + 1, result: 456 },
+        ]);
+        const [resultA, resultB, resultC] = await transport.someMethod().someOtherMethod().someMethod().sendBatch();
+        expect(resultA).toBe(123);
+        expect(resultB).toBe(456);
+        expect(resultC).toBe(789);
     });
     it('throws errors from a JSON-RPC 2.0 endpoint', async () => {
         expect.assertions(3);
         (makeHttpRequest as jest.Mock).mockResolvedValueOnce({ error: { code: 123, data: 'abc', message: 'o no' } });
-        const sendPromise = transport.send('someMethod', undefined);
+        const sendPromise = transport.someMethod().send();
         await expect(sendPromise).rejects.toThrow(SolanaJsonRpcError);
         await expect(sendPromise).rejects.toThrow(/o no/);
         await expect(sendPromise).rejects.toMatchObject({ code: 123, data: 'abc' });
+    });
+    it('throws the first error of a batch from a JSON-RPC 2.0 endpoint', async () => {
+        expect.assertions(3);
+        // Produce requests in order.
+        const startId = Date.now();
+        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId);
+        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId + 1);
+        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId + 2);
+        // Mock the responses being returned out of order.
+        (makeHttpRequest as jest.Mock).mockResolvedValueOnce([
+            { error: { code: 456, data: 'def', message: 'also bad' }, id: startId + 2 },
+            { error: { code: 123, data: 'abc', message: 'o no' }, id: startId },
+            { id: startId + 1, result: 123 },
+        ]);
+        const sendBatchPromise = transport.someMethod().someOtherMethod().someMethod().sendBatch();
+        await expect(sendBatchPromise).rejects.toThrow(SolanaJsonRpcError);
+        await expect(sendBatchPromise).rejects.toThrow(/o no/);
+        await expect(sendBatchPromise).rejects.toMatchObject({ code: 123, data: 'abc' });
     });
 });

--- a/packages/rpc-transport/src/index.ts
+++ b/packages/rpc-transport/src/index.ts
@@ -1,7 +1,1 @@
-import { createJsonRpcTransport } from './json-rpc-transport';
-
-export interface IJsonRpcTransport {
-    send<TParams, TResponse>(method: string, params: TParams): Promise<TResponse>;
-}
-
-export { createJsonRpcTransport };
+export * from './json-rpc-transport';

--- a/packages/rpc-transport/src/json-rpc-transport-types.ts
+++ b/packages/rpc-transport/src/json-rpc-transport-types.ts
@@ -1,0 +1,80 @@
+/**
+ * Public API.
+ */
+export type Transport<TApi> = TransportMethods<TApi>;
+export type ArmedTransport<Api, TResponse> = ArmedTransportMethods<Api, TResponse> & {
+    send(): Promise<TResponse>;
+};
+export type ArmedBatchTransport<Api, TResponses extends unknown[]> = ArmedBatchTransportMethods<Api, TResponses> & {
+    sendBatch(): Promise<TResponses>;
+};
+
+/**
+ * Private transport-building types.
+ */
+type TransportMethods<TApi> = {
+    [TMethodName in keyof TApi]: ArmedTransportReturner<TApi, ApiMethodImplementations<TApi, TMethodName>>;
+};
+type ArmedTransportMethods<TApi, TResponse> = {
+    [TMethodName in keyof TApi]: ArmedBatchTransportReturner<
+        TApi,
+        ApiMethodImplementations<TApi, TMethodName>,
+        [TResponse]
+    >;
+};
+type ArmedBatchTransportMethods<TApi, TResponses extends unknown[]> = {
+    [TMethodName in keyof TApi]: ArmedBatchTransportReturner<
+        TApi,
+        ApiMethodImplementations<TApi, TMethodName>,
+        TResponses
+    >;
+};
+type ApiMethodImplementations<TApi, TMethod extends keyof TApi> = Overloads<TApi[TMethod]>;
+type ArmedTransportReturner<TApi, TMethodImplementations> = UnionToIntersection<
+    Flatten<{
+        // Check that this property of the TApi interface is, in fact, a function.
+        [P in keyof TMethodImplementations]: TMethodImplementations[P] extends Callable
+            ? (
+                  ...args: Parameters<TMethodImplementations[P]>
+              ) => ArmedTransport<TApi, ReturnType<TMethodImplementations[P]>>
+            : never;
+    }>
+>;
+type ArmedBatchTransportReturner<TApi, TMethodImplementations, TResponses extends unknown[]> = UnionToIntersection<
+    Flatten<{
+        // Check that this property of the TApi interface is, in fact, a function.
+        [P in keyof TMethodImplementations]: TMethodImplementations[P] extends Callable
+            ? (
+                  ...args: Parameters<TMethodImplementations[P]>
+              ) => ArmedBatchTransport<TApi, [...TResponses, ReturnType<TMethodImplementations[P]>]>
+            : never;
+    }>
+>;
+
+/**
+ * Utility types that do terrible, awful things.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Callable = (...args: any[]) => any;
+type Flatten<T> = T extends (infer Item)[] ? Item : never;
+type Overloads<T> =
+    // Have an RPC method with more than 3 overloads? Add another section and update this comment
+    T extends {
+        (...args: infer A1): infer R1;
+        (...args: infer A2): infer R2;
+        (...args: infer A3): infer R3;
+    }
+        ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3]
+        : T extends {
+              (...args: infer A1): infer R1;
+              (...args: infer A2): infer R2;
+          }
+        ? [(...args: A1) => R1, (...args: A2) => R2]
+        : T extends {
+              (...args: infer A1): infer R1;
+          }
+        ? [(...args: A1) => R1]
+        : unknown;
+type UnionToIntersection<T> = (T extends unknown ? (x: T) => unknown : never) extends (x: infer R) => unknown
+    ? R
+    : never;

--- a/packages/rpc-transport/src/json-rpc-transport.ts
+++ b/packages/rpc-transport/src/json-rpc-transport.ts
@@ -1,39 +1,149 @@
-import { IJsonRpcTransport } from '.';
 import { makeHttpRequest } from './http-request';
 import { SolanaJsonRpcError } from './json-rpc-errors';
 import { createJsonRpcMessage } from './json-rpc-message';
+import { ArmedBatchTransport, ArmedTransport, Transport } from './json-rpc-transport-types';
 import { patchParamsForSolanaLabsRpc } from './params-patcher';
 
-type Config = Readonly<{
+interface IHasIdentifier {
+    readonly id: number;
+}
+type JsonRpcResponse<TResponse> = IHasIdentifier &
+    Readonly<{ result: TResponse } | { error: { code: number; message: string; data?: unknown } }>;
+type JsonRpcBatchResponse<TResponses extends unknown[]> = [
+    ...{ [P in keyof TResponses]: JsonRpcResponse<TResponses[P]> }
+];
+type JsonRpcMessage = ReturnType<typeof createJsonRpcMessage>;
+
+type TransportConfig = Readonly<{
     onIntegerOverflow?: (method: string, keyPath: (number | string)[], value: bigint) => void;
     url: string;
 }>;
 
-type JsonRpcResponse<TResponse> = Readonly<
-    { result: TResponse } | { error: { code: number; message: string; data?: unknown } }
->;
-
-export function createJsonRpcTransport({ onIntegerOverflow, url }: Config): IJsonRpcTransport {
-    return {
-        async send<TParams, TResponse>(method: string, params: TParams): Promise<TResponse> {
-            const patchedParams = patchParamsForSolanaLabsRpc(
-                params,
-                onIntegerOverflow
-                    ? (keyPath, value) => {
-                          onIntegerOverflow(method, keyPath, value);
-                      }
-                    : undefined
-            );
-            const jsonRpcMessage = createJsonRpcMessage(method, patchedParams);
-            const response = await makeHttpRequest<JsonRpcResponse<TResponse>>({
-                payload: jsonRpcMessage,
-                url,
-            });
-            if ('error' in response) {
-                throw new SolanaJsonRpcError(response.error);
-            } else {
-                return response.result as TResponse;
-            }
+function createArmedJsonRpcTransport<TRpcApi extends object, TResponse>(
+    transportConfig: TransportConfig,
+    pendingMessage: JsonRpcMessage
+) {
+    const { url } = transportConfig;
+    const transport = {
+        async send(): Promise<TResponse> {
+            return await sendPayload(pendingMessage, url);
         },
-    };
+    } as ArmedTransport<TRpcApi, TResponse>;
+    return makeProxy<TRpcApi, TResponse>(transport, transportConfig, pendingMessage);
+}
+
+function createArmedBatchJsonRpcTransport<TRpcApi extends object, TResponses extends unknown[]>(
+    transportConfig: TransportConfig,
+    pendingMessages: JsonRpcMessage[]
+) {
+    const { url } = transportConfig;
+    const transport = {
+        async sendBatch(): Promise<TResponses> {
+            return await sendPayload(pendingMessages, url);
+        },
+    } as ArmedBatchTransport<TRpcApi, TResponses>;
+    return makeProxy<TRpcApi, TResponses>(transport, transportConfig, pendingMessages);
+}
+
+function makeProxy<TRpcApi, TResponses extends unknown[]>(
+    transport: ArmedBatchTransport<TRpcApi, TResponses>,
+    transportConfig: TransportConfig,
+    pendingRequests: JsonRpcMessage[]
+): ArmedBatchTransport<TRpcApi, TResponses>;
+function makeProxy<TRpcApi, TResponse>(
+    transport: ArmedTransport<TRpcApi, TResponse>,
+    transportConfig: TransportConfig,
+    pendingRequest: JsonRpcMessage
+): ArmedTransport<TRpcApi, TResponse>;
+function makeProxy<TRpcApi>(transport: Transport<TRpcApi>, transportConfig: TransportConfig): Transport<TRpcApi>;
+function makeProxy<TRpcApi, TResponseOrResponses>(
+    transport:
+        | Transport<TRpcApi>
+        | (TResponseOrResponses extends unknown[]
+              ? ArmedBatchTransport<TRpcApi, TResponseOrResponses>
+              : ArmedTransport<TRpcApi, TResponseOrResponses>),
+    transportConfig: TransportConfig,
+    pendingRequestOrRequests?: JsonRpcMessage | JsonRpcMessage[]
+):
+    | Transport<TRpcApi>
+    | (TResponseOrResponses extends unknown[]
+          ? ArmedBatchTransport<TRpcApi, TResponseOrResponses>
+          : ArmedTransport<TRpcApi, TResponseOrResponses>) {
+    const { onIntegerOverflow } = transportConfig;
+    return new Proxy(transport, {
+        defineProperty() {
+            return false;
+        },
+        deleteProperty() {
+            return false;
+        },
+        get<TMethodName extends keyof typeof transport>(
+            ...args: Parameters<NonNullable<ProxyHandler<typeof transport>['get']>>
+        ) {
+            const [target, p] = args;
+            return p in target
+                ? Reflect.get(...args)
+                : function (
+                      ...params: Parameters<
+                          (typeof transport)[TMethodName] extends (...args: unknown[]) => unknown
+                              ? (typeof transport)[TMethodName]
+                              : never
+                      >
+                  ) {
+                      const methodName = p.toString();
+                      const patchedParams = patchParamsForSolanaLabsRpc(
+                          params,
+                          onIntegerOverflow
+                              ? (keyPath, value) => {
+                                    onIntegerOverflow(methodName, keyPath, value);
+                                }
+                              : undefined
+                      );
+                      const newMessage = createJsonRpcMessage(methodName, patchedParams);
+                      if (pendingRequestOrRequests == null) {
+                          return createArmedJsonRpcTransport(transportConfig, newMessage);
+                      } else {
+                          const nextPendingMessages = Array.isArray(pendingRequestOrRequests)
+                              ? [...pendingRequestOrRequests, newMessage]
+                              : [pendingRequestOrRequests, newMessage];
+                          return createArmedBatchJsonRpcTransport(transportConfig, nextPendingMessages);
+                      }
+                  };
+        },
+    });
+}
+
+function processResponse<TResponse>(response: JsonRpcResponse<TResponse>) {
+    if ('error' in response) {
+        throw new SolanaJsonRpcError(response.error);
+    } else {
+        return response.result as TResponse;
+    }
+}
+
+function sendPayload<TResponses extends unknown[]>(payload: IHasIdentifier[], url: string): Promise<TResponses>;
+function sendPayload<TResponse>(payload: IHasIdentifier, url: string): Promise<TResponse>;
+async function sendPayload<TResponseOrResponses>(payload: IHasIdentifier | IHasIdentifier[], url: string) {
+    const responseOrResponses = await makeHttpRequest<
+        TResponseOrResponses extends unknown[]
+            ? JsonRpcBatchResponse<TResponseOrResponses>
+            : JsonRpcResponse<TResponseOrResponses>
+    >({
+        payload,
+        url,
+    });
+
+    if (Array.isArray(responseOrResponses)) {
+        const requestOrder = (payload as IHasIdentifier[]).map(p => p.id);
+        return responseOrResponses
+            .sort((a, b) => requestOrder.indexOf(a.id) - requestOrder.indexOf(b.id))
+            .map(processResponse);
+    } else {
+        return processResponse(responseOrResponses);
+    }
+}
+
+export function createJsonRpcTransport<TRpcApi extends object>(transportConfig: TransportConfig) {
+    const transport = {} as Transport<TRpcApi>;
+    return makeProxy<TRpcApi>(transport, transportConfig);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,6 +572,12 @@ importers:
       '@solana/fetch-impl-browser':
         specifier: workspace:*
         version: link:../fetch-impl-browser
+      '@solana/keys':
+        specifier: workspace:*
+        version: link:../keys
+      '@solana/rpc-core':
+        specifier: workspace:*
+        version: link:../rpc-core
       node-fetch:
         specifier: ^2.6.7
         version: 2.6.7


### PR DESCRIPTION
[experimental] Invert the responsibilities of the transport and rpc
## Summary

Previously, the RPC API was responsible for:

* exposing RPC methods using a JavaScript proxy
* formatting params for delivery to an RPC server
* calling `send()` on a supplied transport

What I discovered was that this made a whole bunch of things _really_ hard.

* supplying a per-call cancellation signal
* bundling calls in a batch

In this PR, we inside out this design.

* the RPC package is now exclusively made up of types
* the transport features a generic that accepts that type, exposing all of its methods
* the transport now ‘collects’ calls until you call `send()` or `sendBatch()`
* the ‘send’ methods are a logical place to configure a cancellation signal, and more.

Look at the tests to see how this works in practice, but in the meantime here's an example:

```ts
const devnet = createJsonRpcTransport({ url:'https://api.devnet.solana.com' });

const blockHeight = await devnet
  .getBlockHeight({ commitment: 'finalized' })
  .send();

const [blockHeight, balance] = await devnet
  .getBlockHeight({ commitment: 'finalized' })
  .getBalance('M2mx93ekt1fmXSVkTrUL9xVFHkmME8HTUi5Cyc5aF7K' as Base58EncodedAddress)
  .sendBatch();
```

## Test Plan

```shell
pnpm test:unit:browser
pnpm test:unit:node
```
