### PR TITLE
refactor(experimental): a serializer for the transaction version header

### DIFF
--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -60,6 +60,10 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
+    "dependencies": {
+        "@metaplex-foundation/umi": "link:/home/sol/src/umi-git/packages/umi/",
+        "@metaplex-foundation/umi-serializer-data-view": "link:/home/sol/src/umi-git/packages/umi-serializer-data-view/"
+    },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.0",
         "@solana/instructions": "workspace:*",

--- a/packages/transactions/src/serializers/__tests__/transaction-version-test.ts
+++ b/packages/transactions/src/serializers/__tests__/transaction-version-test.ts
@@ -1,0 +1,31 @@
+import { TransactionVersion } from '../../types';
+import { transactionVersionHeader } from '../transaction-version';
+
+const VERSION_FLAG_MASK = 0x80;
+const VERSION_TEST_CASES = // Versions 0–127
+    [...Array(128).keys()].map(version => [version | VERSION_FLAG_MASK, version as TransactionVersion] as const);
+describe('Transaction version serializer', () => {
+    it('serializes no data when the version is `legacy`', () => {
+        expect(transactionVersionHeader.serialize('legacy')).toEqual(new Uint8Array());
+    });
+    it.each(VERSION_TEST_CASES)('serializes to `%s` when the version is `%s`', (expected, version) => {
+        expect(transactionVersionHeader.serialize(version)).toEqual(new Uint8Array([expected]));
+    });
+    it.each(VERSION_TEST_CASES)('deserializes `%s` to the version `%s`', (byte, expected) => {
+        expect(transactionVersionHeader.deserialize(new Uint8Array([byte]))[0]).toEqual(expected);
+    });
+    it('deserializes to `legacy` when missing the version flag', () => {
+        expect(
+            transactionVersionHeader.deserialize(
+                // eg. just a byte that indicates that there are 3 required signers
+                new Uint8Array([3])
+            )[0]
+        ).toBe('legacy');
+    });
+    it.each([-1 as TransactionVersion, 128 as TransactionVersion])(
+        'throws when passed the out-of-range version `%s`',
+        version => {
+            expect(() => transactionVersionHeader.serialize(version)).toThrow();
+        }
+    );
+});

--- a/packages/transactions/src/serializers/transaction-version.ts
+++ b/packages/transactions/src/serializers/transaction-version.ts
@@ -1,0 +1,29 @@
+import { TransactionVersion } from '../types';
+
+const VERSION_FLAG_MASK = 0x80;
+
+export const transactionVersionHeader = {
+    description: __DEV__ ? 'A single byte that encodes the version of the transaction' : '',
+    deserialize: (bytes: Uint8Array, offset = 0): [TransactionVersion, number] => {
+        const firstByte = bytes[offset];
+        if ((firstByte & VERSION_FLAG_MASK) === 0) {
+            // No version flag set; it's a legacy (unversioned) transaction.
+            return ['legacy', offset];
+        } else {
+            const version = (firstByte ^ VERSION_FLAG_MASK) as TransactionVersion;
+            return [version, offset + 1];
+        }
+    },
+    fixedSize: null,
+    maxSize: 1,
+    serialize: (value: TransactionVersion): Uint8Array => {
+        if (value === 'legacy') {
+            return new Uint8Array();
+        }
+        if (value < 0 || value > 127) {
+            // TODO: Coded error.
+            throw new Error(`Transaction version must be in the range [0, 127]. \`${value}\` given.`);
+        }
+        return new Uint8Array([value | VERSION_FLAG_MASK]);
+    },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,13 @@ importers:
         version: 29.5.1
 
   packages/transactions:
+    dependencies:
+      '@metaplex-foundation/umi':
+        specifier: link:/home/sol/src/umi-git/packages/umi/
+        version: link:../../../umi-git/packages/umi
+      '@metaplex-foundation/umi-serializer-data-view':
+        specifier: link:/home/sol/src/umi-git/packages/umi-serializer-data-view/
+        version: link:../../../umi-git/packages/umi-serializer-data-view
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.0


### PR DESCRIPTION
refactor(experimental): a serializer for the transaction version header
## Summary

This is the very first transaction serializer. It demonstrates how we'll use the serializer from Metaplex's Umi library to define custom serializers for transactions.

## Test Plan

```
cd packages/transactions
pnpm test:unit:browser
pnpm test:unit:node
```
