### PR TITLE
refactor(experimental): delete the batch API

### DIFF
--- a/packages/rpc-transport/src/__tests__/json-rpc-test.ts
+++ b/packages/rpc-transport/src/__tests__/json-rpc-test.ts
@@ -36,45 +36,11 @@ describe('JSON-RPC 2.0', () => {
             payload: { ...createJsonRpcMessage('someMethod', [123]), id: expect.any(Number) },
         });
     });
-    it('sends a batch of requests to the transport', () => {
-        rpc.someMethod(123).someMethod(456).sendBatch();
-        expect(makeHttpRequest).toHaveBeenCalledWith({
-            payload: [
-                { ...createJsonRpcMessage('someMethod', [123]), id: expect.any(Number) },
-                { ...createJsonRpcMessage('someMethod', [456]), id: expect.any(Number) },
-            ],
-        });
-    });
     it('returns results from the transport', async () => {
         expect.assertions(1);
         (makeHttpRequest as jest.Mock).mockResolvedValueOnce({ result: 123 });
         const result = await rpc.someMethod().send();
         expect(result).toBe(123);
-    });
-    it('returns a batch of results from the transport', async () => {
-        expect.assertions(2);
-        (makeHttpRequest as jest.Mock).mockResolvedValueOnce([{ result: 123 }, { result: 456 }]);
-        const [resultA, resultB] = await rpc.someMethod().someMethod().sendBatch();
-        expect(resultA).toBe(123);
-        expect(resultB).toBe(456);
-    });
-    it('reorders results of a batch from the transport in request order', async () => {
-        expect.assertions(3);
-        // Produce requests in order.
-        const startId = Date.now();
-        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId);
-        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId + 1);
-        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId + 2);
-        // Mock the responses being returned out of order.
-        (makeHttpRequest as jest.Mock).mockResolvedValueOnce([
-            { id: startId + 2, result: 789 },
-            { id: startId, result: 123 },
-            { id: startId + 1, result: 456 },
-        ]);
-        const [resultA, resultB, resultC] = await rpc.someMethod().someMethod().someMethod().sendBatch();
-        expect(resultA).toBe(123);
-        expect(resultB).toBe(456);
-        expect(resultC).toBe(789);
     });
     it('throws errors from the transport', async () => {
         expect.assertions(3);
@@ -83,24 +49,6 @@ describe('JSON-RPC 2.0', () => {
         await expect(sendPromise).rejects.toThrow(SolanaJsonRpcError);
         await expect(sendPromise).rejects.toThrow(/o no/);
         await expect(sendPromise).rejects.toMatchObject({ code: 123, data: 'abc' });
-    });
-    it('throws the first error of a batch from the transport', async () => {
-        expect.assertions(3);
-        // Produce requests in order.
-        const startId = Date.now();
-        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId);
-        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId + 1);
-        (getNextMessageId as jest.Mock).mockReturnValueOnce(startId + 2);
-        // Mock the responses being returned out of order.
-        (makeHttpRequest as jest.Mock).mockResolvedValueOnce([
-            { error: { code: 456, data: 'def', message: 'also bad' }, id: startId + 2 },
-            { error: { code: 123, data: 'abc', message: 'o no' }, id: startId },
-            { id: startId + 1, result: 123 },
-        ]);
-        const sendBatchPromise = rpc.someMethod().someMethod().someMethod().sendBatch();
-        await expect(sendBatchPromise).rejects.toThrow(SolanaJsonRpcError);
-        await expect(sendBatchPromise).rejects.toThrow(/o no/);
-        await expect(sendBatchPromise).rejects.toMatchObject({ code: 123, data: 'abc' });
     });
     describe('when calling a method having a concrete implementation', () => {
         let rpc: Rpc<TestRpcMethods>;

--- a/packages/rpc-transport/src/json-rpc.ts
+++ b/packages/rpc-transport/src/json-rpc.ts
@@ -1,31 +1,18 @@
 import { SolanaJsonRpcError } from './json-rpc-errors';
 import { createJsonRpcMessage } from './json-rpc-message';
-import {
-    ArmedBatchRpc,
-    ArmedBatchRpcOwnMethods,
-    ArmedRpc,
-    ArmedRpcOwnMethods,
-    SendOptions,
-    Rpc,
-    RpcConfig,
-    RpcRequest,
-} from './json-rpc-types';
+import { PendingRpcRequest, SendOptions, Rpc, RpcConfig, RpcRequest } from './json-rpc-types';
 
 interface IHasIdentifier {
     readonly id: number;
 }
 type JsonRpcResponse<TResponse> = IHasIdentifier &
     Readonly<{ result: TResponse } | { error: { code: number; message: string; data?: unknown } }>;
-type JsonRpcBatchResponse<TResponses extends unknown[]> = [
-    ...{ [P in keyof TResponses]: JsonRpcResponse<TResponses[P]> }
-];
-type RpcRequestBatch<T> = { [P in keyof T]: RpcRequest<T[P]> };
 
-function createArmedJsonRpc<TRpcMethods, TResponse>(
+function createPendingRpcRequest<TRpcMethods, TResponse>(
     rpcConfig: RpcConfig<TRpcMethods>,
     pendingRequest: RpcRequest<TResponse>
-): ArmedRpc<TRpcMethods, TResponse> {
-    const overrides = {
+): PendingRpcRequest<TResponse> {
+    return {
         async send(options?: SendOptions): Promise<TResponse> {
             const { methodName, params, responseProcessor } = pendingRequest;
             const payload = createJsonRpcMessage(methodName, params);
@@ -40,60 +27,9 @@ function createArmedJsonRpc<TRpcMethods, TResponse>(
             }
         },
     };
-    return makeProxy(rpcConfig, overrides, pendingRequest);
 }
 
-function createArmedBatchJsonRpc<TRpcMethods, TResponses extends unknown[]>(
-    rpcConfig: RpcConfig<TRpcMethods>,
-    pendingRequests: RpcRequestBatch<TResponses>
-): ArmedBatchRpc<TRpcMethods, TResponses> {
-    const overrides = {
-        async sendBatch(options?: SendOptions): Promise<TResponses> {
-            const payload = pendingRequests.map(({ methodName, params }) => createJsonRpcMessage(methodName, params));
-            const responses = await rpcConfig.transport<JsonRpcBatchResponse<unknown[]>>({
-                payload,
-                signal: options?.abortSignal,
-            });
-            const requestOrder = payload.map(p => p.id);
-            return responses
-                .sort((a, b) => requestOrder.indexOf(a.id) - requestOrder.indexOf(b.id))
-                .map((response, ii) => {
-                    if ('error' in response) {
-                        throw new SolanaJsonRpcError(response.error);
-                    } else {
-                        const { responseProcessor } = pendingRequests[ii];
-                        return responseProcessor ? responseProcessor(response.result) : response.result;
-                    }
-                }) as TResponses;
-        },
-    };
-    return makeProxy(rpcConfig, overrides, pendingRequests);
-}
-
-function makeProxy<TRpcMethods, TResponses extends unknown[]>(
-    rpcConfig: RpcConfig<TRpcMethods>,
-    overrides: ArmedBatchRpcOwnMethods<TResponses>,
-    pendingRequests: RpcRequestBatch<TResponses>
-): ArmedBatchRpc<TRpcMethods, TResponses>;
-function makeProxy<TRpcMethods, TResponse>(
-    rpcConfig: RpcConfig<TRpcMethods>,
-    overrides: ArmedRpcOwnMethods<TResponse>,
-    pendingRequest: RpcRequest<TResponse>
-): ArmedRpc<TRpcMethods, TResponse>;
-function makeProxy<TRpcMethods>(rpcConfig: RpcConfig<TRpcMethods>): Rpc<TRpcMethods>;
-function makeProxy<TRpcMethods, TResponseOrResponses>(
-    rpcConfig: RpcConfig<TRpcMethods>,
-    overrides?: TResponseOrResponses extends unknown[]
-        ? ArmedBatchRpcOwnMethods<TResponseOrResponses>
-        : ArmedRpcOwnMethods<TResponseOrResponses>,
-    pendingRequestOrRequests?: TResponseOrResponses extends unknown[]
-        ? RpcRequestBatch<TResponseOrResponses>
-        : RpcRequest<TResponseOrResponses>
-):
-    | Rpc<TRpcMethods>
-    | (TResponseOrResponses extends unknown[]
-          ? ArmedBatchRpc<TRpcMethods, TResponseOrResponses>
-          : ArmedRpc<TRpcMethods, TResponseOrResponses>) {
+function makeProxy<TRpcMethods>(rpcConfig: RpcConfig<TRpcMethods>): Rpc<TRpcMethods> {
     return new Proxy(rpcConfig.api, {
         defineProperty() {
             return false;
@@ -102,30 +38,16 @@ function makeProxy<TRpcMethods, TResponseOrResponses>(
             return false;
         },
         get(target, p, receiver) {
-            if (overrides && Reflect.has(overrides, p)) {
-                return Reflect.get(overrides, p, receiver);
-            }
             return function (...rawParams: unknown[]) {
                 const methodName = p.toString();
                 const createRpcRequest = Reflect.get(target, methodName, receiver);
                 const newRequest = createRpcRequest
                     ? createRpcRequest(...rawParams)
                     : { methodName, params: rawParams };
-                if (pendingRequestOrRequests == null) {
-                    return createArmedJsonRpc(rpcConfig, newRequest);
-                } else {
-                    const nextPendingRequests = Array.isArray(pendingRequestOrRequests)
-                        ? [...pendingRequestOrRequests, newRequest]
-                        : [pendingRequestOrRequests, newRequest];
-                    return createArmedBatchJsonRpc(rpcConfig, nextPendingRequests);
-                }
+                return createPendingRpcRequest(rpcConfig, newRequest);
             };
         },
-    }) as
-        | Rpc<TRpcMethods>
-        | (TResponseOrResponses extends unknown[]
-              ? ArmedBatchRpc<TRpcMethods, TResponseOrResponses>
-              : ArmedRpc<TRpcMethods, TResponseOrResponses>);
+    }) as Rpc<TRpcMethods>;
 }
 
 export function createJsonRpc<TRpcMethods>(rpcConfig: RpcConfig<TRpcMethods>): Rpc<TRpcMethods> {


### PR DESCRIPTION
refactor(experimental): delete the batch API
## Summary

I had a long discussion with RPC providers about the JSON-RPC batch API.

In summary,

* it causes problems with resource exhaustion,
* makes it difficult to balance load,

…on top of having the user-facing drawbacks of,

* blowing the entire request up if even one method fails,
* making the entire batch take as long as the slowest request

For all of these reasons, and the detail that I go into [here](https://twitter.com/steveluscher/status/1532443998488363008), we're going to eliminate the batch API as designed here.

*This doesn't mean that you can't still batch in Solana apps*.

1. In fact, you can use the API that remains to do _proper_ batching using JavaScript primitives,
2. We're going to commit to delivering HTTP/2 pipelining in web3.js in _both_ Node and the browser.

## Test Plan

**DON'T DO THIS:**

```ts
// These execute in series. Each network request will wait
// for the one before it to finish before even starting.
const latestBlockhash = await rpc.getLatestBlockhash().send();
const accountInfo = await rpc.getAccountInfo(ownerAddress).send();
const epoch = await rpc.getEpoch().send();
```

Do this instead:

```ts
// These execute in parallel and will all share the same
// connection wherever HTTP/2 is available.
const [
  latestBlockhash,
  accountInfo,
  epoch,
] = await Promise.allSettled([
  rpc.getLatestBlockhash().send(),
  rpc.getAccountInfo(ownerAddress).send(),
  rpc.getEpoch().send(),
]);
// Example result:
//   { status: 'fulfilled', value: 'QaMAF1AaapDdocMdZgXqKX2ixd7YYSxTpKHMcsbcF318' },
//   { status: 'rejected', reason: Error },
//   { status: 'fulfilled', value: 420 },
```

Using `Promise.allSettled` you get _all_ of the benefits of batching, _plus_ the benefits of being able to properly load balance your requests (fewer rate limits and blocks), _plus_ you get to salvage successful requests despite _some_ of the requests in your batch having failed.
