### PR TITLE
refactor(experimental): a function to compile a transaction's lifetime into a message

### DIFF
--- a/packages/transactions/src/__tests__/compile-lifetime-token-test.ts
+++ b/packages/transactions/src/__tests__/compile-lifetime-token-test.ts
@@ -1,0 +1,19 @@
+import { Blockhash } from '@solana/rpc-core';
+
+import { getCompiledLifetimeToken } from '../compile-lifetime-token';
+
+describe('getCompiledLifetimeToken', () => {
+    it('compiles a recent blockhash lifetime constraint', () => {
+        const token = getCompiledLifetimeToken({
+            blockhash: 'abc' as Blockhash,
+            lastValidBlockHeight: 100n,
+        });
+        expect(token).toBe('abc');
+    });
+    it('compiles a nonce lifetime constraint', () => {
+        const token = getCompiledLifetimeToken({
+            nonce: 'abc',
+        });
+        expect(token).toBe('abc');
+    });
+});

--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -1,0 +1,34 @@
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { ITransactionWithBlockhashLifetime } from '../blockhash';
+import { getCompiledLifetimeToken } from '../compile-lifetime-token';
+import { ITransactionWithFeePayer } from '../fee-payer';
+import { compileMessage } from '../message';
+import { BaseTransaction } from '../types';
+
+jest.mock('../compile-lifetime-token');
+
+const MOCK_LIFETIME_CONSTRAINT =
+    'SOME_CONSTRAINT' as unknown as ITransactionWithBlockhashLifetime['lifetimeConstraint'];
+
+describe('compileMessage', () => {
+    let baseTx: BaseTransaction & ITransactionWithFeePayer & ITransactionWithBlockhashLifetime;
+    beforeEach(() => {
+        baseTx = {
+            feePayer: 'abc' as Base58EncodedAddress<'abc'>,
+            instructions: [],
+            lifetimeConstraint: MOCK_LIFETIME_CONSTRAINT,
+            version: 0,
+        };
+    });
+    describe('lifetime constraints', () => {
+        beforeEach(() => {
+            jest.mocked(getCompiledLifetimeToken).mockReturnValue('abc');
+        });
+        it('sets `lifetimeToken` to the return value of `getCompiledLifetimeToken`', () => {
+            const message = compileMessage(baseTx);
+            expect(getCompiledLifetimeToken).toHaveBeenCalledWith('SOME_CONSTRAINT');
+            expect(message.lifetimeToken).toBe('abc');
+        });
+    });
+});

--- a/packages/transactions/src/compile-lifetime-token.ts
+++ b/packages/transactions/src/compile-lifetime-token.ts
@@ -1,0 +1,10 @@
+import { IDurableNonceTransaction, ITransactionWithBlockhashLifetime } from './index';
+
+export function getCompiledLifetimeToken(
+    lifetimeConstraint: (ITransactionWithBlockhashLifetime | IDurableNonceTransaction)['lifetimeConstraint']
+): string {
+    if ('nonce' in lifetimeConstraint) {
+        return lifetimeConstraint.nonce;
+    }
+    return lifetimeConstraint.blockhash;
+}

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -1,0 +1,15 @@
+import { ITransactionWithBlockhashLifetime } from './blockhash';
+import { getCompiledLifetimeToken } from './compile-lifetime-token';
+import { IDurableNonceTransaction } from './durable-nonce';
+import { ITransactionWithFeePayer } from './fee-payer';
+import { BaseTransaction } from './types';
+
+export function compileMessage(
+    transaction: BaseTransaction &
+        ITransactionWithFeePayer &
+        (ITransactionWithBlockhashLifetime | IDurableNonceTransaction)
+) {
+    return {
+        lifetimeToken: getCompiledLifetimeToken(transaction.lifetimeConstraint),
+    };
+}


### PR DESCRIPTION
refactor(experimental): a function to compile a transaction's lifetime into a message
## Summary

This is the beginning of the message compiler. In this step, we process the transaction's lifetime constraint into a simple lifetime _token_ of the message.

* for transactions whose lifetimes are constrained by a recent blockhash, the token becomes the blockhash
* for transactions whose lifetimes are constrained by a durable nonce, the token becomes the nonce

## Test Plan


```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1359).
* #1365
* #1364
* #1363
* #1362
* #1361
* #1360
* __->__ #1359