### PR TITLE
refactor(experimental): add the `getBalance` RPC method

### DIFF
--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -8,12 +8,17 @@ import { GetAccountInfoApi } from './rpc-methods/getAccountInfo';
 import { GetBlockHeightApi } from './rpc-methods/getBlockHeight';
 import { GetBlocksApi } from './rpc-methods/getBlocks';
 import { GetInflationRewardApi } from './rpc-methods/getInflationReward';
+import { GetBalanceApi } from './rpc-methods/getBalance';
 
 type Config = Readonly<{
     onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;
 }>;
 
-export type SolanaRpcMethods = GetAccountInfoApi & GetBlockHeightApi & GetBlocksApi & GetInflationRewardApi;
+export type SolanaRpcMethods = GetAccountInfoApi &
+    GetBalanceApi &
+    GetBlockHeightApi &
+    GetBlocksApi &
+    GetInflationRewardApi;
 
 export function createSolanaRpcApi(config?: Config): IRpcApi<SolanaRpcMethods> {
     return new Proxy({} as IRpcApi<SolanaRpcMethods>, {

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
@@ -29,11 +29,11 @@ describe('getBalance', () => {
         });
     });
 
-    describe('returns a non-zero balance for an address with lamports', () => {
-        it('returns the correct balance for a fixture account', async () => {
+    describe('given an account with a non-zero balance', () => {
+        // See scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json
+        const publicKey = '4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc' as Base58EncodedAddress;
+        it('returns the correct balance', async () => {
             expect.assertions(1);
-            // See scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json
-            const publicKey = '4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc' as Base58EncodedAddress;
             const balancePromise = transport.getBalance(publicKey).send();
             await expect(balancePromise).resolves.toHaveProperty('value', BigInt(5_000_000));
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
@@ -1,0 +1,56 @@
+import { createJsonRpcTransport } from '@solana/rpc-transport';
+import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-errors';
+import type { Transport } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
+import fetchMock from 'jest-fetch-mock';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../../index';
+import { Commitment } from '../common';
+import { assertIsBase58EncodedAddress } from '@solana/keys';
+
+describe('getBalance', () => {
+    let transport: Transport<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        transport = createJsonRpcTransport({
+            api: createSolanaRpcApi(),
+            url: 'http://127.0.0.1:8899',
+        });
+    });
+
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            it('returns a balance of zero for a new address', async () => {
+                expect.assertions(1);
+                // This key is random, don't re-use in any tests that affect balance
+                const publicKey = '4BfxgLzn6pEuVB2ynBMqckHFdYD8VNcrheDFFCB6U5TH';
+                assertIsBase58EncodedAddress(publicKey);
+                const balance = await transport.getBalance(publicKey).send();
+                expect(balance.value).toEqual(BigInt(0));
+            });
+        });
+    });
+
+    describe('returns a non-zero balance for an address with lamports', () => {
+        // TODO: requires requestAirdrop or something else that can give an address lamports
+        it.todo('returns the correct balance after an airdrop');
+    });
+
+    describe('when called with a `minContextSlot` higher than the highest slot available', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            // This key is random, don't re-use in any tests that affect balance
+            const publicKey = '4BfxgLzn6pEuVB2ynBMqckHFdYD8VNcrheDFFCB6U5TH';
+            assertIsBase58EncodedAddress(publicKey);
+            const sendPromise = transport
+                .getBalance(publicKey, {
+                    minContextSlot: 2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
+                })
+                .send();
+            await expect(sendPromise).rejects.toMatchObject({
+                code: -32016 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/common.ts
+++ b/packages/rpc-core/src/rpc-methods/common.ts
@@ -12,3 +12,10 @@ export type Slot = U64UnsafeBeyond2Pow53Minus1;
 // truncated or rounded because of a downcast to JavaScript `number` between your calling code and
 // the JSON-RPC transport.
 export type U64UnsafeBeyond2Pow53Minus1 = bigint;
+
+export type RpcResponse<TValue> = Readonly<{
+    context: Readonly<{
+        slot: Slot;
+    }>;
+    value: TValue;
+}>;

--- a/packages/rpc-core/src/rpc-methods/getBalance.ts
+++ b/packages/rpc-core/src/rpc-methods/getBalance.ts
@@ -1,12 +1,7 @@
 import { Base58EncodedAddress } from '@solana/keys';
-import { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import { Commitment, RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
-type GetBalanceApiResponse = Readonly<{
-    context: Readonly<{
-        slot: Slot;
-    }>;
-    value: U64UnsafeBeyond2Pow53Minus1;
-}>;
+type GetBalanceApiResponse = RpcResponse<U64UnsafeBeyond2Pow53Minus1>;
 
 export interface GetBalanceApi {
     /**

--- a/packages/rpc-core/src/rpc-methods/getBalance.ts
+++ b/packages/rpc-core/src/rpc-methods/getBalance.ts
@@ -1,0 +1,22 @@
+import { Base58EncodedAddress } from '@solana/keys';
+import { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+
+type GetBalanceApiResponse = Readonly<{
+    context: Readonly<{
+        slot: Slot;
+    }>;
+    value: U64UnsafeBeyond2Pow53Minus1;
+}>;
+
+export interface GetBalanceApi {
+    /**
+     * Returns the balance of the account of provided Pubkey
+     */
+    getBalance(
+        address: Base58EncodedAddress,
+        config?: Readonly<{
+            commitment?: Commitment;
+            minContextSlot?: Slot;
+        }>
+    ): GetBalanceApiResponse;
+}

--- a/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json
+++ b/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json
@@ -1,0 +1,13 @@
+{
+  "pubkey": "4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc",
+  "account": {
+    "lamports": 5000000,
+    "data": [
+      "",
+      "base64"
+    ],
+    "owner": "11111111111111111111111111111111",
+    "executable": false,
+    "rentEpoch": 18446744073709551615
+  }
+}

--- a/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json
+++ b/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json
@@ -1,13 +1,10 @@
 {
-  "pubkey": "4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc",
-  "account": {
-    "lamports": 5000000,
-    "data": [
-      "",
-      "base64"
-    ],
-    "owner": "11111111111111111111111111111111",
-    "executable": false,
-    "rentEpoch": 18446744073709551615
-  }
+    "pubkey": "4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc",
+    "account": {
+        "lamports": 5000000,
+        "data": ["", "base64"],
+        "owner": "11111111111111111111111111111111",
+        "executable": false,
+        "rentEpoch": 18446744073709551615
+    }
 }

--- a/scripts/start-shared-test-validator.sh
+++ b/scripts/start-shared-test-validator.sh
@@ -9,6 +9,7 @@ EXCLUSIVE_LOCK_FILE="/var/lock/.solanatestvalidator.exclusivelock"
 SHARED_LOCK_FILE="/var/lock/.solanatestvalidator.sharedlock"
 TEST_VALIDATOR=$HOME/.local/share/solana/install/active_release/bin/solana-test-validator
 TEST_VALIDATOR_LEDGER="$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )/test-ledger"
+FIXTURE_ACCOUNTS_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")/fixtures" ; pwd -P)"
 
 (
   trap : INT # Resume execution any time we receive SIGINT
@@ -16,7 +17,7 @@ TEST_VALIDATOR_LEDGER="$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )/test
   flock -s 200 || exit 1
   (
     if flock -nx 200; then
-      $TEST_VALIDATOR --ledger $TEST_VALIDATOR_LEDGER --reset --quiet >/dev/null &
+      $TEST_VALIDATOR --ledger $TEST_VALIDATOR_LEDGER --reset --quiet --account-dir $FIXTURE_ACCOUNTS_DIR >/dev/null &
       validator_pid=$!
       echo "Started test validator (PID $validator_pid)"
       wait


### PR DESCRIPTION
## Summary
Add the `getBalance` API and unit tests
Note that we currently only test for a zero balance, as we haven't implemented any RPC methods that will give a non-zero balance

## Test Plan
```
pnpm turbo test:unit:node test:unit:browser
```

Note that since we don't have keygen yet, I've just hardcoded an address which is assumed to have a zero balance in the local validator. See also https://xkcd.com/221/ 