### PR TITLE
refactor(experimental): add a numeric value allowlist to the response patcher

### DIFF
--- a/packages/rpc-transport/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-transport/src/response-patcher-allowed-numeric-values.ts
@@ -1,0 +1,9 @@
+import { KeyPath } from './response-patcher';
+
+import { SolanaJsonRpcApi } from '@solana/rpc-core';
+
+/**
+ * These are keypaths at the end of which you will find a numeric value that should *not* be upcast
+ * to a `bigint`. These are values that are legitimately defined as `u8` or `usize` on the backend.
+ */
+export const ALLOWED_NUMERIC_KEYPATHS: Partial<Record<keyof SolanaJsonRpcApi, readonly KeyPath[]>> = {};

--- a/packages/rpc-transport/src/response-patcher-types.ts
+++ b/packages/rpc-transport/src/response-patcher-types.ts
@@ -1,0 +1,3 @@
+export type KeyPathWildcard = { readonly __keyPathWildcard: unique symbol };
+
+export const KEYPATH_WILDCARD = {} as KeyPathWildcard;

--- a/packages/rpc-transport/src/response-patcher.ts
+++ b/packages/rpc-transport/src/response-patcher.ts
@@ -1,20 +1,41 @@
+import { ALLOWED_NUMERIC_KEYPATHS } from './response-patcher-allowed-numeric-values';
+import { KeyPathWildcard, KEYPATH_WILDCARD } from './response-patcher-types';
+
+import { SolanaJsonRpcApi } from '@solana/rpc-core';
+
+export type KeyPath = ReadonlyArray<KeyPathWildcard | number | string | KeyPath>;
 type Patched<T> = T extends object ? { [Property in keyof T]: Patched<T[Property]> } : T extends number ? bigint : T;
 // FIXME(https://github.com/microsoft/TypeScript/issues/33014)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TypescriptBug33014 = any;
 
-function visitNode<T>(value: T): Patched<T> {
+function getNextAllowedKeypaths(keyPaths: readonly KeyPath[], property: number | string) {
+    return keyPaths
+        .filter(keyPath => (keyPath[0] === KEYPATH_WILDCARD && typeof property === 'number') || keyPath[0] === property)
+        .map(keyPath => keyPath.slice(1));
+}
+
+function visitNode<T>(value: T, allowedKeypaths: readonly KeyPath[]): Patched<T> {
     if (Array.isArray(value)) {
-        return value.map(element => visitNode(element)) as TypescriptBug33014;
+        return value.map((element, ii) => {
+            const nextAllowedKeypaths = getNextAllowedKeypaths(allowedKeypaths, ii);
+            return visitNode(element, nextAllowedKeypaths);
+        }) as TypescriptBug33014;
     } else if (typeof value === 'object' && value !== null) {
         const out = {} as TypescriptBug33014;
         for (const propName in value) {
             if (Object.prototype.hasOwnProperty.call(value, propName)) {
-                out[propName] = visitNode(value[propName]);
+                const nextAllowedKeypaths = getNextAllowedKeypaths(allowedKeypaths, propName);
+                out[propName] = visitNode(value[propName], nextAllowedKeypaths);
             }
         }
         return out as TypescriptBug33014;
-    } else if (typeof value === 'number') {
+    } else if (
+        typeof value === 'number' &&
+        // The presence of an allowed keypath on the route to this value implies it's allowlisted;
+        // Upcast the value to `bigint` unless an allowed keypath is present.
+        allowedKeypaths.length === 0
+    ) {
         // FIXME(solana-labs/solana/issues/30341) Create a data type to represent u64 in the Solana
         // JSON RPC implementation so that we can throw away this entire patcher instead of unsafely
         // upcasting `numbers` to `bigints`.
@@ -24,6 +45,6 @@ function visitNode<T>(value: T): Patched<T> {
     }
 }
 
-export function patchResponseForSolanaLabsRpc<T>(response: T): Patched<T> {
-    return visitNode(response);
+export function patchResponseForSolanaLabsRpc<T>(response: T, methodName?: keyof SolanaJsonRpcApi): Patched<T> {
+    return visitNode(response, (methodName && ALLOWED_NUMERIC_KEYPATHS[methodName]) ?? []);
 }

--- a/packages/test-config/jest-dev.config.ts
+++ b/packages/test-config/jest-dev.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
         'jest-watch-typeahead/filename',
         'jest-watch-typeahead/testname',
     ],
+    workerThreads: true,
 };
 
 export default config;


### PR DESCRIPTION
refactor(experimental): add a numeric value allowlist to the response patcher

## Summary
Most of the values that come from the RPC are supposed to be `u64` (ie. must be represented as JavaScript `bigint`, eventually). Some are legitimately `usize` or `u8` though.

In this PR we create an allowlist for those method/path pairs. Any value at that path for that method will not be upcast.
## Test Plan

```
cd packages/rpc-transport
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1239).
* #1241
* #1232
* __->__ #1239