### PR TITLE
refactor(experimental): omit properties when deserializing instructions without addresses or data

### DIFF
--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -35,15 +35,16 @@ describe('compileMessage', () => {
             jest.mocked(getCompiledAddressTableLookups).mockReturnValue(expectedAddressTableLookups);
         });
         describe("when the transaction version is `'legacy'`", () => {
+            let legacyBaseTx: typeof baseTx & Readonly<{ version: 'legacy' }>;
             beforeEach(() => {
-                baseTx = { ...baseTx, version: 'legacy' };
+                legacyBaseTx = { ...baseTx, version: 'legacy' };
             });
             it('does not set `addressTableLookups`', () => {
-                const message = compileMessage(baseTx);
+                const message = compileMessage(legacyBaseTx);
                 expect(message).not.toHaveProperty('addressTableLookups');
             });
-            it('does not call  `getCompiledAddressTableLookups`', () => {
-                compileMessage(baseTx);
+            it('does not call `getCompiledAddressTableLookups`', () => {
+                compileMessage(legacyBaseTx);
                 expect(getCompiledAddressTableLookups).not.toHaveBeenCalled();
             });
         });

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -9,11 +9,35 @@ import { IDurableNonceTransaction } from './durable-nonce';
 import { ITransactionWithFeePayer } from './fee-payer';
 import { BaseTransaction } from './types';
 
+type BaseCompiledMessage = Readonly<{
+    header: ReturnType<typeof getCompiledMessageHeader>;
+    instructions: ReturnType<typeof getCompiledInstructions>;
+    lifetimeToken: ReturnType<typeof getCompiledLifetimeToken>;
+    staticAccounts: ReturnType<typeof getCompiledStaticAccounts>;
+}>;
+
+type CompilableTransaction = BaseTransaction &
+    ITransactionWithFeePayer &
+    (ITransactionWithBlockhashLifetime | IDurableNonceTransaction);
+
+export type CompiledMessage = LegacyCompiledMessage | VersionedCompiledMessage;
+
+type LegacyCompiledMessage = BaseCompiledMessage &
+    Readonly<{
+        version: 'legacy';
+    }>;
+
+type VersionedCompiledMessage = BaseCompiledMessage &
+    Readonly<{
+        addressTableLookups?: ReturnType<typeof getCompiledAddressTableLookups>;
+        version: number;
+    }>;
+
 export function compileMessage(
-    transaction: BaseTransaction &
-        ITransactionWithFeePayer &
-        (ITransactionWithBlockhashLifetime | IDurableNonceTransaction)
-) {
+    transaction: CompilableTransaction & Readonly<{ version: 'legacy' }>
+): LegacyCompiledMessage;
+export function compileMessage(transaction: CompilableTransaction): VersionedCompiledMessage;
+export function compileMessage(transaction: CompilableTransaction): CompiledMessage {
     const addressMap = getAddressMapFromInstructions(transaction.feePayer, transaction.instructions);
     const orderedAccounts = getOrderedAccountsFromAddressMap(addressMap);
     return {

--- a/packages/transactions/src/serializers/__tests__/instruction-test.ts
+++ b/packages/transactions/src/serializers/__tests__/instruction-test.ts
@@ -105,7 +105,7 @@ describe('Instruction codec', () => {
                     4,
                 ])
             )[0]
-        ).toHaveProperty('addressIndices', undefined);
+        ).not.toHaveProperty('addressIndices');
     });
     it('omits the `data` property when the instruction data is zero-length', () => {
         expect(
@@ -121,6 +121,6 @@ describe('Instruction codec', () => {
                     0, // Compact-u16 length
                 ])
             )[0]
-        ).toHaveProperty('data', undefined);
+        ).not.toHaveProperty('data');
     });
 });


### PR DESCRIPTION
refactor(experimental): omit properties when deserializing instructions without addresses or data

## Summary

Loris showed me a good way to do this. Now we don't have to suffer with present-but-undefined properties.

## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1376).
* #1374
* #1373
* __->__ #1376
* #1375