### PR TITLE
chore: don't build typedefs with the build of every package

### DIFF
--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -7,9 +7,8 @@ type Platform =
     // React Native
     | 'native';
 
-export function getBaseConfig(platform: Platform, format: Format[], options: Options): Options[] {
+export function getBaseConfig(platform: Platform, format: Format[], _options: Options): Options[] {
     return [true, false].map<Options>(isDebugBuild => ({
-        clean: true,
         define: {
             __BROWSER__: `${platform === 'browser'}`,
             __NODEJS__: `${platform === 'node'}`,
@@ -32,8 +31,7 @@ export function getBaseConfig(platform: Platform, format: Format[], options: Opt
         name: platform,
         // Inline private, non-published packages.
         // WARNING: This inlines packages recursively. Make sure these don't have deep dep trees.
-        noExternal: ['@solana/fetch-impl-browser'],
-        onSuccess: options.watch ? 'tsc -p ./tsconfig.declarations.json' : undefined,
+        noExternal: ['fetch-impl-browser'],
         outExtension({ format }) {
             let extension;
             if (format === 'iife') {

--- a/packages/fetch-impl-browser/package.json
+++ b/packages/fetch-impl-browser/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@solana/fetch-impl-browser",
-    "version": "0.0.0-development",
-    "description": "A browser fork of the fetch implementation used by @solana/rpc-transport",
+    "name": "fetch-impl-browser",
+    "version": "0.0.0",
+    "private": true,
     "main": "./dist/index.browser.cjs",
     "module": "./dist/index.browser.js",
     "types": "./dist/types/index.d.ts",
@@ -10,12 +10,6 @@
         "./dist/"
     ],
     "sideEffects": false,
-    "keywords": [
-        "blockchain",
-        "solana",
-        "web3"
-    ],
-    "private": true,
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.browser.ts",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
@@ -24,15 +18,6 @@
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",
         "test:typecheck": "tsc --noEmit"
-    },
-    "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/solana-labs/solana-web3.js"
-    },
-    "bugs": {
-        "url": "http://github.com/solana-labs/solana-web3.js/issues"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/fetch-impl-browser/tsconfig.json
+++ b/packages/fetch-impl-browser/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "lib": ["DOM"]
     },
-    "display": "@solana/fetch-impl-browser",
+    "display": "Fetch Implementation (Browser)",
     "extends": "tsconfig/base.json",
     "include": ["src"]
 }

--- a/packages/rpc-transport/package.json
+++ b/packages/rpc-transport/package.json
@@ -62,7 +62,6 @@
     ],
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.0",
-        "@solana/fetch-impl-browser": "workspace:*",
         "@swc/core": "^1.3.18",
         "@swc/jest": "^0.2.23",
         "@types/jest": "^29.5.0",
@@ -100,6 +99,7 @@
     },
     "dependencies": {
         "@solana/keys": "workspace:*",
+        "fetch-impl-browser": "workspace:*",
         "node-fetch": "^2.6.7"
     }
 }

--- a/packages/rpc-transport/src/http-request.ts
+++ b/packages/rpc-transport/src/http-request.ts
@@ -1,6 +1,6 @@
-import fetchImplBrowser from '@solana/fetch-impl-browser';
 import { SolanaHttpError } from './http-request-errors';
 
+import fetchImplBrowser from 'fetch-impl-browser';
 import fetchImplNode from 'node-fetch';
 
 type Config = Readonly<{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,6 +593,9 @@ importers:
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
+      fetch-impl-browser:
+        specifier: workspace:*
+        version: link:../fetch-impl-browser
       node-fetch:
         specifier: ^2.6.7
         version: 2.6.7
@@ -600,9 +603,6 @@ importers:
       '@solana/eslint-config-solana':
         specifier: ^1.0.0
         version: 1.0.0(@typescript-eslint/eslint-plugin@5.57.1)(@typescript-eslint/parser@5.57.1)(eslint-plugin-jest@27.2.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-sort-keys-fix@1.1.2)(eslint@8.37.0)(typescript@5.0.3)
-      '@solana/fetch-impl-browser':
-        specifier: workspace:*
-        version: link:../fetch-impl-browser
       '@swc/core':
         specifier: ^1.3.18
         version: 1.3.32

--- a/turbo.json
+++ b/turbo.json
@@ -32,7 +32,7 @@
             "outputs": ["dist/**", "lib/**"]
         },
         "compile:typedefs": {
-            "dependsOn": ["clean", "compile:js", "^compile:typedefs"],
+            "dependsOn": ["clean", "^compile:typedefs"],
             "inputs": ["rollup.config.types.js", "tsconfig.*", "src/**"],
             "outputs": ["declarations/**", "dist/**/*.d.ts", "lib/**/*.d.ts"]
         },


### PR DESCRIPTION
chore: don't build typedefs with the build of every package
## Summary

The existing build config builds the typedefs with every package built, and also builds every package every time you build the typedefs. Let's stop that.

## Test Plan

CI run
