### PR TITLE
fix: Fix getPA type when config is undefined

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -3627,7 +3627,7 @@ export class Connection {
    */
   async getProgramAccounts(
     programId: PublicKey,
-    configOrCommitment?: GetProgramAccountsConfig &
+    configOrCommitment: GetProgramAccountsConfig &
       Readonly<{withContext: true}>,
   ): Promise<RpcResponseAndContext<GetProgramAccountsResponse>>;
   // eslint-disable-next-line no-dupe-class-members


### PR DESCRIPTION
when using `connection.getProgramAccounts(<public-key>)`, without a config argument, the return type is `RpcResponseAndContext<GetProgramAccountsResponse>` while configOrCommitment is false so it does not run the function returning the context. This result into an error at runtime for anyone trying to access `value`.