### PR TITLE
refactor(experimental): add the getSlotLeaders RPC method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leaders-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leaders-test.ts
@@ -1,0 +1,60 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getSlotLeaders', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    describe('when called with a valid slot', () => {
+        it('returns the node public keys', async () => {
+            expect.assertions(2);
+            const minimumLedgerSlot = (await rpc.minimumLedgerSlot().send()) as bigint;
+
+            const result = await rpc.getSlotLeaders(minimumLedgerSlot, 3).send();
+            expect(Array.isArray(result)).toBe(true);
+            expect(typeof result[0]).toBe('string');
+        });
+    });
+
+    describe('when called with a `startSlot` higher than the highest slot available', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const sendPromise = rpc
+                .getSlotLeaders(
+                    2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
+                    3
+                )
+                .send();
+            await expect(sendPromise).rejects.toMatchObject({
+                code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+
+    describe('when called with a `limit` greater than 5000', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const minimumLedgerSlot = (await rpc.minimumLedgerSlot().send()) as bigint;
+
+            const sendPromise = rpc.getSlotLeaders(minimumLedgerSlot, 5001).send();
+            await expect(sendPromise).rejects.toMatchObject({
+                code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getSlotLeaders.ts
+++ b/packages/rpc-core/src/rpc-methods/getSlotLeaders.ts
@@ -1,0 +1,18 @@
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { Slot } from './common';
+
+/** array of Node identity public keys as base-58 encoded strings */
+type GetSlotLeadersApiResponse = Base58EncodedAddress[];
+
+export interface GetSlotLeadersApi {
+    /**
+     * Returns the slot leaders for a given slot range
+     */
+    getSlotLeaders(
+        /** Start slot, as u64 integer */
+        startSlot: Slot,
+        /** Limit (between 1 and 5000) */
+        limit: number
+    ): GetSlotLeadersApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -18,6 +18,7 @@ import { GetMaxShredInsertSlotApi } from './getMaxShredInsertSlot';
 import { GetRecentPerformanceSamplesApi } from './getRecentPerformanceSamples';
 import { GetSignaturesForAddressApi } from './getSignaturesForAddress';
 import { GetSlotApi } from './getSlot';
+import { GetSlotLeadersApi } from './getSlotLeaders';
 import { GetStakeMinimumDelegationApi } from './getStakeMinimumDelegation';
 import { GetSupplyApi } from './getSupply';
 import { GetTokenLargestAccountsApi } from './getTokenLargestAccounts';
@@ -46,6 +47,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetRecentPerformanceSamplesApi &
     GetSignaturesForAddressApi &
     GetSlotApi &
+    GetSlotLeadersApi &
     GetStakeMinimumDelegationApi &
     GetSupplyApi &
     GetTokenLargestAccountsApi &


### PR DESCRIPTION
This PR adds the `getSlotLeaders` RPC method

I've used `minimumLedgerSlot` which we already have implemented to find a valid start slot for the test

Note that the docs mistakenly say these params are optional but they're required, see docs PR: https://github.com/solana-labs/solana/pull/32376 

- [x] I read the [JSON-RPC docs](https://docs.solana.com/api/http) for my method and implemented it faithfully as a Typescript interface in [`packages/rpc-core/src/rpc-methods`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods)
- [x] I have commented the inputs and outputs of my Typescript interface using text from the JSON-RPC docs
- [x] I have read through the Rust source code of my RPC method to make sure that it accepts the inputs that I expect, returns the outputs that I expect, and applies the defaults I expect when an input is not supplied
- [x] Wherever my method's return value changes based on its inputs, I've implemented that as a [Typescript function overload](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/rpc-methods/getAccountInfo.ts#L80-L114)) (N/A)
- [x] I have written a test in [`packages/rpc-core/src/rpc-methods/__tests__`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods/__tests__) that exercises as much of my RPC method's functionality as is practical
- [x] Wherever my test relies on reading account data I have created an account fixture in [`scripts/fixtures`](https://github.com/solana-labs/solana-web3.js/tree/master/scripts/fixtures) that gets loaded into the test validator ([example](https://github.com/solana-labs/solana-web3.js/blob/master/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json)) (N/A)
- [x] If my RPC method returns a numeric value _other_ than a `u64` or `usize` (eg. a `u8`) I have encoded an exception for that return value so that it does _not_ get upcast to a `bigint` in the RPC ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts#L12)) (N/A)