### PR TITLE
refactor(experimental): you can now configure an HTTP agent on a trasnport

### DIFF
--- a/packages/rpc-transport/src/transports/http/__tests__/http-transport-agent-test.ts
+++ b/packages/rpc-transport/src/transports/http/__tests__/http-transport-agent-test.ts
@@ -1,0 +1,38 @@
+import { IRpcTransport } from '../../transport-types';
+import { createHttpTransport } from '../http-transport';
+
+import fetchMock from 'jest-fetch-mock-fork';
+
+describe('createHttpTransport and HTTP agent config', () => {
+    let agent: jest.Mock;
+    let transport: IRpcTransport;
+    beforeEach(() => {
+        agent = jest.fn();
+        fetchMock.once(JSON.stringify({ ok: true }));
+        transport = createHttpTransport({
+            httpAgentNodeOnly: agent,
+            url: 'fake://url',
+        });
+    });
+    if (__NODEJS__) {
+        it('passes the configured agent through to the transport implementation in Node environments', () => {
+            transport({ payload: 123 });
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    agent,
+                })
+            );
+        });
+    } else {
+        it('does not pass the configured agent through to the transport implementation in non-Node environments', () => {
+            transport({ payload: 123 });
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.not.objectContaining({
+                    agent,
+                })
+            );
+        });
+    }
+});

--- a/packages/rpc-transport/src/transports/http/http-transport.ts
+++ b/packages/rpc-transport/src/transports/http/http-transport.ts
@@ -7,15 +7,25 @@ import {
 import { IRpcTransport } from '../transport-types';
 
 import fetchImpl from 'fetch-impl';
+import type { Agent as NodeHttpAgent } from 'node:http';
+import type { Agent as NodeHttpsAgent } from 'node:https';
 
 type Config = Readonly<{
     headers?: AllowedHttpRequestHeaders;
+    httpAgentNodeOnly?: NodeHttpAgent | NodeHttpsAgent | ((parsedUrl: URL) => NodeHttpAgent | NodeHttpsAgent);
     url: string;
 }>;
 
-export function createHttpTransport({ headers, url }: Config): IRpcTransport {
+export function createHttpTransport({ httpAgentNodeOnly, headers, url }: Config): IRpcTransport {
     if (__DEV__ && headers) {
         assertIsAllowedHttpRequestHeaders(headers);
+    }
+    const agent = __NODEJS__ ? httpAgentNodeOnly : undefined;
+    if (__DEV__ && httpAgentNodeOnly != null) {
+        console.warn(
+            'createHttpTransport(): The `httpAgentNodeOnly` config you supplied has been ' +
+                'ignored; HTTP agents are only usable in Node environments.'
+        );
     }
     const customHeaders = headers && normalizeHeaders(headers);
     return async function makeHttpRequest<TResponse>({
@@ -24,6 +34,7 @@ export function createHttpTransport({ headers, url }: Config): IRpcTransport {
     }: Parameters<IRpcTransport>[0]): Promise<TResponse> {
         const body = JSON.stringify(payload);
         const requestInfo = {
+            agent,
             body,
             headers: {
                 ...customHeaders,


### PR DESCRIPTION
refactor(experimental): you can now configure an HTTP agent on a trasnport
## Summary

Notably we are _not_ going to create one by default. Agent configuration is RPC specific and can change over time. We do not want to be prescriptive here.

## Test Plan

```
pnpm turbo test:unit:node test:unit:browser
```
