### PR TITLE
refactor(experimental): a function to compile a transaction's address table lookups into a message

### DIFF
--- a/packages/transactions/src/__tests__/compile-address-table-lookups-test.ts
+++ b/packages/transactions/src/__tests__/compile-address-table-lookups-test.ts
@@ -1,0 +1,100 @@
+import { AccountRole } from '@solana/instructions';
+import { Base58EncodedAddress, getBase58EncodedAddressComparator } from '@solana/keys';
+
+import { OrderedAccounts } from '../accounts';
+import { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
+
+const MOCK_ADDRESSES: ReadonlyArray<Base58EncodedAddress> = [
+    'BRwZRKsvKkG45g59269qZ5e8UaECFim5Qfxex44UKwDG',
+    'AZE3mXbzNp8SfZYBfL4L67ejQ8zmatAKKezUdCarKnUL',
+    'Awft9caFzun5FcVTaXJAkAYDBgbEDF5QALeaqeY3M3Va',
+    'ARc8zz6T14LZQTpjryhBGDuNZb3YmNT9PtEuBSuVM5xo',
+    '6Tu9wk1r9yGwzd3xdrVzDttmkTN98iiffq7L25JKTvwh',
+    '4R6dgeBbwPjnTSN78KGxhB78oFsxaobiwBsCBLAyauqA',
+] as Base58EncodedAddress[];
+
+let _nextMockAddress = 0;
+function getMockAddress() {
+    return `${_nextMockAddress++}` as Base58EncodedAddress;
+}
+
+describe('getCompiledAddressTableLookups', () => {
+    it('returns address table lookups in lexical order', () => {
+        const sortedAddresses = [...MOCK_ADDRESSES].sort(getBase58EncodedAddressComparator());
+        const orderedAccounts = [
+            {
+                address: getMockAddress(),
+                addressIndex: 10,
+                lookupTableAddress: sortedAddresses[1],
+                role: AccountRole.WRITABLE,
+            },
+            {
+                address: getMockAddress(),
+                addressIndex: 20,
+                lookupTableAddress: sortedAddresses[2],
+                role: AccountRole.WRITABLE,
+            },
+            {
+                address: getMockAddress(),
+                addressIndex: 30,
+                lookupTableAddress: sortedAddresses[0],
+                role: AccountRole.READONLY,
+            },
+            {
+                address: getMockAddress(),
+                addressIndex: 40,
+                lookupTableAddress: sortedAddresses[3],
+                role: AccountRole.READONLY,
+            },
+            {
+                address: getMockAddress(),
+                addressIndex: 50,
+                lookupTableAddress: sortedAddresses[2],
+                role: AccountRole.READONLY,
+            },
+        ] as OrderedAccounts;
+        const compiledAddressTableLookups = getCompiledAddressTableLookups(orderedAccounts);
+        expect(compiledAddressTableLookups).toHaveProperty('0.lookupTableAddress', sortedAddresses[0]);
+        expect(compiledAddressTableLookups).toHaveProperty('1.lookupTableAddress', sortedAddresses[1]);
+        expect(compiledAddressTableLookups).toHaveProperty('2.lookupTableAddress', sortedAddresses[2]);
+        expect(compiledAddressTableLookups).toHaveProperty('3.lookupTableAddress', sortedAddresses[3]);
+    });
+    it('populates readable/writable address indices in order', () => {
+        const lookupTableAddress = getMockAddress();
+        const orderedAccounts = [
+            {
+                address: getMockAddress(),
+                addressIndex: 20,
+                lookupTableAddress,
+                role: AccountRole.WRITABLE,
+            },
+            {
+                address: getMockAddress(),
+                addressIndex: 10,
+                lookupTableAddress,
+                role: AccountRole.WRITABLE,
+            },
+            {
+                address: getMockAddress(),
+                addressIndex: 30,
+                lookupTableAddress,
+                role: AccountRole.READONLY,
+            },
+            {
+                address: getMockAddress(),
+                addressIndex: 50,
+                lookupTableAddress,
+                role: AccountRole.READONLY,
+            },
+            {
+                address: getMockAddress(),
+                addressIndex: 40,
+                lookupTableAddress,
+                role: AccountRole.READONLY,
+            },
+        ] as OrderedAccounts;
+        const compiledAddressTableLookups = getCompiledAddressTableLookups(orderedAccounts);
+        expect(compiledAddressTableLookups).toHaveProperty('0.readableIndices', [30, 50, 40]);
+        expect(compiledAddressTableLookups).toHaveProperty('0.writableIndices', [20, 10]);
+    });
+});

--- a/packages/transactions/src/__tests__/compile-instructions-test.ts
+++ b/packages/transactions/src/__tests__/compile-instructions-test.ts
@@ -1,0 +1,80 @@
+import { AccountRole, IInstruction } from '@solana/instructions';
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { OrderedAccounts } from '../accounts';
+import { getCompiledInstructions } from '../compile-instructions';
+
+let _nextMockAddress = 0;
+function getMockAddress() {
+    return `${_nextMockAddress++}` as Base58EncodedAddress;
+}
+
+describe('getCompiledInstructions', () => {
+    it('compiles no account indices when are no accounts', () => {
+        const compiledInstructions = getCompiledInstructions(
+            [{ programAddress: getMockAddress() }],
+            [] as unknown as OrderedAccounts
+        );
+        expect(compiledInstructions[0]).not.toHaveProperty('accountIndices');
+    });
+    it('compiles no data when there is no data', () => {
+        const compiledInstructions = getCompiledInstructions(
+            [{ programAddress: getMockAddress() }],
+            [] as unknown as OrderedAccounts
+        );
+        expect(compiledInstructions[0]).not.toHaveProperty('data');
+    });
+    it('compiles account addresses into indices of the account addresses', () => {
+        const addressAtIndex2 = getMockAddress();
+        const addressAtIndex3 = getMockAddress();
+        const addressAtIndex4 = getMockAddress();
+        const lookupTableAddress = getMockAddress();
+        const programAddressAtIndex1 = getMockAddress();
+        const instructions = [
+            {
+                accounts: [
+                    { address: addressAtIndex3, role: AccountRole.READONLY },
+                    { address: addressAtIndex2, role: AccountRole.WRITABLE },
+                ],
+                programAddress: programAddressAtIndex1,
+            },
+            {
+                accounts: [
+                    {
+                        address: addressAtIndex4,
+                        addressIndex: 0,
+                        lookupTableAddress,
+                        role: AccountRole.WRITABLE,
+                    },
+                    { address: addressAtIndex2, role: AccountRole.READONLY },
+                ],
+                programAddress: programAddressAtIndex1,
+            },
+        ] as IInstruction[];
+        const compiledInstructions = getCompiledInstructions(instructions, [
+            { address: getMockAddress(), role: AccountRole.WRITABLE_SIGNER },
+            { address: programAddressAtIndex1, role: AccountRole.READONLY },
+            { address: addressAtIndex2, role: AccountRole.WRITABLE },
+            { address: addressAtIndex3, role: AccountRole.READONLY },
+            { address: addressAtIndex4, addressIndex: 0, lookupTableAddress, role: AccountRole.WRITABLE },
+        ] as OrderedAccounts);
+        expect(compiledInstructions).toHaveProperty('0.accountIndices', [3, 2]);
+        expect(compiledInstructions).toHaveProperty('1.accountIndices', [4, 2]);
+    });
+    it('copies over the instruction data verbatim', () => {
+        const expectedData = new Uint8Array([1, 2, 3]);
+        const compiledInstructions = getCompiledInstructions(
+            [{ data: expectedData, programAddress: getMockAddress() }],
+            [] as unknown as OrderedAccounts
+        );
+        expect(compiledInstructions[0]).toHaveProperty('data', expectedData);
+    });
+    it('compiles the program address into a program address index', () => {
+        const programAddress = getMockAddress();
+        const compiledInstructions = getCompiledInstructions([{ programAddress }], [
+            { address: getMockAddress(), role: AccountRole.WRITABLE_SIGNER },
+            { address: programAddress, role: AccountRole.READONLY },
+        ] as OrderedAccounts);
+        expect(compiledInstructions[0]).toHaveProperty('programAddressIndex', 1);
+    });
+});

--- a/packages/transactions/src/__tests__/compile-static-accounts.ts
+++ b/packages/transactions/src/__tests__/compile-static-accounts.ts
@@ -1,0 +1,51 @@
+import { AccountRole } from '@solana/instructions';
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { OrderedAccounts } from '../accounts';
+import { getCompiledStaticAccounts } from '../compile-static-accounts';
+
+let _nextMockAddress = 0;
+function getMockAddress() {
+    return `${_nextMockAddress++}` as Base58EncodedAddress;
+}
+
+describe('getCompiledStaticAccounts', () => {
+    it('returns an array of addresses of each account in order', () => {
+        const orderedAccounts = [
+            { address: getMockAddress(), role: AccountRole.WRITABLE_SIGNER },
+            { address: getMockAddress(), role: AccountRole.READONLY_SIGNER },
+            { address: getMockAddress(), role: AccountRole.WRITABLE },
+            { address: getMockAddress(), role: AccountRole.READONLY },
+        ] as OrderedAccounts;
+        const compiledStaticAccounts = getCompiledStaticAccounts(orderedAccounts);
+        expect(compiledStaticAccounts).toEqual([
+            orderedAccounts[0].address,
+            orderedAccounts[1].address,
+            orderedAccounts[2].address,
+            orderedAccounts[3].address,
+        ]);
+    });
+    it('omits lookup table accounts', () => {
+        const orderedAccounts = [
+            { address: getMockAddress(), role: AccountRole.WRITABLE_SIGNER },
+            { address: getMockAddress(), role: AccountRole.READONLY_SIGNER },
+            { address: getMockAddress(), role: AccountRole.WRITABLE },
+            { address: getMockAddress(), role: AccountRole.READONLY },
+            {
+                address: getMockAddress(),
+                addressIndex: 0,
+                lookupTableAddress: getMockAddress(),
+                role: AccountRole.WRITABLE,
+            },
+            {
+                address: getMockAddress(),
+                addressIndex: 1,
+                lookupTableAddress: getMockAddress(),
+                role: AccountRole.READONLY,
+            },
+        ] as OrderedAccounts;
+        const compiledStaticAccounts = getCompiledStaticAccounts(orderedAccounts);
+        expect(compiledStaticAccounts).not.toContain(orderedAccounts[4].address);
+        expect(compiledStaticAccounts).not.toContain(orderedAccounts[5].address);
+    });
+});

--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -2,12 +2,14 @@ import { Base58EncodedAddress } from '@solana/keys';
 
 import { ITransactionWithBlockhashLifetime } from '../blockhash';
 import { getCompiledMessageHeader } from '../compile-header';
+import { getCompiledInstructions } from '../compile-instructions';
 import { getCompiledLifetimeToken } from '../compile-lifetime-token';
 import { ITransactionWithFeePayer } from '../fee-payer';
 import { compileMessage } from '../message';
 import { BaseTransaction } from '../types';
 
 jest.mock('../compile-header');
+jest.mock('../compile-instructions');
 jest.mock('../compile-lifetime-token');
 
 const MOCK_LIFETIME_CONSTRAINT =
@@ -36,6 +38,20 @@ describe('compileMessage', () => {
             const message = compileMessage(baseTx);
             expect(getCompiledMessageHeader).toHaveBeenCalled();
             expect(message.header).toBe(expectedCompiledMessageHeader);
+        });
+    });
+    describe('instructions', () => {
+        const expectedInstructions = [] as ReturnType<typeof getCompiledInstructions>;
+        beforeEach(() => {
+            jest.mocked(getCompiledInstructions).mockReturnValue(expectedInstructions);
+        });
+        it('sets `instructions` to the return value of `getCompiledInstructions`', () => {
+            const message = compileMessage(baseTx);
+            expect(getCompiledInstructions).toHaveBeenCalledWith(
+                baseTx.instructions,
+                expect.any(Array) /* orderedAccounts */
+            );
+            expect(message.instructions).toBe(expectedInstructions);
         });
     });
     describe('lifetime constraints', () => {

--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -4,6 +4,7 @@ import { ITransactionWithBlockhashLifetime } from '../blockhash';
 import { getCompiledMessageHeader } from '../compile-header';
 import { getCompiledInstructions } from '../compile-instructions';
 import { getCompiledLifetimeToken } from '../compile-lifetime-token';
+import { getCompiledStaticAccounts } from '../compile-static-accounts';
 import { ITransactionWithFeePayer } from '../fee-payer';
 import { compileMessage } from '../message';
 import { BaseTransaction } from '../types';
@@ -11,6 +12,7 @@ import { BaseTransaction } from '../types';
 jest.mock('../compile-header');
 jest.mock('../compile-instructions');
 jest.mock('../compile-lifetime-token');
+jest.mock('../compile-static-accounts');
 
 const MOCK_LIFETIME_CONSTRAINT =
     'SOME_CONSTRAINT' as unknown as ITransactionWithBlockhashLifetime['lifetimeConstraint'];
@@ -62,6 +64,17 @@ describe('compileMessage', () => {
             const message = compileMessage(baseTx);
             expect(getCompiledLifetimeToken).toHaveBeenCalledWith('SOME_CONSTRAINT');
             expect(message.lifetimeToken).toBe('abc');
+        });
+    });
+    describe('static accounts', () => {
+        const expectedStaticAccounts = [] as ReturnType<typeof getCompiledStaticAccounts>;
+        beforeEach(() => {
+            jest.mocked(getCompiledStaticAccounts).mockReturnValue(expectedStaticAccounts);
+        });
+        it('sets `staticAccounts` to the return value of `getCompiledStaticAccounts`', () => {
+            const message = compileMessage(baseTx);
+            expect(getCompiledStaticAccounts).toHaveBeenCalled();
+            expect(message.staticAccounts).toBe(expectedStaticAccounts);
         });
     });
     describe('versions', () => {

--- a/packages/transactions/src/compile-address-table-lookups.ts
+++ b/packages/transactions/src/compile-address-table-lookups.ts
@@ -1,0 +1,37 @@
+import { AccountRole } from '@solana/instructions';
+import { Base58EncodedAddress, getBase58EncodedAddressComparator } from '@solana/keys';
+
+import { OrderedAccounts } from './accounts';
+
+type AddressTableLookup = Readonly<{
+    lookupTableAddress: Base58EncodedAddress;
+    readableIndices: readonly number[];
+    writableIndices: readonly number[];
+}>;
+
+export function getCompiledAddressTableLookups(orderedAccounts: OrderedAccounts): AddressTableLookup[] {
+    const index: Record<
+        Base58EncodedAddress,
+        { readonly readableIndices: number[]; readonly writableIndices: number[] }
+    > = {};
+    for (const account of orderedAccounts) {
+        if (!('lookupTableAddress' in account)) {
+            continue;
+        }
+        const entry = (index[account.lookupTableAddress] ||= {
+            readableIndices: [],
+            writableIndices: [],
+        });
+        if (account.role === AccountRole.WRITABLE) {
+            entry.writableIndices.push(account.addressIndex);
+        } else {
+            entry.readableIndices.push(account.addressIndex);
+        }
+    }
+    return Object.keys(index)
+        .sort(getBase58EncodedAddressComparator())
+        .map(lookupTableAddress => ({
+            lookupTableAddress: lookupTableAddress as Base58EncodedAddress,
+            ...index[lookupTableAddress as unknown as Base58EncodedAddress],
+        }));
+}

--- a/packages/transactions/src/compile-instructions.ts
+++ b/packages/transactions/src/compile-instructions.ts
@@ -1,0 +1,32 @@
+import { IInstruction } from '@solana/instructions';
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { OrderedAccounts } from './accounts';
+
+type CompiledInstruction = Readonly<{
+    addressIndices?: number[];
+    data?: Uint8Array;
+    programAddressIndex: number;
+}>;
+
+function getAccountIndex(orderedAccounts: OrderedAccounts) {
+    const out: Record<Base58EncodedAddress, number> = {};
+    for (const [index, account] of orderedAccounts.entries()) {
+        out[account.address] = index;
+    }
+    return out;
+}
+
+export function getCompiledInstructions(
+    instructions: readonly IInstruction[],
+    orderedAccounts: OrderedAccounts
+): CompiledInstruction[] {
+    const accountIndex = getAccountIndex(orderedAccounts);
+    return instructions.map(({ accounts, data, programAddress }) => {
+        return {
+            programAddressIndex: accountIndex[programAddress],
+            ...(accounts ? { accountIndices: accounts.map(({ address }) => accountIndex[address]) } : null),
+            ...(data ? { data } : null),
+        };
+    });
+}

--- a/packages/transactions/src/compile-static-accounts.ts
+++ b/packages/transactions/src/compile-static-accounts.ts
@@ -1,0 +1,10 @@
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { OrderedAccounts } from './accounts';
+
+export function getCompiledStaticAccounts(orderedAccounts: OrderedAccounts): Base58EncodedAddress[] {
+    const firstLookupTableAccountIndex = orderedAccounts.findIndex(account => 'lookupTableAddress' in account);
+    const orderedStaticAccounts =
+        firstLookupTableAccountIndex === -1 ? orderedAccounts : orderedAccounts.slice(0, firstLookupTableAccountIndex);
+    return orderedStaticAccounts.map(({ address }) => address);
+}

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -1,6 +1,7 @@
 import { getAddressMapFromInstructions, getOrderedAccountsFromAddressMap } from './accounts';
 import { ITransactionWithBlockhashLifetime } from './blockhash';
 import { getCompiledMessageHeader } from './compile-header';
+import { getCompiledInstructions } from './compile-instructions';
 import { getCompiledLifetimeToken } from './compile-lifetime-token';
 import { IDurableNonceTransaction } from './durable-nonce';
 import { ITransactionWithFeePayer } from './fee-payer';
@@ -15,6 +16,7 @@ export function compileMessage(
     const orderedAccounts = getOrderedAccountsFromAddressMap(addressMap);
     return {
         header: getCompiledMessageHeader(orderedAccounts),
+        instructions: getCompiledInstructions(transaction.instructions, orderedAccounts),
         lifetimeToken: getCompiledLifetimeToken(transaction.lifetimeConstraint),
         version: transaction.version,
     };

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -1,5 +1,6 @@
 import { getAddressMapFromInstructions, getOrderedAccountsFromAddressMap } from './accounts';
 import { ITransactionWithBlockhashLifetime } from './blockhash';
+import { getCompiledAddressTableLookups } from './compile-address-table-lookups';
 import { getCompiledMessageHeader } from './compile-header';
 import { getCompiledInstructions } from './compile-instructions';
 import { getCompiledLifetimeToken } from './compile-lifetime-token';
@@ -16,6 +17,9 @@ export function compileMessage(
     const addressMap = getAddressMapFromInstructions(transaction.feePayer, transaction.instructions);
     const orderedAccounts = getOrderedAccountsFromAddressMap(addressMap);
     return {
+        ...(transaction.version !== 'legacy'
+            ? { addressTableLookups: getCompiledAddressTableLookups(orderedAccounts) }
+            : null),
         header: getCompiledMessageHeader(orderedAccounts),
         instructions: getCompiledInstructions(transaction.instructions, orderedAccounts),
         lifetimeToken: getCompiledLifetimeToken(transaction.lifetimeConstraint),

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -3,6 +3,7 @@ import { ITransactionWithBlockhashLifetime } from './blockhash';
 import { getCompiledMessageHeader } from './compile-header';
 import { getCompiledInstructions } from './compile-instructions';
 import { getCompiledLifetimeToken } from './compile-lifetime-token';
+import { getCompiledStaticAccounts } from './compile-static-accounts';
 import { IDurableNonceTransaction } from './durable-nonce';
 import { ITransactionWithFeePayer } from './fee-payer';
 import { BaseTransaction } from './types';
@@ -18,6 +19,7 @@ export function compileMessage(
         header: getCompiledMessageHeader(orderedAccounts),
         instructions: getCompiledInstructions(transaction.instructions, orderedAccounts),
         lifetimeToken: getCompiledLifetimeToken(transaction.lifetimeConstraint),
+        staticAccounts: getCompiledStaticAccounts(orderedAccounts),
         version: transaction.version,
     };
 }


### PR DESCRIPTION
refactor(experimental): a function to compile a transaction's address table lookups into a message
## Summary

Once we have an ordered list of accounts, producing the address table lookups for a transaction is a matter of rolling them up into a `Vec<MessageAddressTableLookup>`. This PR implements that.

## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1365).
* #1372
* #1371
* #1370
* #1369
* #1368
* __->__ #1365
* #1364
* #1363