### PR TITLE
refactor(experimental): add the getEpochSchedule RPC method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-epoch-schedule-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-epoch-schedule-test.ts
@@ -1,0 +1,29 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getEpochSchedule', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    it('returns the epoch schedule', async () => {
+        expect.assertions(1);
+        const epochSchedulePromise = rpc.getEpochSchedule().send();
+        await expect(epochSchedulePromise).resolves.toMatchObject({
+            firstNormalEpoch: expect.any(BigInt),
+            firstNormalSlot: expect.any(BigInt),
+            leaderScheduleSlotOffset: expect.any(BigInt),
+            slotsPerEpoch: expect.any(BigInt),
+            warmup: expect.any(Boolean),
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getEpochSchedule.ts
+++ b/packages/rpc-core/src/rpc-methods/getEpochSchedule.ts
@@ -1,0 +1,21 @@
+import { U64UnsafeBeyond2Pow53Minus1 } from './common';
+
+type GetEpochScheduleApiResponse = Readonly<{
+    /** the maximum number of slots in each epoch */
+    slotsPerEpoch: U64UnsafeBeyond2Pow53Minus1;
+    /** the number of slots before beginning of an epoch to calculate a leader schedule for that epoch */
+    leaderScheduleSlotOffset: U64UnsafeBeyond2Pow53Minus1;
+    /** whether epochs start short and grow */
+    warmup: boolean;
+    /** first normal-length epoch, log2(slotsPerEpoch) - log2(MINIMUM_SLOTS_PER_EPOCH) */
+    firstNormalEpoch: U64UnsafeBeyond2Pow53Minus1;
+    /** MINIMUM_SLOTS_PER_EPOCH * (2^(firstNormalEpoch) - 1) */
+    firstNormalSlot: U64UnsafeBeyond2Pow53Minus1;
+}>;
+
+export interface GetEpochScheduleApi {
+    /**
+     * Returns the epoch schedule information from this cluster's genesis config
+     */
+    getEpochSchedule(): GetEpochScheduleApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -9,6 +9,7 @@ import { GetBlockProductionApi } from './getBlockProduction';
 import { GetBlocksApi } from './getBlocks';
 import { GetBlockTimeApi } from './getBlockTime';
 import { GetEpochInfoApi } from './getEpochInfo';
+import { GetEpochScheduleApi } from './getEpochSchedule';
 import { GetFirstAvailableBlockApi } from './getFirstAvailableBlock';
 import { GetInflationRewardApi } from './getInflationReward';
 import { GetLatestBlockhashApi } from './getLatestBlockhash';
@@ -23,7 +24,6 @@ import { GetTransactionApi } from './getTransaction';
 import { GetTransactionCountApi } from './getTransactionCount';
 import { GetVoteAccountsApi } from './getVoteAccounts';
 import { MinimumLedgerSlotApi } from './minimumLedgerSlot';
-import { GetEpochScheduleApi } from './getEpochSchedule';
 
 type Config = Readonly<{
     onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -23,6 +23,7 @@ import { GetTransactionApi } from './getTransaction';
 import { GetTransactionCountApi } from './getTransactionCount';
 import { GetVoteAccountsApi } from './getVoteAccounts';
 import { MinimumLedgerSlotApi } from './minimumLedgerSlot';
+import { GetEpochScheduleApi } from './getEpochSchedule';
 
 type Config = Readonly<{
     onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;
@@ -35,6 +36,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetBlocksApi &
     GetBlockTimeApi &
     GetEpochInfoApi &
+    GetEpochScheduleApi &
     GetFirstAvailableBlockApi &
     GetInflationRewardApi &
     GetLatestBlockhashApi &


### PR DESCRIPTION
Nice straightforward RPC method for once! Used in the `ClusterProvider` in explorer, which would be good to migrate to new web3js! 