### PR TITLE
refactor(experimental): a function to compile a transaction into an ordered list of accounts

### DIFF
--- a/packages/transactions/src/__tests__/accounts-test.ts
+++ b/packages/transactions/src/__tests__/accounts-test.ts
@@ -1,0 +1,563 @@
+import { AccountRole, IAccountLookupMeta, IInstruction } from '@solana/instructions';
+import { Base58EncodedAddress, getBase58EncodedAddressComparator } from '@solana/keys';
+
+import {
+    ADDRESS_MAP_TYPE_PROPERTY as TYPE,
+    AddressMapEntryType,
+    getAddressMapFromInstructions,
+    getOrderedAccountsFromAddressMap,
+} from '../accounts';
+
+type AccountRoleEnumName = keyof typeof AccountRole;
+type TestCase = {
+    aRole: AccountRoleEnumName;
+    bRole: AccountRoleEnumName;
+    expectedEntry:
+        | typeof FEE_PAYER_ENTRY
+        | typeof LUT_ENTRY_READONLY
+        | typeof LUT_ENTRY_WRITABLE
+        | typeof STATIC_ENTRY_READONLY
+        | typeof STATIC_ENTRY_READONLY_SIGNER
+        | typeof STATIC_ENTRY_WRITABLE
+        | typeof STATIC_ENTRY_WRITABLE_SIGNER;
+    instructionOrder: [string, (i: IInstruction[]) => IInstruction[]];
+    lutRole: AccountRoleEnumName;
+    role: AccountRoleEnumName;
+    staticRole: AccountRoleEnumName;
+};
+
+const MOCK_ADDRESSES: ReadonlyArray<Base58EncodedAddress> = [
+    'BRwZRKsvKkG45g59269qZ5e8UaECFim5Qfxex44UKwDG',
+    'AZE3mXbzNp8SfZYBfL4L67ejQ8zmatAKKezUdCarKnUL',
+    'Awft9caFzun5FcVTaXJAkAYDBgbEDF5QALeaqeY3M3Va',
+    'ARc8zz6T14LZQTpjryhBGDuNZb3YmNT9PtEuBSuVM5xo',
+    '6Tu9wk1r9yGwzd3xdrVzDttmkTN98iiffq7L25JKTvwh',
+    '4R6dgeBbwPjnTSN78KGxhB78oFsxaobiwBsCBLAyauqA',
+] as Base58EncodedAddress[];
+
+let _nextMockAddress = 0;
+function getMockAddress() {
+    return `${_nextMockAddress++}` as Base58EncodedAddress;
+}
+function forwardOrder(i: IInstruction[]) {
+    return i;
+}
+function reverseOrder(i: IInstruction[]) {
+    return i.reverse();
+}
+
+const FEE_PAYER_ENTRY = { [TYPE]: AddressMapEntryType.FEE_PAYER, role: AccountRole.WRITABLE_SIGNER } as const;
+const LUT_ENTRY_READONLY = { [TYPE]: AddressMapEntryType.LOOKUP_TABLE, role: AccountRole.READONLY } as const;
+const LUT_ENTRY_WRITABLE = { [TYPE]: AddressMapEntryType.LOOKUP_TABLE, role: AccountRole.WRITABLE } as const;
+const STATIC_ENTRY_READONLY = { [TYPE]: AddressMapEntryType.STATIC, role: AccountRole.READONLY } as const;
+const STATIC_ENTRY_READONLY_SIGNER = { [TYPE]: AddressMapEntryType.STATIC, role: AccountRole.READONLY_SIGNER } as const;
+const STATIC_ENTRY_WRITABLE = { [TYPE]: AddressMapEntryType.STATIC, role: AccountRole.WRITABLE } as const;
+const STATIC_ENTRY_WRITABLE_SIGNER = { [TYPE]: AddressMapEntryType.STATIC, role: AccountRole.WRITABLE_SIGNER } as const;
+
+describe('getAddressMapFromInstructions', () => {
+    it('creates a fee-payer entry for the fee payer', () => {
+        const feePayerAddress = getMockAddress();
+        const addressMap = getAddressMapFromInstructions(feePayerAddress, []);
+        expect(addressMap).toHaveProperty(feePayerAddress, FEE_PAYER_ENTRY);
+    });
+    it('creates a READONLY static entry for a program address', () => {
+        const programAddress = getMockAddress();
+        const addressMap = getAddressMapFromInstructions(/* fee payer */ getMockAddress(), [{ programAddress }]);
+        expect(addressMap).toHaveProperty(programAddress, STATIC_ENTRY_READONLY);
+    });
+    it('creates a READONLY static entry for a static account address', () => {
+        const staticAccountAddress = getMockAddress();
+        const addressMap = getAddressMapFromInstructions(/* fee payer */ getMockAddress(), [
+            {
+                accounts: [{ address: staticAccountAddress, role: AccountRole.READONLY }],
+                programAddress: getMockAddress(),
+            },
+        ]);
+        expect(addressMap).toHaveProperty(staticAccountAddress, STATIC_ENTRY_READONLY);
+    });
+    it.each`
+        role                 | expectedEntry
+        ${'READONLY'}        | ${STATIC_ENTRY_READONLY}
+        ${'WRITABLE'}        | ${STATIC_ENTRY_WRITABLE}
+        ${'READONLY_SIGNER'} | ${STATIC_ENTRY_READONLY_SIGNER}
+        ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+    `('creates a $role static entry for a $role static account address', ({ expectedEntry, role }: TestCase) => {
+        const staticAccountAddress = getMockAddress();
+        const addressMap = getAddressMapFromInstructions(/* fee payer */ getMockAddress(), [
+            {
+                accounts: [{ address: staticAccountAddress, role: AccountRole[role] }],
+                programAddress: getMockAddress(),
+            },
+        ]);
+        expect(addressMap).toHaveProperty(staticAccountAddress, expectedEntry);
+    });
+    it.each`
+        role          | expectedEntry
+        ${'READONLY'} | ${LUT_ENTRY_READONLY}
+        ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE}
+    `('creates a $role lut entry for a $role lookup table address', ({ expectedEntry, role }: TestCase) => {
+        const lutAccountAddress = getMockAddress();
+        const lutMeta = {
+            addressIndex: 0,
+            lookupTableAddress: getMockAddress(),
+            role: AccountRole[role],
+        };
+        const addressMap = getAddressMapFromInstructions(/* fee payer */ getMockAddress(), [
+            {
+                accounts: [{ address: lutAccountAddress, ...lutMeta }],
+                programAddress: getMockAddress(),
+            },
+        ]);
+        expect(addressMap).toHaveProperty(lutAccountAddress, { ...expectedEntry, ...lutMeta });
+    });
+    it('fatals given a matching fee payer and program address', () => {
+        const commonAddress = getMockAddress();
+        expect(() => {
+            getAddressMapFromInstructions(/* fee payer */ commonAddress, [{ programAddress: commonAddress }]);
+        }).toThrow();
+    });
+    it.each(['READONLY', 'WRITABLE', 'READONLY_SIGNER', 'WRITABLE_SIGNER'] as AccountRoleEnumName[])(
+        'creates a fee-payer entry given a matching fee payer and %s static account address',
+        role => {
+            const commonAddress = getMockAddress();
+            const addressMap = getAddressMapFromInstructions(/* fee payer */ commonAddress, [
+                {
+                    accounts: [{ address: commonAddress, role: AccountRole[role] }],
+                    programAddress: getMockAddress(),
+                },
+            ]);
+            expect(addressMap).toHaveProperty(commonAddress, FEE_PAYER_ENTRY);
+        }
+    );
+    it.each(['READONLY', 'WRITABLE'] as AccountRoleEnumName[])(
+        'creates a fee-payer entry given a matching fee payer and %s lookup table address',
+        role => {
+            const commonAddress = getMockAddress();
+            const addressMap = getAddressMapFromInstructions(/* fee payer */ commonAddress, [
+                {
+                    accounts: [
+                        {
+                            address: commonAddress,
+                            addressIndex: 0,
+                            lookupTableAddress: getMockAddress(),
+                            role: AccountRole[role],
+                        } as IAccountLookupMeta<typeof commonAddress>,
+                    ],
+                    programAddress: getMockAddress(),
+                },
+            ]);
+            expect(addressMap).toHaveProperty(commonAddress, FEE_PAYER_ENTRY);
+        }
+    );
+    it('creates one READONLY static entry given two matching program addresses', () => {
+        const commonAddress = getMockAddress();
+        const addressMap = getAddressMapFromInstructions(/* fee payer */ getMockAddress(), [
+            { programAddress: commonAddress },
+            { programAddress: commonAddress },
+        ]);
+        expect(addressMap).toHaveProperty(commonAddress, STATIC_ENTRY_READONLY);
+    });
+    it.each`
+        role                 | instructionOrder
+        ${'READONLY'}        | ${['static address comes first', forwardOrder]}
+        ${'READONLY_SIGNER'} | ${['static address comes first', forwardOrder]}
+        ${'READONLY'}        | ${['program address comes first', reverseOrder]}
+        ${'READONLY_SIGNER'} | ${['program address comes first', reverseOrder]}
+    `(
+        'creates a $role static entry given a matching program and $role static account address when the $instructionOrder.0',
+        ({ instructionOrder: [_, orderInstructions], role }: TestCase) => {
+            const commonAddress = getMockAddress();
+            const addressMap = getAddressMapFromInstructions(
+                /* fee payer */ getMockAddress(),
+                orderInstructions([
+                    {
+                        accounts: [{ address: commonAddress, role: AccountRole[role] }],
+                        programAddress: getMockAddress(),
+                    },
+                    {
+                        programAddress: commonAddress,
+                    },
+                ])
+            );
+            expect(addressMap).toHaveProperty(commonAddress, {
+                [TYPE]: AddressMapEntryType.STATIC,
+                role: AccountRole[role],
+            });
+        }
+    );
+    it.each`
+        role                 | instructionOrder
+        ${'WRITABLE'}        | ${['static address comes first', forwardOrder]}
+        ${'WRITABLE_SIGNER'} | ${['static address comes first', forwardOrder]}
+        ${'WRITABLE'}        | ${['program address comes first', reverseOrder]}
+        ${'WRITABLE_SIGNER'} | ${['program address comes first', reverseOrder]}
+    `(
+        'fatals given a matching program and $role static account address when the $instructionOrder.0',
+        ({ instructionOrder: [_, orderInstructions], role }: TestCase) => {
+            const commonAddress = getMockAddress();
+            expect(() =>
+                getAddressMapFromInstructions(
+                    /* fee payer */ getMockAddress(),
+                    orderInstructions([
+                        {
+                            accounts: [{ address: commonAddress, role: AccountRole[role] }],
+                            programAddress: getMockAddress(),
+                        },
+                        { programAddress: commonAddress },
+                    ])
+                )
+            ).toThrow();
+        }
+    );
+    it.each`
+        instructionOrder
+        ${['lut address comes first', forwardOrder]}
+        ${['program address comes first', reverseOrder]}
+    `(
+        'creates a READONLY static entry given a matching program and READONLY lookup table address when the $instructionOrder.0',
+        ({ instructionOrder: [_, orderInstructions] }: TestCase) => {
+            const commonAddress = getMockAddress();
+            const addressMap = getAddressMapFromInstructions(
+                /* fee payer */ getMockAddress(),
+                orderInstructions([
+                    {
+                        accounts: [
+                            {
+                                address: commonAddress,
+                                addressIndex: 0,
+                                lookupTableAddress: getMockAddress(),
+                                role: AccountRole.READONLY,
+                            },
+                        ],
+                        programAddress: getMockAddress(),
+                    },
+                    { programAddress: commonAddress },
+                ])
+            );
+            expect(addressMap).toHaveProperty(commonAddress, STATIC_ENTRY_READONLY);
+        }
+    );
+    it.each`
+        instructionOrder
+        ${['lut address comes first', forwardOrder]}
+        ${['program address comes first', reverseOrder]}
+    `(
+        'fatals given a matching program and WRITABLE lookup table address when the $instructionOrder.0',
+        ({ instructionOrder: [_, orderInstructions] }: TestCase) => {
+            const commonAddress = getMockAddress();
+            expect(() =>
+                getAddressMapFromInstructions(
+                    /* fee payer */ getMockAddress(),
+                    orderInstructions([
+                        {
+                            accounts: [
+                                {
+                                    address: commonAddress,
+                                    addressIndex: 0,
+                                    lookupTableAddress: getMockAddress(),
+                                    role: AccountRole.WRITABLE,
+                                },
+                            ],
+                            programAddress: getMockAddress(),
+                        },
+                        { programAddress: commonAddress },
+                    ])
+                )
+            ).toThrow();
+        }
+    );
+    it.each`
+        aRole                | bRole                | endRole              | expectedEntry
+        ${'READONLY'}        | ${'READONLY'}        | ${'READONLY'}        | ${STATIC_ENTRY_READONLY}
+        ${'READONLY'}        | ${'WRITABLE'}        | ${'WRITABLE'}        | ${STATIC_ENTRY_WRITABLE}
+        ${'READONLY'}        | ${'READONLY_SIGNER'} | ${'READONLY_SIGNER'} | ${STATIC_ENTRY_READONLY_SIGNER}
+        ${'READONLY'}        | ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+        ${'WRITABLE'}        | ${'READONLY'}        | ${'WRITABLE'}        | ${STATIC_ENTRY_WRITABLE}
+        ${'WRITABLE'}        | ${'WRITABLE'}        | ${'WRITABLE'}        | ${STATIC_ENTRY_WRITABLE}
+        ${'WRITABLE'}        | ${'READONLY_SIGNER'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+        ${'WRITABLE'}        | ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+        ${'READONLY_SIGNER'} | ${'READONLY'}        | ${'READONLY_SIGNER'} | ${STATIC_ENTRY_READONLY_SIGNER}
+        ${'READONLY_SIGNER'} | ${'WRITABLE'}        | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+        ${'READONLY_SIGNER'} | ${'READONLY_SIGNER'} | ${'READONLY_SIGNER'} | ${STATIC_ENTRY_READONLY_SIGNER}
+        ${'READONLY_SIGNER'} | ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+        ${'WRITABLE_SIGNER'} | ${'READONLY'}        | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+        ${'WRITABLE_SIGNER'} | ${'WRITABLE'}        | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+        ${'WRITABLE_SIGNER'} | ${'READONLY_SIGNER'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+        ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER}
+    `(
+        'creates one $endRole static entry given matching $aRole and $bRole static accounts',
+        ({ aRole, bRole, expectedEntry }: TestCase) => {
+            const commonAddress = getMockAddress();
+            const addressMap = getAddressMapFromInstructions(/* fee payer */ getMockAddress(), [
+                {
+                    accounts: [{ address: commonAddress, role: AccountRole[aRole] }],
+                    programAddress: getMockAddress(),
+                },
+                {
+                    accounts: [{ address: commonAddress, role: AccountRole[bRole] }],
+                    programAddress: getMockAddress(),
+                },
+            ]);
+            expect(addressMap).toHaveProperty(commonAddress, expectedEntry);
+        }
+    );
+    it.each`
+        staticRole    | lutRole       | endRole       | expectedEntry         | instructionOrder
+        ${'READONLY'} | ${'READONLY'} | ${'READONLY'} | ${LUT_ENTRY_READONLY} | ${['lut address comes first', forwardOrder]}
+        ${'READONLY'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['lut address comes first', forwardOrder]}
+        ${'WRITABLE'} | ${'READONLY'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['lut address comes first', forwardOrder]}
+        ${'WRITABLE'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['lut address comes first', forwardOrder]}
+        ${'READONLY'} | ${'READONLY'} | ${'READONLY'} | ${LUT_ENTRY_READONLY} | ${['static address comes first', reverseOrder]}
+        ${'READONLY'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['static address comes first', reverseOrder]}
+        ${'WRITABLE'} | ${'READONLY'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['static address comes first', reverseOrder]}
+        ${'WRITABLE'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['static address comes first', reverseOrder]}
+    `(
+        'creates a $endRole lut entry given a matching $staticRole static and $lutRole lookup table address when the $instructionOrder.0 because the static address is not a signer',
+        ({ expectedEntry, instructionOrder: [_, orderInstructions], lutRole, staticRole }: TestCase) => {
+            const commonAddress = getMockAddress();
+            const lutMeta = {
+                addressIndex: 0,
+                lookupTableAddress: getMockAddress(),
+            };
+            const addressMap = getAddressMapFromInstructions(
+                /* fee payer */ getMockAddress(),
+                orderInstructions([
+                    {
+                        accounts: [{ address: commonAddress, ...lutMeta, role: AccountRole[lutRole] }],
+                        programAddress: getMockAddress(),
+                    },
+                    {
+                        accounts: [{ address: commonAddress, role: AccountRole[staticRole] }],
+                        programAddress: getMockAddress(),
+                    },
+                ])
+            );
+            expect(addressMap).toHaveProperty(commonAddress, { ...expectedEntry, ...lutMeta });
+        }
+    );
+    it.each`
+        staticRole           | lutRole       | endRole              | expectedEntry                   | instructionOrder
+        ${'READONLY_SIGNER'} | ${'READONLY'} | ${'READONLY_SIGNER'} | ${STATIC_ENTRY_READONLY_SIGNER} | ${['lut address comes first', forwardOrder]}
+        ${'READONLY_SIGNER'} | ${'WRITABLE'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${['lut address comes first', forwardOrder]}
+        ${'WRITABLE_SIGNER'} | ${'READONLY'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${['lut address comes first', forwardOrder]}
+        ${'WRITABLE_SIGNER'} | ${'WRITABLE'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${['lut address comes first', forwardOrder]}
+        ${'READONLY_SIGNER'} | ${'READONLY'} | ${'READONLY_SIGNER'} | ${STATIC_ENTRY_READONLY_SIGNER} | ${['static address comes first', reverseOrder]}
+        ${'READONLY_SIGNER'} | ${'WRITABLE'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${['static address comes first', reverseOrder]}
+        ${'WRITABLE_SIGNER'} | ${'READONLY'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${['static address comes first', reverseOrder]}
+        ${'WRITABLE_SIGNER'} | ${'WRITABLE'} | ${'WRITABLE_SIGNER'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${['static address comes first', reverseOrder]}
+    `(
+        'creates a $endRole static entry given a matching $staticRole static and $lutRole lookup table address when the $instructionOrder.0 because the static address is a signer',
+        ({ expectedEntry, instructionOrder: [_, orderInstructions], lutRole, staticRole }) => {
+            const commonAddress = getMockAddress();
+            const lutMeta = {
+                addressIndex: 0,
+                lookupTableAddress: getMockAddress(),
+            };
+            const addressMap = getAddressMapFromInstructions(
+                /* fee payer */ getMockAddress(),
+                orderInstructions([
+                    {
+                        accounts: [{ address: commonAddress, ...lutMeta, role: AccountRole[lutRole] }],
+                        programAddress: getMockAddress(),
+                    },
+                    {
+                        accounts: [{ address: commonAddress, role: AccountRole[staticRole] }],
+                        programAddress: getMockAddress(),
+                    },
+                ])
+            );
+            expect(addressMap).toHaveProperty(commonAddress, expectedEntry);
+        }
+    );
+    it.each`
+        aRole         | bRole         | endRole       | expectedEntry
+        ${'READONLY'} | ${'READONLY'} | ${'READONLY'} | ${LUT_ENTRY_READONLY}
+        ${'READONLY'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE}
+        ${'WRITABLE'} | ${'READONLY'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE}
+        ${'WRITABLE'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE}
+    `(
+        'creates one $endRole lut entry given matching $aRole and $bRole lut addresses',
+        ({ aRole, bRole, expectedEntry }: TestCase) => {
+            const commonAddress = getMockAddress();
+            const lutMeta = {
+                addressIndex: 0,
+                lookupTableAddress: getMockAddress(),
+            };
+            const addressMap = getAddressMapFromInstructions(/* fee payer */ getMockAddress(), [
+                {
+                    accounts: [{ address: commonAddress, ...lutMeta, role: AccountRole[aRole] }],
+                    programAddress: getMockAddress(),
+                },
+                {
+                    accounts: [{ address: commonAddress, ...lutMeta, role: AccountRole[bRole] }],
+                    programAddress: getMockAddress(),
+                },
+            ]);
+            expect(addressMap).toHaveProperty(commonAddress, { ...expectedEntry, ...lutMeta });
+        }
+    );
+    it.each`
+        aRole         | bRole         | endRole       | expectedEntry         | instructionOrder
+        ${'READONLY'} | ${'READONLY'} | ${'READONLY'} | ${LUT_ENTRY_READONLY} | ${['comes first', forwardOrder]}
+        ${'READONLY'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['comes first', forwardOrder]}
+        ${'WRITABLE'} | ${'READONLY'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['comes first', forwardOrder]}
+        ${'WRITABLE'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['comes first', forwardOrder]}
+        ${'READONLY'} | ${'READONLY'} | ${'READONLY'} | ${LUT_ENTRY_READONLY} | ${['comes last', reverseOrder]}
+        ${'READONLY'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['comes last', reverseOrder]}
+        ${'WRITABLE'} | ${'READONLY'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['comes last', reverseOrder]}
+        ${'WRITABLE'} | ${'WRITABLE'} | ${'WRITABLE'} | ${LUT_ENTRY_WRITABLE} | ${['comes last', reverseOrder]}
+    `(
+        'creates one $endRole lut entry given matching $aRole and $bRole lut addresses from different lookup tables, preferring the table with the lower address when it $instructionOrder.0',
+        ({ aRole, bRole, expectedEntry, instructionOrder: [_, orderInstructions] }) => {
+            const commonAddress = getMockAddress();
+            const sortedAddresses = MOCK_ADDRESSES.slice(0, 2).sort(getBase58EncodedAddressComparator());
+            const lowerLutMeta = {
+                addressIndex: 9,
+                lookupTableAddress: sortedAddresses[0], // Address which sorts lower.
+            };
+            const higherLutMeta = {
+                addressIndex: 6,
+                lookupTableAddress: sortedAddresses[1], // Address which sorts higher.
+            };
+            const addressMap = getAddressMapFromInstructions(
+                /* fee payer */ getMockAddress(),
+                orderInstructions([
+                    {
+                        accounts: [{ address: commonAddress, role: AccountRole[aRole], ...lowerLutMeta }],
+                        programAddress: getMockAddress(),
+                    },
+                    {
+                        accounts: [{ address: commonAddress, role: AccountRole[bRole], ...higherLutMeta }],
+                        programAddress: getMockAddress(),
+                    },
+                ])
+            );
+            expect(addressMap).toHaveProperty(commonAddress, { ...expectedEntry, ...lowerLutMeta });
+        }
+    );
+});
+
+describe('getOrderedAccountsFromAddressMap', () => {
+    let sortedAddresses: Base58EncodedAddress[];
+    beforeEach(() => {
+        sortedAddresses = [...MOCK_ADDRESSES].sort(getBase58EncodedAddressComparator());
+    });
+    it.each(['READONLY', 'WRITABLE', 'READONLY_SIGNER', 'WRITABLE_SIGNER'] as AccountRoleEnumName[])(
+        'puts the fee payer before %s static addresses',
+        role => {
+            const orderedAccounts = getOrderedAccountsFromAddressMap({
+                [sortedAddresses[0]]: { [TYPE]: AddressMapEntryType.STATIC, role: AccountRole[role] },
+                [sortedAddresses[1]]: { [TYPE]: AddressMapEntryType.FEE_PAYER, role: AccountRole.WRITABLE_SIGNER },
+            });
+            expect(orderedAccounts).toHaveProperty('0', {
+                [TYPE]: AddressMapEntryType.FEE_PAYER,
+                address: sortedAddresses[1],
+                role: AccountRole.WRITABLE_SIGNER,
+            });
+        }
+    );
+    it.each(['READONLY', 'WRITABLE'] as AccountRoleEnumName[])(
+        'puts the fee payer before %s lookup table addresses',
+        role => {
+            const orderedAccounts = getOrderedAccountsFromAddressMap({
+                [sortedAddresses[0]]: {
+                    [TYPE]: AddressMapEntryType.LOOKUP_TABLE,
+                    addressIndex: 0,
+                    lookupTableAddress: getMockAddress(),
+                    role: AccountRole[role] as Exclude<
+                        AccountRole,
+                        AccountRole.READONLY_SIGNER | AccountRole.WRITABLE_SIGNER
+                    >,
+                },
+                [sortedAddresses[1]]: { [TYPE]: AddressMapEntryType.FEE_PAYER, role: AccountRole.WRITABLE_SIGNER },
+            });
+            expect(orderedAccounts).toHaveProperty('0', {
+                [TYPE]: AddressMapEntryType.FEE_PAYER,
+                address: sortedAddresses[1],
+                role: AccountRole.WRITABLE_SIGNER,
+            });
+        }
+    );
+    it.each(['READONLY', 'WRITABLE', 'READONLY_SIGNER', 'WRITABLE_SIGNER'] as AccountRoleEnumName[])(
+        'orders %s static account addresses in lexical order',
+        role => {
+            const roleMeta = { role: AccountRole[role] };
+            const orderedAccounts = getOrderedAccountsFromAddressMap({
+                [sortedAddresses[1]]: { [TYPE]: AddressMapEntryType.STATIC, ...roleMeta },
+                [sortedAddresses[0]]: { [TYPE]: AddressMapEntryType.STATIC, ...roleMeta },
+            });
+            expect(orderedAccounts).toEqual([
+                { [TYPE]: AddressMapEntryType.STATIC, address: sortedAddresses[0], ...roleMeta },
+                { [TYPE]: AddressMapEntryType.STATIC, address: sortedAddresses[1], ...roleMeta },
+            ]);
+        }
+    );
+    it.each(['READONLY', 'WRITABLE'] as AccountRoleEnumName[])(
+        'orders %s lookup table addresses by the lexical order of the address of their lookup table first, then by the addresses themselves',
+        role => {
+            const firstLutMeta = {
+                addressIndex: 0,
+                lookupTableAddress: sortedAddresses[0],
+            };
+            const secondLutMeta = {
+                addressIndex: 0,
+                lookupTableAddress: sortedAddresses[1],
+            };
+            const roleMeta = {
+                role: AccountRole[role] as Exclude<
+                    AccountRole,
+                    AccountRole.READONLY_SIGNER | AccountRole.WRITABLE_SIGNER
+                >,
+            };
+            const orderedAccounts = getOrderedAccountsFromAddressMap({
+                [sortedAddresses[3]]: { [TYPE]: AddressMapEntryType.LOOKUP_TABLE, ...secondLutMeta, ...roleMeta },
+                [sortedAddresses[2]]: { [TYPE]: AddressMapEntryType.LOOKUP_TABLE, ...secondLutMeta, ...roleMeta },
+                [sortedAddresses[5]]: { [TYPE]: AddressMapEntryType.LOOKUP_TABLE, ...firstLutMeta, ...roleMeta },
+                [sortedAddresses[4]]: { [TYPE]: AddressMapEntryType.LOOKUP_TABLE, ...firstLutMeta, ...roleMeta },
+            });
+            expect(orderedAccounts).toEqual([
+                { [TYPE]: AddressMapEntryType.LOOKUP_TABLE, address: sortedAddresses[4], ...firstLutMeta, ...roleMeta },
+                { [TYPE]: AddressMapEntryType.LOOKUP_TABLE, address: sortedAddresses[5], ...firstLutMeta, ...roleMeta },
+                {
+                    [TYPE]: AddressMapEntryType.LOOKUP_TABLE,
+                    address: sortedAddresses[2],
+                    ...secondLutMeta,
+                    ...roleMeta,
+                },
+                {
+                    [TYPE]: AddressMapEntryType.LOOKUP_TABLE,
+                    address: sortedAddresses[3],
+                    ...secondLutMeta,
+                    ...roleMeta,
+                },
+            ]);
+        }
+    );
+    it.each`
+        beforeKind                  | beforeEntry                     | afterKind                   | afterEntry
+        ${'WRITABLE lookup table'}  | ${LUT_ENTRY_WRITABLE}           | ${'READONLY lookup table'}  | ${LUT_ENTRY_READONLY}
+        ${'READONLY static'}        | ${STATIC_ENTRY_READONLY}        | ${'READONLY lookup table'}  | ${LUT_ENTRY_READONLY}
+        ${'READONLY static'}        | ${STATIC_ENTRY_READONLY}        | ${'WRITABLE lookup table'}  | ${LUT_ENTRY_WRITABLE}
+        ${'WRITABLE static'}        | ${STATIC_ENTRY_WRITABLE}        | ${'READONLY lookup table'}  | ${LUT_ENTRY_READONLY}
+        ${'WRITABLE static'}        | ${STATIC_ENTRY_WRITABLE}        | ${'WRITABLE lookup table'}  | ${LUT_ENTRY_WRITABLE}
+        ${'WRITABLE static'}        | ${STATIC_ENTRY_WRITABLE}        | ${'READONLY static'}        | ${STATIC_ENTRY_READONLY}
+        ${'READONLY_SIGNER static'} | ${STATIC_ENTRY_READONLY_SIGNER} | ${'READONLY lookup table'}  | ${LUT_ENTRY_READONLY}
+        ${'READONLY_SIGNER static'} | ${STATIC_ENTRY_READONLY_SIGNER} | ${'WRITABLE lookup table'}  | ${LUT_ENTRY_WRITABLE}
+        ${'READONLY_SIGNER static'} | ${STATIC_ENTRY_READONLY_SIGNER} | ${'READONLY static'}        | ${STATIC_ENTRY_READONLY}
+        ${'READONLY_SIGNER static'} | ${STATIC_ENTRY_READONLY_SIGNER} | ${'WRITABLE static'}        | ${STATIC_ENTRY_WRITABLE}
+        ${'WRITABLE_SIGNER static'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${'READONLY lookup table'}  | ${LUT_ENTRY_READONLY}
+        ${'WRITABLE_SIGNER static'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${'WRITABLE lookup table'}  | ${LUT_ENTRY_WRITABLE}
+        ${'WRITABLE_SIGNER static'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${'READONLY static'}        | ${STATIC_ENTRY_READONLY}
+        ${'WRITABLE_SIGNER static'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${'WRITABLE static'}        | ${STATIC_ENTRY_WRITABLE}
+        ${'WRITABLE_SIGNER static'} | ${STATIC_ENTRY_WRITABLE_SIGNER} | ${'READONLY_SIGNER static'} | ${STATIC_ENTRY_READONLY_SIGNER}
+    `('orders $beforeKind addresses before $afterKind addresses', ({ afterEntry, beforeEntry }) => {
+        const orderedAccounts = getOrderedAccountsFromAddressMap({
+            [sortedAddresses[0]]: afterEntry,
+            [sortedAddresses[1]]: beforeEntry,
+        });
+        expect(orderedAccounts).toEqual([
+            { address: sortedAddresses[1], ...beforeEntry },
+            { address: sortedAddresses[0], ...afterEntry },
+        ]);
+    });
+});

--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -31,4 +31,10 @@ describe('compileMessage', () => {
             expect(message.lifetimeToken).toBe('abc');
         });
     });
+    describe('versions', () => {
+        it('compiles the version', () => {
+            const message = compileMessage(baseTx);
+            expect(message).toHaveProperty('version', 0);
+        });
+    });
 });

--- a/packages/transactions/src/accounts.ts
+++ b/packages/transactions/src/accounts.ts
@@ -1,0 +1,247 @@
+import {
+    AccountRole,
+    IAccountLookupMeta,
+    IAccountMeta,
+    IInstruction,
+    isSignerRole,
+    isWritableRole,
+    mergeRoles,
+    ReadonlyAccount,
+    ReadonlyAccountLookup,
+    ReadonlySignerAccount,
+    WritableAccount,
+    WritableAccountLookup,
+    WritableSignerAccount,
+} from '@solana/instructions';
+import { Base58EncodedAddress, getBase58EncodedAddressComparator } from '@solana/keys';
+
+export const enum AddressMapEntryType {
+    FEE_PAYER,
+    LOOKUP_TABLE,
+    STATIC,
+}
+
+type AddressMap = {
+    [address: string]: FeePayerAccountEntry | LookupTableAccountEntry | StaticAccountEntry;
+};
+type FeePayerAccountEntry = Omit<WritableSignerAccount, 'address'> & {
+    [TYPE]: AddressMapEntryType.FEE_PAYER;
+};
+type LookupTableAccountEntry = Omit<ReadonlyAccountLookup | WritableAccountLookup, 'address'> & {
+    [TYPE]: AddressMapEntryType.LOOKUP_TABLE;
+};
+export type OrderedAccounts = (IAccountMeta | IAccountLookupMeta)[] & { readonly __orderedAccounts: unique symbol };
+type StaticAccountEntry = Omit<
+    ReadonlyAccount | ReadonlySignerAccount | WritableAccount | WritableSignerAccount,
+    'address'
+> & { [TYPE]: AddressMapEntryType.STATIC };
+
+function upsert(
+    addressMap: AddressMap,
+    address: Base58EncodedAddress,
+    update: (
+        entry: FeePayerAccountEntry | LookupTableAccountEntry | StaticAccountEntry | Record<never, never>
+    ) => AddressMap[Base58EncodedAddress]
+) {
+    addressMap[address] = update(addressMap[address] ?? { role: AccountRole.READONLY });
+}
+
+const TYPE = Symbol('AddressMapTypeProperty');
+export const ADDRESS_MAP_TYPE_PROPERTY: typeof TYPE = TYPE;
+
+export function getAddressMapFromInstructions(
+    feePayer: Base58EncodedAddress,
+    instructions: readonly IInstruction[]
+): AddressMap {
+    const addressMap: AddressMap = {
+        [feePayer]: { [TYPE]: AddressMapEntryType.FEE_PAYER, role: AccountRole.WRITABLE_SIGNER },
+    };
+    const addressesOfInvokedPrograms = new Set<Base58EncodedAddress>();
+    for (const instruction of instructions) {
+        upsert(addressMap, instruction.programAddress, entry => {
+            addressesOfInvokedPrograms.add(instruction.programAddress);
+            if (TYPE in entry) {
+                if (isWritableRole(entry.role)) {
+                    switch (entry[TYPE]) {
+                        case AddressMapEntryType.FEE_PAYER:
+                            // TODO: Coded error.
+                            throw new Error(
+                                'This transaction includes an address ' +
+                                    `(\`${instruction.programAddress}\`) which is both invoked ` +
+                                    'and set as the fee payer. Program addresses may not pay fees.'
+                            );
+                        default:
+                            // TODO: Coded error.
+                            throw new Error(
+                                'This transaction includes an address ' +
+                                    `(\`${instruction.programAddress}\`) which is both invoked ` +
+                                    'and marked writable. Program addresses may not be writable.'
+                            );
+                    }
+                }
+                if (entry[TYPE] === AddressMapEntryType.STATIC) {
+                    return entry;
+                }
+            }
+            return { [TYPE]: AddressMapEntryType.STATIC, role: AccountRole.READONLY };
+        });
+        let addressComparator: ReturnType<typeof getBase58EncodedAddressComparator>;
+        if (!instruction.accounts) {
+            continue;
+        }
+        for (const account of instruction.accounts) {
+            upsert(addressMap, account.address, entry => {
+                const {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    address: _,
+                    ...accountMeta
+                } = account;
+                if (TYPE in entry) {
+                    switch (entry[TYPE]) {
+                        case AddressMapEntryType.FEE_PAYER:
+                            // The fee payer already has the highest rank -- it is by definition
+                            // writable-signer. Return it, no matter how `account` is configured
+                            return entry as FeePayerAccountEntry;
+                        case AddressMapEntryType.LOOKUP_TABLE: {
+                            const nextRole = mergeRoles(entry.role, accountMeta.role);
+                            if ('lookupTableAddress' in accountMeta) {
+                                const shouldReplaceEntry =
+                                    // Consider using the new LOOKUP_TABLE if its address is different...
+                                    entry.lookupTableAddress !== accountMeta.lookupTableAddress &&
+                                    // ...and sorts before the existing one.
+                                    (addressComparator ||= getBase58EncodedAddressComparator())(
+                                        accountMeta.lookupTableAddress,
+                                        entry.lookupTableAddress
+                                    ) < 0;
+                                if (shouldReplaceEntry) {
+                                    return {
+                                        [TYPE]: AddressMapEntryType.LOOKUP_TABLE,
+                                        ...accountMeta,
+                                        role: nextRole,
+                                    } as LookupTableAccountEntry;
+                                }
+                            } else if (isSignerRole(accountMeta.role)) {
+                                // Upgrade this LOOKUP_TABLE entry to a static entry if it must sign.
+                                return {
+                                    [TYPE]: AddressMapEntryType.STATIC,
+                                    role: nextRole,
+                                } as StaticAccountEntry;
+                            }
+                            if (entry.role !== nextRole) {
+                                return {
+                                    ...entry,
+                                    role: nextRole,
+                                } as LookupTableAccountEntry;
+                            } else {
+                                return entry as LookupTableAccountEntry;
+                            }
+                        }
+                        case AddressMapEntryType.STATIC: {
+                            const nextRole = mergeRoles(entry.role, accountMeta.role);
+                            if (
+                                // Check to see if this address represents a program that is invoked
+                                // in this transaction.
+                                addressesOfInvokedPrograms.has(account.address)
+                            ) {
+                                if (isWritableRole(accountMeta.role)) {
+                                    // TODO: Coded error.
+                                    throw new Error(
+                                        'This transaction includes an address ' +
+                                            `(\`${account.address}\`) which is both invoked and ` +
+                                            'marked writable. Program addresses may not be ' +
+                                            'writable.'
+                                    );
+                                }
+                                if (entry.role !== nextRole) {
+                                    return {
+                                        ...entry,
+                                        role: nextRole,
+                                    } as StaticAccountEntry;
+                                } else {
+                                    return entry as StaticAccountEntry;
+                                }
+                            } else if (
+                                'lookupTableAddress' in accountMeta &&
+                                // Static accounts can be 'upgraded' to lookup table accounts as
+                                // long as they are not require to sign the transaction.
+                                !isSignerRole(entry.role)
+                            ) {
+                                return {
+                                    ...accountMeta,
+                                    [TYPE]: AddressMapEntryType.LOOKUP_TABLE,
+                                    role: nextRole,
+                                } as LookupTableAccountEntry;
+                            } else {
+                                if (entry.role !== nextRole) {
+                                    // The account's role ranks higher than the current entry's.
+                                    return {
+                                        ...entry,
+                                        role: nextRole,
+                                    } as StaticAccountEntry;
+                                } else {
+                                    return entry as StaticAccountEntry;
+                                }
+                            }
+                        }
+                    }
+                }
+                if ('lookupTableAddress' in accountMeta) {
+                    return {
+                        ...accountMeta,
+                        [TYPE]: AddressMapEntryType.LOOKUP_TABLE,
+                    };
+                } else {
+                    return {
+                        ...accountMeta,
+                        [TYPE]: AddressMapEntryType.STATIC,
+                    };
+                }
+            });
+        }
+    }
+    return addressMap;
+}
+
+export function getOrderedAccountsFromAddressMap(addressMap: AddressMap): OrderedAccounts {
+    let addressComparator: ReturnType<typeof getBase58EncodedAddressComparator>;
+    const orderedAccounts: (IAccountMeta | IAccountLookupMeta)[] = Object.entries(addressMap)
+        .sort(([leftAddress, leftEntry], [rightAddress, rightEntry]) => {
+            // STEP 1: Rapid precedence check. Fee payer, then static addresses, then lookups.
+            if (leftEntry[TYPE] !== rightEntry[TYPE]) {
+                if (leftEntry[TYPE] === AddressMapEntryType.FEE_PAYER) {
+                    return -1;
+                } else if (rightEntry[TYPE] === AddressMapEntryType.FEE_PAYER) {
+                    return 1;
+                } else if (leftEntry[TYPE] === AddressMapEntryType.STATIC) {
+                    return -1;
+                } else if (rightEntry[TYPE] === AddressMapEntryType.STATIC) {
+                    return 1;
+                }
+            }
+            // STEP 2: Sort by signer-writability.
+            const leftIsSigner = isSignerRole(leftEntry.role);
+            if (leftIsSigner !== isSignerRole(rightEntry.role)) {
+                return leftIsSigner ? -1 : 1;
+            }
+            const leftIsWritable = isWritableRole(leftEntry.role);
+            if (leftIsWritable !== isWritableRole(rightEntry.role)) {
+                return leftIsWritable ? -1 : 1;
+            }
+            // STEP 3: Sort by address.
+            addressComparator ||= getBase58EncodedAddressComparator();
+            if (
+                leftEntry[TYPE] === AddressMapEntryType.LOOKUP_TABLE &&
+                rightEntry[TYPE] === AddressMapEntryType.LOOKUP_TABLE &&
+                leftEntry.lookupTableAddress !== rightEntry.lookupTableAddress
+            ) {
+                return addressComparator(leftEntry.lookupTableAddress, rightEntry.lookupTableAddress);
+            } else {
+                return addressComparator(leftAddress, rightAddress);
+            }
+        })
+        .map(([address, addressMeta]) => ({
+            address: address as Base58EncodedAddress<typeof address>,
+            ...addressMeta,
+        }));
+    return orderedAccounts as unknown as OrderedAccounts;
+}

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -11,5 +11,6 @@ export function compileMessage(
 ) {
     return {
         lifetimeToken: getCompiledLifetimeToken(transaction.lifetimeConstraint),
+        version: transaction.version,
     };
 }


### PR DESCRIPTION
refactor(experimental): a function to compile a transaction into an ordered list of accounts
## Summary

There is a very particular way in which accounts are laid out in Solana transactions that get sent to the network. Signers before non signers. Writable accounts before readonly accounts. Static accounts before lookup table accounts. Invoked accounts may sign transactions but may never be writable. The list goes on.

In this PR, we encode all of this logic and write copious tests for it. What results is a function that can take in a transaction (fee payer + instructions) and produce an ordered list of accounts ready to be serialized into a transactions wire format.

## Test Plan
```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1361).
* #1365
* #1364
* #1363
* #1362
* __->__ #1361
* #1360