### PR TITLE
refactor(experimental): add the `getVoteAccounts` RPC method

### DIFF
--- a/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
@@ -12,4 +12,8 @@ export const ALLOWED_NUMERIC_KEYPATHS: Partial<
     getBlockTime: [[]],
     getInflationReward: [[KEYPATH_WILDCARD, 'commission']],
     getRecentPerformanceSamples: [[KEYPATH_WILDCARD, 'samplePeriodSecs']],
+    getVoteAccounts: [
+        ['current', KEYPATH_WILDCARD, 'commission'],
+        ['delinquent', KEYPATH_WILDCARD, 'commission'],
+    ],
 };

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-vote-accounts.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-vote-accounts.ts
@@ -1,0 +1,56 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { Commitment } from '../common';
+import { Base58EncodedAddress } from '@solana/keys';
+
+describe('getVoteAccounts', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            it('returns current and delinquent vote accounts', async () => {
+                expect.assertions(1);
+                const voteAccountsPromise = rpc.getVoteAccounts().send();
+                await expect(voteAccountsPromise).resolves.toMatchObject({
+                    current: expect.any(Array),
+                    delinquent: expect.any(Array),
+                });
+            });
+
+            // TODO: don't have a way to create vote accounts yet
+            it.todo('returns vote accounts with the correct shape');
+        });
+    });
+
+    describe('when called with a `votePubkey` of a single vote account', () => {
+        it.todo('returns only that vote account');
+    });
+
+    describe('when called with a `votePubkey` of a vote account that does not exist', () => {
+        it('returns empty `current` and `delinquent` fields', async () => {
+            expect.assertions(1);
+            // randomly generated address, don't re-use in anything that creates a vote account
+            const address =
+                '2eTCZxWZkU5h3Mo162gLRTECzuJhPgC1McB9rCcoqNm2' as Base58EncodedAddress<'2eTCZxWZkU5h3Mo162gLRTECzuJhPgC1McB9rCcoqNm2'>;
+            const voteAccountsPromise = rpc.getVoteAccounts({ votePubkey: address }).send();
+            await expect(voteAccountsPromise).resolves.toMatchObject({
+                current: [],
+                delinquent: [],
+            });
+        });
+    });
+
+    describe('when called with `keepUnstakedDelinquents` set to false', () => {
+        it.todo('filters out delinquent vote accounts with `activeStake` of 0');
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getVoteAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getVoteAccounts.ts
@@ -1,0 +1,49 @@
+import { Base58EncodedAddress } from '@solana/keys';
+import { Commitment, U64UnsafeBeyond2Pow53Minus1 } from './common';
+
+type Epoch = U64UnsafeBeyond2Pow53Minus1;
+type Credits = U64UnsafeBeyond2Pow53Minus1;
+type PreviousCredits = U64UnsafeBeyond2Pow53Minus1;
+
+type EpochCredit = [Epoch, Credits, PreviousCredits];
+
+type VoteAccount<TVotePubkey extends Base58EncodedAddress> = Readonly<{
+    /** Vote account address */
+    votePubkey: TVotePubkey;
+    /** Validator identity */
+    nodePubkey: Base58EncodedAddress;
+    /** the stake, in lamports, delegated to this vote account and active in this epoch */
+    activatedStake: U64UnsafeBeyond2Pow53Minus1;
+    /** whether the vote account is staked for this epoch */
+    epochVoteAccount: boolean;
+    /** percentage (0-100) of rewards payout owed to the vote account */
+    commission: number;
+    /** Most recent slot voted on by this vote account */
+    lastVote: U64UnsafeBeyond2Pow53Minus1;
+    /** Latest history of earned credits for up to five epochs */
+    epochCredits: readonly EpochCredit[];
+    /** Current root slot for this vote account */
+    rootSlot: U64UnsafeBeyond2Pow53Minus1;
+}>;
+
+type GetVoteAccountsApiResponse<TVotePubkey extends Base58EncodedAddress> = Readonly<{
+    current: readonly VoteAccount<TVotePubkey>[];
+    delinquent: readonly VoteAccount<TVotePubkey>[];
+}>;
+
+type GetVoteAccountsConfig<TVotePubkey extends Base58EncodedAddress> = Readonly<{
+    commitment?: Commitment;
+    /** Only return results for this validator vote address */
+    votePubkey?: TVotePubkey;
+    /** Do not filter out delinquent validators with no stake */
+    keepUnstakedDelinquents?: boolean;
+    /** Specify the number of slots behind the tip that a validator must fall to be considered delinquent. **NOTE:** For the sake of consistency between ecosystem products, _it is **not** recommended that this argument be specified._ */
+    delinquentSlotDistance?: U64UnsafeBeyond2Pow53Minus1;
+}>;
+
+export interface GetVoteAccountsApi {
+    /** Returns the account info and associated stake for all the voting accounts in the current bank. */
+    getVoteAccounts<TVoteAccount extends Base58EncodedAddress>(
+        config?: GetVoteAccountsConfig<TVoteAccount>
+    ): GetVoteAccountsApiResponse<TVoteAccount>;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -19,6 +19,7 @@ import { GetSlotApi } from './getSlot';
 import { GetStakeMinimumDelegationApi } from './getStakeMinimumDelegation';
 import { GetSupplyApi } from './getSupply';
 import { GetTransactionCountApi } from './getTransactionCount';
+import { GetVoteAccountsApi } from './getVoteAccounts';
 import { MinimumLedgerSlotApi } from './minimumLedgerSlot';
 
 type Config = Readonly<{
@@ -43,6 +44,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetStakeMinimumDelegationApi &
     GetSupplyApi &
     GetTransactionCountApi &
+    GetVoteAccountsApi &
     MinimumLedgerSlotApi;
 
 export function createSolanaRpcApi(config?: Config): IRpcApi<SolanaRpcMethods> {


### PR DESCRIPTION
Adds the `getVoteAccounts` RPC method which returns the current + delinquent voting accounts

I've found that in the test validator we start with no vote accounts, and then get 1 current one. To test this in more depth we'll need a way to create active + delinquent ones and modify their stakes.

Note that when called with `votePubkey` the response is narrowed a bit, but I haven't modeled this in the types. This is because there are 3 possible responses:

- `current` with length 1 and `delinquent` with length 0, if the `votePubkey` is active
- `current` with length 0 and `delinquent` with length 1, if the `votePubkey` is not active
- `current` with length 0 and `delinquent` with length 0, if the pubkey is not a vote account, or if it's filtered out by `keepUnstakedDelinquents`

I don't think in practice this is likely to be a useful narrowing, so I've just kept it as `{current: [VoteAccount], delinquent: [VoteAccount]}` for now. 

- [x] I read the [JSON-RPC docs](https://docs.solana.com/api/http) for my method and implemented it faithfully as a Typescript interface in [`packages/rpc-core/src/rpc-methods`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods)
- [x] I have commented the inputs and outputs of my Typescript interface using text from the JSON-RPC docs
- [x] I have read through the Rust source code of my RPC method to make sure that it accepts the inputs that I expect, returns the outputs that I expect, and applies the defaults I expect when an input is not supplied
- [x] Wherever my method's return value changes based on its inputs, I've implemented that as a [Typescript function overload](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/rpc-methods/getAccountInfo.ts#L80-L114)) (N/A)
- [x] I have written a test in [`packages/rpc-core/src/rpc-methods/__tests__`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods/__tests__) that exercises as much of my RPC method's functionality as is practical
- [x] Wherever my test relies on reading account data I have created an account fixture in [`scripts/fixtures`](https://github.com/solana-labs/solana-web3.js/tree/master/scripts/fixtures) that gets loaded into the test validator ([example](https://github.com/solana-labs/solana-web3.js/blob/master/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json)) (N/A)
- [x] If my RPC method returns a numeric value _other_ than a `u64` or `usize` (eg. a `u8`) I have encoded an exception for that return value so that it does _not_ get upcast to a `bigint` in the RPC ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts#L12))