### PR TITLE
refactor(experimental): a function to compile a transaction's version into a message

### DIFF
--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -31,4 +31,10 @@ describe('compileMessage', () => {
             expect(message.lifetimeToken).toBe('abc');
         });
     });
+    describe('versions', () => {
+        it('compiles the version', () => {
+            const message = compileMessage(baseTx);
+            expect(message).toHaveProperty('version', 0);
+        });
+    });
 });

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -11,5 +11,6 @@ export function compileMessage(
 ) {
     return {
         lifetimeToken: getCompiledLifetimeToken(transaction.lifetimeConstraint),
+        version: transaction.version,
     };
 }


### PR DESCRIPTION
refactor(experimental): a function to compile a transaction's version into a message
## Summary

This code compiles a transaction's version into a message data structure.

## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1360).
* #1365
* #1364
* #1363
* #1362
* #1361
* __->__ #1360