### PR TITLE
refactor(experimental): introduce the ability to be able to cancel rpc requests

### DIFF
--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -79,7 +79,7 @@
         "eslint-plugin-sort-keys-fix": "^1.1.2",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
-        "jest-fetch-mock": "^3.0.3",
+        "jest-fetch-mock-fork": "^3.0.4",
         "jest-runner-eslint": "^2.0.0",
         "jest-runner-prettier": "^1.0.0",
         "postcss": "^8.4.12",

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
@@ -1,7 +1,7 @@
 import { createJsonRpcTransport } from '@solana/rpc-transport';
 import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-errors';
 import type { Transport } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
-import fetchMock from 'jest-fetch-mock';
+import fetchMock from 'jest-fetch-mock-fork';
 import { createSolanaRpcApi, SolanaRpcMethods } from '../../index';
 import { Commitment } from '../common';
 import { Base58EncodedAddress } from '@solana/keys';

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-block-height-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-block-height-test.ts
@@ -1,7 +1,7 @@
 import { createJsonRpcTransport } from '@solana/rpc-transport';
 import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-errors';
 import type { Transport } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
-import fetchMock from 'jest-fetch-mock';
+import fetchMock from 'jest-fetch-mock-fork';
 import { SolanaRpcMethods, createSolanaRpcApi } from '../../index';
 import { Commitment } from '../common';
 

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-reward-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-reward-test.ts
@@ -1,7 +1,7 @@
 import { createJsonRpcTransport } from '@solana/rpc-transport';
 import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-errors';
 import type { Transport } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
-import fetchMock from 'jest-fetch-mock';
+import fetchMock from 'jest-fetch-mock-fork';
 import { createSolanaRpcApi, SolanaRpcMethods } from '../../index';
 import { Commitment } from '../common';
 

--- a/packages/rpc-transport/package.json
+++ b/packages/rpc-transport/package.json
@@ -76,7 +76,7 @@
         "fetch-impl": "workspace:*",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
-        "jest-fetch-mock": "^3.0.3",
+        "jest-fetch-mock-fork": "^3.0.4",
         "jest-runner-eslint": "^2.0.0",
         "jest-runner-prettier": "^1.0.0",
         "postcss": "^8.4.12",

--- a/packages/rpc-transport/src/http-request.ts
+++ b/packages/rpc-transport/src/http-request.ts
@@ -3,17 +3,19 @@ import { SolanaHttpError } from './http-request-errors';
 import fetchImpl from 'fetch-impl';
 
 type Config = Readonly<{
+    abortSignal?: AbortSignal;
     payload: unknown;
     url: string;
 }>;
 
-export async function makeHttpRequest<TResponse>({ payload, url }: Config): Promise<TResponse> {
+export async function makeHttpRequest<TResponse>({ abortSignal, payload, url }: Config): Promise<TResponse> {
     const requestInfo = {
         body: JSON.stringify(payload),
         headers: {
             'Content-type': 'application/json',
         },
         method: 'POST',
+        signal: abortSignal,
     };
     const response = await fetchImpl(url, requestInfo);
     if (!response.ok) {

--- a/packages/rpc-transport/src/json-rpc-transport/index.ts
+++ b/packages/rpc-transport/src/json-rpc-transport/index.ts
@@ -6,6 +6,7 @@ import {
     ArmedBatchTransportOwnMethods,
     ArmedTransport,
     ArmedTransportOwnMethods,
+    SendOptions,
     Transport,
     TransportConfig,
     TransportRequest,
@@ -26,10 +27,11 @@ function createArmedJsonRpcTransport<TRpcMethods, TResponse>(
     pendingRequest: TransportRequest<TResponse>
 ): ArmedTransport<TRpcMethods, TResponse> {
     const overrides = {
-        async send(): Promise<TResponse> {
+        async send(options?: SendOptions): Promise<TResponse> {
             const { methodName, params, responseProcessor } = pendingRequest;
             const payload = createJsonRpcMessage(methodName, params);
             const response = await makeHttpRequest<JsonRpcResponse<unknown>>({
+                abortSignal: options?.abortSignal,
                 payload,
                 url: transportConfig.url,
             });
@@ -48,9 +50,10 @@ function createArmedBatchJsonRpcTransport<TRpcMethods, TResponses extends unknow
     pendingRequests: TransportRequestBatch<TResponses>
 ): ArmedBatchTransport<TRpcMethods, TResponses> {
     const overrides = {
-        async sendBatch(): Promise<TResponses> {
+        async sendBatch(options?: SendOptions): Promise<TResponses> {
             const payload = pendingRequests.map(({ methodName, params }) => createJsonRpcMessage(methodName, params));
             const responses = await makeHttpRequest<JsonRpcBatchResponse<unknown[]>>({
+                abortSignal: options?.abortSignal,
                 payload,
                 url: transportConfig.url,
             });

--- a/packages/rpc-transport/src/json-rpc-transport/json-rpc-transport-types.ts
+++ b/packages/rpc-transport/src/json-rpc-transport/json-rpc-transport-types.ts
@@ -6,6 +6,9 @@ export type IRpcApi<TRpcMethods> = {
         ? (...rawParams: unknown[]) => TransportRequest<ReturnType<TRpcMethods[MethodName]>>
         : never;
 };
+export type SendOptions = Readonly<{
+    abortSignal?: AbortSignal;
+}>;
 export type Transport<TRpcMethods> = TransportMethods<TRpcMethods>;
 export type TransportConfig<TRpcMethods> = Readonly<{
     api: IRpcApi<TRpcMethods>;
@@ -17,12 +20,12 @@ export type TransportRequest<TResponse> = {
     responseProcessor?: (response: unknown) => TResponse;
 };
 export interface ArmedTransportOwnMethods<TResponse> {
-    send(): Promise<TResponse>;
+    send(options?: SendOptions): Promise<TResponse>;
 }
 export type ArmedTransport<TRpcMethods, TResponse> = ArmedTransportMethods<TRpcMethods, TResponse> &
     ArmedTransportOwnMethods<TResponse>;
 export interface ArmedBatchTransportOwnMethods<TResponses> {
-    sendBatch(): Promise<TResponses>;
+    sendBatch(options?: SendOptions): Promise<TResponses>;
 }
 export type ArmedBatchTransport<TRpcMethods, TResponses extends unknown[]> = ArmedBatchTransportMethods<
     TRpcMethods,

--- a/packages/test-config/package.json
+++ b/packages/test-config/package.json
@@ -15,7 +15,7 @@
         "jest": "^29.5.0",
         "jest-dev-server": "^8.0.5",
         "jest-environment-jsdom": "^29.5.0",
-        "jest-fetch-mock": "^3.0.3",
+        "jest-fetch-mock-fork": "^3.0.4",
         "jest-runner-eslint": "^2.0.0",
         "jest-runner-prettier": "^1.0.0",
         "jest-watch-master": "^1.0.0",
@@ -27,7 +27,7 @@
         "@types/jest": "^29.5.0",
         "jest": "^29.5.0",
         "jest-dev-server": "^8.0.5",
-        "jest-fetch-mock": "^3.0.3",
+        "jest-fetch-mock-fork": "^3.0.4",
         "tsconfig": "workspace:*"
     }
 }

--- a/packages/test-config/setup-fetch-mock.ts
+++ b/packages/test-config/setup-fetch-mock.ts
@@ -1,4 +1,4 @@
-import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock-fork';
 enableFetchMocks();
 
 beforeEach(() => {

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,22 +1,22 @@
 {
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
-  "compilerOptions": {
-    "composite": false,
-    "declaration": true,
-    "declarationMap": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "inlineSources": false,
-    "isolatedModules": true,
-    "moduleResolution": "node",
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "preserveWatchOutput": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "ES2020"
-  },
-  "exclude": ["node_modules"]
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "display": "Default",
+    "compilerOptions": {
+        "composite": false,
+        "declaration": true,
+        "declarationMap": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "inlineSources": false,
+        "isolatedModules": true,
+        "moduleResolution": "node",
+        "noFallthroughCasesInSwitch": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "preserveWatchOutput": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "target": "ES2020"
+    },
+    "exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,9 +540,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.5.0
         version: 29.5.0
-      jest-fetch-mock:
-        specifier: ^3.0.3
-        version: 3.0.3
+      jest-fetch-mock-fork:
+        specifier: ^3.0.4
+        version: 3.0.4
       jest-runner-eslint:
         specifier: ^2.0.0
         version: 2.0.0(eslint@8.37.0)(jest@29.5.0)
@@ -625,9 +625,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.5.0
         version: 29.5.0
-      jest-fetch-mock:
-        specifier: ^3.0.3
-        version: 3.0.3
+      jest-fetch-mock-fork:
+        specifier: ^3.0.4
+        version: 3.0.4
       jest-runner-eslint:
         specifier: ^2.0.0
         version: 2.0.0(eslint@8.37.0)(jest@29.5.0)
@@ -692,9 +692,9 @@ importers:
       jest-dev-server:
         specifier: ^8.0.5
         version: 8.0.5
-      jest-fetch-mock:
-        specifier: ^3.0.3
-        version: 3.0.3
+      jest-fetch-mock-fork:
+        specifier: ^3.0.4
+        version: 3.0.4
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -7051,10 +7051,11 @@ packages:
       jest-mock: 29.5.0
       jest-util: 29.5.0
 
-  /jest-fetch-mock@3.0.3:
-    resolution: {integrity: sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==}
+  /jest-fetch-mock-fork@3.0.4:
+    resolution: {integrity: sha512-1VNwBvy8j1JhSKpgY8fp1fM1CTN8p+0tjSzL00Z88y+s68r1tsOywDqDv0PdylEpMtd1h70281lKHMugvsi4tQ==}
     dependencies:
       cross-fetch: 3.1.5
+      domexception: 2.0.1
       promise-polyfill: 8.3.0
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
refactor(experimental): introduce the ability to be able to cancel rpc requests
## Summary

The `send()` and `sendBatch()` APIs give us a logical per-request API surface to pass in an `AbortSignal`. Whenever that signal is triggered, we can pass it to the underlying transport implementation (in this case, `fetch`).

## Test Plan

```
pnpm turbo test:unit:node test:unit:browser
```
