### PR TITLE
refactor(experimental): a serializer for the transaction message header

### DIFF
--- a/packages/transactions/src/serializers/__tests__/header-test.ts
+++ b/packages/transactions/src/serializers/__tests__/header-test.ts
@@ -1,0 +1,24 @@
+import { getMessageHeaderCodec } from '../header';
+
+describe('Message header codec', () => {
+    let messageHeader: ReturnType<typeof getMessageHeaderCodec>;
+    beforeEach(() => {
+        messageHeader = getMessageHeaderCodec();
+    });
+    it('serializes header data according to spec', () => {
+        expect(
+            messageHeader.serialize({
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 2,
+                numSignerAccounts: 3,
+            })
+        ).toEqual(new Uint8Array([3, 2, 1]));
+    });
+    it('deserializes header data according to spec', () => {
+        expect(messageHeader.deserialize(new Uint8Array([3, 2, 1]))[0]).toEqual({
+            numReadonlyNonSignerAccounts: 1,
+            numReadonlySignerAccounts: 2,
+            numSignerAccounts: 3,
+        });
+    });
+});

--- a/packages/transactions/src/serializers/header.ts
+++ b/packages/transactions/src/serializers/header.ts
@@ -1,0 +1,51 @@
+import { Serializer, struct, u8 } from '@metaplex-foundation/umi-serializers';
+
+import { getCompiledMessageHeader } from '../compile-header';
+
+type MessageHeader = ReturnType<typeof getCompiledMessageHeader>;
+
+export function getMessageHeaderCodec(): Serializer<MessageHeader> {
+    return struct(
+        [
+            [
+                'numSignerAccounts',
+                u8(
+                    __DEV__
+                        ? {
+                              description:
+                                  'The expected number of addresses in the static address list belonging to accounts that are required to sign this transaction',
+                          }
+                        : undefined
+                ),
+            ],
+            [
+                'numReadonlySignerAccounts',
+                u8(
+                    __DEV__
+                        ? {
+                              description:
+                                  'The expected number of addresses in the static address list belonging to accounts that are required to sign this transaction, but may not be writable',
+                          }
+                        : undefined
+                ),
+            ],
+            [
+                'numReadonlyNonSignerAccounts',
+                u8(
+                    __DEV__
+                        ? {
+                              description:
+                                  'The expected number of addresses in the static address list belonging to accounts that are neither signers, nor writable',
+                          }
+                        : undefined
+                ),
+            ],
+        ],
+        __DEV__
+            ? {
+                  description:
+                      'The transaction message header containing counts of the signer, readonly-signer, and readonly-nonsigner account addresses',
+              }
+            : undefined
+    );
+}


### PR DESCRIPTION
refactor(experimental): a serializer for the transaction message header
## Summary

This simple data structure tracks the count of signer, readonly-signer, and readonly-nonsigner addresses the parser should expect to find in the static accounts list.

## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1369).
* #1374
* #1373
* #1372
* #1370
* __->__ #1369