### PR TITLE
Refactor (experimental): add getSupply RPC method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-supply-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-supply-test.ts
@@ -1,0 +1,45 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+import { SolanaRpcMethods, createSolanaRpcApi } from '../index';
+import { Commitment } from '../common';
+
+describe('getSupply', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            it('returns the supply', async () => {
+                expect.assertions(1);
+                const supply = await rpc.getSupply({ commitment }).send();
+
+                expect(supply).toMatchObject({
+                    value: expect.objectContaining({
+                        circulating: expect.any(BigInt),
+                        nonCirculating: expect.any(BigInt),
+                        total: expect.any(BigInt),
+                    }),
+                });
+
+                // TODO: we don't reliably have non-circulating accounts in test validator yet
+                // expect(supply.value.nonCirculatingAccounts.length).toBeGreaterThan(0);
+            });
+        });
+    });
+
+    describe('when called with `excludeNonCirculatingAccountsList: true`', () => {
+        it.todo('returns an empty `nonCirculatingAccounts` array');
+    });
+
+    describe('when called with `excludeNonCirculatingAccountsList: false`', () => {
+        it.todo('returns a non-empty `nonCirculatingAccounts` array');
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getSupply.ts
@@ -1,0 +1,44 @@
+import { Base58EncodedAddress } from '@solana/keys';
+import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, RpcResponse } from './common';
+
+type GetSupplyConfig = Readonly<{
+    commitment?: Commitment;
+    excludeNonCirculatingAccountsList?: boolean;
+}>;
+
+type GetSupplyApiResponseBase = RpcResponse<{
+    /** Total supply in lamports */
+    total: LamportsUnsafeBeyond2Pow53Minus1;
+    /** Circulating supply in lamports */
+    circulating: LamportsUnsafeBeyond2Pow53Minus1;
+    /** Non-circulating supply in lamports */
+    nonCirculating: LamportsUnsafeBeyond2Pow53Minus1;
+}>;
+
+type GetSupplyApiResponseWithNonCirculatingAccounts = GetSupplyApiResponseBase &
+    Readonly<{
+        value: Readonly<{
+            /** an array of account addresses of non-circulating accounts */
+            nonCirculatingAccounts: [Base58EncodedAddress];
+        }>;
+    }>;
+
+type GetSupplyApiResponseWithoutNonCirculatingAccounts = GetSupplyApiResponseBase &
+    Readonly<{
+        value: Readonly<{
+            nonCirculatingAccounts: [];
+        }>;
+    }>;
+
+export interface GetSupplyApi {
+    /**
+     * Returns information about the current supply.
+     */
+    getSupply(
+        config: GetSupplyConfig &
+            Readonly<{
+                excludeNonCirculatingAccountsList: true;
+            }>
+    ): GetSupplyApiResponseWithoutNonCirculatingAccounts;
+    getSupply(config?: GetSupplyConfig): GetSupplyApiResponseWithNonCirculatingAccounts;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -17,6 +17,7 @@ import { GetTransactionCountApi } from './getTransactionCount';
 import { MinimumLedgerSlotApi } from './minimumLedgerSlot';
 import { GetEpochInfoApi } from './getEpochInfo';
 import { GetRecentPerformanceSamplesApi } from './getRecentPerformanceSamples';
+import { GetSupplyApi } from './getSupply';
 
 type Config = Readonly<{
     onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;
@@ -36,6 +37,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetRecentPerformanceSamplesApi &
     GetSlotApi &
     GetStakeMinimumDelegationApi &
+    GetSupplyApi &
     GetTransactionCountApi &
     MinimumLedgerSlotApi;
 


### PR DESCRIPTION
Adds the `getSupply` RPC method which returns the circulating/total SOL. It also returns `nonCirculatingAccounts`, which is a list of non-circulating account addresses. When called with `excludeNonCirculatingAccountsList: true`, this is an empty list.

I've found that in the test validator we start with no non-circulating accounts, and then quickly get a lot of them. But for now I've skipped the tests that require a non-empty list to be returned.

- [x] I read the [JSON-RPC docs](https://docs.solana.com/api/http) for my method and implemented it faithfully as a Typescript interface in [`packages/rpc-core/src/rpc-methods`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods)
- [x] I have commented the inputs and outputs of my Typescript interface using text from the JSON-RPC docs
- [x] I have read through the Rust source code of my RPC method to make sure that it accepts the inputs that I expect, returns the outputs that I expect, and applies the defaults I expect when an input is not supplied
- [x] Wherever my method's return value changes based on its inputs, I've implemented that as a [Typescript function overload](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/rpc-methods/getAccountInfo.ts#L80-L114))
- [x] I have written a test in [`packages/rpc-core/src/rpc-methods/__tests__`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods/__tests__) that exercises as much of my RPC method's functionality as is practical
- [x] Wherever my test relies on reading account data I have created an account fixture in [`scripts/fixtures`](https://github.com/solana-labs/solana-web3.js/tree/master/scripts/fixtures) that gets loaded into the test validator ([example](https://github.com/solana-labs/solana-web3.js/blob/master/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json)) (N/A)
- [x] If my RPC method returns a numeric value _other_ than a `u64` or `usize` (eg. a `u8`) I have encoded an exception for that return value so that it does _not_ get upcast to a `bigint` in the RPC ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts#L12)) (N/A)