### PR TITLE
refactor(experimental): Add IsBlockhashValid API

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/is-blockhash-valid-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/is-blockhash-valid-test.ts
@@ -1,0 +1,29 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { Blockhash } from '../../blockhash';
+import { Commitment } from '../common';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('isBlockhashValid', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            it('returns the result as a bool wrapped in an RpcResponse', async () => {
+                expect.assertions(1);
+                const blockhash = '9PCVWkKP3bq1sT5eLFurUysMvVs4PxJsTfza5QSBB4d1' as Blockhash;
+                const result = await rpc.isBlockhashValid(blockhash, { commitment }).send();
+                expect(result.value).toEqual(expect.any(Boolean));
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -24,6 +24,7 @@ import { GetTokenLargestAccountsApi } from './getTokenLargestAccounts';
 import { GetTransactionApi } from './getTransaction';
 import { GetTransactionCountApi } from './getTransactionCount';
 import { GetVoteAccountsApi } from './getVoteAccounts';
+import { IsBlockhashValidApi } from './isBlockhashValid';
 import { MinimumLedgerSlotApi } from './minimumLedgerSlot';
 
 type Config = Readonly<{
@@ -52,6 +53,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetTransactionApi &
     GetTransactionCountApi &
     GetVoteAccountsApi &
+    IsBlockhashValidApi &
     MinimumLedgerSlotApi;
 
 export function createSolanaRpcApi(config?: Config): IRpcApi<SolanaRpcMethods> {

--- a/packages/rpc-core/src/rpc-methods/isBlockhashValid.ts
+++ b/packages/rpc-core/src/rpc-methods/isBlockhashValid.ts
@@ -1,0 +1,20 @@
+import { Blockhash } from '../blockhash';
+import { Commitment, RpcResponse, Slot } from './common';
+
+type IsBlockhashValidApiResponse = RpcResponse<boolean>;
+
+export interface IsBlockhashValidApi {
+    /**
+     * Returns whether a blockhash is still valid or not
+     */
+    isBlockhashValid(
+        /** query blockhash, as a base-58 encoded string */
+        blockhash: Blockhash,
+        config?: Readonly<{
+            /** Defaults to `finalized` */
+            commitment?: Commitment;
+            /** The minimum slot that the request can be evaluated at */
+            minContextSlot?: Slot;
+        }>
+    ): IsBlockhashValidApiResponse;
+}


### PR DESCRIPTION
# Summary
Add the IsBlockhashValid API + unit tests

# Checklist

- [x] I read the [JSON-RPC docs](https://docs.solana.com/api/http) for my method and implemented it faithfully as a Typescript interface in [`packages/rpc-core/src/rpc-methods`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods)
- [x] I have commented the inputs and outputs of my Typescript interface using text from the JSON-RPC docs
- [x] I have read through the Rust source code of my RPC method to make sure that it accepts the inputs that I expect, returns the outputs that I expect, and applies the defaults I expect when an input is not supplied
- [x] Wherever my method's return value changes based on its inputs, I've implemented that as a [Typescript function overload](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/rpc-methods/getAccountInfo.ts#L80-L114))
- [x] I have written a test in [`packages/rpc-core/src/rpc-methods/__tests__`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/rpc-core/src/rpc-methods/__tests__) that exercises as much of my RPC method's functionality as is practical
- [x] Wherever my test relies on reading account data I have created an account fixture in [`scripts/fixtures`](https://github.com/solana-labs/solana-web3.js/tree/master/scripts/fixtures) that gets loaded into the test validator ([example](https://github.com/solana-labs/solana-web3.js/blob/master/scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json))
- [x] If my RPC method returns a numeric value _other_ than a `u64` or `usize` (eg. a `u8`) I have encoded an exception for that return value so that it does _not_ get upcast to a `bigint` in the RPC ([example](https://github.com/solana-labs/solana-web3.js/blob/b69daf278045bc96740450e123a322e0dd95f60e/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts#L12))

Testing wise i can see other methods sometimes only expect the type, do we want a true/false for this API? It will have to depend on read from another API if we want to exercise `true`