### PR TITLE
refactor(experimental): install the response patcher into the RPC transport

### DIFF
--- a/packages/rpc-transport/src/json-rpc-transport/__tests__/json-rpc-method-get-block-height-test.ts
+++ b/packages/rpc-transport/src/json-rpc-transport/__tests__/json-rpc-method-get-block-height-test.ts
@@ -16,7 +16,7 @@ describe('getBlockHeight', () => {
     });
     (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
         describe(`when called with \`${commitment}\` commitment`, () => {
-            it.failing('returns the block height as a bigint', async () => {
+            it('returns the block height as a bigint', async () => {
                 expect.assertions(1);
                 const blockHeight = await transport.getBlockHeight({ commitment }).send();
                 expect(blockHeight).toEqual(expect.any(BigInt));
@@ -24,7 +24,7 @@ describe('getBlockHeight', () => {
         });
     });
     describe('when called with a `minContextSlot` of 0', () => {
-        it.failing('returns the block height as a bigint', async () => {
+        it('returns the block height as a bigint', async () => {
             expect.assertions(1);
             const blockHeight = await transport.getBlockHeight({ minContextSlot: 0n }).send();
             expect(blockHeight).toEqual(expect.any(BigInt));

--- a/packages/rpc-transport/src/json-rpc-transport/__tests__/json-rpc-transport-response-patcher-test.ts
+++ b/packages/rpc-transport/src/json-rpc-transport/__tests__/json-rpc-transport-response-patcher-test.ts
@@ -1,0 +1,28 @@
+import { createJsonRpcTransport } from '..';
+import { makeHttpRequest } from '../../http-request';
+import { Transport } from '../json-rpc-transport-types';
+import { patchResponseForSolanaLabsRpc } from '../../response-patcher';
+
+jest.mock('../../http-request');
+jest.mock('../../response-patcher');
+
+interface TestRpcApi {
+    someMethod(...args: unknown[]): unknown;
+}
+
+// FIXME(solana-labs/solana/issues/30341) The JSON RPC was designed to communicate JavaScript
+// `Numbers` over the wire, which puts values over `Number.MAX_SAFE_INTEGER` at risk of rounding
+// errors. This test ensures that the response patcher is called.
+describe('Solana JSON-RPC response patcher', () => {
+    let transport: Transport<TestRpcApi>;
+    const url = 'fake://url';
+    beforeEach(() => {
+        transport = createJsonRpcTransport({ url });
+    });
+    it('calls the response patcher with the response and the method name', async () => {
+        expect.assertions(1);
+        (makeHttpRequest as jest.Mock).mockResolvedValueOnce({ result: 456 });
+        await transport.someMethod(123).send();
+        expect(patchResponseForSolanaLabsRpc).toHaveBeenCalledWith(456, 'someMethod');
+    });
+});

--- a/packages/rpc-transport/src/json-rpc-transport/__tests__/json-rpc-transport-test.ts
+++ b/packages/rpc-transport/src/json-rpc-transport/__tests__/json-rpc-transport-test.ts
@@ -1,4 +1,5 @@
 import { makeHttpRequest } from '../../http-request';
+import { patchResponseForSolanaLabsRpc } from '../../response-patcher';
 import { SolanaJsonRpcError } from '../json-rpc-errors';
 import { createJsonRpcMessage } from '../json-rpc-message';
 import { getNextMessageId } from '../json-rpc-message-id';
@@ -6,6 +7,7 @@ import { createJsonRpcTransport } from '..';
 import { Transport } from '../json-rpc-transport-types';
 
 jest.mock('../../http-request');
+jest.mock('../../response-patcher');
 jest.mock('../json-rpc-message-id');
 
 interface TestRpcApi {
@@ -26,6 +28,7 @@ describe('JSON-RPC 2.0 transport', () => {
         );
         let counter = 0;
         (getNextMessageId as jest.Mock).mockImplementation(() => counter++);
+        (patchResponseForSolanaLabsRpc as jest.Mock).mockImplementation(p => p);
     });
     it('sends a request to a JSON-RPC 2.0 endpoint', () => {
         transport.someMethod(123).send();

--- a/packages/rpc-transport/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-transport/src/response-patcher-allowed-numeric-values.ts
@@ -1,0 +1,9 @@
+import { KeyPath } from './response-patcher';
+
+import { SolanaJsonRpcApi } from '@solana/rpc-core';
+
+/**
+ * These are keypaths at the end of which you will find a numeric value that should *not* be upcast
+ * to a `bigint`. These are values that are legitimately defined as `u8` or `usize` on the backend.
+ */
+export const ALLOWED_NUMERIC_KEYPATHS: Partial<Record<keyof SolanaJsonRpcApi, readonly KeyPath[]>> = {};

--- a/packages/rpc-transport/src/response-patcher-types.ts
+++ b/packages/rpc-transport/src/response-patcher-types.ts
@@ -1,0 +1,3 @@
+export type KeyPathWildcard = { readonly __keyPathWildcard: unique symbol };
+
+export const KEYPATH_WILDCARD = {} as KeyPathWildcard;

--- a/packages/rpc-transport/src/response-patcher.ts
+++ b/packages/rpc-transport/src/response-patcher.ts
@@ -1,20 +1,41 @@
+import { ALLOWED_NUMERIC_KEYPATHS } from './response-patcher-allowed-numeric-values';
+import { KeyPathWildcard, KEYPATH_WILDCARD } from './response-patcher-types';
+
+import { SolanaJsonRpcApi } from '@solana/rpc-core';
+
+export type KeyPath = ReadonlyArray<KeyPathWildcard | number | string | KeyPath>;
 type Patched<T> = T extends object ? { [Property in keyof T]: Patched<T[Property]> } : T extends number ? bigint : T;
 // FIXME(https://github.com/microsoft/TypeScript/issues/33014)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TypescriptBug33014 = any;
 
-function visitNode<T>(value: T): Patched<T> {
+function getNextAllowedKeypaths(keyPaths: readonly KeyPath[], property: number | string) {
+    return keyPaths
+        .filter(keyPath => (keyPath[0] === KEYPATH_WILDCARD && typeof property === 'number') || keyPath[0] === property)
+        .map(keyPath => keyPath.slice(1));
+}
+
+function visitNode<T>(value: T, allowedKeypaths: readonly KeyPath[]): Patched<T> {
     if (Array.isArray(value)) {
-        return value.map(element => visitNode(element)) as TypescriptBug33014;
+        return value.map((element, ii) => {
+            const nextAllowedKeypaths = getNextAllowedKeypaths(allowedKeypaths, ii);
+            return visitNode(element, nextAllowedKeypaths);
+        }) as TypescriptBug33014;
     } else if (typeof value === 'object' && value !== null) {
         const out = {} as TypescriptBug33014;
         for (const propName in value) {
             if (Object.prototype.hasOwnProperty.call(value, propName)) {
-                out[propName] = visitNode(value[propName]);
+                const nextAllowedKeypaths = getNextAllowedKeypaths(allowedKeypaths, propName);
+                out[propName] = visitNode(value[propName], nextAllowedKeypaths);
             }
         }
         return out as TypescriptBug33014;
-    } else if (typeof value === 'number') {
+    } else if (
+        typeof value === 'number' &&
+        // The presence of an allowed keypath on the route to this value implies it's allowlisted;
+        // Upcast the value to `bigint` unless an allowed keypath is present.
+        allowedKeypaths.length === 0
+    ) {
         // FIXME(solana-labs/solana/issues/30341) Create a data type to represent u64 in the Solana
         // JSON RPC implementation so that we can throw away this entire patcher instead of unsafely
         // upcasting `numbers` to `bigints`.
@@ -24,6 +45,6 @@ function visitNode<T>(value: T): Patched<T> {
     }
 }
 
-export function patchResponseForSolanaLabsRpc<T>(response: T): Patched<T> {
-    return visitNode(response);
+export function patchResponseForSolanaLabsRpc<T>(response: T, methodName?: keyof SolanaJsonRpcApi): Patched<T> {
+    return visitNode(response, (methodName && ALLOWED_NUMERIC_KEYPATHS[methodName]) ?? []);
 }

--- a/packages/test-config/jest-dev.config.ts
+++ b/packages/test-config/jest-dev.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
         'jest-watch-typeahead/filename',
         'jest-watch-typeahead/testname',
     ],
+    workerThreads: true,
 };
 
 export default config;


### PR DESCRIPTION
refactor(experimental): install the response patcher into the RPC transport
## Summary
The patcher will operate over the response, converting numbers to `bigint` as it goes. Eventually we will teach it which numbers to leav alone, since there are some values in RPC responses that are legitimately `u8` or `usize`.

## Test Plan
```
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1232).
* #1241
* __->__ #1232
* #1239