### PR TITLE
refactor(experimental): add the `getBlockTime` RPC method

### DIFF
--- a/packages/rpc-core/src/__tests__/unix-timestamp-test.ts
+++ b/packages/rpc-core/src/__tests__/unix-timestamp-test.ts
@@ -1,0 +1,35 @@
+import { assertIsUnixTimestamp } from '../unix-timestamp';
+
+describe('assertIsUnixTimestamp()', () => {
+    it('throws when supplied a too large number', () => {
+        expect(() => {
+            assertIsUnixTimestamp(Number.MAX_SAFE_INTEGER);
+        }).toThrow();
+        expect(() => {
+            assertIsUnixTimestamp(8.64e15 + 1);
+        }).toThrow();
+    });
+    it('throws when supplied a too small number', () => {
+        expect(() => {
+            assertIsUnixTimestamp(Number.MIN_SAFE_INTEGER);
+        }).toThrow();
+        expect(() => {
+            assertIsUnixTimestamp(-8.64e15 - 1);
+        }).toThrow();
+    });
+    it('does not throw when supplied a zero timestamp', () => {
+        expect(() => {
+            assertIsUnixTimestamp(0);
+        }).not.toThrow();
+    });
+    it('does not throw when supplied a valid non-zero timestamp', () => {
+        expect(() => {
+            assertIsUnixTimestamp(1_000_000_000);
+        }).not.toThrow();
+    });
+    it('does not throw when supplied the max valid timestamp', () => {
+        expect(() => {
+            assertIsUnixTimestamp(8.64e15);
+        }).not.toThrow();
+    });
+});

--- a/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
@@ -9,6 +9,7 @@ import { KEYPATH_WILDCARD } from './response-patcher-types';
 export const ALLOWED_NUMERIC_KEYPATHS: Partial<
     Record<keyof ReturnType<typeof createSolanaRpcApi>, readonly KeyPath[]>
 > = {
+    getBlockTime: [[]],
     getInflationReward: [[KEYPATH_WILDCARD, 'commission']],
     getRecentPerformanceSamples: [[KEYPATH_WILDCARD, 'samplePeriodSecs']],
 };

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-block-time-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-block-time-test.ts
@@ -1,0 +1,52 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getBlockTime', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    describe('when called with a currently available block', () => {
+        // TODO: either use getFirstAvailableBlock when implemented, or we'll need a way to control the ledger
+        it.todo('returns a block time');
+
+        // it('returns a block time', async () => {
+        //     const blockTimePromise = rpc.getBlockTime(0n).send();
+        //     await expect(blockTimePromise).resolves.toEqual(expect.any(Number));
+        // })
+    });
+
+    describe('when called with a block that has been cleaned up', () => {
+        // TODO: will need a way to control the ledger and get a past block that has been cleaned up
+        // Expected error:
+        /*
+    "error": {
+      "code": -32001,
+      "message": "Block 150 cleaned up, does not exist on node. First available block: 141077"
+    }
+    */
+        it.todo('returns an error');
+    });
+
+    describe('when called with a block higher than the highest block available', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const blockNumber = 2n ** 63n - 1n; // u64:MAX; safe bet it'll be too high.
+            const blockTimePromise = rpc.getBlockTime(blockNumber).send();
+            await expect(blockTimePromise).rejects.toMatchObject({
+                code: -32004 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/common.ts
+++ b/packages/rpc-core/src/rpc-methods/common.ts
@@ -13,6 +13,8 @@ export type LamportsUnsafeBeyond2Pow53Minus1 = bigint & { readonly __lamports: u
 
 export type Slot = U64UnsafeBeyond2Pow53Minus1;
 
+export type UnixTimestamp = number & { readonly __unixTimestamp: unique symbol };
+
 // FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
 // truncated or rounded because of a downcast to JavaScript `number` between your calling code and
 // the JSON-RPC transport.

--- a/packages/rpc-core/src/rpc-methods/common.ts
+++ b/packages/rpc-core/src/rpc-methods/common.ts
@@ -13,8 +13,6 @@ export type LamportsUnsafeBeyond2Pow53Minus1 = bigint & { readonly __lamports: u
 
 export type Slot = U64UnsafeBeyond2Pow53Minus1;
 
-export type UnixTimestamp = number & { readonly __unixTimestamp: unique symbol };
-
 // FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
 // truncated or rounded because of a downcast to JavaScript `number` between your calling code and
 // the JSON-RPC transport.

--- a/packages/rpc-core/src/rpc-methods/getBlockTime.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockTime.ts
@@ -1,4 +1,5 @@
-import { Slot, UnixTimestamp } from './common';
+import { UnixTimestamp } from '../unix-timestamp';
+import { Slot } from './common';
 
 /** Estimated production time, as Unix timestamp (seconds since the Unix epoch) */
 type GetBlockTimeApiResponse = UnixTimestamp;

--- a/packages/rpc-core/src/rpc-methods/getBlockTime.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockTime.ts
@@ -1,0 +1,14 @@
+import { Slot, UnixTimestamp } from './common';
+
+/** Estimated production time, as Unix timestamp (seconds since the Unix epoch) */
+type GetBlockTimeApiResponse = UnixTimestamp;
+
+export interface GetBlockTimeApi {
+    /**
+     * Returns the estimated production time of a block.
+     */
+    getBlockTime(
+        /** block number, identified by Slot */
+        blockNumber: Slot
+    ): GetBlockTimeApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -17,6 +17,7 @@ import { GetTransactionCountApi } from './getTransactionCount';
 import { MinimumLedgerSlotApi } from './minimumLedgerSlot';
 import { GetEpochInfoApi } from './getEpochInfo';
 import { GetRecentPerformanceSamplesApi } from './getRecentPerformanceSamples';
+import { GetBlockTimeApi } from './getBlockTime';
 
 type Config = Readonly<{
     onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;
@@ -27,6 +28,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetBlockHeightApi &
     GetBlockProductionApi &
     GetBlocksApi &
+    GetBlockTimeApi &
     GetEpochInfoApi &
     GetFirstAvailableBlockApi &
     GetInflationRewardApi &

--- a/packages/rpc-core/src/unix-timestamp.ts
+++ b/packages/rpc-core/src/unix-timestamp.ts
@@ -1,0 +1,14 @@
+export type UnixTimestamp = number & { readonly __unixTimestamp: unique symbol };
+
+export function assertIsUnixTimestamp(putativeTimestamp: number): asserts putativeTimestamp is UnixTimestamp {
+    // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
+    try {
+        if (putativeTimestamp > 8.64e15 || putativeTimestamp < -8.64e15) {
+            throw new Error('Expected input number to be less than or equal to 8.64e15');
+        }
+    } catch (e) {
+        throw new Error(`\`${putativeTimestamp}\` is not a timestamp`, {
+            cause: e,
+        });
+    }
+}


### PR DESCRIPTION
Adds the `getBlockTime` RPC method

Note that I think [the current docs](https://docs.solana.com/api/http#getblocktime) are slightly incorrect, this method doesn't return null. It either returns the block time or an error. Fix in https://github.com/solana-labs/solana/pull/31653

Note that tests here are limited. I think there are 3 responses:

- Returns the block time for an available block. For this to be reliable in tests we need to either get an available block (eg using `getFirstAvailableBlock` when implemented), or be able to control the ledger so that a certain block is guaranteed to be available
- Returns an error when a block has been cleaned up. For this to be performant in tests we'll need a way to control the ledger so that a block is cleaned up, without waiting however long that would take to happen on its own
- Returns an error when a block is not available up. I've included a test using the usual maxint for this. 

---

- [x] I read the [JSON-RPC docs](https://docs.solana.com/api/http) for my method and implemented it faithfully as a Typescript interface in [`packages/rpc-core/src/rpc-methods`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods)
- [x] I have commented the inputs and outputs of my Typescript interface using text from the JSON-RPC docs
- [x] I have read through the Rust source code of my RPC method to make sure that it accepts the inputs that I expect, returns the outputs that I expect, and applies the defaults I expect when an input is not supplied
- [x] Wherever my method's return value changes based on its inputs, I've implemented that as a [Typescript function overload](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/rpc-methods/getAccountInfo.ts#L80-L114)) (N/A)
- [x] I have written a test in [`packages/rpc-core/src/rpc-methods/__tests__`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods/__tests__) that exercises as much of my RPC method's functionality as is practical
- [x] Wherever my test relies on reading account data I have created an account fixture in [`scripts/fixtures`](https://github.com/solana-labs/solana-web3.js/tree/master/scripts/fixtures) that gets loaded into the test validator ([example](https://github.com/solana-labs/solana-web3.js/blob/master/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json)) (N/A)
- [x] If my RPC method returns a numeric value _other_ than a `u64` or `usize` (eg. a `u8`) I have encoded an exception for that return value so that it does _not_ get upcast to a `bigint` in the RPC ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts#L12)) (N/A)