### PR TITLE
refactor(experimental): types that describe the lifetime of a transaction

### DIFF
--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -64,6 +64,7 @@
         "@solana/eslint-config-solana": "^1.0.0",
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
+        "@solana/rpc-core": "workspace:*",
         "@swc/core": "^1.3.18",
         "@swc/jest": "^0.2.23",
         "@types/jest": "^29.5.0",

--- a/packages/transactions/src/blockhash.ts
+++ b/packages/transactions/src/blockhash.ts
@@ -1,0 +1,10 @@
+import { Blockhash } from '@solana/rpc-core';
+
+type BlockhashLifetimeConstraint = Readonly<{
+    blockhash: Blockhash;
+    lastValidBlockHeight: bigint;
+}>;
+
+export interface ITransactionWithBlockhashLifetime {
+    readonly lifetimeConstraint: BlockhashLifetimeConstraint;
+}

--- a/packages/transactions/src/durable-nonce.ts
+++ b/packages/transactions/src/durable-nonce.ts
@@ -1,0 +1,33 @@
+import { IInstruction, IInstructionWithAccounts, IInstructionWithData } from '@solana/instructions';
+import { ReadonlyAccount, ReadonlySignerAccount, WritableAccount } from '@solana/instructions/dist/types/accounts';
+
+type AdvanceNonceAccountInstruction<
+    TNonceAccountAddress extends string = string,
+    TNonceAuthorityAddress extends string = string
+> = IInstruction<'11111111111111111111111111111111'> &
+    IInstructionWithAccounts<
+        [
+            WritableAccount<TNonceAccountAddress>,
+            ReadonlyAccount<'SysvarRecentB1ockHashes11111111111111111111'>,
+            ReadonlySignerAccount<TNonceAuthorityAddress>
+        ]
+    > &
+    IInstructionWithData<AdvanceNonceAccountInstructionData>;
+type AdvanceNonceAccountInstructionData = Uint8Array & {
+    readonly __advanceNonceAccountInstructionData: unique symbol;
+};
+type NonceLifetimeConstraint = Readonly<{
+    nonce: string;
+}>;
+
+export interface IDurableNonceTransaction<
+    TNonceAccountAddress extends string = string,
+    TNonceAuthorityAddress extends string = string
+> {
+    readonly instructions: [
+        // The first instruction *must* be the system program's `AdvanceNonceAccount` instruction.
+        AdvanceNonceAccountInstruction<TNonceAccountAddress, TNonceAuthorityAddress>,
+        ...IInstruction[]
+    ];
+    readonly lifetimeConstraint: NonceLifetimeConstraint;
+}

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -1,2 +1,4 @@
+export * from './blockhash';
 export * from './create-transaction';
+export * from './durable-nonce';
 export * from './types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,6 +800,9 @@ importers:
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
+      '@solana/rpc-core':
+        specifier: workspace:*
+        version: link:../rpc-core
       '@swc/core':
         specifier: ^1.3.18
         version: 1.3.18


### PR DESCRIPTION
refactor(experimental): types that describe the lifetime of a transaction
## Summary

There are two ways to describe the lifetime of a transaction: either with a ‘recent’ blockhash or with a durable nonce. This PR introduces the types that describe those two lifetimes.

## Test Plan

Observe this is a type error because there is no `AdvanceNonce` instruction.

```ts
const tx: BaseTransaction & IDurableNonceTransaction = {
    lifetimeConstraint: {
        nonce: 'abc',
    },
    instructions: [],
    version: 0,
};
```

Observe this typechecks:

```ts
const tx: BaseTransaction & IDurableNonceTransaction = {
    instructions: [
        {
            accounts: [
                {
                    address: 'abc' as Base58EncodedAddress,
                    isSigner: false,
                    isWritable: true,
                },
                {
                    address:
                        'SysvarRecentB1ockHashes11111111111111111111' as Base58EncodedAddress<'SysvarRecentB1ockHashes11111111111111111111'>,
                    isSigner: false,
                    isWritable: false,
                },
                {
                    address: 'abc' as Base58EncodedAddress,
                    isSigner: true,
                    isWritable: false,
                },
            ],
            data: new Uint8Array(0) as AdvanceNonceAccountInstructionData,
            programAddress:
                '11111111111111111111111111111111' as Base58EncodedAddress<'11111111111111111111111111111111'>,
        },
    ],
    lifetimeConstraint: {
        nonce: 'abc',
    },
    version: 0,
};
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1347).
* #1351
* #1350
* #1349
* #1348
* __->__ #1347