### PR TITLE
Refactor (experimental): add the `getRecentPerformanceSamples`  RPC method

### DIFF
--- a/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
@@ -10,4 +10,5 @@ export const ALLOWED_NUMERIC_KEYPATHS: Partial<
     Record<keyof ReturnType<typeof createSolanaRpcApi>, readonly KeyPath[]>
 > = {
     getInflationReward: [[KEYPATH_WILDCARD, 'commission']],
+    getRecentPerformanceSamples: [[KEYPATH_WILDCARD, 'samplePeriodSecs']],
 };

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-recent-performance-samples-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-recent-performance-samples-test.ts
@@ -1,0 +1,10 @@
+describe('getRecentPerformanceSamples', () => {
+    // TODO: need a way to create performance samples without waiting 60s
+    describe('when called without a limit', () => {
+        it.todo('returns the latest performance samples');
+    });
+
+    describe('when called with a limit', () => {
+        it.todo('only returns the requested number of performance samples');
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getRecentPerformanceSamples.ts
+++ b/packages/rpc-core/src/rpc-methods/getRecentPerformanceSamples.ts
@@ -1,0 +1,26 @@
+import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+
+type PerformanceSample = Readonly<{
+    /** Slot in which sample was taken at */
+    slot: Slot;
+    /** Number of transactions in sample */
+    numTransactions: U64UnsafeBeyond2Pow53Minus1;
+    /** Number of slots in sample */
+    numSlots: U64UnsafeBeyond2Pow53Minus1;
+    /** Number of seconds in a sample window */
+    samplePeriodSecs: number;
+    /** Number of non-vote transactions in sample. */
+    numNonVoteTransaction: U64UnsafeBeyond2Pow53Minus1;
+}>;
+
+type GetRecentPerformanceSamplesApiResponse = readonly PerformanceSample[];
+
+export interface GetRecentPerformanceSamplesApi {
+    /**
+     * Returns a list of recent performance samples, in reverse slot order. Performance samples are taken every 60 seconds and include the number of transactions and slots that occur in a given time window.
+     */
+    getRecentPerformanceSamples(
+        /** number of samples to return (maximum 720) */
+        limit?: number
+    ): GetRecentPerformanceSamplesApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -16,6 +16,7 @@ import { GetStakeMinimumDelegationApi } from './getStakeMinimumDelegation';
 import { GetTransactionCountApi } from './getTransactionCount';
 import { MinimumLedgerSlotApi } from './minimumLedgerSlot';
 import { GetEpochInfoApi } from './getEpochInfo';
+import { GetRecentPerformanceSamplesApi } from './getRecentPerformanceSamples';
 
 type Config = Readonly<{
     onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;
@@ -26,16 +27,18 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetBlockHeightApi &
     GetBlockProductionApi &
     GetBlocksApi &
+    GetEpochInfoApi &
     GetFirstAvailableBlockApi &
     GetInflationRewardApi &
     GetLatestBlockhashApi &
     GetMaxRetransmitSlotApi &
     GetMaxShredInsertSlotApi &
+    GetRecentPerformanceSamplesApi &
     GetSlotApi &
     GetStakeMinimumDelegationApi &
     GetTransactionCountApi &
-    MinimumLedgerSlotApi &
-    GetEpochInfoApi;
+    MinimumLedgerSlotApi;
+
 export function createSolanaRpcApi(config?: Config): IRpcApi<SolanaRpcMethods> {
     return new Proxy({} as IRpcApi<SolanaRpcMethods>, {
         defineProperty() {


### PR DESCRIPTION
Adds the `getRecentPerformanceSamples` RPC method which returns the latest performance samples

Currently the performance sample rate is 60s, so we don't have any data for the first 60s. This makes it impossible to meaningfully unit test this for now. We'll need to find a way to create performance samples without waiting 60s. 

- [x] I read the [JSON-RPC docs](https://docs.solana.com/api/http) for my method and implemented it faithfully as a Typescript interface in [`packages/rpc-core/src/rpc-methods`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods)
- [x] I have commented the inputs and outputs of my Typescript interface using text from the JSON-RPC docs
- [x] I have read through the Rust source code of my RPC method to make sure that it accepts the inputs that I expect, returns the outputs that I expect, and applies the defaults I expect when an input is not supplied
- [x] Wherever my method's return value changes based on its inputs, I've implemented that as a [Typescript function overload](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/rpc-methods/getAccountInfo.ts#L80-L114)) (N/A)
- [x] I have written a test in [`packages/rpc-core/src/rpc-methods/__tests__`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods/__tests__) that exercises as much of my RPC method's functionality as is practical (Todos for now)
- [x] Wherever my test relies on reading account data I have created an account fixture in [`scripts/fixtures`](https://github.com/solana-labs/solana-web3.js/tree/master/scripts/fixtures) that gets loaded into the test validator ([example](https://github.com/solana-labs/solana-web3.js/blob/master/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json)) (N/A)
- [x] If my RPC method returns a numeric value _other_ than a `u64` or `usize` (eg. a `u8`) I have encoded an exception for that return value so that it does _not_ get upcast to a `bigint` in the RPC ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts#L12))