### PR TITLE
chore: create a special publish step just for the experimental package

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -40,7 +40,7 @@
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
-        "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
+        "publish-packages": "sed -i 's/@solana\\/web3\\.js-experimental/@solana\\/web3\\.js/g' package.json && sed -i 's/@solana\\/web3\\.js/@solana\\/web3\\.js-bak/g' ../library-legacy/package.json && pnpm publish --tag experimental --access public --no-git-checks && git reset --hard",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/turbo.json
+++ b/turbo.json
@@ -84,6 +84,11 @@
             "dependsOn": ["^compile:js"],
             "inputs": ["babel.config.json", "src/**", "test/**"],
             "outputs": []
+        },
+        "@solana/web3.js-experimental#publish-packages": {
+            "cache": false,
+            "dependsOn": ["build", "@solana/web3.js#publish-packages"],
+            "outputs": []
         }
     },
     "remoteCache": {


### PR DESCRIPTION
What I really want to happen here is for the new `web3.js` library to be published such that anyone can install it by doing `npm install @solana/web3.js@experimental`.

Finally put in the work on the build system to do that.