### PR TITLE
refactor(experimental): Send the content length along with each request

### DIFF
--- a/packages/rpc-transport/src/__tests__/http-transport-test.ts
+++ b/packages/rpc-transport/src/__tests__/http-transport-test.ts
@@ -44,13 +44,35 @@ describe('makeHttpRequest', () => {
                 })
             );
         });
-        it('sets the content type header to `application/json`', () => {
+        it('sets the content type header to `application/json; charset=utf-8`', () => {
             makeHttpRequest({ payload: 123, url: 'fake://url' });
             expect(fetchMock).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
                     headers: expect.objectContaining({
-                        'Content-type': 'application/json',
+                        'Content-Type': 'application/json; charset=utf-8',
+                    }),
+                })
+            );
+        });
+        it('sets the content length header to the length of the JSON-stringified payload', () => {
+            makeHttpRequest({
+                payload:
+                    // Shruggie: https://emojipedia.org/person-shrugging/
+                    '\xAF\\\x5F\x28\u30C4\x29\x5F\x2F\xAF' +
+                    ' ' +
+                    // https://emojipedia.org/waving-hand-medium-skin-tone/
+                    '\u{1F44B}\u{1F3FD}' +
+                    ' ' +
+                    // https://tinyurl.com/bdemuf3r
+                    '\u{1F469}\u{1F3FB}\u200D\u2764\uFE0F\u200D\u{1F469}\u{1F3FF}',
+                url: 'fake://url',
+            });
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'Content-Length': '30',
                     }),
                 })
             );

--- a/packages/rpc-transport/src/http-request.ts
+++ b/packages/rpc-transport/src/http-request.ts
@@ -9,10 +9,12 @@ type Config = Readonly<{
 }>;
 
 export async function makeHttpRequest<TResponse>({ abortSignal, payload, url }: Config): Promise<TResponse> {
+    const body = JSON.stringify(payload);
     const requestInfo = {
-        body: JSON.stringify(payload),
+        body,
         headers: {
-            'Content-type': 'application/json',
+            'Content-Length': body.length.toString(),
+            'Content-Type': 'application/json; charset=utf-8',
         },
         method: 'POST',
         signal: abortSignal,


### PR DESCRIPTION
refactor(experimental): Send the content length along with each request
## Summary

After `JSON` stringifying the payload, count its byte length and include that as the `Content-Length` header. Also mark the `Content-Type` as `UTF-8`

## Test Plan

```
pnpm turbo test:unit:node test:unit:browser
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1264).
* #1266
* #1265
* __->__ #1264