### PR TITLE
refactor(experimental): a helper to add instructions to a transaction

### DIFF
--- a/packages/transactions/src/__tests__/instructions-test.ts
+++ b/packages/transactions/src/__tests__/instructions-test.ts
@@ -1,0 +1,79 @@
+import 'test-matchers/toBeFrozenObject';
+
+import { IInstruction } from '@solana/instructions';
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { appendTransactionInstruction, prependTransactionInstruction } from '../instructions';
+import { ITransactionWithSignatures } from '../signatures';
+import { BaseTransaction } from '../types';
+
+const PROGRAM_A =
+    'AALQD2dt1k43Acrkp4SvdhZaN4S115Ff2Bi7rHPti3sL' as Base58EncodedAddress<'AALQD2dt1k43Acrkp4SvdhZaN4S115Ff2Bi7rHPti3sL'>;
+const PROGRAM_B =
+    'DNAbkMkoMLRXF7wuLCrTzouMyzi25krr3B94yW87VvxU' as Base58EncodedAddress<'DNAbkMkoMLRXF7wuLCrTzouMyzi25krr3B94yW87VvxU'>;
+
+describe('Transaction instruction helpers', () => {
+    let baseTx: BaseTransaction;
+    let exampleInstruction: IInstruction<string>;
+    beforeEach(() => {
+        baseTx = {
+            instructions: [
+                {
+                    programAddress: PROGRAM_A,
+                },
+            ],
+            version: 0,
+        };
+        exampleInstruction = {
+            programAddress: PROGRAM_B,
+        };
+    });
+    describe('appendTransactionInstruction', () => {
+        it('adds the instruction to the end of the list', () => {
+            const txWithAddedInstruction = appendTransactionInstruction(exampleInstruction, baseTx);
+            expect(txWithAddedInstruction.instructions).toMatchObject([...baseTx.instructions, exampleInstruction]);
+        });
+        describe('given a transaction with signatures', () => {
+            let txWithSignatures: BaseTransaction & ITransactionWithSignatures;
+            beforeEach(() => {
+                txWithSignatures = {
+                    ...baseTx,
+                    signatures: {},
+                };
+            });
+            it('clears the signatures when the fee payer is different than the current one', () => {
+                expect(appendTransactionInstruction(exampleInstruction, txWithSignatures)).not.toHaveProperty(
+                    'signatures'
+                );
+            });
+        });
+        it('freezes the object', () => {
+            const txWithAddedInstruction = appendTransactionInstruction(exampleInstruction, baseTx);
+            expect(txWithAddedInstruction).toBeFrozenObject();
+        });
+    });
+    describe('prependTransactionInstruction', () => {
+        it('adds the instruction to the beginning of the list', () => {
+            const txWithAddedInstruction = prependTransactionInstruction(exampleInstruction, baseTx);
+            expect(txWithAddedInstruction.instructions).toMatchObject([exampleInstruction, ...baseTx.instructions]);
+        });
+        describe('given a transaction with signatures', () => {
+            let txWithSignatures: BaseTransaction & ITransactionWithSignatures;
+            beforeEach(() => {
+                txWithSignatures = {
+                    ...baseTx,
+                    signatures: {},
+                };
+            });
+            it('clears the signatures when the fee payer is different than the current one', () => {
+                expect(prependTransactionInstruction(exampleInstruction, txWithSignatures)).not.toHaveProperty(
+                    'signatures'
+                );
+            });
+        });
+        it('freezes the object', () => {
+            const txWithAddedInstruction = prependTransactionInstruction(exampleInstruction, baseTx);
+            expect(txWithAddedInstruction).toBeFrozenObject();
+        });
+    });
+});

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -2,5 +2,6 @@ export * from './blockhash';
 export * from './create-transaction';
 export * from './durable-nonce';
 export * from './fee-payer';
+export * from './instructions';
 export * from './signatures';
 export * from './types';

--- a/packages/transactions/src/instructions.ts
+++ b/packages/transactions/src/instructions.ts
@@ -1,0 +1,46 @@
+import { ITransactionWithSignatures } from './signatures';
+import { BaseTransaction } from './types';
+
+function replaceInstructions<TTransaction extends BaseTransaction, TInstructions>(
+    transaction: TTransaction | (TTransaction & ITransactionWithSignatures),
+    nextInstructions: TInstructions
+): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
+    let out;
+    if ('signatures' in transaction) {
+        // The implication of the instructions changing is that any existing signatures are invalid.
+        const {
+            signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
+            ...unsignedTransaction
+        } = transaction;
+        out = {
+            ...unsignedTransaction,
+            instructions: nextInstructions,
+        };
+    } else {
+        out = {
+            ...transaction,
+            instructions: nextInstructions,
+        };
+    }
+    return out;
+}
+
+export function appendTransactionInstruction<TTransaction extends BaseTransaction>(
+    instruction: TTransaction['instructions'][number],
+    transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
+): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
+    const nextInstructions = [...transaction.instructions, instruction] as const;
+    const out = replaceInstructions(transaction, nextInstructions);
+    Object.freeze(out);
+    return out;
+}
+
+export function prependTransactionInstruction<TTransaction extends BaseTransaction>(
+    instruction: TTransaction['instructions'][number],
+    transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
+): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
+    const nextInstructions = [instruction, ...transaction.instructions] as const;
+    const out = replaceInstructions(transaction, nextInstructions);
+    Object.freeze(out);
+    return out;
+}


### PR DESCRIPTION
refactor(experimental): a helper to add instructions to a transaction
## Summary

This helper takes care of appending instructions to the list, and unsetting the signatures each time a new instruction is added.
## Test Plan

```
cd packages/transactions
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1350).
* #1351
* __->__ #1350