### PR TITLE
refactor(experimental): a seriailzer for address table lookups

### DIFF
--- a/packages/transactions/src/serializers/__tests__/address-table-lookup-test.ts
+++ b/packages/transactions/src/serializers/__tests__/address-table-lookup-test.ts
@@ -1,0 +1,56 @@
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { getCompiledAddressTableLookups } from '../../compile-address-table-lookups';
+import { getAddressTableLookupCodec } from '../address-table-lookup';
+
+type AddressTableLookup = ReturnType<typeof getCompiledAddressTableLookups>[number];
+
+describe('Address table lookup serializer', () => {
+    let addressTableLookup: ReturnType<typeof getAddressTableLookupCodec>;
+    beforeEach(() => {
+        addressTableLookup = getAddressTableLookupCodec();
+    });
+    it('serializes an `AddressTableLookup` according to the spec', () => {
+        expect(
+            addressTableLookup.serialize({
+                lookupTableAddress: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Base58EncodedAddress, // decodes to [11{32}]
+                readableIndices: [33, 22],
+                writableIndices: [44],
+            } as AddressTableLookup)
+        ).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // Lookup table account address
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                // Compact array of writable indices
+                1, // Compact-u16 length
+                    44, // Writable indicies
+                // Compact array of read-only indices
+                2, // Compact-u16 length
+                    33, 22, // Read-only indicies
+            ])
+        );
+    });
+    it('deserializes an `AddressTableLookup` according to the spec', () => {
+        const byteArray =
+            // prettier-ignore
+            new Uint8Array([
+                // Lookup table account address
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                // Compact array of writable indices
+                1, // Compact-u16 length
+                    44, // Writable indicies
+                // Compact array of read-only indices
+                2, // Compact-u16 length
+                    33, 22, // Read-only indicies
+            ]);
+        const [lookup, offset] = addressTableLookup.deserialize(byteArray);
+        expect(lookup).toEqual({
+            lookupTableAddress: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Base58EncodedAddress, // decodes to [11{32}]
+            readableIndices: [33, 22],
+            writableIndices: [44],
+        });
+        // Expect the entire byte array to have been consumed.
+        expect(offset).toBe(byteArray.byteLength);
+    });
+});

--- a/packages/transactions/src/serializers/address-table-lookup.ts
+++ b/packages/transactions/src/serializers/address-table-lookup.ts
@@ -1,0 +1,58 @@
+import { array, Serializer, shortU16, struct, StructToSerializerTuple, u8 } from '@metaplex-foundation/umi-serializers';
+
+import { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
+import { getBase58EncodedAddressCodec } from './address';
+
+type AddressTableLookup = ReturnType<typeof getCompiledAddressTableLookups>[number];
+
+export function getAddressTableLookupCodec(): Serializer<AddressTableLookup> {
+    return struct(
+        [
+            [
+                'lookupTableAddress',
+                getBase58EncodedAddressCodec(
+                    __DEV__
+                        ? {
+                              description:
+                                  'The address of the address lookup table account from which ' +
+                                  'instruction addresses should be looked up',
+                          }
+                        : undefined
+                ),
+            ],
+            [
+                'writableIndices',
+                array(u8(), {
+                    ...(__DEV__
+                        ? {
+                              description:
+                                  'The indices of the accounts in the lookup table that should ' +
+                                  'be loaded as writeable',
+                          }
+                        : null),
+                    size: shortU16(),
+                }),
+            ],
+            [
+                'readableIndices',
+                array(u8(), {
+                    ...(__DEV__
+                        ? {
+                              description:
+                                  'The indices of the accounts in the lookup table that should ' +
+                                  'be loaded as read-only',
+                          }
+                        : undefined),
+                    size: shortU16(),
+                }),
+            ],
+        ] as StructToSerializerTuple<AddressTableLookup, AddressTableLookup>,
+        __DEV__
+            ? {
+                  description:
+                      'A pointer to the address of an address lookup table, along with the ' +
+                      'readonly/writeable indices of the addresses that should be loaded from it',
+              }
+            : undefined
+    );
+}

--- a/packages/transactions/src/serializers/address.ts
+++ b/packages/transactions/src/serializers/address.ts
@@ -1,9 +1,13 @@
 import { base58, Serializer, string } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/keys';
 
-export function getBase58EncodedAddressCodec(): Serializer<Base58EncodedAddress> {
+type Config = Readonly<{
+    description: string;
+}>;
+
+export function getBase58EncodedAddressCodec(config?: Config): Serializer<Base58EncodedAddress> {
     return string({
-        description: __DEV__ ? 'A 32-byte account address' : '',
+        description: config?.description ?? (__DEV__ ? 'A 32-byte account address' : ''),
         encoding: base58,
         size: 32,
     }) as unknown as Serializer<Base58EncodedAddress>;


### PR DESCRIPTION
refactor(experimental): a seriailzer for address table lookups
## Summary

An address table lookup forms part of v0 transactions. Each one contains the address of the lookup table account itself, the indices of the accounts within that should be write-locked, and the indices of the accounts that should be read-only.

## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1373).
* #1374
* __->__ #1373