### PR TITLE
Export some more required types from rpc-core

### DIFF
--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -1,2 +1,5 @@
 export * from './blockhash';
 export * from './rpc-methods';
+export * from './stringified-bigint';
+export * from './transaction-signature';
+export * from './unix-timestamp';


### PR DESCRIPTION
These types are intended to be exported, so that apps can create/pass them around. They follow the same pattern as `blockhash` which is exported. 