### PR TITLE
refactor(experimental): only accept `application/json` encoding through the RPC

### DIFF
--- a/packages/rpc-transport/src/__tests__/http-transport-test.ts
+++ b/packages/rpc-transport/src/__tests__/http-transport-test.ts
@@ -44,6 +44,17 @@ describe('makeHttpRequest', () => {
                 })
             );
         });
+        it('sets the accept header to `application/json`', () => {
+            makeHttpRequest({ payload: 123, url: 'fake://url' });
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        Accept: 'application/json',
+                    }),
+                })
+            );
+        });
         it('sets the content type header to `application/json; charset=utf-8`', () => {
             makeHttpRequest({ payload: 123, url: 'fake://url' });
             expect(fetchMock).toHaveBeenCalledWith(

--- a/packages/rpc-transport/src/http-request.ts
+++ b/packages/rpc-transport/src/http-request.ts
@@ -13,6 +13,7 @@ export async function makeHttpRequest<TResponse>({ abortSignal, payload, url }: 
     const requestInfo = {
         body,
         headers: {
+            Accept: 'application/json',
             'Content-Length': body.length.toString(),
             'Content-Type': 'application/json; charset=utf-8',
         },


### PR DESCRIPTION
refactor(experimental): only accept `application/json` encoding through the RPC

## Summary

That's all we understand.

## Test Plan

```
pnpm turbo test:unit:browser test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1265).
* #1266
* __->__ #1265