### PR TITLE
refactor(experimental): a serializer for the compiled message of a transaction

### DIFF
--- a/packages/transactions/src/serializers/__tests__/address-table-lookup-test.ts
+++ b/packages/transactions/src/serializers/__tests__/address-table-lookup-test.ts
@@ -1,0 +1,56 @@
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { getCompiledAddressTableLookups } from '../../compile-address-table-lookups';
+import { getAddressTableLookupCodec } from '../address-table-lookup';
+
+type AddressTableLookup = ReturnType<typeof getCompiledAddressTableLookups>[number];
+
+describe('Address table lookup serializer', () => {
+    let addressTableLookup: ReturnType<typeof getAddressTableLookupCodec>;
+    beforeEach(() => {
+        addressTableLookup = getAddressTableLookupCodec();
+    });
+    it('serializes an `AddressTableLookup` according to the spec', () => {
+        expect(
+            addressTableLookup.serialize({
+                lookupTableAddress: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Base58EncodedAddress, // decodes to [11{32}]
+                readableIndices: [33, 22],
+                writableIndices: [44],
+            } as AddressTableLookup)
+        ).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // Lookup table account address
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                // Compact array of writable indices
+                1, // Compact-u16 length
+                    44, // Writable indicies
+                // Compact array of read-only indices
+                2, // Compact-u16 length
+                    33, 22, // Read-only indicies
+            ])
+        );
+    });
+    it('deserializes an `AddressTableLookup` according to the spec', () => {
+        const byteArray =
+            // prettier-ignore
+            new Uint8Array([
+                // Lookup table account address
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                // Compact array of writable indices
+                1, // Compact-u16 length
+                    44, // Writable indicies
+                // Compact array of read-only indices
+                2, // Compact-u16 length
+                    33, 22, // Read-only indicies
+            ]);
+        const [lookup, offset] = addressTableLookup.deserialize(byteArray);
+        expect(lookup).toEqual({
+            lookupTableAddress: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Base58EncodedAddress, // decodes to [11{32}]
+            readableIndices: [33, 22],
+            writableIndices: [44],
+        });
+        // Expect the entire byte array to have been consumed.
+        expect(offset).toBe(byteArray.byteLength);
+    });
+});

--- a/packages/transactions/src/serializers/__tests__/message-test.ts
+++ b/packages/transactions/src/serializers/__tests__/message-test.ts
@@ -1,0 +1,369 @@
+import { Serializer } from '@metaplex-foundation/umi-serializers';
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { CompiledMessage } from '../../message';
+import { getCompiledMessageCodec, getCompiledMessageDecoder, getCompiledMessageEncoder } from '../message';
+
+describe.each([getCompiledMessageCodec, getCompiledMessageEncoder])(
+    'Transaction message serializer %p',
+    serializerFactory => {
+        let compiledMessage: Serializer<CompiledMessage>;
+        beforeEach(() => {
+            compiledMessage = serializerFactory();
+        });
+        it('serializes a transaction according to the spec', () => {
+            const byteArray = compiledMessage.serialize({
+                addressTableLookups: [
+                    {
+                        lookupTableAddress: '3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7' as Base58EncodedAddress, // decodes to [44{32}]
+                        readableIndices: [77],
+                        writableIndices: [66, 55],
+                    },
+                ],
+                header: {
+                    numReadonlyNonSignerAccounts: 1,
+                    numReadonlySignerAccounts: 2,
+                    numSignerAccounts: 3,
+                },
+                instructions: [
+                    { programAddressIndex: 44 },
+                    { addressIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
+                ],
+                lifetimeToken: '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL', // decodes to [33{32}]
+                staticAccounts: [
+                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
+                    '2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z', // decodes to [22{32}]
+                ] as Base58EncodedAddress[],
+                version: 0,
+            });
+            expect(byteArray).toStrictEqual(
+                // prettier-ignore
+                new Uint8Array([
+                    /** VERSION HEADER */
+                    128, // 0 + version mask
+
+                    /** MESSAGE HEADER */
+                    3, // numSignerAccounts
+                    2, // numReadonlySignerAccount
+                    1, // numReadonlyNonSignerAccounts
+
+                    /** STATIC ADDRESSES */
+                    2, // Number of static accounts
+                        11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                        22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, // 2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z
+
+                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                    33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
+
+                    /* INSTRUCTIONS */
+                    2, // Number of instructions
+
+                        // First instruction
+                        44, // Program address index
+                        0, // Number of address indices
+                        0, // Length of instruction data
+
+                        // Second instruction
+                        55, // Program address index
+                        2, // Number of address indices
+                            77, 66, // Address indices
+                        3, // Length of instruction data
+                            7, 8, 9, // Instruction data itself
+
+                    /** ADDRESS TABLE LOOKUPS */
+                    1, // Number of address table lookups
+
+                        // First address table lookup
+                        44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, // Address of lookup table 3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7
+                        2, // Number of writable indices
+                            66, 55, // Writable indices
+                        1, // Number of readonly indices
+                            77, // Readonly indices
+                ])
+            );
+        });
+        it('serializes a versioned transaction with `undefined` address table lookups', () => {
+            const byteArray = compiledMessage.serialize({
+                /** `addressTableLookups` is not defined */
+                header: {
+                    numReadonlyNonSignerAccounts: 1,
+                    numReadonlySignerAccounts: 2,
+                    numSignerAccounts: 3,
+                },
+                instructions: [],
+                lifetimeToken: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
+                staticAccounts: [],
+                version: 0,
+            });
+            expect(byteArray).toStrictEqual(
+                // prettier-ignore
+                new Uint8Array([
+                    /** VERSION HEADER */
+                    128, // 0 + version mask
+
+                    /** MESSAGE HEADER */
+                    3, // numSignerAccounts
+                    2, // numReadonlySignerAccount
+                    1, // numReadonlyNonSignerAccounts
+
+                    /** STATIC ADDRESSES */
+                    0, // Number of static accounts
+
+                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
+
+                    /* INSTRUCTIONS */
+                    0, // Number of instructions
+
+                    /** ADDRESS TABLE LOOKUPS get serialized despite not being in the source object */
+                    0, // Number of address table lookups
+                ])
+            );
+        });
+        it('omits the version header for `legacy` transactions', () => {
+            expect(
+                compiledMessage.serialize({
+                    header: {
+                        numReadonlyNonSignerAccounts: 1,
+                        numReadonlySignerAccounts: 2,
+                        numSignerAccounts: 3,
+                    },
+                    instructions: [],
+                    lifetimeToken: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
+                    staticAccounts: [],
+                    version: 'legacy',
+                })
+            ).toStrictEqual(
+                // prettier-ignore
+                new Uint8Array([
+                    /** NO VERSION HEADER */
+
+                    /** MESSAGE HEADER */
+                    3, // numSignerAccounts
+                    2, // numReadonlySignerAccount
+                    1, // numReadonlyNonSignerAccounts
+
+                    /** STATIC ADDRESSES */
+                    0, // Number of static accounts
+
+                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+
+                    /* INSTRUCTIONS */
+                    0, // Number of instructions
+                ])
+            );
+        });
+        it('omits the address table lookups for `legacy` transactions', () => {
+            expect(
+                getCompiledMessageCodec().serialize({
+                    header: {
+                        numReadonlyNonSignerAccounts: 1,
+                        numReadonlySignerAccounts: 2,
+                        numSignerAccounts: 3,
+                    },
+                    instructions: [],
+                    lifetimeToken: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
+                    staticAccounts: [],
+                    version: 'legacy',
+                })
+            ).toStrictEqual(
+                // prettier-ignore
+                new Uint8Array([
+                    /** MESSAGE HEADER */
+                    3, // numSignerAccounts
+                    2, // numReadonlySignerAccount
+                    1, // numReadonlyNonSignerAccounts
+
+                    /** STATIC ADDRESSES */
+                    0, // Number of static accounts
+
+                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+
+                    /* INSTRUCTIONS */
+                    0, // Number of instructions
+
+                    /** NO ADDRESS TABLE LOOKUPS */
+                ])
+            );
+        });
+    }
+);
+
+describe.each([getCompiledMessageCodec, getCompiledMessageDecoder])(
+    'Transaction message deserializer %p',
+    serializerFactory => {
+        let compiledMessage: Serializer<CompiledMessage>;
+        beforeEach(() => {
+            compiledMessage = serializerFactory();
+        });
+        it('deserializes a version 0 transaction according to the spec', () => {
+            const byteArray =
+                // prettier-ignore
+                new Uint8Array([
+                    /** VERSION HEADER */
+                    128, // 0 + version mask
+
+                    /** MESSAGE HEADER */
+                    3, // numSignerAccounts
+                    2, // numReadonlySignerAccount
+                    1, // numReadonlyNonSignerAccounts
+
+                    /** STATIC ADDRESSES */
+                    2, // Number of static accounts
+                        11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                        22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, // 2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z
+
+                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                    33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
+
+                    /* INSTRUCTIONS */
+                    2, // Number of instructions
+
+                        // First instruction
+                        44, // Program address index
+                        0, // Number of address indices
+                        0, // Length of instruction data
+
+                        // Second instruction
+                        55, // Program address index
+                        2, // Number of address indices
+                            77, 66, // Address indices
+                        3, // Length of instruction data
+                            7, 8, 9, // Instruction data itself
+
+                    /** ADDRESS TABLE LOOKUPS */
+                    1, // Number of address table lookups
+
+                        // First address table lookup
+                        44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, // Address of lookup table 3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7
+                        2, // Number of writable indices
+                            66, 55, // Writable indices
+                        1, // Number of readonly indices
+                            77, // Readonly indices
+                ]);
+            const [message, offset] = compiledMessage.deserialize(byteArray);
+            expect(message).toStrictEqual({
+                addressTableLookups: [
+                    {
+                        lookupTableAddress: '3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7' as Base58EncodedAddress, // decodes to [44{32}]
+                        readableIndices: [77],
+                        writableIndices: [66, 55],
+                    },
+                ],
+                header: {
+                    numReadonlyNonSignerAccounts: 1,
+                    numReadonlySignerAccounts: 2,
+                    numSignerAccounts: 3,
+                },
+                instructions: [
+                    { programAddressIndex: 44 },
+                    { addressIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
+                ],
+                lifetimeToken: '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL', // decodes to [33{32}]
+                staticAccounts: [
+                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
+                    '2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z', // decodes to [22{32}]
+                ] as Base58EncodedAddress[],
+                version: 0,
+            });
+            // Expect the entire byte array to have been consumed.
+            expect(offset).toBe(byteArray.byteLength);
+        });
+        it('omits the `addressTableLookups` property of a versioned transaction when the address table lookups are zero-length', () => {
+            expect(
+                compiledMessage.deserialize(
+                    // prettier-ignore
+                    new Uint8Array([
+                        /** VERSION HEADER */
+                        128, // 0 + version mask
+
+                        /** MESSAGE HEADER */
+                        3, // numSignerAccounts
+                        2, // numReadonlySignerAccount
+                        1, // numReadonlyNonSignerAccounts
+
+                        /** STATIC ADDRESSES */
+                        0, // Number of static accounts
+
+                        /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                        33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
+
+                        /* INSTRUCTIONS */
+                        0, // Number of instructions
+                    ])
+                )[0]
+            ).not.toHaveProperty('addressTableLookups');
+        });
+        it('deserializes a legacy transaction according to the spec', () => {
+            const byteArray =
+                // prettier-ignore
+                new Uint8Array([
+                    /** MESSAGE HEADER */
+                    3, // numSignerAccounts
+                    2, // numReadonlySignerAccount
+                    1, // numReadonlyNonSignerAccounts
+
+                    /** STATIC ADDRESSES */
+                    2, // Number of static accounts
+                        11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                        22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, // 2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z
+
+                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                    33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
+
+                    /* INSTRUCTIONS */
+                    2, // Number of instructions
+
+                        // First instruction
+                        44, // Program address index
+                        0, // Number of address indices
+                        0, // Length of instruction data
+
+                        // Second instruction
+                        55, // Program address index
+                        2, // Number of address indices
+                            77, 66, // Address indices
+                        3, // Length of instruction data
+                            7, 8, 9, // Instruction data itself
+                ]);
+            const [message, offset] = compiledMessage.deserialize(byteArray);
+            expect(message).toStrictEqual({
+                header: {
+                    numReadonlyNonSignerAccounts: 1,
+                    numReadonlySignerAccounts: 2,
+                    numSignerAccounts: 3,
+                },
+                instructions: [
+                    { programAddressIndex: 44 },
+                    { addressIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
+                ],
+                lifetimeToken: '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL', // decodes to [33{32}]
+                staticAccounts: [
+                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
+                    '2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z', // decodes to [22{32}]
+                ] as Base58EncodedAddress[],
+                version: 'legacy',
+            });
+            // Expect the entire byte array to have been consumed.
+            expect(offset).toBe(byteArray.byteLength);
+        });
+    }
+);
+
+describe('The transaction message decode-only factory', () => {
+    it('throws when you call `serialize`', () => {
+        expect(getCompiledMessageDecoder().serialize).toThrowErrorMatchingInlineSnapshot(
+            `"No encoder exists for CompiledMessage. Use \`getCompiledMessageEncoder()\` if you need a encoder, and \`getCompiledMessageCodec()\` if you need to both encode and decode CompiledMessage"`
+        );
+    });
+});
+
+describe('The transaction message encode-only factory', () => {
+    it('throws when you call `deserialize`', () => {
+        expect(getCompiledMessageEncoder().deserialize).toThrowErrorMatchingInlineSnapshot(
+            `"No decoder exists for CompiledMessage. Use \`getCompiledMessageDecoder()\` if you need a decoder, and \`getCompiledMessageCodec()\` if you need to both encode and decode CompiledMessage"`
+        );
+    });
+});

--- a/packages/transactions/src/serializers/address-table-lookup.ts
+++ b/packages/transactions/src/serializers/address-table-lookup.ts
@@ -1,0 +1,58 @@
+import { array, Serializer, shortU16, struct, StructToSerializerTuple, u8 } from '@metaplex-foundation/umi-serializers';
+
+import { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
+import { getBase58EncodedAddressCodec } from './address';
+
+type AddressTableLookup = ReturnType<typeof getCompiledAddressTableLookups>[number];
+
+export function getAddressTableLookupCodec(): Serializer<AddressTableLookup> {
+    return struct(
+        [
+            [
+                'lookupTableAddress',
+                getBase58EncodedAddressCodec(
+                    __DEV__
+                        ? {
+                              description:
+                                  'The address of the address lookup table account from which ' +
+                                  'instruction addresses should be looked up',
+                          }
+                        : undefined
+                ),
+            ],
+            [
+                'writableIndices',
+                array(u8(), {
+                    ...(__DEV__
+                        ? {
+                              description:
+                                  'The indices of the accounts in the lookup table that should ' +
+                                  'be loaded as writeable',
+                          }
+                        : null),
+                    size: shortU16(),
+                }),
+            ],
+            [
+                'readableIndices',
+                array(u8(), {
+                    ...(__DEV__
+                        ? {
+                              description:
+                                  'The indices of the accounts in the lookup table that should ' +
+                                  'be loaded as read-only',
+                          }
+                        : undefined),
+                    size: shortU16(),
+                }),
+            ],
+        ] as StructToSerializerTuple<AddressTableLookup, AddressTableLookup>,
+        __DEV__
+            ? {
+                  description:
+                      'A pointer to the address of an address lookup table, along with the ' +
+                      'readonly/writeable indices of the addresses that should be loaded from it',
+              }
+            : undefined
+    );
+}

--- a/packages/transactions/src/serializers/address.ts
+++ b/packages/transactions/src/serializers/address.ts
@@ -1,9 +1,13 @@
 import { base58, Serializer, string } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/keys';
 
-export function getBase58EncodedAddressCodec(): Serializer<Base58EncodedAddress> {
+type Config = Readonly<{
+    description: string;
+}>;
+
+export function getBase58EncodedAddressCodec(config?: Config): Serializer<Base58EncodedAddress> {
     return string({
-        description: __DEV__ ? 'A 32-byte account address' : '',
+        description: config?.description ?? (__DEV__ ? 'A 32-byte account address' : ''),
         encoding: base58,
         size: 32,
     }) as unknown as Serializer<Base58EncodedAddress>;

--- a/packages/transactions/src/serializers/message.ts
+++ b/packages/transactions/src/serializers/message.ts
@@ -1,0 +1,128 @@
+import {
+    array,
+    base58,
+    mapSerializer,
+    Serializer,
+    shortU16,
+    string,
+    struct,
+    StructToSerializerTuple,
+} from '@metaplex-foundation/umi-serializers';
+
+import { CompiledMessage } from '../message';
+import { getBase58EncodedAddressCodec } from './address';
+import { getAddressTableLookupCodec } from './address-table-lookup';
+import { getMessageHeaderCodec } from './header';
+import { getInstructionCodec } from './instruction';
+import { getTransactionVersionCodec } from './transaction-version';
+import { getUnimplementedDecoder, getUnimplementedEncoder } from './unimplemented';
+
+const BASE_CONFIG = {
+    description: __DEV__ ? 'The wire format of a Solana transaction message' : '',
+    fixedSize: null,
+    maxSize: null,
+} as const;
+
+function deserialize(bytes: Uint8Array, offset = 0): [CompiledMessage, number] {
+    const preludeAndOffset = struct(getPreludeStructSerializerTuple()).deserialize(bytes, offset);
+    const [prelude, endOfPreludeOffset] = preludeAndOffset;
+    if (prelude.version === 'legacy') {
+        return preludeAndOffset;
+    }
+    const [addressTableLookups, finalOffset] = getAddressTableLookupsSerializer().deserialize(
+        bytes,
+        endOfPreludeOffset
+    );
+    return [
+        {
+            ...prelude,
+            ...(addressTableLookups.length ? { addressTableLookups } : null),
+        },
+        finalOffset,
+    ];
+}
+
+function serialize(compiledMessage: CompiledMessage) {
+    if (compiledMessage.version === 'legacy') {
+        return struct(getPreludeStructSerializerTuple()).serialize(compiledMessage);
+    } else {
+        return mapSerializer(
+            struct([
+                ...getPreludeStructSerializerTuple(),
+                ['addressTableLookups', getAddressTableLookupsSerializer()],
+            ] as StructToSerializerTuple<CompiledMessage, CompiledMessage>),
+            (value: CompiledMessage) => {
+                if (value.version === 'legacy') {
+                    return value;
+                }
+                return {
+                    ...value,
+                    addressTableLookups: value.addressTableLookups ?? [],
+                } as Exclude<CompiledMessage, { readonly version: 'legacy' }>;
+            }
+        ).serialize(compiledMessage);
+    }
+}
+
+function getPreludeStructSerializerTuple(): StructToSerializerTuple<CompiledMessage, CompiledMessage> {
+    return [
+        ['version', getTransactionVersionCodec()],
+        ['header', getMessageHeaderCodec()],
+        [
+            'staticAccounts',
+            array(getBase58EncodedAddressCodec(), {
+                description: __DEV__ ? 'A compact-array of static account addresses belonging to this transaction' : '',
+                size: shortU16(),
+            }),
+        ],
+        [
+            'lifetimeToken',
+            string({
+                description: __DEV__
+                    ? 'A 32-byte token that specifies the lifetime of this transaction (eg. a ' +
+                      'recent blockhash, or a durable nonce)'
+                    : '',
+                encoding: base58,
+                size: 32,
+            }),
+        ],
+        [
+            'instructions',
+            array(getInstructionCodec(), {
+                description: __DEV__ ? 'A compact-array of instructions belonging to this transaction' : '',
+                size: shortU16(),
+            }),
+        ],
+    ];
+}
+
+function getAddressTableLookupsSerializer() {
+    return array(getAddressTableLookupCodec(), {
+        ...(__DEV__ ? { description: 'A compact array of address table lookups belonging to this transaction' } : null),
+        size: shortU16(),
+    });
+}
+
+export function getCompiledMessageEncoder(): Serializer<CompiledMessage> {
+    return {
+        ...BASE_CONFIG,
+        deserialize: getUnimplementedDecoder('CompiledMessage'),
+        serialize,
+    };
+}
+
+export function getCompiledMessageDecoder(): Serializer<CompiledMessage> {
+    return {
+        ...BASE_CONFIG,
+        deserialize,
+        serialize: getUnimplementedEncoder('CompiledMessage'),
+    };
+}
+
+export function getCompiledMessageCodec(): Serializer<CompiledMessage> {
+    return {
+        ...BASE_CONFIG,
+        deserialize,
+        serialize,
+    };
+}


### PR DESCRIPTION
refactor(experimental): a serializer for the compiled message of a transaction

## Summary
This is the big one. This brings together every serializer into one codec for a transaction message. These are the bytes that will be signed by the signers' private keys. Given this, and the signatures, we will have a transaction that can be landed on the network.

## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1374).
* __->__ #1374
* #1373