### PR TITLE
refactor(experimental): convert signer-writability flags on accounts into `role` enum

### DIFF
--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -43,7 +43,9 @@
         "test:treeshakability:browser": "agadoo dist/index.browser.js",
         "test:treeshakability:native": "agadoo dist/index.node.js",
         "test:treeshakability:node": "agadoo dist/index.native.js",
-        "test:typecheck": "tsc --noEmit"
+        "test:typecheck": "tsc --noEmit",
+        "test:unit:browser": "jest -c node_modules/test-config/jest-unit.config.browser.ts --rootDir . --silent",
+        "test:unit:node": "jest -c node_modules/test-config/jest-unit.config.node.ts --rootDir . --silent"
     },
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "license": "MIT",

--- a/packages/instructions/src/__tests__/roles-test.ts
+++ b/packages/instructions/src/__tests__/roles-test.ts
@@ -1,0 +1,126 @@
+import {
+    AccountRole,
+    downgradeRoleToNonSigner,
+    downgradeRoleToReadonly,
+    isSignerRole,
+    isWritableRole,
+    mergeRoles,
+    upgradeRoleToSigner,
+    upgradeRoleToWritable,
+} from '../roles';
+
+describe('downgradeRoleToNonSigner', () => {
+    it.each`
+        role                 | expected
+        ${'READONLY'}        | ${'READONLY'}
+        ${'WRITABLE'}        | ${'WRITABLE'}
+        ${'READONLY_SIGNER'} | ${'READONLY'}
+        ${'WRITABLE_SIGNER'} | ${'WRITABLE'}
+    `(
+        'downgrades $role to $expected',
+        ({ role, expected }: { role: keyof typeof AccountRole; expected: keyof typeof AccountRole }) => {
+            expect(downgradeRoleToNonSigner(AccountRole[role])).toBe(AccountRole[expected]);
+        }
+    );
+});
+
+describe('downgradeRoleToReadonly', () => {
+    it.each`
+        role                 | expected
+        ${'READONLY'}        | ${'READONLY'}
+        ${'WRITABLE'}        | ${'READONLY'}
+        ${'READONLY_SIGNER'} | ${'READONLY_SIGNER'}
+        ${'WRITABLE_SIGNER'} | ${'READONLY_SIGNER'}
+    `(
+        'downgrades $role to $expected',
+        ({ role, expected }: { role: keyof typeof AccountRole; expected: keyof typeof AccountRole }) => {
+            expect(downgradeRoleToReadonly(AccountRole[role])).toBe(AccountRole[expected]);
+        }
+    );
+});
+
+describe('isSignerRole', () => {
+    it.each([AccountRole.READONLY, AccountRole.WRITABLE])('returns `false` for AccountRole.$role', role => {
+        expect(isSignerRole(role)).toBe(false);
+    });
+    it.each([AccountRole.READONLY_SIGNER, AccountRole.WRITABLE_SIGNER])(
+        'returns `true` for AccountRole.$role',
+        role => {
+            expect(isSignerRole(role)).toBe(true);
+        }
+    );
+});
+
+describe('isWritableRole', () => {
+    it.each([AccountRole.READONLY, AccountRole.READONLY_SIGNER])('returns `false` for AccountRole.$role', role => {
+        expect(isWritableRole(role)).toBe(false);
+    });
+    it.each([AccountRole.WRITABLE, AccountRole.WRITABLE_SIGNER])('returns `true` for AccountRole.$role', role => {
+        expect(isWritableRole(role)).toBe(true);
+    });
+});
+
+describe('mergeRoles', () => {
+    it.each`
+        aRole                | bRole                | expected
+        ${'READONLY'}        | ${'READONLY'}        | ${'READONLY'}
+        ${'READONLY'}        | ${'WRITABLE'}        | ${'WRITABLE'}
+        ${'READONLY'}        | ${'READONLY_SIGNER'} | ${'READONLY_SIGNER'}
+        ${'READONLY'}        | ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'}
+        ${'WRITABLE'}        | ${'READONLY'}        | ${'WRITABLE'}
+        ${'WRITABLE'}        | ${'WRITABLE'}        | ${'WRITABLE'}
+        ${'WRITABLE'}        | ${'READONLY_SIGNER'} | ${'WRITABLE_SIGNER'}
+        ${'WRITABLE'}        | ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'}
+        ${'READONLY_SIGNER'} | ${'READONLY'}        | ${'READONLY_SIGNER'}
+        ${'READONLY_SIGNER'} | ${'WRITABLE'}        | ${'WRITABLE_SIGNER'}
+        ${'READONLY_SIGNER'} | ${'READONLY_SIGNER'} | ${'READONLY_SIGNER'}
+        ${'READONLY_SIGNER'} | ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'}
+        ${'WRITABLE_SIGNER'} | ${'READONLY'}        | ${'WRITABLE_SIGNER'}
+        ${'WRITABLE_SIGNER'} | ${'WRITABLE'}        | ${'WRITABLE_SIGNER'}
+        ${'WRITABLE_SIGNER'} | ${'READONLY_SIGNER'} | ${'WRITABLE_SIGNER'}
+        ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'}
+    `(
+        'returns $expected when given $aRole and $bRole',
+        ({
+            aRole,
+            bRole,
+            expected,
+        }: {
+            aRole: keyof typeof AccountRole;
+            bRole: keyof typeof AccountRole;
+            expected: keyof typeof AccountRole;
+        }) => {
+            expect(mergeRoles(AccountRole[aRole], AccountRole[bRole])).toBe(AccountRole[expected]);
+        }
+    );
+});
+
+describe('upgradeRoleToSigner', () => {
+    it.each`
+        role                 | expected
+        ${'READONLY'}        | ${'READONLY_SIGNER'}
+        ${'WRITABLE'}        | ${'WRITABLE_SIGNER'}
+        ${'READONLY_SIGNER'} | ${'READONLY_SIGNER'}
+        ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'}
+    `(
+        'upgrades $role to $expected',
+        ({ role, expected }: { role: keyof typeof AccountRole; expected: keyof typeof AccountRole }) => {
+            expect(upgradeRoleToSigner(AccountRole[role])).toBe(AccountRole[expected]);
+        }
+    );
+});
+
+describe('upgradeRoleToWritable', () => {
+    it.each`
+        role                 | expected
+        ${'READONLY'}        | ${'WRITABLE'}
+        ${'WRITABLE'}        | ${'WRITABLE'}
+        ${'READONLY_SIGNER'} | ${'WRITABLE_SIGNER'}
+        ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'}
+    `(
+        'upgrades $role to $expected',
+        ({ role, expected }: { role: keyof typeof AccountRole; expected: keyof typeof AccountRole }) => {
+            expect(upgradeRoleToWritable(AccountRole[role])).toBe(AccountRole[expected]);
+        }
+    );
+});

--- a/packages/instructions/src/accounts.ts
+++ b/packages/instructions/src/accounts.ts
@@ -1,32 +1,35 @@
 import { Base58EncodedAddress } from '@solana/keys';
 
+import { AccountRole } from './roles';
+
 export interface IAccountMeta<TAddress extends string = string> {
     readonly address: Base58EncodedAddress<TAddress>;
-    readonly isSigner: boolean;
-    readonly isWritable: boolean;
+    readonly role: AccountRole;
 }
 
-export type ReadonlyAccount<TAddress extends string = string> = IAccountMeta<TAddress> &
-    Readonly<{ isSigner: false; isWritable: false }>;
-export type WritableAccount<TAddress extends string = string> = IAccountMeta<TAddress> &
-    Readonly<{ isSigner: false; isWritable: true }>;
-export type ReadonlySignerAccount<TAddress extends string = string> = IAccountMeta<TAddress> &
-    Readonly<{ isSigner: true; isWritable: false }>;
-export type WritableSignerAccount<TAddress extends string = string> = IAccountMeta<TAddress> &
-    Readonly<{ isSigner: true; isWritable: true }>;
+export type ReadonlyAccount<TAddress extends string = string> = IAccountMeta<TAddress> & {
+    readonly role: AccountRole.READONLY;
+};
+export type WritableAccount<TAddress extends string = string> = IAccountMeta<TAddress> & { role: AccountRole.WRITABLE };
+export type ReadonlySignerAccount<TAddress extends string = string> = IAccountMeta<TAddress> & {
+    role: AccountRole.READONLY_SIGNER;
+};
+export type WritableSignerAccount<TAddress extends string = string> = IAccountMeta<TAddress> & {
+    role: AccountRole.WRITABLE_SIGNER;
+};
 
 export interface IAccountLookupMeta<TAddress extends string = string, TLookupTableAddress extends string = string> {
     readonly address: Base58EncodedAddress<TAddress>;
     readonly addressIndex: number;
     readonly lookupTableAddress: Base58EncodedAddress<TLookupTableAddress>;
-    readonly isWritable: boolean;
+    readonly role: AccountRole.READONLY | AccountRole.WRITABLE;
 }
 
 export type ReadonlyAccountLookup<
     TAddress extends string = string,
     TLookupTableAddress extends string = string
-> = IAccountLookupMeta<TAddress, TLookupTableAddress> & Readonly<{ isWritable: false }>;
+> = IAccountLookupMeta<TAddress, TLookupTableAddress> & { readonly role: AccountRole.READONLY };
 export type WritableAccountLookup<
     TAddress extends string = string,
     TLookupTableAddress extends string = string
-> = IAccountLookupMeta<TAddress, TLookupTableAddress> & Readonly<{ isWritable: true }>;
+> = IAccountLookupMeta<TAddress, TLookupTableAddress> & { readonly role: AccountRole.WRITABLE };

--- a/packages/instructions/src/index.ts
+++ b/packages/instructions/src/index.ts
@@ -1,2 +1,3 @@
 export * from './accounts';
 export * from './instruction';
+export * from './roles';

--- a/packages/instructions/src/roles.ts
+++ b/packages/instructions/src/roles.ts
@@ -1,0 +1,64 @@
+/**
+ * Quick primer on bitwise operations: https://stackoverflow.com/a/1436448/802047
+ */
+
+export enum AccountRole {
+    // Bitflag guide: is signer ⌄⌄ is writable
+    WRITABLE_SIGNER = /* 3 */ 0b11, // prettier-ignore
+    READONLY_SIGNER = /* 2 */ 0b10, // prettier-ignore
+    WRITABLE =        /* 1 */ 0b01, // prettier-ignore
+    READONLY =        /* 0 */ 0b00, // prettier-ignore
+}
+
+const IS_SIGNER_BITMASK = 0b10;
+const IS_WRITABLE_BITMASK = 0b01;
+
+export function downgradeRoleToNonSigner(role: AccountRole.READONLY_SIGNER): AccountRole.READONLY;
+export function downgradeRoleToNonSigner(role: AccountRole.WRITABLE_SIGNER): AccountRole.WRITABLE;
+export function downgradeRoleToNonSigner(role: AccountRole): AccountRole;
+export function downgradeRoleToNonSigner(role: AccountRole): AccountRole {
+    return role & ~IS_SIGNER_BITMASK;
+}
+
+export function downgradeRoleToReadonly(role: AccountRole.WRITABLE): AccountRole.READONLY;
+export function downgradeRoleToReadonly(role: AccountRole.WRITABLE_SIGNER): AccountRole.READONLY_SIGNER;
+export function downgradeRoleToReadonly(role: AccountRole): AccountRole;
+export function downgradeRoleToReadonly(role: AccountRole): AccountRole {
+    return role & ~IS_WRITABLE_BITMASK;
+}
+
+export function isSignerRole(role: AccountRole): role is AccountRole.READONLY_SIGNER | AccountRole.WRITABLE_SIGNER {
+    return role >= AccountRole.READONLY_SIGNER;
+}
+
+export function isWritableRole(role: AccountRole): role is AccountRole.WRITABLE | AccountRole.WRITABLE_SIGNER {
+    return (role & IS_WRITABLE_BITMASK) !== 0;
+}
+
+export function mergeRoles(roleA: AccountRole.WRITABLE, roleB: AccountRole.READONLY_SIGNER): AccountRole.WRITABLE_SIGNER; // prettier-ignore
+export function mergeRoles(roleA: AccountRole.READONLY_SIGNER, roleB: AccountRole.WRITABLE): AccountRole.WRITABLE_SIGNER; // prettier-ignore
+export function mergeRoles(roleA: AccountRole, roleB: AccountRole.WRITABLE_SIGNER): AccountRole.WRITABLE_SIGNER; // prettier-ignore
+export function mergeRoles(roleA: AccountRole.WRITABLE_SIGNER, roleB: AccountRole): AccountRole.WRITABLE_SIGNER; // prettier-ignore
+export function mergeRoles(roleA: AccountRole, roleB: AccountRole.READONLY_SIGNER): AccountRole.READONLY_SIGNER; // prettier-ignore
+export function mergeRoles(roleA: AccountRole.READONLY_SIGNER, roleB: AccountRole): AccountRole.READONLY_SIGNER; // prettier-ignore
+export function mergeRoles(roleA: AccountRole, roleB: AccountRole.WRITABLE): AccountRole.WRITABLE; // prettier-ignore
+export function mergeRoles(roleA: AccountRole.WRITABLE, roleB: AccountRole): AccountRole.WRITABLE; // prettier-ignore
+export function mergeRoles(roleA: AccountRole.READONLY, roleB: AccountRole.READONLY): AccountRole.READONLY; // prettier-ignore
+export function mergeRoles(roleA: AccountRole, roleB: AccountRole): AccountRole; // prettier-ignore
+export function mergeRoles(roleA: AccountRole, roleB: AccountRole): AccountRole {
+    return roleA | roleB;
+}
+
+export function upgradeRoleToSigner(role: AccountRole.READONLY): AccountRole.READONLY_SIGNER;
+export function upgradeRoleToSigner(role: AccountRole.WRITABLE): AccountRole.WRITABLE_SIGNER;
+export function upgradeRoleToSigner(role: AccountRole): AccountRole;
+export function upgradeRoleToSigner(role: AccountRole): AccountRole {
+    return role | IS_SIGNER_BITMASK;
+}
+
+export function upgradeRoleToWritable(role: AccountRole.READONLY): AccountRole.WRITABLE;
+export function upgradeRoleToWritable(role: AccountRole.READONLY_SIGNER): AccountRole.WRITABLE_SIGNER;
+export function upgradeRoleToWritable(role: AccountRole): AccountRole;
+export function upgradeRoleToWritable(role: AccountRole): AccountRole {
+    return role | IS_WRITABLE_BITMASK;
+}


### PR DESCRIPTION
refactor(experimental): convert signer-writability flags on accounts into `role` enum
## Summary

Instead of tweaking `isSigner` and `isWritable` flags on account metadata, let's create one enum to describe all four combinations. This enables us to finally treat account metadata as a discriminated union in TypeScript. That is to say that checking an account's `role` will now refine its type down to the type containing that role.

* Makes code less verbose, particularly tests
* Makes it less tempting to mutate an object in-place by twiddling the boolean of `isSigner` or `isWritable`

## Test Plan

See next PRs.
