### PR TITLE
refactor(experimental): set up a pattern for splitting the serializers into co/dec/codec slices

### DIFF
--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -61,8 +61,7 @@
         "maintained node versions"
     ],
     "dependencies": {
-        "@metaplex-foundation/umi": "link:/home/sol/src/umi-git/packages/umi/",
-        "@metaplex-foundation/umi-serializer-data-view": "link:/home/sol/src/umi-git/packages/umi-serializer-data-view/"
+        "@metaplex-foundation/umi-serializers": "^0.8.2"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.0",

--- a/packages/transactions/src/serializers/__tests__/transaction-version-test.ts
+++ b/packages/transactions/src/serializers/__tests__/transaction-version-test.ts
@@ -1,31 +1,71 @@
+import { Serializer } from '@metaplex-foundation/umi-serializers';
+
 import { TransactionVersion } from '../../types';
-import { transactionVersionHeader } from '../transaction-version';
+import {
+    getTransactionVersionCodec,
+    getTransactionVersionDecoder,
+    getTransactionVersionEncoder,
+} from '../transaction-version';
 
 const VERSION_FLAG_MASK = 0x80;
 const VERSION_TEST_CASES = // Versions 0–127
     [...Array(128).keys()].map(version => [version | VERSION_FLAG_MASK, version as TransactionVersion] as const);
-describe('Transaction version serializer', () => {
-    it('serializes no data when the version is `legacy`', () => {
-        expect(transactionVersionHeader.serialize('legacy')).toEqual(new Uint8Array());
+
+describe.each([getTransactionVersionCodec, getTransactionVersionEncoder])(
+    'Transaction version serializer',
+    serializerFactory => {
+        let transactionVersion: Serializer<TransactionVersion>;
+        beforeEach(() => {
+            transactionVersion = serializerFactory();
+        });
+        it('serializes no data when the version is `legacy`', () => {
+            expect(transactionVersion.serialize('legacy')).toEqual(new Uint8Array());
+        });
+        it.each(VERSION_TEST_CASES)('serializes to `%s` when the version is `%s`', (expected, version) => {
+            expect(transactionVersion.serialize(version)).toEqual(new Uint8Array([expected]));
+        });
+        it.each([-1 as TransactionVersion, 128 as TransactionVersion])(
+            'throws when passed the out-of-range version `%s`',
+            version => {
+                expect(() => transactionVersion.serialize(version)).toThrow();
+            }
+        );
+    }
+);
+
+describe.each([getTransactionVersionCodec, getTransactionVersionDecoder])(
+    'Transaction version deserializer',
+    serializerFactory => {
+        let transactionVersion: Serializer<TransactionVersion>;
+        beforeEach(() => {
+            transactionVersion = serializerFactory();
+        });
+        it.each(VERSION_TEST_CASES)('deserializes `%s` to the version `%s`', (byte, expected) => {
+            expect(transactionVersion.deserialize(new Uint8Array([byte]))[0]).toEqual(expected);
+        });
+        it('deserializes to `legacy` when missing the version flag', () => {
+            expect(
+                transactionVersion.deserialize(
+                    // eg. just a byte that indicates that there are 3 required signers
+                    new Uint8Array([3])
+                )[0]
+            ).toBe('legacy');
+        });
+    }
+);
+
+describe('The transaction version decode-only factory', () => {
+    it('throws when you call `serialize`', () => {
+        expect(getTransactionVersionDecoder().serialize).toThrowErrorMatchingInlineSnapshot(
+            `"No encoder exists for TransactionVersion. Use \`getTransactionVersionEncoder()\` if you need a encoder, and \`getTransactionVersionCodec()\` if you need to both encode and decode TransactionVersion"`
+        );
     });
-    it.each(VERSION_TEST_CASES)('serializes to `%s` when the version is `%s`', (expected, version) => {
-        expect(transactionVersionHeader.serialize(version)).toEqual(new Uint8Array([expected]));
+});
+
+describe('The transaction version encode-only factory', () => {
+    it('throws when you call `deserialize`', () => {
+        expect(getTransactionVersionEncoder().deserialize).toThrowErrorMatchingInlineSnapshot(
+            `"No decoder exists for TransactionVersion. Use \`getTransactionVersionDecoder()\` if you need a decoder, and \`getTransactionVersionCodec()\` if you need to both encode and decode TransactionVersion"`
+        );
     });
-    it.each(VERSION_TEST_CASES)('deserializes `%s` to the version `%s`', (byte, expected) => {
-        expect(transactionVersionHeader.deserialize(new Uint8Array([byte]))[0]).toEqual(expected);
-    });
-    it('deserializes to `legacy` when missing the version flag', () => {
-        expect(
-            transactionVersionHeader.deserialize(
-                // eg. just a byte that indicates that there are 3 required signers
-                new Uint8Array([3])
-            )[0]
-        ).toBe('legacy');
-    });
-    it.each([-1 as TransactionVersion, 128 as TransactionVersion])(
-        'throws when passed the out-of-range version `%s`',
-        version => {
-            expect(() => transactionVersionHeader.serialize(version)).toThrow();
-        }
-    );
 });

--- a/packages/transactions/src/serializers/transaction-version.ts
+++ b/packages/transactions/src/serializers/transaction-version.ts
@@ -1,29 +1,58 @@
+import { Serializer } from '@metaplex-foundation/umi-serializers';
+
 import { TransactionVersion } from '../types';
+import { getUnimplementedDecoder, getUnimplementedEncoder } from './unimplemented';
 
 const VERSION_FLAG_MASK = 0x80;
 
-export const transactionVersionHeader = {
+const BASE_CONFIG = {
     description: __DEV__ ? 'A single byte that encodes the version of the transaction' : '',
-    deserialize: (bytes: Uint8Array, offset = 0): [TransactionVersion, number] => {
-        const firstByte = bytes[offset];
-        if ((firstByte & VERSION_FLAG_MASK) === 0) {
-            // No version flag set; it's a legacy (unversioned) transaction.
-            return ['legacy', offset];
-        } else {
-            const version = (firstByte ^ VERSION_FLAG_MASK) as TransactionVersion;
-            return [version, offset + 1];
-        }
-    },
     fixedSize: null,
     maxSize: 1,
-    serialize: (value: TransactionVersion): Uint8Array => {
-        if (value === 'legacy') {
-            return new Uint8Array();
-        }
-        if (value < 0 || value > 127) {
-            // TODO: Coded error.
-            throw new Error(`Transaction version must be in the range [0, 127]. \`${value}\` given.`);
-        }
-        return new Uint8Array([value | VERSION_FLAG_MASK]);
-    },
-};
+} as const;
+
+function deserialize(bytes: Uint8Array, offset = 0): [TransactionVersion, number] {
+    const firstByte = bytes[offset];
+    if ((firstByte & VERSION_FLAG_MASK) === 0) {
+        // No version flag set; it's a legacy (unversioned) transaction.
+        return ['legacy', offset];
+    } else {
+        const version = (firstByte ^ VERSION_FLAG_MASK) as TransactionVersion;
+        return [version, offset + 1];
+    }
+}
+
+function serialize(value: TransactionVersion): Uint8Array {
+    if (value === 'legacy') {
+        return new Uint8Array();
+    }
+    if (value < 0 || value > 127) {
+        // TODO: Coded error.
+        throw new Error(`Transaction version must be in the range [0, 127]. \`${value}\` given.`);
+    }
+    return new Uint8Array([value | VERSION_FLAG_MASK]);
+}
+
+export function getTransactionVersionDecoder(): Serializer<TransactionVersion> {
+    return {
+        ...BASE_CONFIG,
+        deserialize,
+        serialize: getUnimplementedEncoder('TransactionVersion'),
+    };
+}
+
+export function getTransactionVersionEncoder(): Serializer<TransactionVersion> {
+    return {
+        ...BASE_CONFIG,
+        deserialize: getUnimplementedDecoder('TransactionVersion'),
+        serialize,
+    };
+}
+
+export function getTransactionVersionCodec(): Serializer<TransactionVersion> {
+    return {
+        ...BASE_CONFIG,
+        deserialize,
+        serialize,
+    };
+}

--- a/packages/transactions/src/serializers/unimplemented.ts
+++ b/packages/transactions/src/serializers/unimplemented.ts
@@ -1,0 +1,18 @@
+function getError(type: 'decoder' | 'encoder', name: string) {
+    const functionSuffix = name + type[0].toUpperCase() + type.slice(1);
+    return new Error(
+        `No ${type} exists for ${name}. Use \`get${functionSuffix}()\` if you need a ${type}, and \`get${name}Codec()\` if you need to both encode and decode ${name}`
+    );
+}
+
+export function getUnimplementedDecoder(name: string): () => never {
+    return () => {
+        throw getError('decoder', name);
+    };
+}
+
+export function getUnimplementedEncoder(name: string): () => never {
+    return () => {
+        throw getError('encoder', name);
+    };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -791,12 +791,9 @@ importers:
 
   packages/transactions:
     dependencies:
-      '@metaplex-foundation/umi':
-        specifier: link:/home/sol/src/umi-git/packages/umi/
-        version: link:../../../umi-git/packages/umi
-      '@metaplex-foundation/umi-serializer-data-view':
-        specifier: link:/home/sol/src/umi-git/packages/umi-serializer-data-view/
-        version: link:../../../umi-git/packages/umi-serializer-data-view
+      '@metaplex-foundation/umi-serializers':
+        specifier: ^0.8.2
+        version: 0.8.2
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.0
@@ -3201,6 +3198,16 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  /@metaplex-foundation/umi-options@0.8.2:
+    resolution: {integrity: sha512-xFoViuyVHZ1xtZjd7r6AieecfoRbx9bEwlUByqqWs8tmeA1MZb8bg/neO3vUN4aB3DbWxUbJZTEHZrq8fUP1AA==}
+    dev: false
+
+  /@metaplex-foundation/umi-public-keys@0.8.2:
+    resolution: {integrity: sha512-66ZXWJAFtdfc228q61fPtdi5o3ILqinhdf84rT2lYy21SzoLNcveqm4sbp5pDJ482hBU6xAs8W6xeGpzTTBRDw==}
+    dependencies:
+      '@metaplex-foundation/umi-serializers-encodings': 0.8.2
+    dev: false
+
   /@metaplex-foundation/umi-serializers-core@0.8.2:
     resolution: {integrity: sha512-grncCh1iyMmoWuFowulLMaoQOdetnVVa+m7CXXxEQ340ygnH3ls8WWBHHnP338309DCsRN2J+pPbqwkOHF/3yA==}
     dev: false
@@ -3209,6 +3216,22 @@ packages:
     resolution: {integrity: sha512-Em9oxKSHlY30upbQ40V5zV82+gIfKqYpcGkoHAM5ensDx6G0JKLthooazLdSp1hHOP5QfwOpL+Srj76MXyoq4Q==}
     dependencies:
       '@metaplex-foundation/umi-serializers-core': 0.8.2
+    dev: false
+
+  /@metaplex-foundation/umi-serializers-numbers@0.8.2:
+    resolution: {integrity: sha512-STQEKGjkFXmG5okZHw9z3mXpHGf6SAcH5xr0K49mb5NIOY9icW9YZEVaccIhUpwYykMXgUI3IEetR2Rmrvhs0Q==}
+    dependencies:
+      '@metaplex-foundation/umi-serializers-core': 0.8.2
+    dev: false
+
+  /@metaplex-foundation/umi-serializers@0.8.2:
+    resolution: {integrity: sha512-N+BCKGb2RnLWvNHY+U3B9dfZUATDLWHp9/5ufJLqGDY1uFS84aTmSPGb3/lOisdtHG6//t6IBY9cprnEOP0l8g==}
+    dependencies:
+      '@metaplex-foundation/umi-options': 0.8.2
+      '@metaplex-foundation/umi-public-keys': 0.8.2
+      '@metaplex-foundation/umi-serializers-core': 0.8.2
+      '@metaplex-foundation/umi-serializers-encodings': 0.8.2
+      '@metaplex-foundation/umi-serializers-numbers': 0.8.2
     dev: false
 
   /@noble/curves@1.0.0:


### PR DESCRIPTION
refactor(experimental): set up a pattern for splitting the serializers into co/dec/codec slices
## Summary

Most use cases for these serializers will only ever need to encode or decode, never both. This PR sets up a standard for splitting serializers into a version that encodes, decodes, or does both. Import the one you need, and let your build system tree-shake the other one away.

## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1368).
* #1374
* #1373
* #1372
* #1370
* #1369
* __->__ #1368