### PR TITLE
refactor(experimental): shim `Crypto` in both browser and Node environments

### DIFF
--- a/packages/test-config/jest-unit.config.common.ts
+++ b/packages/test-config/jest-unit.config.common.ts
@@ -8,6 +8,7 @@ const config: Partial<Config.InitialProjectOptions> = {
         path.resolve(__dirname, 'setup-dev-mode.ts'),
         path.resolve(__dirname, 'setup-define-version-constant.ts'),
         path.resolve(__dirname, 'setup-fetch-mock.ts'),
+        path.resolve(__dirname, 'setup-webcrypto.ts'),
     ],
     transform: {
         '^.+\\.(ts|js)$': [

--- a/packages/test-config/jest-unit.config.node.ts
+++ b/packages/test-config/jest-unit.config.node.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { Config } from '@jest/types';
 
 import commonConfig from './jest-unit.config.common';
@@ -16,7 +14,6 @@ const config: Partial<Config.InitialProjectOptions> = {
         __NODEJS__: true,
         __REACTNATIVE__: false,
     },
-    setupFilesAfterEnv: [...(commonConfig.setupFilesAfterEnv ?? []), path.resolve(__dirname, 'setup-node-crypto.ts')],
 };
 
 export default config;

--- a/packages/test-config/setup-node-crypto.ts
+++ b/packages/test-config/setup-node-crypto.ts
@@ -1,5 +1,0 @@
-import crypto from 'node:crypto';
-
-if (typeof globalThis.crypto === 'undefined') {
-    globalThis.crypto = crypto as Crypto;
-}

--- a/packages/test-config/setup-webcrypto.ts
+++ b/packages/test-config/setup-webcrypto.ts
@@ -1,0 +1,13 @@
+import crypto from 'node:crypto';
+
+if (typeof globalThis.crypto === 'undefined') {
+    Object.defineProperty(globalThis, 'crypto', {
+        value: crypto.webcrypto,
+        writable: true, // Allow tests to delete it.
+    });
+}
+if (typeof globalThis.crypto.subtle === 'undefined') {
+    Object.defineProperty(globalThis.crypto, 'subtle', {
+        value: crypto.webcrypto.subtle,
+    });
+}


### PR DESCRIPTION
refactor(experimental): shim `Crypto` in both browser and Node environments

## Summary

The idea here is that we're going to _presume_ that the browser has an Ed25519-compatible key generator, then polyfill it otherwise. From that perspective, the tests should just presume that it's present, and we should leave the testing of the polyfill up to the polyfill tests.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1392).
* #1400
* #1399
* #1398
* #1397
* #1396
* #1395
* #1394
* #1379
* #1393
* __->__ #1392