### PR TITLE
refactor(experimental): add the `getEpochInfo` RPC method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-epoch-info-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-epoch-info-test.ts
@@ -1,0 +1,51 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { Commitment } from '../common';
+
+describe('getEpochInfo', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            it('returns epoch info', async () => {
+                expect.assertions(1);
+                const epochInfoPromise = rpc.getEpochInfo().send();
+                await expect(epochInfoPromise).resolves.toMatchObject({
+                    absoluteSlot: expect.any(BigInt),
+                    blockHeight: expect.any(BigInt),
+                    epoch: expect.any(BigInt),
+                    slotIndex: expect.any(BigInt),
+                    slotsInEpoch: expect.any(BigInt),
+                    transactionCount: expect.any(BigInt),
+                });
+            });
+        });
+    });
+
+    describe('when called with a `minContextSlot` higher than the highest slot available', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const epochInfoPromise = rpc
+                .getEpochInfo({
+                    minContextSlot: 2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
+                })
+                .send();
+            await expect(epochInfoPromise).rejects.toMatchObject({
+                code: -32016 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getEpochInfo.ts
+++ b/packages/rpc-core/src/rpc-methods/getEpochInfo.ts
@@ -1,0 +1,28 @@
+import { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+
+type GetEpochInfoApiResponse = Readonly<{
+    /** the current slot */
+    absoluteSlot: Slot;
+    /** the current block height */
+    blockHeight: U64UnsafeBeyond2Pow53Minus1;
+    /** the current epoch */
+    epoch: U64UnsafeBeyond2Pow53Minus1;
+    /** the current slot relative to the start of the current epoch */
+    slotIndex: U64UnsafeBeyond2Pow53Minus1;
+    /** the number of slots in this epoch */
+    slotsInEpoch: U64UnsafeBeyond2Pow53Minus1;
+    /** total number of transactions processed without error since genesis */
+    transactionCount: U64UnsafeBeyond2Pow53Minus1 | null;
+}>;
+
+export interface GetEpochInfoApi {
+    /**
+     * Returns the balance of the account of provided Pubkey
+     */
+    getEpochInfo(
+        config?: Readonly<{
+            commitment?: Commitment;
+            minContextSlot?: Slot;
+        }>
+    ): GetEpochInfoApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -15,6 +15,7 @@ import { GetSlotApi } from './getSlot';
 import { GetStakeMinimumDelegationApi } from './getStakeMinimumDelegation';
 import { GetTransactionCountApi } from './getTransactionCount';
 import { MinimumLedgerSlotApi } from './minimumLedgerSlot';
+import { GetEpochInfoApi } from './getEpochInfo';
 
 type Config = Readonly<{
     onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;
@@ -33,7 +34,8 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetSlotApi &
     GetStakeMinimumDelegationApi &
     GetTransactionCountApi &
-    MinimumLedgerSlotApi;
+    MinimumLedgerSlotApi &
+    GetEpochInfoApi;
 export function createSolanaRpcApi(config?: Config): IRpcApi<SolanaRpcMethods> {
     return new Proxy({} as IRpcApi<SolanaRpcMethods>, {
         defineProperty() {


### PR DESCRIPTION
Adds the `getEpochInfo` RPC method

Note that [the current docs](https://docs.solana.com/api/http#getepochinfo) are incorrect, this method doesn't take an address parameter. Fix in https://github.com/solana-labs/solana/pull/31651

- [x] I read the [JSON-RPC docs](https://docs.solana.com/api/http) for my method and implemented it faithfully as a Typescript interface in [`packages/rpc-core/src/rpc-methods`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods)
- [x] I have commented the inputs and outputs of my Typescript interface using text from the JSON-RPC docs
- [x] I have read through the Rust source code of my RPC method to make sure that it accepts the inputs that I expect, returns the outputs that I expect, and applies the defaults I expect when an input is not supplied
- [x] Wherever my method's return value changes based on its inputs, I've implemented that as a [Typescript function overload](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/rpc-methods/getAccountInfo.ts#L80-L114)) (N/A)
- [x] I have written a test in [`packages/rpc-core/src/rpc-methods/__tests__`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods/__tests__) that exercises as much of my RPC method's functionality as is practical
- [x] Wherever my test relies on reading account data I have created an account fixture in [`scripts/fixtures`](https://github.com/solana-labs/solana-web3.js/tree/master/scripts/fixtures) that gets loaded into the test validator ([example](https://github.com/solana-labs/solana-web3.js/blob/master/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json)) (N/A)
- [x] If my RPC method returns a numeric value _other_ than a `u64` or `usize` (eg. a `u8`) I have encoded an exception for that return value so that it does _not_ get upcast to a `bigint` in the RPC ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts#L12)) (N/A)