### PR TITLE
refactor(experimental): a function to compile a transaction's instructions into a message

### DIFF
--- a/packages/transactions/src/__tests__/compile-instructions-test.ts
+++ b/packages/transactions/src/__tests__/compile-instructions-test.ts
@@ -1,0 +1,80 @@
+import { AccountRole, IInstruction } from '@solana/instructions';
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { OrderedAccounts } from '../accounts';
+import { getCompiledInstructions } from '../compile-instructions';
+
+let _nextMockAddress = 0;
+function getMockAddress() {
+    return `${_nextMockAddress++}` as Base58EncodedAddress;
+}
+
+describe('getCompiledInstructions', () => {
+    it('compiles no account indices when are no accounts', () => {
+        const compiledInstructions = getCompiledInstructions(
+            [{ programAddress: getMockAddress() }],
+            [] as unknown as OrderedAccounts
+        );
+        expect(compiledInstructions[0]).not.toHaveProperty('accountIndices');
+    });
+    it('compiles no data when there is no data', () => {
+        const compiledInstructions = getCompiledInstructions(
+            [{ programAddress: getMockAddress() }],
+            [] as unknown as OrderedAccounts
+        );
+        expect(compiledInstructions[0]).not.toHaveProperty('data');
+    });
+    it('compiles account addresses into indices of the account addresses', () => {
+        const addressAtIndex2 = getMockAddress();
+        const addressAtIndex3 = getMockAddress();
+        const addressAtIndex4 = getMockAddress();
+        const lookupTableAddress = getMockAddress();
+        const programAddressAtIndex1 = getMockAddress();
+        const instructions = [
+            {
+                accounts: [
+                    { address: addressAtIndex3, role: AccountRole.READONLY },
+                    { address: addressAtIndex2, role: AccountRole.WRITABLE },
+                ],
+                programAddress: programAddressAtIndex1,
+            },
+            {
+                accounts: [
+                    {
+                        address: addressAtIndex4,
+                        addressIndex: 0,
+                        lookupTableAddress,
+                        role: AccountRole.WRITABLE,
+                    },
+                    { address: addressAtIndex2, role: AccountRole.READONLY },
+                ],
+                programAddress: programAddressAtIndex1,
+            },
+        ] as IInstruction[];
+        const compiledInstructions = getCompiledInstructions(instructions, [
+            { address: getMockAddress(), role: AccountRole.WRITABLE_SIGNER },
+            { address: programAddressAtIndex1, role: AccountRole.READONLY },
+            { address: addressAtIndex2, role: AccountRole.WRITABLE },
+            { address: addressAtIndex3, role: AccountRole.READONLY },
+            { address: addressAtIndex4, addressIndex: 0, lookupTableAddress, role: AccountRole.WRITABLE },
+        ] as OrderedAccounts);
+        expect(compiledInstructions).toHaveProperty('0.accountIndices', [3, 2]);
+        expect(compiledInstructions).toHaveProperty('1.accountIndices', [4, 2]);
+    });
+    it('copies over the instruction data verbatim', () => {
+        const expectedData = new Uint8Array([1, 2, 3]);
+        const compiledInstructions = getCompiledInstructions(
+            [{ data: expectedData, programAddress: getMockAddress() }],
+            [] as unknown as OrderedAccounts
+        );
+        expect(compiledInstructions[0]).toHaveProperty('data', expectedData);
+    });
+    it('compiles the program address into a program address index', () => {
+        const programAddress = getMockAddress();
+        const compiledInstructions = getCompiledInstructions([{ programAddress }], [
+            { address: getMockAddress(), role: AccountRole.WRITABLE_SIGNER },
+            { address: programAddress, role: AccountRole.READONLY },
+        ] as OrderedAccounts);
+        expect(compiledInstructions[0]).toHaveProperty('programAddressIndex', 1);
+    });
+});

--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -2,12 +2,14 @@ import { Base58EncodedAddress } from '@solana/keys';
 
 import { ITransactionWithBlockhashLifetime } from '../blockhash';
 import { getCompiledMessageHeader } from '../compile-header';
+import { getCompiledInstructions } from '../compile-instructions';
 import { getCompiledLifetimeToken } from '../compile-lifetime-token';
 import { ITransactionWithFeePayer } from '../fee-payer';
 import { compileMessage } from '../message';
 import { BaseTransaction } from '../types';
 
 jest.mock('../compile-header');
+jest.mock('../compile-instructions');
 jest.mock('../compile-lifetime-token');
 
 const MOCK_LIFETIME_CONSTRAINT =
@@ -36,6 +38,20 @@ describe('compileMessage', () => {
             const message = compileMessage(baseTx);
             expect(getCompiledMessageHeader).toHaveBeenCalled();
             expect(message.header).toBe(expectedCompiledMessageHeader);
+        });
+    });
+    describe('instructions', () => {
+        const expectedInstructions = [] as ReturnType<typeof getCompiledInstructions>;
+        beforeEach(() => {
+            jest.mocked(getCompiledInstructions).mockReturnValue(expectedInstructions);
+        });
+        it('sets `instructions` to the return value of `getCompiledInstructions`', () => {
+            const message = compileMessage(baseTx);
+            expect(getCompiledInstructions).toHaveBeenCalledWith(
+                baseTx.instructions,
+                expect.any(Array) /* orderedAccounts */
+            );
+            expect(message.instructions).toBe(expectedInstructions);
         });
     });
     describe('lifetime constraints', () => {

--- a/packages/transactions/src/compile-instructions.ts
+++ b/packages/transactions/src/compile-instructions.ts
@@ -1,0 +1,32 @@
+import { IInstruction } from '@solana/instructions';
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { OrderedAccounts } from './accounts';
+
+type CompiledInstruction = Readonly<{
+    addressIndices?: number[];
+    data?: Uint8Array;
+    programAddressIndex: number;
+}>;
+
+function getAccountIndex(orderedAccounts: OrderedAccounts) {
+    const out: Record<Base58EncodedAddress, number> = {};
+    for (const [index, account] of orderedAccounts.entries()) {
+        out[account.address] = index;
+    }
+    return out;
+}
+
+export function getCompiledInstructions(
+    instructions: readonly IInstruction[],
+    orderedAccounts: OrderedAccounts
+): CompiledInstruction[] {
+    const accountIndex = getAccountIndex(orderedAccounts);
+    return instructions.map(({ accounts, data, programAddress }) => {
+        return {
+            programAddressIndex: accountIndex[programAddress],
+            ...(accounts ? { accountIndices: accounts.map(({ address }) => accountIndex[address]) } : null),
+            ...(data ? { data } : null),
+        };
+    });
+}

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -1,6 +1,7 @@
 import { getAddressMapFromInstructions, getOrderedAccountsFromAddressMap } from './accounts';
 import { ITransactionWithBlockhashLifetime } from './blockhash';
 import { getCompiledMessageHeader } from './compile-header';
+import { getCompiledInstructions } from './compile-instructions';
 import { getCompiledLifetimeToken } from './compile-lifetime-token';
 import { IDurableNonceTransaction } from './durable-nonce';
 import { ITransactionWithFeePayer } from './fee-payer';
@@ -15,6 +16,7 @@ export function compileMessage(
     const orderedAccounts = getOrderedAccountsFromAddressMap(addressMap);
     return {
         header: getCompiledMessageHeader(orderedAccounts),
+        instructions: getCompiledInstructions(transaction.instructions, orderedAccounts),
         lifetimeToken: getCompiledLifetimeToken(transaction.lifetimeConstraint),
         version: transaction.version,
     };


### PR DESCRIPTION
refactor(experimental): a function to compile a transaction's instructions into a message
## Summary

Over the wire, transaction instructions don't carry the addresses that they refer to, but rather the _indices_ of those addresses in a sidecar address table. This function takes in the ordered addresses and the instructions, and returns the instructions with the addresses replaced with indices.


## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1363).
* #1372
* #1371
* #1370
* #1369
* #1368
* #1365
* #1364
* __->__ #1363