### PR TITLE
refactor(experimental): disambiguate between legacy and versioned messages in the message compiler

### DIFF
--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -35,15 +35,16 @@ describe('compileMessage', () => {
             jest.mocked(getCompiledAddressTableLookups).mockReturnValue(expectedAddressTableLookups);
         });
         describe("when the transaction version is `'legacy'`", () => {
+            let legacyBaseTx: typeof baseTx & Readonly<{ version: 'legacy' }>;
             beforeEach(() => {
-                baseTx = { ...baseTx, version: 'legacy' };
+                legacyBaseTx = { ...baseTx, version: 'legacy' };
             });
             it('does not set `addressTableLookups`', () => {
-                const message = compileMessage(baseTx);
+                const message = compileMessage(legacyBaseTx);
                 expect(message).not.toHaveProperty('addressTableLookups');
             });
-            it('does not call  `getCompiledAddressTableLookups`', () => {
-                compileMessage(baseTx);
+            it('does not call `getCompiledAddressTableLookups`', () => {
+                compileMessage(legacyBaseTx);
                 expect(getCompiledAddressTableLookups).not.toHaveBeenCalled();
             });
         });

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -9,11 +9,35 @@ import { IDurableNonceTransaction } from './durable-nonce';
 import { ITransactionWithFeePayer } from './fee-payer';
 import { BaseTransaction } from './types';
 
+type BaseCompiledMessage = Readonly<{
+    header: ReturnType<typeof getCompiledMessageHeader>;
+    instructions: ReturnType<typeof getCompiledInstructions>;
+    lifetimeToken: ReturnType<typeof getCompiledLifetimeToken>;
+    staticAccounts: ReturnType<typeof getCompiledStaticAccounts>;
+}>;
+
+type CompilableTransaction = BaseTransaction &
+    ITransactionWithFeePayer &
+    (ITransactionWithBlockhashLifetime | IDurableNonceTransaction);
+
+export type CompiledMessage = LegacyCompiledMessage | VersionedCompiledMessage;
+
+type LegacyCompiledMessage = BaseCompiledMessage &
+    Readonly<{
+        version: 'legacy';
+    }>;
+
+type VersionedCompiledMessage = BaseCompiledMessage &
+    Readonly<{
+        addressTableLookups?: ReturnType<typeof getCompiledAddressTableLookups>;
+        version: number;
+    }>;
+
 export function compileMessage(
-    transaction: BaseTransaction &
-        ITransactionWithFeePayer &
-        (ITransactionWithBlockhashLifetime | IDurableNonceTransaction)
-) {
+    transaction: CompilableTransaction & Readonly<{ version: 'legacy' }>
+): LegacyCompiledMessage;
+export function compileMessage(transaction: CompilableTransaction): VersionedCompiledMessage;
+export function compileMessage(transaction: CompilableTransaction): CompiledMessage {
     const addressMap = getAddressMapFromInstructions(transaction.feePayer, transaction.instructions);
     const orderedAccounts = getOrderedAccountsFromAddressMap(addressMap);
     return {


### PR DESCRIPTION
refactor(experimental): disambiguate between legacy and versioned messages in the message compiler

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1375).
* #1374
* #1373
* #1376
* __->__ #1375