### PR TITLE
refactor(experimental): bye bye `bs58`

### DIFF
--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -60,6 +60,9 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
+    "dependencies": {
+        "@metaplex-foundation/umi-serializers-encodings": "^0.8.2"
+    },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.1",
         "@swc/core": "^1.3.18",
@@ -93,8 +96,5 @@
                 "path": "./dist/index*.js"
             }
         ]
-    },
-    "dependencies": {
-        "bs58": "^5.0.0"
     }
 }

--- a/packages/keys/src/__tests__/base58-test.ts
+++ b/packages/keys/src/__tests__/base58-test.ts
@@ -1,4 +1,4 @@
-import bs58 from 'bs58';
+import { base58 } from '@metaplex-foundation/umi-serializers-encodings';
 
 import { assertIsBase58EncodedAddress, getBase58EncodedAddressComparator } from '../base58';
 
@@ -27,7 +27,7 @@ describe('base58', () => {
         });
         [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44].forEach(len => {
             it(`attempts to decode input strings of exactly ${len} characters`, () => {
-                const decodeMethod = jest.spyOn(bs58, 'decode');
+                const decodeMethod = jest.spyOn(base58, 'serialize');
                 try {
                     assertIsBase58EncodedAddress('1'.repeat(len));
                     // eslint-disable-next-line no-empty
@@ -36,7 +36,7 @@ describe('base58', () => {
             });
         });
         it('does not attempt to decode too-short input strings', () => {
-            const decodeMethod = jest.spyOn(bs58, 'decode');
+            const decodeMethod = jest.spyOn(base58, 'serialize');
             try {
                 assertIsBase58EncodedAddress(
                     // 31 bytes [0, ..., 0]
@@ -47,7 +47,7 @@ describe('base58', () => {
             expect(decodeMethod).not.toHaveBeenCalled();
         });
         it('does not attempt to decode too-long input strings', () => {
-            const decodeMethod = jest.spyOn(bs58, 'decode');
+            const decodeMethod = jest.spyOn(base58, 'serialize');
             try {
                 assertIsBase58EncodedAddress(
                     // 33 bytes [0, 255, ..., 255]

--- a/packages/keys/src/base58.ts
+++ b/packages/keys/src/base58.ts
@@ -1,4 +1,4 @@
-import bs58 from 'bs58';
+import { base58 } from '@metaplex-foundation/umi-serializers-encodings';
 
 export type Base58EncodedAddress<TAddress extends string = string> = TAddress & {
     readonly __base58EncodedAddress: unique symbol;
@@ -18,7 +18,7 @@ export function assertIsBase58EncodedAddress(
             throw new Error('Expected input string to decode to a byte array of length 32.');
         }
         // Slow-path; actually attempt to decode the input string.
-        const bytes = bs58.decode(putativeBase58EncodedAddress);
+        const bytes = base58.serialize(putativeBase58EncodedAddress);
         const numBytes = bytes.byteLength;
         if (numBytes !== 32) {
             throw new Error(`Expected input string to decode to a byte array of length 32. Actual length: ${numBytes}`);

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -61,8 +61,8 @@
         "maintained node versions"
     ],
     "dependencies": {
-        "@solana/keys": "workspace:*",
-        "bs58": "^5.0.0"
+        "@metaplex-foundation/umi-serializers-encodings": "^0.8.2",
+        "@solana/keys": "workspace:*"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.1",

--- a/packages/rpc-core/src/__tests__/blockhash-test.ts
+++ b/packages/rpc-core/src/__tests__/blockhash-test.ts
@@ -1,61 +1,59 @@
-import bs58 from 'bs58';
+import { base58 } from '@metaplex-foundation/umi-serializers-encodings';
 
 import { assertIsBlockhash } from '../blockhash';
 
-describe('base58', () => {
-    describe('assertIsBlockhash()', () => {
-        it('throws when supplied a non-base58 string', () => {
-            expect(() => {
-                assertIsBlockhash('not-a-base-58-encoded-string');
-            }).toThrow();
-        });
-        it('throws when the decoded byte array has a length other than 32 bytes', () => {
-            expect(() => {
-                assertIsBlockhash(
-                    // 31 bytes [128, ..., 128]
-                    '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM'
-                );
-            }).toThrow();
-        });
-        it('does not throw when supplied a base-58 encoded hash', () => {
-            expect(() => {
-                assertIsBlockhash('11111111111111111111111111111111');
-            }).not.toThrow();
-        });
-        it('returns undefined when supplied a base-58 encoded hash', () => {
-            expect(assertIsBlockhash('11111111111111111111111111111111')).toBeUndefined();
-        });
-        [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44].forEach(len => {
-            it(`attempts to decode input strings of exactly ${len} characters`, () => {
-                const decodeMethod = jest.spyOn(bs58, 'decode');
-                try {
-                    assertIsBlockhash('1'.repeat(len));
-                    // eslint-disable-next-line no-empty
-                } catch {}
-                expect(decodeMethod).toHaveBeenCalled();
-            });
-        });
-        it('does not attempt to decode too-short input strings', () => {
-            const decodeMethod = jest.spyOn(bs58, 'decode');
+describe('assertIsBlockhash()', () => {
+    it('throws when supplied a non-base58 string', () => {
+        expect(() => {
+            assertIsBlockhash('not-a-base-58-encoded-string');
+        }).toThrow();
+    });
+    it('throws when the decoded byte array has a length other than 32 bytes', () => {
+        expect(() => {
+            assertIsBlockhash(
+                // 31 bytes [128, ..., 128]
+                '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM'
+            );
+        }).toThrow();
+    });
+    it('does not throw when supplied a base-58 encoded hash', () => {
+        expect(() => {
+            assertIsBlockhash('11111111111111111111111111111111');
+        }).not.toThrow();
+    });
+    it('returns undefined when supplied a base-58 encoded hash', () => {
+        expect(assertIsBlockhash('11111111111111111111111111111111')).toBeUndefined();
+    });
+    [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44].forEach(len => {
+        it(`attempts to decode input strings of exactly ${len} characters`, () => {
+            const decodeMethod = jest.spyOn(base58, 'serialize');
             try {
-                assertIsBlockhash(
-                    // 31 bytes [0, ..., 0]
-                    '1111111111111111111111111111111' // 31 characters
-                );
+                assertIsBlockhash('1'.repeat(len));
                 // eslint-disable-next-line no-empty
             } catch {}
-            expect(decodeMethod).not.toHaveBeenCalled();
+            expect(decodeMethod).toHaveBeenCalled();
         });
-        it('does not attempt to decode too-long input strings', () => {
-            const decodeMethod = jest.spyOn(bs58, 'decode');
-            try {
-                assertIsBlockhash(
-                    // 33 bytes [0, 255, ..., 255]
-                    '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG' // 45 characters
-                );
-                // eslint-disable-next-line no-empty
-            } catch {}
-            expect(decodeMethod).not.toHaveBeenCalled();
-        });
+    });
+    it('does not attempt to decode too-short input strings', () => {
+        const decodeMethod = jest.spyOn(base58, 'serialize');
+        try {
+            assertIsBlockhash(
+                // 31 bytes [0, ..., 0]
+                '1111111111111111111111111111111' // 31 characters
+            );
+            // eslint-disable-next-line no-empty
+        } catch {}
+        expect(decodeMethod).not.toHaveBeenCalled();
+    });
+    it('does not attempt to decode too-long input strings', () => {
+        const decodeMethod = jest.spyOn(base58, 'serialize');
+        try {
+            assertIsBlockhash(
+                // 33 bytes [0, 255, ..., 255]
+                '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG' // 45 characters
+            );
+            // eslint-disable-next-line no-empty
+        } catch {}
+        expect(decodeMethod).not.toHaveBeenCalled();
     });
 });

--- a/packages/rpc-core/src/__tests__/transaction-signature-test.ts
+++ b/packages/rpc-core/src/__tests__/transaction-signature-test.ts
@@ -1,4 +1,4 @@
-import bs58 from 'bs58';
+import { base58 } from '@metaplex-foundation/umi-serializers-encodings';
 
 import { assertIsTransactionSignature } from '../transaction-signature';
 
@@ -43,7 +43,7 @@ describe('assertIsTransactionSignature()', () => {
     [64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88].forEach(
         len => {
             it(`attempts to decode input strings of exactly ${len} characters`, () => {
-                const decodeMethod = jest.spyOn(bs58, 'decode');
+                const decodeMethod = jest.spyOn(base58, 'serialize');
                 try {
                     assertIsTransactionSignature('1'.repeat(len));
                     // eslint-disable-next-line no-empty
@@ -53,7 +53,7 @@ describe('assertIsTransactionSignature()', () => {
         }
     );
     it('does not attempt to decode too-short input strings', () => {
-        const decodeMethod = jest.spyOn(bs58, 'decode');
+        const decodeMethod = jest.spyOn(base58, 'serialize');
         try {
             assertIsTransactionSignature(
                 // 63 bytes [0, ..., 0]
@@ -64,7 +64,7 @@ describe('assertIsTransactionSignature()', () => {
         expect(decodeMethod).not.toHaveBeenCalled();
     });
     it('does not attempt to decode too-long input strings', () => {
-        const decodeMethod = jest.spyOn(bs58, 'decode');
+        const decodeMethod = jest.spyOn(base58, 'serialize');
         try {
             assertIsTransactionSignature(
                 // 65 bytes [0, 255, ..., 255]

--- a/packages/rpc-core/src/blockhash.ts
+++ b/packages/rpc-core/src/blockhash.ts
@@ -1,4 +1,4 @@
-import bs58 from 'bs58';
+import { base58 } from '@metaplex-foundation/umi-serializers-encodings';
 
 export type Blockhash = string & { readonly __blockhash: unique symbol };
 
@@ -14,7 +14,7 @@ export function assertIsBlockhash(putativeBlockhash: string): asserts putativeBl
             throw new Error('Expected input string to decode to a byte array of length 32.');
         }
         // Slow-path; actually attempt to decode the input string.
-        const bytes = bs58.decode(putativeBlockhash);
+        const bytes = base58.serialize(putativeBlockhash);
         const numBytes = bytes.byteLength;
         if (numBytes !== 32) {
             throw new Error(`Expected input string to decode to a byte array of length 32. Actual length: ${numBytes}`);

--- a/packages/rpc-core/src/transaction-signature.ts
+++ b/packages/rpc-core/src/transaction-signature.ts
@@ -1,4 +1,4 @@
-import bs58 from 'bs58';
+import { base58 } from '@metaplex-foundation/umi-serializers-encodings';
 
 export type TransactionSignature = string & { readonly __sig: unique symbol };
 
@@ -16,7 +16,7 @@ export function assertIsTransactionSignature(
             throw new Error('Expected input string to decode to a byte array of length 64.');
         }
         // Slow-path; actually attempt to decode the input string.
-        const bytes = bs58.decode(putativeTransactionSignature);
+        const bytes = base58.serialize(putativeTransactionSignature);
         const numBytes = bytes.byteLength;
         if (numBytes !== 64) {
             throw new Error(`Expected input string to decode to a byte array of length 64. Actual length: ${numBytes}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,9 +186,9 @@ importers:
 
   packages/keys:
     dependencies:
-      bs58:
-        specifier: ^5.0.0
-        version: 5.0.0
+      '@metaplex-foundation/umi-serializers-encodings':
+        specifier: ^0.8.2
+        version: 0.8.2
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.1
@@ -573,12 +573,12 @@ importers:
 
   packages/rpc-core:
     dependencies:
+      '@metaplex-foundation/umi-serializers-encodings':
+        specifier: ^0.8.2
+        version: 0.8.2
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
-      bs58:
-        specifier: ^5.0.0
-        version: 5.0.0
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.1
@@ -3201,6 +3201,16 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  /@metaplex-foundation/umi-serializers-core@0.8.2:
+    resolution: {integrity: sha512-grncCh1iyMmoWuFowulLMaoQOdetnVVa+m7CXXxEQ340ygnH3ls8WWBHHnP338309DCsRN2J+pPbqwkOHF/3yA==}
+    dev: false
+
+  /@metaplex-foundation/umi-serializers-encodings@0.8.2:
+    resolution: {integrity: sha512-Em9oxKSHlY30upbQ40V5zV82+gIfKqYpcGkoHAM5ensDx6G0JKLthooazLdSp1hHOP5QfwOpL+Srj76MXyoq4Q==}
+    dependencies:
+      '@metaplex-foundation/umi-serializers-core': 0.8.2
+    dev: false
+
   /@noble/curves@1.0.0:
     resolution: {integrity: sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==}
     dependencies:
@@ -5091,10 +5101,6 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
-  /base-x@4.0.0:
-    resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
-    dev: false
-
   /base64-arraybuffer@0.1.5:
     resolution: {integrity: sha512-437oANT9tP582zZMwSvZGy2nmSeAb8DW2me3y+Uv1Wp2Rulr8Mqlyrv3E7MLxmsiaPSMMDmiDVzgE+e8zlMx9g==}
     engines: {node: '>= 0.6.0'}
@@ -5232,12 +5238,6 @@ packages:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
     dependencies:
       base-x: 3.0.9
-
-  /bs58@5.0.0:
-    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
-    dependencies:
-      base-x: 4.0.0
-    dev: false
 
   /bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}


### PR DESCRIPTION
refactor(experimental): bye bye `bs58`
## Summary

This library is very frustrating in that it's large, not tree-shakable, and esm-only. Let's switch it out for Umi's slimmed down implementation.

## Test Plan

```
pnpm test:unit:browser
pnpm test:unit:node
```
