### PR TITLE
refactor(experimental): basic types for transactions with signatures

### DIFF
--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -1,4 +1,5 @@
 export * from './blockhash';
 export * from './create-transaction';
 export * from './durable-nonce';
+export * from './signatures';
 export * from './types';

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -1,0 +1,11 @@
+import { Base58EncodedAddress } from '@solana/keys';
+
+type Base64EncodedSignature = string & {
+    readonly __base64EncodedSignature: unique symbol;
+};
+export interface IFullySignedTransaction extends ITransactionWithSignatures {
+    readonly __fullySignedTransaction: unique symbol;
+}
+export interface ITransactionWithSignatures {
+    readonly signatures: Readonly<Record<Base58EncodedAddress, Base64EncodedSignature>>;
+}


### PR DESCRIPTION
refactor(experimental): basic types for transactions with signatures
## Summary

This PR introduces just the very basic types that describe whether a transaction has signatures or not, including an opaque type that we can use to denote a transaction which is _fully_ signed.

## Test Plan

None yet.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1348).
* #1351
* #1350
* #1349
* __->__ #1348