### PR TITLE
refactor(experimental): add a comparator you can use to sort base58 addresses

### DIFF
--- a/packages/keys/src/__tests__/base58-test.ts
+++ b/packages/keys/src/__tests__/base58-test.ts
@@ -1,6 +1,6 @@
 import bs58 from 'bs58';
 
-import { assertIsBase58EncodedAddress } from '../base58';
+import { assertIsBase58EncodedAddress, getBase58EncodedAddressComparator } from '../base58';
 
 describe('base58', () => {
     describe('assertIsBase58EncodedAddress()', () => {
@@ -56,6 +56,39 @@ describe('base58', () => {
                 // eslint-disable-next-line no-empty
             } catch {}
             expect(decodeMethod).not.toHaveBeenCalled();
+        });
+    });
+    describe('getBase58EncodedAddressComparator', () => {
+        it('sorts base 58 addresses', () => {
+            expect(
+                // These addresses were chosen such that sorting these conventionally (ie. using
+                // the default `Array.sort`) or numerically (ie. on the basis of the underlying
+                // numerical value of the address) would fail to produce the expected output. This
+                // exercises the 'specialness' of the base 58 encoded address comparator.
+                [
+                    'Ht1VrhoyhwMGMpBBi89BPdJp5R39Mu49suKx3A22W9Qs',
+                    'J9ZSLc9qPg3FR8UqfN6ae1QkVReUmnpLgQqFkGEPqmod',
+                    '6JYSQqSHY1E5JDwEfgWMieozqA1KCwiP2cH69to9eWKH',
+                    '7YR1xA7yzFAT4yQCsS4rpowjU1tsh5YUJd9hWMHRppcX',
+                    '7grJ9YUAEHxckLFqCY7fq8cM1UrragNSuPH1dvwJ8EEK',
+                    'AJBPNWCjVLwxff2eJynW56cMRCGmyU4y3vbuvtVdgVgb',
+                    'B8A2zUEDtJjR7nrokNUJYhgUQiwEBzC88rZc6WUE5ZeF',
+                    'BKggsVVp7yLmXtPuBDtC3FXBzvLyyye3Q2tFKUUGCHLj',
+                    'Ds72joawSKQ9nCDAAmGMKFiwiY6HR7PDzYDHDzZom3tj',
+                    'F1zKr4ZUYo5UAnH1fvYaD6R7ne137NYfS1r5HrCb8NpF',
+                ].sort(getBase58EncodedAddressComparator())
+            ).toEqual([
+                '6JYSQqSHY1E5JDwEfgWMieozqA1KCwiP2cH69to9eWKH',
+                '7grJ9YUAEHxckLFqCY7fq8cM1UrragNSuPH1dvwJ8EEK',
+                '7YR1xA7yzFAT4yQCsS4rpowjU1tsh5YUJd9hWMHRppcX',
+                'AJBPNWCjVLwxff2eJynW56cMRCGmyU4y3vbuvtVdgVgb',
+                'B8A2zUEDtJjR7nrokNUJYhgUQiwEBzC88rZc6WUE5ZeF',
+                'BKggsVVp7yLmXtPuBDtC3FXBzvLyyye3Q2tFKUUGCHLj',
+                'Ds72joawSKQ9nCDAAmGMKFiwiY6HR7PDzYDHDzZom3tj',
+                'F1zKr4ZUYo5UAnH1fvYaD6R7ne137NYfS1r5HrCb8NpF',
+                'Ht1VrhoyhwMGMpBBi89BPdJp5R39Mu49suKx3A22W9Qs',
+                'J9ZSLc9qPg3FR8UqfN6ae1QkVReUmnpLgQqFkGEPqmod',
+            ]);
         });
     });
 });

--- a/packages/keys/src/base58.ts
+++ b/packages/keys/src/base58.ts
@@ -29,3 +29,14 @@ export function assertIsBase58EncodedAddress(
         });
     }
 }
+
+export function getBase58EncodedAddressComparator(): (x: string, y: string) => number {
+    return new Intl.Collator('en', {
+        caseFirst: 'lower',
+        ignorePunctuation: false,
+        localeMatcher: 'best fit',
+        numeric: false,
+        sensitivity: 'variant',
+        usage: 'sort',
+    }).compare;
+}


### PR DESCRIPTION
refactor(experimental): add a comparator you can use to sort base58 addresses
## Summary

We sort addresses peculiarly. Not based on the value of the underlying key. Not using the default `Array.sort()`. Rather, using `localeCompare` with a specific set of options. This PR encodes this into the new experimental library, through the use of a getter that returns you the compare functino of an `Intl.Collator`.

## Test Plan

```
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1342).
* #1302
* #1345
* #1344
* #1343
* __->__ #1342