### PR TITLE
refactor(experimental): introduce a `createDefaultRpc()` method to the library

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -44,7 +44,9 @@
         "test:treeshakability:browser": "agadoo dist/index.browser.js",
         "test:treeshakability:native": "agadoo dist/index.node.js",
         "test:treeshakability:node": "agadoo dist/index.native.js",
-        "test:typecheck": "tsc --noEmit"
+        "test:typecheck": "tsc --noEmit",
+        "test:unit:browser": "jest -c node_modules/test-config/jest-unit.config.browser.ts --rootDir . --silent",
+        "test:unit:node": "jest -c node_modules/test-config/jest-unit.config.node.ts --rootDir . --silent"
     },
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "license": "MIT",
@@ -60,10 +62,12 @@
         "maintained node versions"
     ],
     "dependencies": {
-        "@solana/keys": "workspace:*"
+        "@solana/keys": "workspace:*",
+        "@solana/rpc-transport": "workspace:*"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^0.0.4",
+        "@solana/rpc-core": "workspace:*",
         "@swc/core": "^1.3.18",
         "@swc/jest": "^0.2.23",
         "@types/jest": "^29.5.0",

--- a/packages/library/src/__tests__/rpc-test.ts
+++ b/packages/library/src/__tests__/rpc-test.ts
@@ -1,0 +1,34 @@
+import { createDefaultRpc } from '../rpc';
+import { SolanaJsonRpcIntegerOverflowError } from '../rpc-integer-overflow-error';
+
+import { SolanaJsonRpcApi } from '@solana/rpc-core';
+import { Transport } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
+
+describe('RPC', () => {
+    let transport: Transport<SolanaJsonRpcApi>;
+    beforeEach(() => {
+        transport = createDefaultRpc('fake://url');
+    });
+    describe('with respect to integer overflows', () => {
+        it('does not throw when called with a value up to `Number.MAX_SAFE_INTEGER`', () => {
+            expect(() => {
+                transport.getBlocks(BigInt(Number.MAX_SAFE_INTEGER));
+            }).not.toThrow();
+        });
+        it('does not throw when called with a value up to `-Number.MAX_SAFE_INTEGER`', () => {
+            expect(() => {
+                transport.getBlocks(BigInt(-Number.MAX_SAFE_INTEGER));
+            }).not.toThrow();
+        });
+        it('throws when called with a value greater than `Number.MAX_SAFE_INTEGER`', () => {
+            expect(() => {
+                transport.getBlocks(BigInt(Number.MAX_SAFE_INTEGER) + 1n);
+            }).toThrow(SolanaJsonRpcIntegerOverflowError);
+        });
+        it('throws when called with a value less than `-Number.MAX_SAFE_INTEGER`', () => {
+            expect(() => {
+                transport.getBlocks(BigInt(-Number.MAX_SAFE_INTEGER) - 1n);
+            }).toThrow(SolanaJsonRpcIntegerOverflowError);
+        });
+    });
+});

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -1,1 +1,2 @@
 export * from '@solana/keys';
+export * from './rpc';

--- a/packages/library/src/rpc-default-config.ts
+++ b/packages/library/src/rpc-default-config.ts
@@ -1,0 +1,9 @@
+import { SolanaJsonRpcIntegerOverflowError } from './rpc-integer-overflow-error';
+
+import { createJsonRpcTransport } from '@solana/rpc-transport';
+
+export const DEFAULT_RPC_CONFIG: Partial<Parameters<typeof createJsonRpcTransport>[0]> = {
+    onIntegerOverflow(...args) {
+        throw new SolanaJsonRpcIntegerOverflowError(...args);
+    },
+};

--- a/packages/library/src/rpc.ts
+++ b/packages/library/src/rpc.ts
@@ -1,0 +1,12 @@
+import { DEFAULT_RPC_CONFIG } from './rpc-default-config';
+
+import { SolanaJsonRpcApi } from '@solana/rpc-core';
+import { createJsonRpcTransport } from '@solana/rpc-transport';
+import { Transport } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
+
+export function createDefaultRpc(url: string): Transport<SolanaJsonRpcApi> {
+    return createJsonRpcTransport({
+        ...DEFAULT_RPC_CONFIG,
+        url,
+    }) as Transport<SolanaJsonRpcApi>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,10 +197,16 @@ importers:
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
+      '@solana/rpc-transport':
+        specifier: workspace:*
+        version: link:../rpc-transport
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^0.0.4
         version: 0.0.4(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.49.0)(eslint-plugin-jest@27.2.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-sort-keys-fix@1.1.2)(eslint@8.33.0)(typescript@4.9.4)
+      '@solana/rpc-core':
+        specifier: workspace:*
+        version: link:../rpc-core
       '@swc/core':
         specifier: ^1.3.18
         version: 1.3.32


### PR DESCRIPTION
refactor(experimental): introduce a `createDefaultRpc()` method to the library
## Summary

You can use this to create a transport with default config. Supply only a URL.

## Test Plan

```
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1227).
* #1241
* #1239
* #1232
* #1231
* #1230
* #1229
* #1228
* __->__ #1227