### PR TITLE
refactor(experimental): jest setup/teardown functions for test validator

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -44,7 +44,9 @@
         "test:treeshakability:browser": "agadoo dist/index.browser.js",
         "test:treeshakability:native": "agadoo dist/index.node.js",
         "test:treeshakability:node": "agadoo dist/index.native.js",
-        "test:typecheck": "tsc --noEmit"
+        "test:typecheck": "tsc --noEmit",
+        "test:unit:browser": "jest -c node_modules/test-config/jest-unit.config.browser.ts --rootDir . --silent",
+        "test:unit:node": "jest -c node_modules/test-config/jest-unit.config.node.ts --rootDir . --silent"
     },
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "license": "MIT",
@@ -60,10 +62,12 @@
         "maintained node versions"
     ],
     "dependencies": {
-        "@solana/keys": "workspace:*"
+        "@solana/keys": "workspace:*",
+        "@solana/rpc-transport": "workspace:*"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^0.0.4",
+        "@solana/rpc-core": "workspace:*",
         "@swc/core": "^1.3.18",
         "@swc/jest": "^0.2.23",
         "@types/jest": "^29.5.0",

--- a/packages/library/src/__tests__/rpc-test.ts
+++ b/packages/library/src/__tests__/rpc-test.ts
@@ -1,0 +1,34 @@
+import { createDefaultRpc } from '../rpc';
+import { SolanaJsonRpcIntegerOverflowError } from '../rpc-integer-overflow-error';
+
+import { SolanaJsonRpcApi } from '@solana/rpc-core';
+import { Transport } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
+
+describe('RPC', () => {
+    let transport: Transport<SolanaJsonRpcApi>;
+    beforeEach(() => {
+        transport = createDefaultRpc('fake://url');
+    });
+    describe('with respect to integer overflows', () => {
+        it('does not throw when called with a value up to `Number.MAX_SAFE_INTEGER`', () => {
+            expect(() => {
+                transport.getBlocks(BigInt(Number.MAX_SAFE_INTEGER));
+            }).not.toThrow();
+        });
+        it('does not throw when called with a value up to `-Number.MAX_SAFE_INTEGER`', () => {
+            expect(() => {
+                transport.getBlocks(BigInt(-Number.MAX_SAFE_INTEGER));
+            }).not.toThrow();
+        });
+        it('throws when called with a value greater than `Number.MAX_SAFE_INTEGER`', () => {
+            expect(() => {
+                transport.getBlocks(BigInt(Number.MAX_SAFE_INTEGER) + 1n);
+            }).toThrow(SolanaJsonRpcIntegerOverflowError);
+        });
+        it('throws when called with a value less than `-Number.MAX_SAFE_INTEGER`', () => {
+            expect(() => {
+                transport.getBlocks(BigInt(-Number.MAX_SAFE_INTEGER) - 1n);
+            }).toThrow(SolanaJsonRpcIntegerOverflowError);
+        });
+    });
+});

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -1,1 +1,2 @@
 export * from '@solana/keys';
+export * from './rpc';

--- a/packages/library/src/rpc-default-config.ts
+++ b/packages/library/src/rpc-default-config.ts
@@ -1,0 +1,9 @@
+import { SolanaJsonRpcIntegerOverflowError } from './rpc-integer-overflow-error';
+
+import { createJsonRpcTransport } from '@solana/rpc-transport';
+
+export const DEFAULT_RPC_CONFIG: Partial<Parameters<typeof createJsonRpcTransport>[0]> = {
+    onIntegerOverflow(...args) {
+        throw new SolanaJsonRpcIntegerOverflowError(...args);
+    },
+};

--- a/packages/library/src/rpc.ts
+++ b/packages/library/src/rpc.ts
@@ -1,0 +1,12 @@
+import { DEFAULT_RPC_CONFIG } from './rpc-default-config';
+
+import { SolanaJsonRpcApi } from '@solana/rpc-core';
+import { createJsonRpcTransport } from '@solana/rpc-transport';
+import { Transport } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
+
+export function createDefaultRpc(url: string): Transport<SolanaJsonRpcApi> {
+    return createJsonRpcTransport({
+        ...DEFAULT_RPC_CONFIG,
+        url,
+    }) as Transport<SolanaJsonRpcApi>;
+}

--- a/packages/test-config/package.json
+++ b/packages/test-config/package.json
@@ -7,10 +7,13 @@
         "jest-lint.config.ts",
         "jest-prettier.config.ts",
         "jest-unit.config.browser.ts",
-        "jest-unit.config.node.ts"
+        "jest-unit.config.node.ts",
+        "test-validator-setup.js",
+        "test-validator-teardown.js"
     ],
     "peerDependencies": {
         "jest": "^29.5.0",
+        "jest-dev-server": "^8.0.5",
         "jest-environment-jsdom": "^29.5.0",
         "jest-fetch-mock": "^3.0.3",
         "jest-runner-eslint": "^1.1.0",
@@ -23,6 +26,7 @@
         "@jest/types": "^29.5.0",
         "@types/jest": "^29.5.0",
         "jest": "^29.5.0",
+        "jest-dev-server": "^8.0.5",
         "jest-fetch-mock": "^3.0.3",
         "tsconfig": "workspace:*"
     }

--- a/packages/test-config/test-validator-setup.js
+++ b/packages/test-config/test-validator-setup.js
@@ -1,0 +1,13 @@
+/* eslint-disable */
+const { setup } = require('jest-dev-server');
+
+module.exports = async function globalSetup() {
+    globalThis.servers = await setup({
+        command: '../../scripts/start-shared-test-validator.sh',
+        host: '127.0.0.1',
+        launchTimeout: 50000,
+        path: 'health',
+        port: 8899,
+        protocol: 'http',
+    });
+};

--- a/packages/test-config/test-validator-teardown.js
+++ b/packages/test-config/test-validator-teardown.js
@@ -1,0 +1,6 @@
+/* eslint-disable */
+const { teardown } = require('jest-dev-server');
+
+module.exports = async function globalTeardown() {
+    await teardown(globalThis.servers);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,10 +197,16 @@ importers:
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
+      '@solana/rpc-transport':
+        specifier: workspace:*
+        version: link:../rpc-transport
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^0.0.4
         version: 0.0.4(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.49.0)(eslint-plugin-jest@27.2.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-sort-keys-fix@1.1.2)(eslint@8.33.0)(typescript@4.9.4)
+      '@solana/rpc-core':
+        specifier: workspace:*
+        version: link:../rpc-core
       '@swc/core':
         specifier: ^1.3.18
         version: 1.3.32

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,6 +697,9 @@ importers:
       jest:
         specifier: ^29.5.0
         version: 29.5.0(@types/node@18.11.17)(ts-node@10.9.1)
+      jest-dev-server:
+        specifier: ^8.0.5
+        version: 8.0.5
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -4161,7 +4164,6 @@ packages:
     resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /acorn@8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
@@ -4879,6 +4881,11 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /commander@5.1.0:
+    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
+    dev: true
+
   /commitlint@17.4.2:
     resolution: {integrity: sha512-1UQecX+vSJHQXTKFMRZmf8EG3BYYjkT26JLe6FTQhu7N67FiWdWbqXMpcQSpqx/kWNz9a+DX2au2e61IH89PDA==}
     engines: {node: '>=v14'}
@@ -5135,6 +5142,14 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       cssom: 0.3.8
+
+  /cwd@0.10.0:
+    resolution: {integrity: sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      find-pkg: 0.1.2
+      fs-exists-sync: 0.1.0
+    dev: true
 
   /dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
@@ -6333,6 +6348,13 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
+  /expand-tilde@1.2.2:
+    resolution: {integrity: sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      os-homedir: 1.0.2
+    dev: true
+
   /expect@27.5.1:
     resolution: {integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -6498,6 +6520,32 @@ packages:
       - supports-color
     dev: true
 
+  /find-file-up@0.1.3:
+    resolution: {integrity: sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      fs-exists-sync: 0.1.0
+      resolve-dir: 0.1.1
+    dev: true
+
+  /find-pkg@0.1.2:
+    resolution: {integrity: sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      find-file-up: 0.1.3
+    dev: true
+
+  /find-process@1.4.7:
+    resolution: {integrity: sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      commander: 5.1.0
+      debug: 4.3.4(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /find-up@2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
@@ -6596,6 +6644,11 @@ packages:
 
   /fromentries@1.3.2:
     resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
+    dev: true
+
+  /fs-exists-sync@0.1.0:
+    resolution: {integrity: sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /fs-extra@10.0.1:
@@ -6781,6 +6834,24 @@ packages:
       ini: 1.3.8
     dev: true
 
+  /global-modules@0.2.3:
+    resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      global-prefix: 0.1.5
+      is-windows: 0.2.0
+    dev: true
+
+  /global-prefix@0.1.5:
+    resolution: {integrity: sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      homedir-polyfill: 1.0.3
+      ini: 1.3.8
+      is-windows: 0.2.0
+      which: 1.3.1
+    dev: true
+
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -6910,6 +6981,13 @@ packages:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+    dev: true
+
+  /homedir-polyfill@1.0.3:
+    resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      parse-passwd: 1.0.0
     dev: true
 
   /hook-std@2.0.0:
@@ -7295,6 +7373,11 @@ packages:
       call-bind: 1.0.2
     dev: true
 
+  /is-windows@0.2.0:
+    resolution: {integrity: sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /isarray@0.0.1:
     resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
     dev: true
@@ -7505,6 +7588,22 @@ packages:
       ts-node: 10.9.1(@swc/core@1.3.32)(@types/node@18.11.17)(typescript@4.9.5)
     transitivePeerDependencies:
       - supports-color
+
+  /jest-dev-server@8.0.5:
+    resolution: {integrity: sha512-pgf6R6r9z9Cf+9wGEXV24hIPYPPBPpJtETJm4O1hWtnaSiDshOsgQNOLB3EmoZIq+fAfZuLsuaxETf33GhJNGg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      chalk: 4.1.2
+      cwd: 0.10.0
+      find-process: 1.4.7
+      prompts: 2.4.2
+      spawnd: 8.0.5
+      tree-kill: 1.2.2
+      wait-on: 7.0.1(debug@4.3.4)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
 
   /jest-diff@27.5.1:
     resolution: {integrity: sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==}
@@ -9217,6 +9316,11 @@ packages:
       type-check: 0.4.0
       word-wrap: 1.2.3
 
+  /os-homedir@1.0.2:
+    resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /p-each-series@2.2.0:
     resolution: {integrity: sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==}
     engines: {node: '>=8'}
@@ -9363,6 +9467,11 @@ packages:
 
   /parse-multipart-data@1.5.0:
     resolution: {integrity: sha512-ck5zaMF0ydjGfejNMnlo5YU2oJ+pT+80Jb1y4ybanT27j+zbVP/jkYmCrUGsEln0Ox/hZmuvgy8Ra7AxbXP2Mw==}
+    dev: true
+
+  /parse-passwd@1.0.0:
+    resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /parse5@6.0.1:
@@ -9820,6 +9929,14 @@ packages:
     dependencies:
       resolve-from: 5.0.0
 
+  /resolve-dir@0.1.1:
+    resolution: {integrity: sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      expand-tilde: 1.2.2
+      global-modules: 0.2.3
+    dev: true
+
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -10273,6 +10390,14 @@ packages:
 
   /spawn-error-forwarder@1.0.0:
     resolution: {integrity: sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==}
+    dev: true
+
+  /spawnd@8.0.5:
+    resolution: {integrity: sha512-D+crPxX9sSXzF4o/3RjtNcc+PT+CQuSrLsq0VP1SQDy6ka3rD2wUmzkxhD1XlNEcNX0zccQEmPJI2xBYcdpR7Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      signal-exit: 3.0.7
+      tree-kill: 1.2.2
     dev: true
 
   /spdx-correct@3.1.1:
@@ -10730,7 +10855,7 @@ packages:
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.2
       '@types/node': 18.11.17
-      acorn: 8.8.2
+      acorn: 8.8.0
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -11423,6 +11548,13 @@ packages:
       is-number-object: 1.0.6
       is-string: 1.0.7
       is-symbol: 1.0.4
+    dev: true
+
+  /which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
     dev: true
 
   /which@2.0.2:


### PR DESCRIPTION
refactor(experimental): jest setup/teardown functions for test validator
## Summary
Any test that relies on a test validator running on localhost can use these Jest setup/teardown functions. They take care of starting the validator, waiting for it to come alive, and tearing it down at the end of the test.

## Test Plan

See the first PR that makes use of it.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1228).
* #1241
* #1239
* #1232
* #1231
* #1230
* #1229
* __->__ #1228
* #1227