### PR TITLE
feat: add `withContext` flag to `getProgramAccounts`

### DIFF
--- a/packages/library-legacy/test/connection.test.ts
+++ b/packages/library-legacy/test/connection.test.ts
@@ -749,6 +749,36 @@ describe('Connection', function () {
         });
       expect(programAccountsDoMatchFilter).to.have.length(2);
     }
+
+    {
+      await mockRpcResponse({
+        method: 'getProgramAccounts',
+        params: [
+          programId.publicKey.toBase58(),
+          {
+            commitment: 'confirmed',
+            withContext: true,
+          },
+        ],
+        value: {
+          context: {
+            slot: 11,
+          },
+          value: [],
+        },
+      });
+      const programAccountsWithContext = await connection.getProgramAccounts(
+        programId.publicKey,
+        {
+          commitment: 'confirmed',
+          withContext: true,
+        },
+      );
+      expect(programAccountsWithContext).to.have.nested.property(
+        'context.slot',
+      );
+      expect(programAccountsWithContext).to.have.property('value');
+    }
   }).timeout(30 * 1000);
 
   it('get balance', async () => {


### PR DESCRIPTION
feat: add `withContext` flag to `getProgramAccounts`
## Summary

This was missing. When supplied, the RPC wraps the result in a context object.

Fixes #1285.

## Test Plan

```
pnpm test:live-with-test-validator
pnpm test:unit:node
```
