### PR TITLE
refactor(experimental): allow literal `Base58EncodedAddress` types

### DIFF
--- a/packages/keys/src/base58.ts
+++ b/packages/keys/src/base58.ts
@@ -1,10 +1,12 @@
 import bs58 from 'bs58';
 
-export type Base58EncodedAddress = string & { readonly __base58EncodedAddress: unique symbol };
+export type Base58EncodedAddress<TAddress extends string = string> = TAddress & {
+    readonly __base58EncodedAddress: unique symbol;
+};
 
 export function assertIsBase58EncodedAddress(
     putativeBase58EncodedAddress: string
-): asserts putativeBase58EncodedAddress is Base58EncodedAddress {
+): asserts putativeBase58EncodedAddress is Base58EncodedAddress<typeof putativeBase58EncodedAddress> {
     try {
         // Fast-path; see if the input string is of an acceptable length.
         if (

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
@@ -22,7 +22,8 @@ describe('getBalance', () => {
             it('returns a balance of zero for a new address', async () => {
                 expect.assertions(1);
                 // This key is random, don't re-use in any tests that affect balance
-                const publicKey = '4BfxgLzn6pEuVB2ynBMqckHFdYD8VNcrheDFFCB6U5TH' as Base58EncodedAddress;
+                const publicKey =
+                    '4BfxgLzn6pEuVB2ynBMqckHFdYD8VNcrheDFFCB6U5TH' as Base58EncodedAddress<'4BfxgLzn6pEuVB2ynBMqckHFdYD8VNcrheDFFCB6U5TH'>;
                 const balancePromise = rpc.getBalance(publicKey).send();
                 await expect(balancePromise).resolves.toHaveProperty('value', BigInt(0));
             });
@@ -31,7 +32,8 @@ describe('getBalance', () => {
 
     describe('given an account with a non-zero balance', () => {
         // See scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json
-        const publicKey = '4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc' as Base58EncodedAddress;
+        const publicKey =
+            '4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc' as Base58EncodedAddress<'4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc'>;
         it('returns the correct balance', async () => {
             expect.assertions(1);
             const balancePromise = rpc.getBalance(publicKey).send();
@@ -43,7 +45,8 @@ describe('getBalance', () => {
         it('throws an error', async () => {
             expect.assertions(1);
             // This key is random, don't re-use in any tests that affect balance
-            const publicKey = '4BfxgLzn6pEuVB2ynBMqckHFdYD8VNcrheDFFCB6U5TH' as Base58EncodedAddress;
+            const publicKey =
+                '4BfxgLzn6pEuVB2ynBMqckHFdYD8VNcrheDFFCB6U5TH' as Base58EncodedAddress<'4BfxgLzn6pEuVB2ynBMqckHFdYD8VNcrheDFFCB6U5TH'>;
             const sendPromise = rpc
                 .getBalance(publicKey, {
                     minContextSlot: 2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-block-production-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-block-production-test.ts
@@ -48,7 +48,8 @@ describe('getBlockProduction', () => {
         it('returns an empty byIdentity if the identity is not a block producer', async () => {
             expect.assertions(1);
             // Randomly generated address, assumed not to be a block producer
-            const identity = '9NmqDDZa7mH1DBM4zeq9cm7VcRn2un1i2TwuMvjBoVhU' as Base58EncodedAddress;
+            const identity =
+                '9NmqDDZa7mH1DBM4zeq9cm7VcRn2un1i2TwuMvjBoVhU' as Base58EncodedAddress<'9NmqDDZa7mH1DBM4zeq9cm7VcRn2un1i2TwuMvjBoVhU'>;
             const blockProductionPromise = rpc.getBlockProduction({ identity }).send();
             await expect(blockProductionPromise).resolves.toMatchObject({
                 value: expect.objectContaining({


### PR DESCRIPTION
refactor(experimental): allow literal `Base58EncodedAddress` types
## Summary

If you want to not only assert that something is a base58 address, but a _particular_ base58 address you can make use of this new optional type parameter.


## Test Plan

```ts
const memoProgramV2Address = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
assertIsBase58EncodedAddress(memoProgramV2Address);
memoProgramV2Address as Base58EncodedAddress; // OK
memoProgramV2Address as Base58EncodedAddress<'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'>; // OK
memoProgramV2Address as Base58EncodedAddress<'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo'>; // ERROR
```
