### PR TITLE
refactor(experimental): a serializer for transaction instructions

### DIFF
--- a/packages/transactions/src/serializers/__tests__/address-test.ts
+++ b/packages/transactions/src/serializers/__tests__/address-test.ts
@@ -1,0 +1,39 @@
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { getBase58EncodedAddressCodec } from '../address';
+
+describe('Base58 encoded address codec', () => {
+    let address: ReturnType<typeof getBase58EncodedAddressCodec>;
+    beforeEach(() => {
+        address = getBase58EncodedAddressCodec();
+    });
+    it('serializes a base58 encoded address into a 32-byte buffer', () => {
+        expect(
+            address.serialize(
+                '4wBqpZM9xaSheZzJSMawUHDgZ7miWfSsxmfVF5jJpYP' as Base58EncodedAddress<'4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw'>
+            )
+        ).toEqual(
+            new Uint8Array([
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ])
+        );
+    });
+    it('deserializes a byte buffer representing an address into a base58 encoded address', () => {
+        expect(
+            address.deserialize(
+                new Uint8Array([
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+                    28, 29, 30, 31, 32,
+                    // Followed by extra bytes not part of the address
+                    33, 34,
+                ])
+            )[0]
+        ).toBe(
+            '4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw' as Base58EncodedAddress<'4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw'>
+        );
+    });
+    it('fatals when trying to deserialize a byte buffer shorter than 32-bytes', () => {
+        const tooShortBuffer = new Uint8Array(Array(31).fill(0));
+        expect(() => address.deserialize(tooShortBuffer)).toThrow();
+    });
+});

--- a/packages/transactions/src/serializers/__tests__/instruction-test.ts
+++ b/packages/transactions/src/serializers/__tests__/instruction-test.ts
@@ -1,0 +1,126 @@
+import { getInstructionCodec } from '../instruction';
+
+describe('Instruction codec', () => {
+    let instruction: ReturnType<typeof getInstructionCodec>;
+    beforeEach(() => {
+        instruction = getInstructionCodec();
+    });
+    it('serializes an instruction according to spec', () => {
+        expect(
+            instruction.serialize({
+                addressIndices: [1, 2],
+                data: new Uint8Array([4, 5, 6]),
+                programAddressIndex: 7,
+            })
+        ).toEqual(
+            new Uint8Array([
+                // Program id index
+                7,
+                // Compact array of account indices
+                2, // Compact-u16 length
+                1,
+                2,
+                // Compact array of instruction data
+                3, // Compact-u16 length
+                4,
+                5,
+                6,
+            ])
+        );
+    });
+    it('serializes a zero-length compact array when `addressIndices` is `undefined`', () => {
+        expect(
+            instruction.serialize({
+                data: new Uint8Array([3, 4]),
+                programAddressIndex: 1,
+            })
+        ).toEqual(
+            new Uint8Array([
+                // Program id index
+                1,
+                // Compact array of account indices
+                0, // Compact-u16 length
+                // Compact array of instruction data
+                2, // Compact-u16 length
+                3,
+                4,
+            ])
+        );
+    });
+    it('serializes a zero-length compact array when `data` is `undefined`', () => {
+        expect(
+            instruction.serialize({
+                addressIndices: [3, 4],
+                programAddressIndex: 1,
+            })
+        ).toEqual(
+            new Uint8Array([
+                // Program id index
+                1,
+                // Compact array of account indices
+                2, // Compact-u16 length
+                3,
+                4,
+                // Compact array of instruction data
+                0, // Compact-u16 length
+            ])
+        );
+    });
+    it('deserializes an instruction according to spec', () => {
+        expect(
+            instruction.deserialize(
+                new Uint8Array([
+                    // Program id index
+                    1,
+                    // Compact array of account indices
+                    2, // Compact-u16 length
+                    3,
+                    4,
+                    // Compact array of instruction data
+                    5, // Compact-u16 length
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                ])
+            )[0]
+        ).toEqual({
+            addressIndices: [3, 4],
+            data: new Uint8Array([6, 7, 8, 9, 10]),
+            programAddressIndex: 1,
+        });
+    });
+    it('omits the `addressIndices` property when the indices data is zero-length', () => {
+        expect(
+            instruction.deserialize(
+                new Uint8Array([
+                    // Program id index
+                    1,
+                    // Compact array of account indices
+                    0, // Compact-u16 length
+                    // Compact array of instruction data
+                    2, // Compact-u16 length
+                    3,
+                    4,
+                ])
+            )[0]
+        ).toHaveProperty('addressIndices', undefined);
+    });
+    it('omits the `data` property when the instruction data is zero-length', () => {
+        expect(
+            instruction.deserialize(
+                new Uint8Array([
+                    // Program id index
+                    1,
+                    // Compact array of account indices
+                    2, // Compact-u16 length
+                    3,
+                    4,
+                    // Compact array of instruction data
+                    0, // Compact-u16 length
+                ])
+            )[0]
+        ).toHaveProperty('data', undefined);
+    });
+});

--- a/packages/transactions/src/serializers/address.ts
+++ b/packages/transactions/src/serializers/address.ts
@@ -1,0 +1,10 @@
+import { base58, Serializer, string } from '@metaplex-foundation/umi-serializers';
+import { Base58EncodedAddress } from '@solana/keys';
+
+export function getBase58EncodedAddressCodec(): Serializer<Base58EncodedAddress> {
+    return string({
+        description: __DEV__ ? 'A 32-byte account address' : '',
+        encoding: base58,
+        size: 32,
+    }) as unknown as Serializer<Base58EncodedAddress>;
+}

--- a/packages/transactions/src/serializers/instruction.ts
+++ b/packages/transactions/src/serializers/instruction.ts
@@ -1,0 +1,56 @@
+import { array, bytes, mapSerializer, Serializer, shortU16, struct, u8 } from '@metaplex-foundation/umi-serializers';
+
+import { getCompiledInstructions } from '../compile-instructions';
+
+type Instruction = ReturnType<typeof getCompiledInstructions>[number];
+
+export function getInstructionCodec(): Serializer<Instruction> {
+    return struct([
+        [
+            'programAddressIndex',
+            u8(
+                __DEV__
+                    ? {
+                          description:
+                              'The index of the program being called, according to the ' +
+                              'well-ordered accounts list for this transaction',
+                      }
+                    : undefined
+            ),
+        ],
+        [
+            'addressIndices',
+            mapSerializer(
+                array(
+                    u8({
+                        description: __DEV__
+                            ? 'The index of an account, according to the well-ordered accounts ' +
+                              'list for this transaction'
+                            : '',
+                    }),
+                    {
+                        description: __DEV__
+                            ? 'An optional list of account indices, according to the ' +
+                              'well-ordered accounts list for this transaction, in the order in ' +
+                              'which the program being called expects them'
+                            : '',
+                        size: shortU16(),
+                    }
+                ),
+                (value: number[] | undefined) => value ?? [],
+                value => (value.length ? value : undefined)
+            ),
+        ],
+        [
+            'data',
+            mapSerializer(
+                bytes({
+                    description: __DEV__ ? 'An optional buffer of data passed to the instruction' : '',
+                    size: shortU16(),
+                }),
+                (value: Uint8Array | undefined) => value ?? new Uint8Array(0),
+                (value: Uint8Array) => (value.byteLength ? value : undefined)
+            ),
+        ],
+    ]);
+}


### PR DESCRIPTION
refactor(experimental): a serializer for transaction instructions
## Summary

This serializer commutes between `IInstruction` and the wire format of program-index/compact-account-address-indices/compact-array-of-data.

## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1372).
* #1374
* #1373
* __->__ #1372
* #1370