### PR TITLE
refactor(experimental): coalesce requests with identical in-flight requests

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -66,7 +66,8 @@
     "dependencies": {
         "@solana/keys": "workspace:*",
         "@solana/rpc-core": "workspace:*",
-        "@solana/rpc-transport": "workspace:*"
+        "@solana/rpc-transport": "workspace:*",
+        "fast-stable-stringify": "^1.0.0"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.0",

--- a/packages/library/src/__tests__/rpc-request-coalescer-test.ts
+++ b/packages/library/src/__tests__/rpc-request-coalescer-test.ts
@@ -1,0 +1,191 @@
+import { IRpcTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
+import { getRpcTransportWithRequestCoalescing } from '../rpc-request-coalescer';
+
+describe('RPC request coalescer', () => {
+    let coalescedTransport: IRpcTransport;
+    let hashFn: jest.MockedFunction<() => string | undefined>;
+    let mockTransport: jest.MockedFunction<IRpcTransport>;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        hashFn = jest.fn();
+        mockTransport = jest.fn();
+        coalescedTransport = getRpcTransportWithRequestCoalescing(mockTransport, hashFn);
+    });
+    describe('when requests produce the same hash', () => {
+        beforeEach(() => {
+            hashFn.mockReturnValue('samehash');
+        });
+        it('multiple requests in the same tick produce a single transport request', () => {
+            coalescedTransport({ payload: null });
+            coalescedTransport({ payload: null });
+            expect(mockTransport).toHaveBeenCalledTimes(1);
+        });
+        it('multiple requests in different ticks each produce their own transport request', async () => {
+            expect.assertions(1);
+            coalescedTransport({ payload: null });
+            await jest.runOnlyPendingTimersAsync();
+            coalescedTransport({ payload: null });
+            expect(mockTransport).toHaveBeenCalledTimes(2);
+        });
+        it('multiple requests in the same tick receive the same response', async () => {
+            expect.assertions(2);
+            const mockResponse = { response: 'ok' };
+            mockTransport.mockResolvedValueOnce(mockResponse);
+            const responsePromiseA = coalescedTransport({ payload: null });
+            const responsePromiseB = coalescedTransport({ payload: null });
+            await Promise.all([
+                expect(responsePromiseA).resolves.toBe(mockResponse),
+                expect(responsePromiseB).resolves.toBe(mockResponse),
+            ]);
+        });
+        it('multiple requests in different ticks receive different responses', async () => {
+            expect.assertions(2);
+            const mockResponseA = { response: 'okA' };
+            const mockResponseB = { response: 'okB' };
+            mockTransport.mockResolvedValueOnce(mockResponseA);
+            mockTransport.mockResolvedValueOnce(mockResponseB);
+            const responsePromiseA = coalescedTransport({ payload: null });
+            await jest.runOnlyPendingTimersAsync();
+            const responsePromiseB = coalescedTransport({ payload: null });
+            await Promise.all([
+                expect(responsePromiseA).resolves.toBe(mockResponseA),
+                expect(responsePromiseB).resolves.toBe(mockResponseB),
+            ]);
+        });
+        it('multiple requests in the same tick receive the same error in the case of failure', async () => {
+            expect.assertions(2);
+            const mockError = { err: 'bad' };
+            mockTransport.mockRejectedValueOnce(mockError);
+            const responsePromiseA = coalescedTransport({ payload: null });
+            const responsePromiseB = coalescedTransport({ payload: null });
+            await Promise.all([
+                expect(responsePromiseA).rejects.toBe(mockError),
+                expect(responsePromiseB).rejects.toBe(mockError),
+            ]);
+        });
+        it('multiple requests in different ticks receive different errors in the case of failure', async () => {
+            expect.assertions(2);
+            const mockErrorA = { err: 'badA' };
+            const mockErrorB = { err: 'badB' };
+            mockTransport.mockRejectedValueOnce(mockErrorA);
+            mockTransport.mockRejectedValueOnce(mockErrorB);
+            const responsePromiseA = coalescedTransport({ payload: null });
+            // eslint-disable-next-line jest/valid-expect
+            const expectationA = expect(responsePromiseA).rejects.toBe(mockErrorA);
+            await jest.runOnlyPendingTimersAsync();
+            const responsePromiseB = coalescedTransport({ payload: null });
+            // eslint-disable-next-line jest/valid-expect
+            const expectationB = expect(responsePromiseB).rejects.toBe(mockErrorB);
+            await Promise.all([expectationA, expectationB]);
+        });
+        describe('multiple coalesced requests each with an abort signal', () => {
+            let abortControllerA: AbortController;
+            let abortControllerB: AbortController;
+            let responsePromiseA: ReturnType<typeof mockTransport>;
+            let responsePromiseB: ReturnType<typeof mockTransport>;
+            let transportResponsePromise: (value: unknown) => void;
+            beforeEach(() => {
+                abortControllerA = new AbortController();
+                abortControllerB = new AbortController();
+                mockTransport.mockImplementation(
+                    () =>
+                        new Promise(resolve => {
+                            transportResponsePromise = resolve;
+                        })
+                );
+                responsePromiseA = coalescedTransport({ payload: null, signal: abortControllerA.signal });
+                responsePromiseB = coalescedTransport({ payload: null, signal: abortControllerB.signal });
+            });
+            afterEach(async () => {
+                try {
+                    // Unconditionally await the requests so that the tests don't leak.
+                    await Promise.all([responsePromiseA, responsePromiseB]);
+                } catch {
+                    /* empty */
+                }
+            });
+            it('throws an `AbortError` from the aborted request', async () => {
+                expect.assertions(1);
+                abortControllerA.abort('o no');
+                await expect(responsePromiseA).rejects.toThrow(/o no/);
+            });
+            it('aborts the transport when all of the requests abort', async () => {
+                expect.assertions(1);
+                abortControllerA.abort('o no A');
+                abortControllerB.abort('o no B');
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const transportAbortSignal = mockTransport.mock.lastCall![0].signal!;
+                await expect(transportAbortSignal.aborted).toBe(true);
+            });
+            it('does not abort the transport if fewer than every request aborts', async () => {
+                expect.assertions(1);
+                abortControllerA.abort('o no A');
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const transportAbortSignal = mockTransport.mock.lastCall![0].signal!;
+                await expect(transportAbortSignal.aborted).toBe(false);
+            });
+            it('delivers responses to all but the aborted requests', async () => {
+                expect.assertions(2);
+                abortControllerA.abort('o no A');
+                const mockResponse = { response: 'ok' };
+                transportResponsePromise(mockResponse);
+                await Promise.all([
+                    expect(responsePromiseA).rejects.toThrow(/o no A/),
+                    expect(responsePromiseB).resolves.toBe(mockResponse),
+                ]);
+            });
+        });
+    });
+    [
+        {
+            getHashFn() {
+                let counter = 0;
+                return () => `hash-${counter++}`;
+            },
+            hashDescription: 'different hashes',
+        },
+        {
+            getHashFn() {
+                return () => undefined;
+            },
+            hashDescription: 'no hash',
+        },
+    ].forEach(({ hashDescription, getHashFn }) => {
+        describe(`when requests produce ${hashDescription}`, () => {
+            beforeEach(() => {
+                hashFn.mockImplementation(getHashFn());
+            });
+            it('multiple requests in the same tick produce one transport request each', () => {
+                coalescedTransport({ payload: null });
+                coalescedTransport({ payload: null });
+                expect(mockTransport).toHaveBeenCalledTimes(2);
+            });
+            it('multiple requests in the same tick receive different responses', async () => {
+                expect.assertions(2);
+                const mockResponseA = { response: 'okA' };
+                const mockResponseB = { response: 'okB' };
+                mockTransport.mockResolvedValueOnce(mockResponseA);
+                mockTransport.mockResolvedValueOnce(mockResponseB);
+                const responsePromiseA = coalescedTransport({ payload: null });
+                const responsePromiseB = coalescedTransport({ payload: null });
+                await Promise.all([
+                    expect(responsePromiseA).resolves.toBe(mockResponseA),
+                    expect(responsePromiseB).resolves.toBe(mockResponseB),
+                ]);
+            });
+            it('multiple requests in the same tick receive different errors in the case of failure', async () => {
+                expect.assertions(2);
+                const mockErrorA = { err: 'badA' };
+                const mockErrorB = { err: 'badB' };
+                mockTransport.mockRejectedValueOnce(mockErrorA);
+                mockTransport.mockRejectedValueOnce(mockErrorB);
+                const responsePromiseA = coalescedTransport({ payload: null });
+                const responsePromiseB = coalescedTransport({ payload: null });
+                await Promise.all([
+                    expect(responsePromiseA).rejects.toBe(mockErrorA),
+                    expect(responsePromiseB).rejects.toBe(mockErrorB),
+                ]);
+            });
+        });
+    });
+});

--- a/packages/library/src/__tests__/rpc-request-deduplication-test.ts
+++ b/packages/library/src/__tests__/rpc-request-deduplication-test.ts
@@ -1,0 +1,54 @@
+import { getSolanaRpcPayloadDeduplicationKey } from '../rpc-request-deduplication';
+
+describe('getSolanaRpcPayloadDeduplicationKey', () => {
+    it('produces no key for undefined payloads', () => {
+        expect(getSolanaRpcPayloadDeduplicationKey(undefined)).toBeUndefined();
+    });
+    it('produces no key for null payloads', () => {
+        expect(getSolanaRpcPayloadDeduplicationKey(null)).toBeUndefined();
+    });
+    it('produces no key for array payloads', () => {
+        expect(getSolanaRpcPayloadDeduplicationKey([])).toBeUndefined();
+    });
+    it('produces no key for string payloads', () => {
+        expect(getSolanaRpcPayloadDeduplicationKey('o hai')).toBeUndefined();
+    });
+    it('produces no key for numeric payloads', () => {
+        expect(getSolanaRpcPayloadDeduplicationKey(123)).toBeUndefined();
+    });
+    it('produces no key for bigint payloads', () => {
+        expect(getSolanaRpcPayloadDeduplicationKey(123n)).toBeUndefined();
+    });
+    it('produces no key for object payloads that are not JSON-RPC payloads', () => {
+        expect(getSolanaRpcPayloadDeduplicationKey({})).toBeUndefined();
+    });
+    it('produces a key for a JSON-RPC payload', () => {
+        expect(
+            getSolanaRpcPayloadDeduplicationKey({
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'getFoo',
+                params: 'foo',
+            })
+        ).toMatchInlineSnapshot(`"["getFoo","foo"]"`);
+    });
+    it('produces identical keys for two materially identical JSON-RPC payloads', () => {
+        expect(
+            getSolanaRpcPayloadDeduplicationKey({
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'getFoo',
+                params: { a: 1, b: { c: [2, 3], d: 4 } },
+            })
+        ).toEqual(
+            /* eslint-disable sort-keys-fix/sort-keys-fix */
+            getSolanaRpcPayloadDeduplicationKey({
+                jsonrpc: '2.0',
+                method: 'getFoo',
+                params: { b: { d: 4, c: [2, 3] }, a: 1 },
+                id: 2,
+            })
+            /* eslint-enable sort-keys-fix/sort-keys-fix */
+        );
+    });
+});

--- a/packages/library/src/rpc-request-coalescer.ts
+++ b/packages/library/src/rpc-request-coalescer.ts
@@ -1,0 +1,65 @@
+import { IRpcTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
+
+type CoalescedRequest = {
+    readonly abortController: AbortController;
+    numConsumers: number;
+    readonly responsePromise: Promise<unknown>;
+};
+
+type GetDeduplicationKeyFn = (payload: unknown) => string | undefined;
+
+export function getRpcTransportWithRequestCoalescing(
+    transport: IRpcTransport,
+    getDeduplicationKey: GetDeduplicationKeyFn
+): IRpcTransport {
+    let coalescedRequestsByDeduplicationKey: Record<string, CoalescedRequest> | undefined;
+    return async function makeCoalescedHttpRequest<TResponse>(
+        config: Parameters<IRpcTransport>[0]
+    ): Promise<TResponse> {
+        const { payload, signal } = config;
+        const deduplicationKey = getDeduplicationKey(payload);
+        if (deduplicationKey === undefined) {
+            return await transport(config);
+        }
+        if (!coalescedRequestsByDeduplicationKey) {
+            Promise.resolve().then(() => {
+                coalescedRequestsByDeduplicationKey = undefined;
+            });
+            coalescedRequestsByDeduplicationKey = {};
+        }
+        if (coalescedRequestsByDeduplicationKey[deduplicationKey] == null) {
+            const abortController = new AbortController();
+            coalescedRequestsByDeduplicationKey[deduplicationKey] = {
+                abortController,
+                numConsumers: 0,
+                responsePromise: transport<TResponse>({
+                    ...config,
+                    signal: abortController.signal,
+                }),
+            };
+        }
+        const coalescedRequest = coalescedRequestsByDeduplicationKey[deduplicationKey];
+        coalescedRequest.numConsumers++;
+        if (signal) {
+            const responsePromise = coalescedRequest.responsePromise as Promise<TResponse>;
+            return await new Promise<TResponse>((resolve, reject) => {
+                const handleAbort = (e: AbortSignalEventMap['abort']) => {
+                    signal.removeEventListener('abort', handleAbort);
+                    coalescedRequest.numConsumers -= 1;
+                    if (coalescedRequest.numConsumers === 0) {
+                        const abortController = coalescedRequest.abortController;
+                        abortController.abort();
+                    }
+                    const abortError = new DOMException((e.target as AbortSignal).reason, 'AbortError');
+                    reject(abortError);
+                };
+                signal.addEventListener('abort', handleAbort);
+                responsePromise.then(resolve).finally(() => {
+                    signal.removeEventListener('abort', handleAbort);
+                });
+            });
+        } else {
+            return (await coalescedRequest.responsePromise) as TResponse;
+        }
+    };
+}

--- a/packages/library/src/rpc-request-deduplication.ts
+++ b/packages/library/src/rpc-request-deduplication.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import fastStableStringify from 'fast-stable-stringify';
+
+export function getSolanaRpcPayloadDeduplicationKey(payload: unknown): string | undefined {
+    if (payload == null || typeof payload !== 'object' || Array.isArray(payload)) {
+        return;
+    }
+    if ('jsonrpc' in payload && payload.jsonrpc === '2.0' && 'method' in payload && 'params' in payload) {
+        return fastStableStringify([payload.method, payload.params]);
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@solana/rpc-transport':
         specifier: workspace:*
         version: link:../rpc-transport
+      fast-stable-stringify:
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.0


### PR DESCRIPTION
refactor(experimental): coalesce requests with identical in-flight requests
## Background

Throwback to #1208. There, we implemented something I call ‘request coalescing’ at the request of @Jac0xb. He was doing a _ton_ of transaction confirmations in a long-running process, all of them using the blockheight-based confirmation strategy. This resulted in a _ton_ of `getBlockHeight` requests to their RPC infra.

We decided that because the block height depends on nothing but time, essentially, that there was no point in firing off multiple of these requests at the same time. Instead we coalesced all calls into a single request; we either started a new request or associated our request with the currently-in-fight request. This ensured that there was only one request for the same arguments in flight at any given time.

## Summary

In this PR we decide how to bring this into the rewrite of web3.js in a general way. One of this PR's central questions is: can we apply request coalescing to _every_ method?

## Discussion

### Request-in-flight based coalescing

One option is to allow an infinite number of requests to ‘get behind’ one in-flight network fetch. If no fetch exists, the first call creates it. While a fetch is in flight, the next calls add themselves as subscribers to it. The network fetch doesn't have its `AbortSignal` triggered until the last subscriber has called `abort()`.

* If a request is _not_ in flight for a call's parameters, create the request
* If a request _is_ in flight for a call's parameters, add yourself as a subscriber

*Cons*: If a request takes a long time, this might yield unexpected behavior. Imagine that a `getBlockHeight` request takes 5 _seconds_ to respond, and there are calls made at t0, t1, t2, t3, and t4. The value returned will be a different amount of stale from the perspective of each one of those calls. If the call at t4 was allowed to make its own network request, then it _might_ get fresher data.

### Time-windowed coalescing

To combat the effect of slow responses described above, we could add a rule to the coalescing algorithm:

* If a request is _not_ in flight for a call's parameters, create the request
* If a request has been in flight for a call's parameters for more than X ms, create a new request
* If a request has been in flight for a call's parameters for X or fewer ms, add yourself as a subscriber

*Cons*: While this _minimizes_ the effect of slow responses, X still represents a magic number, and each method might require a different tuning of X given its characteristics.

### JavaScript runloop-based coalescing (✅ chose this one)

A variation of the time-windowed algorithm might be to make the ‘time window’ exactly the length of one JavaScript runloop. This is to say that only requests made in the _same_ runloop get coalesced together. You can think of the size of this window as ‘zero’ and the kinds of requests that it coalesces together as being the same as those typically made in a `for` loop.

*Cons*: While this will certainly reduce fetches, without the staleness problems of the last two approaches, ‘identical’ requests made very close together in time but in different runloops will not benefit from coalescing.

## Test Plan

```ts
const rpc = createSolanaRpc({ url: 'https://api.devnet.solana.com' });
for (let ii = 0; ii < 10; ii++) {
  rpc.getBlockHeight.send().then(console.log);
}

```

Observe that only one network request gets made, but all logs report the same value.
