### PR TITLE
chore: move the build deps into the Turborepo config

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "packages/*"
     ],
     "scripts": {
-        "build": "turbo run compile:docs compile:js compile:typedefs test:lint test:prettier test:typecheck test:unit:browser test:unit:node test:live-with-test-validator test:treeshakability:browser test:treeshakability:native test:treeshakability:node",
+        "build": "turbo run build",
         "lint": "turbo run test:lint",
         "publish-packages": "turbo run publish-packages",
         "test": "turbo run test:unit:browser test:unit:node",

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,23 @@
 {
     "$schema": "https://turbo.build/schema.json",
     "pipeline": {
+        "build": {
+            "dependsOn": [
+                "compile:docs",
+                "compile:js",
+                "compile:typedefs",
+                "test:lint",
+                "test:prettier",
+                "test:typecheck",
+                "test:unit:browser",
+                "test:unit:node",
+                "test:live-with-test-validator",
+                "test:treeshakability:browser",
+                "test:treeshakability:native",
+                "test:treeshakability:node"
+            ],
+            "outputs": ["dist/**", "lib/**"]
+        },
         "clean": {
             "outputs": ["dist/**", "lib/**"]
         },
@@ -20,22 +37,8 @@
             "outputs": ["declarations/**", "dist/**/*.d.ts", "lib/**/*.d.ts"]
         },
         "publish-packages": {
-            "dependsOn": [
-                "clean",
-                "compile:docs",
-                "compile:js",
-                "compile:typedefs",
-                "test:lint",
-                "test:prettier",
-                "test:typecheck",
-                "test:unit:browser",
-                "test:unit:node",
-                "test:live-with-test-validator",
-                "test:treeshakability:browser",
-                "test:treeshakability:native",
-                "test:treeshakability:node"
-            ],
-            "outputs": ["dist/**", "lib/**"]
+            "dependsOn": ["build"],
+            "outputs": []
         },
         "test:lint": {
             "inputs": ["src/**", "test/**"],


### PR DESCRIPTION
Moving these into the Turborepo config, formally, lets _other_ steps share them. That is to say if a subpackage calls `turbo build` then it will get all this stuff for free.