### PR TITLE
refactor(experimental): allow the RPC to be configured with custom headers

### DIFF
--- a/packages/library/src/__tests__/rpc-test.ts
+++ b/packages/library/src/__tests__/rpc-test.ts
@@ -4,7 +4,7 @@ import { SolanaJsonRpcIntegerOverflowError } from '../rpc-integer-overflow-error
 describe('RPC', () => {
     let transport: ReturnType<typeof createDefaultRpc>;
     beforeEach(() => {
-        transport = createDefaultRpc('fake://url');
+        transport = createDefaultRpc({ url: 'fake://url' });
     });
     describe('with respect to integer overflows', () => {
         it('does not throw when called with a value up to `Number.MAX_SAFE_INTEGER`', () => {

--- a/packages/library/src/rpc.ts
+++ b/packages/library/src/rpc.ts
@@ -2,11 +2,14 @@ import { SolanaRpcMethods, createSolanaRpcApi } from '@solana/rpc-core';
 import { DEFAULT_RPC_CONFIG } from './rpc-default-config';
 
 import { createJsonRpcTransport } from '@solana/rpc-transport';
-import type { Transport } from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
+import type {
+    Transport,
+    TransportConfig,
+} from '@solana/rpc-transport/dist/types/json-rpc-transport/json-rpc-transport-types';
 
-export function createDefaultRpc(url: string): Transport<SolanaRpcMethods> {
+export function createDefaultRpc(config: Omit<TransportConfig<SolanaRpcMethods>, 'api'>): Transport<SolanaRpcMethods> {
     return createJsonRpcTransport({
+        ...config,
         api: createSolanaRpcApi(DEFAULT_RPC_CONFIG),
-        url,
     });
 }

--- a/packages/rpc-transport/src/__tests__/http-request-headers-test.ts
+++ b/packages/rpc-transport/src/__tests__/http-request-headers-test.ts
@@ -1,0 +1,49 @@
+import { assertIsAllowedHttpRequestHeaders } from '../http-request-headers';
+
+describe('assertIsAllowedHttpRequestHeader', () => {
+    [
+        'Accept-Charset',
+        'Accept-charset',
+        'accept-charset',
+        'ACCEPT-CHARSET',
+        'Accept-Encoding',
+        'Access-Control-Request-Headers',
+        'Access-Control-Request-Method',
+        'Connection',
+        'Content-Length',
+        'Cookie',
+        'Date',
+        'DNT',
+        'Expect',
+        'Host',
+        'Keep-Alive',
+        'Origin',
+        'Permissions-Policy',
+        'Proxy-Anything',
+        'Proxy-Authenticate',
+        'Proxy-Authorization',
+        'Sec-Fetch-Dest',
+        'Sec-Fetch-Mode',
+        'Sec-Fetch-Site',
+        'Sec-Fetch-User',
+        'Referer',
+        'TE',
+        'Trailer',
+        'Transfer-Encoding',
+        'Upgrade',
+        'Via',
+    ].forEach(forbiddenHeader => {
+        it('throws when called with the forbidden header `' + forbiddenHeader + '`', () => {
+            expect(() => {
+                assertIsAllowedHttpRequestHeaders({ [forbiddenHeader]: 'value' });
+            }).toThrow(/This header is forbidden:/);
+        });
+    });
+    ['Authorization', 'Content-Language', 'Solana-Client'].forEach(allowedHeader => {
+        it('does not throw when called with the header `' + allowedHeader + '`', () => {
+            expect(() => {
+                assertIsAllowedHttpRequestHeaders({ [allowedHeader]: 'value' });
+            }).not.toThrow();
+        });
+    });
+});

--- a/packages/rpc-transport/src/http-request-headers.ts
+++ b/packages/rpc-transport/src/http-request-headers.ts
@@ -1,0 +1,106 @@
+export type AllowedHttpRequestHeaders = Readonly<{ [headerName: string]: string }> & {
+    // Someone can still sneak a forbidden header past Typescript if they do something like
+    // fOo-BaR, but at that point they deserve the runtime failure.
+    [K in DisallowedHeaders | ForbiddenHeaders as
+        | K // `Foo-Bar`
+        | Capitalize<Lowercase<K>> // `Foo-bar`
+        | Lowercase<K> // `foo-bar`
+        | Uncapitalize<K> // `foo-Bar`
+        // `FOO-BAR`
+        | Uppercase<K>]?: never;
+};
+// These are headers that we simply don't allow the developer to override because they're
+// fundamental to the operation of the JSON-RPC transport.
+type DisallowedHeaders = 'Accept' | 'Content-Length' | 'Content-Type';
+type ForbiddenHeaders =
+    | 'Accept-Charset'
+    | 'Accept-Encoding'
+    | 'Access-Control-Request-Headers'
+    | 'Access-Control-Request-Method'
+    | 'Connection'
+    | 'Content-Length'
+    | 'Cookie'
+    | 'Date'
+    | 'DNT'
+    | 'Expect'
+    | 'Host'
+    | 'Keep-Alive'
+    | 'Origin'
+    | 'Permissions-Policy'
+    // No currently available Typescript technique allows you to match on a prefix.
+    // | 'Proxy-'
+    // | 'Sec-'
+    | 'Referer'
+    | 'TE'
+    | 'Trailer'
+    | 'Transfer-Encoding'
+    | 'Upgrade'
+    | 'Via';
+
+// These are headers which are fundamental to the JSON-RPC transport, and must not be modified.
+const DISALLOWED_HEADERS: Record<string, boolean> = {
+    accept: true,
+    'content-length': true,
+    'content-type': true,
+};
+// https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
+const FORBIDDEN_HEADERS: Record<string, boolean> = {
+    'accept-charset': true,
+    'accept-encoding': true,
+    'access-control-request-headers': true,
+    'access-control-request-method': true,
+    connection: true,
+    'content-length': true,
+    cookie: true,
+    date: true,
+    dnt: true,
+    expect: true,
+    host: true,
+    'keep-alive': true,
+    origin: true,
+    'permissions-policy': true,
+    // No currently available Typescript technique allows you to match on a prefix.
+    // 'proxy-':true,
+    // 'sec-':true,
+    referer: true,
+    te: true,
+    trailer: true,
+    'transfer-encoding': true,
+    upgrade: true,
+    via: true,
+};
+
+export function assertIsAllowedHttpRequestHeaders(
+    headers: Record<string, string>
+): asserts headers is AllowedHttpRequestHeaders {
+    const badHeaders = Object.keys(headers).filter(headerName => {
+        const lowercaseHeaderName = headerName.toLowerCase();
+        return (
+            DISALLOWED_HEADERS[headerName.toLowerCase()] === true ||
+            FORBIDDEN_HEADERS[headerName.toLowerCase()] === true ||
+            lowercaseHeaderName.startsWith('proxy-') ||
+            lowercaseHeaderName.startsWith('sec-')
+        );
+    });
+    if (badHeaders.length > 0) {
+        throw new Error(
+            `${badHeaders.length > 1 ? 'These headers are' : 'This header is'} forbidden: ` +
+                `\`${badHeaders.join('`, `')}\`. Learn more at ` +
+                'https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name.'
+        );
+    }
+}
+
+/**
+ * Lowercasing header names makes it easier to override user-supplied headers, such as those defined
+ * in the `DisallowedHeaders` type.
+ */
+export function normalizeHeaders<T extends Record<string, string>>(
+    headers: T
+): { [K in keyof T & string as Lowercase<K>]: T[K] } {
+    const out: Record<string, string> = {};
+    for (const headerName in headers) {
+        out[headerName.toLowerCase()] = headers[headerName];
+    }
+    return out as { [K in keyof T & string as Lowercase<K>]: T[K] };
+}

--- a/packages/rpc-transport/src/json-rpc-transport/json-rpc-transport-types.ts
+++ b/packages/rpc-transport/src/json-rpc-transport/json-rpc-transport-types.ts
@@ -1,3 +1,5 @@
+import { AllowedHttpRequestHeaders } from '../http-request-headers';
+
 /**
  * Public API.
  */
@@ -12,6 +14,7 @@ export type SendOptions = Readonly<{
 export type Transport<TRpcMethods> = TransportMethods<TRpcMethods>;
 export type TransportConfig<TRpcMethods> = Readonly<{
     api: IRpcApi<TRpcMethods>;
+    headers?: AllowedHttpRequestHeaders;
     url: string;
 }>;
 export type TransportRequest<TResponse> = {

--- a/packages/test-config/global.d.ts
+++ b/packages/test-config/global.d.ts
@@ -1,0 +1,4 @@
+declare namespace globalThis {
+    // eslint-disable-next-line no-var
+    var __DEV__: boolean;
+}

--- a/packages/test-config/jest-unit.config.common.ts
+++ b/packages/test-config/jest-unit.config.common.ts
@@ -2,12 +2,9 @@ import { Config } from '@jest/types';
 import path from 'path';
 
 const config: Partial<Config.InitialProjectOptions> = {
-    globals: {
-        __DEV__: false,
-    },
     restoreMocks: true,
     roots: ['<rootDir>/src/'],
-    setupFilesAfterEnv: [path.resolve(__dirname, 'setup-fetch-mock.ts')],
+    setupFilesAfterEnv: [path.resolve(__dirname, 'setup-dev-mode.ts'), path.resolve(__dirname, 'setup-fetch-mock.ts')],
     transform: {
         '^.+\\.(ts|js)$': [
             '@swc/jest',

--- a/packages/test-config/setup-dev-mode.ts
+++ b/packages/test-config/setup-dev-mode.ts
@@ -1,0 +1,3 @@
+beforeEach(() => {
+    globalThis.__DEV__ = false;
+});


### PR DESCRIPTION
refactor(experimental): allow the RPC to be configured with custom headers
## Summary

Pains were taken to prevent forbidden headers from being configured on a transport, and to prevent headers necessary for the operation of the JSON-RPC from being overwritten, but otherwise you're free to supply your own custom headers.

## Test Plan

```ts
const rpc = createDefaultRpc({url: 'https://api.devnet.solana.com', headers: {'My-Custom-Header': 'customValue'}});
rpc.getBlockHeight().send();

```

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/13243/232176865-c3484e3d-54e7-4947-a980-df3e7f5eba93.png">


```
pnpm turbo test:unit:node test:unit:browser
```
