### PR TITLE
fix: update the size of vote accounts now that the network has moved on past 1.14.11

### DIFF
--- a/packages/library-legacy/src/programs/vote.ts
+++ b/packages/library-legacy/src/programs/vote.ts
@@ -369,7 +369,7 @@ export class VoteProgram {
    *
    * KEEP IN SYNC WITH `VoteState::size_of()` in https://github.com/solana-labs/solana/blob/a474cb24b9238f5edcc982f65c0b37d4a1046f7e/sdk/program/src/vote/state/mod.rs#L340-L342
    */
-  static space: number = process.env.TEST_LIVE ? 3762 : 3731;
+  static space: number = 3762;
 
   /**
    * Generate an Initialize instruction.


### PR DESCRIPTION
fix: update the size of vote accounts now that the network has moved on past 1.14.11
## Summary

The new size of the vote account is `3762`. This update will make `VoteProgram.initializeAccount()` work with validators newer than 1.14.11 (which is now the majority of the network)

## Test Plan

```ts
pnpm test:live-with-test-validator
```
