### PR TITLE
refactor(experimental): assertion functions that you can use to determine whether Ed25519 is supported

### DIFF
--- a/packages/keys/src/__tests__/guard-test.ts
+++ b/packages/keys/src/__tests__/guard-test.ts
@@ -1,0 +1,215 @@
+import {
+    assertKeyExporterIsAvailable,
+    assertSigningCapabilityIsAvailable,
+    assertVerificationCapabilityIsAvailable,
+} from '../guard';
+
+describe('assertKeyExporterIsAvailable()', () => {
+    let cachedIsSecureContext: boolean;
+    beforeEach(async () => {
+        cachedIsSecureContext = globalThis.isSecureContext;
+        globalThis.isSecureContext = true;
+    });
+    afterEach(() => {
+        globalThis.isSecureContext = cachedIsSecureContext;
+    });
+    it('resolves to `undefined` without throwing', async () => {
+        expect.assertions(1);
+        await expect(assertKeyExporterIsAvailable()).resolves.toBeUndefined();
+    });
+    if (__BROWSER__) {
+        describe('when in an insecure browser context', () => {
+            beforeEach(() => {
+                globalThis.isSecureContext = false;
+            });
+            it('rejects', async () => {
+                expect.assertions(1);
+                await expect(() => assertKeyExporterIsAvailable()).rejects.toThrow();
+            });
+        });
+    }
+    describe('when `SubtleCrypto::exportKey` is not available', () => {
+        let oldExportKey: InstanceType<typeof SubtleCrypto>['exportKey'];
+        beforeEach(() => {
+            oldExportKey = globalThis.crypto.subtle.exportKey;
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            globalThis.crypto.subtle.exportKey = undefined;
+        });
+        afterEach(() => {
+            globalThis.crypto.subtle.exportKey = oldExportKey;
+        });
+        it('rejects', async () => {
+            expect.assertions(1);
+            await expect(assertKeyExporterIsAvailable()).rejects.toThrow();
+        });
+    });
+});
+
+describe('assertKeyGenerationIsAvailable()', () => {
+    let assertKeyGenerationIsAvailable: typeof import('../guard').assertKeyGenerationIsAvailable;
+    let cachedIsSecureContext: boolean;
+    beforeEach(async () => {
+        cachedIsSecureContext = globalThis.isSecureContext;
+        globalThis.isSecureContext = true;
+        await jest.isolateModulesAsync(async () => {
+            const guardModulePromise =
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                import('../guard');
+            assertKeyGenerationIsAvailable = (await guardModulePromise).assertKeyGenerationIsAvailable;
+        });
+    });
+    afterEach(() => {
+        globalThis.isSecureContext = cachedIsSecureContext;
+    });
+    it('resolves to `undefined` without throwing', async () => {
+        expect.assertions(1);
+        await expect(assertKeyGenerationIsAvailable()).resolves.toBeUndefined();
+    });
+    if (__BROWSER__) {
+        describe('when in an insecure browser context', () => {
+            beforeEach(() => {
+                globalThis.isSecureContext = false;
+            });
+            it('rejects', async () => {
+                expect.assertions(1);
+                await expect(() => assertKeyGenerationIsAvailable()).rejects.toThrow();
+            });
+        });
+    }
+    describe('when `SubtleCrypto::generateKey` is not available', () => {
+        let oldGenerateKey: InstanceType<typeof SubtleCrypto>['generateKey'];
+        beforeEach(() => {
+            oldGenerateKey = globalThis.crypto.subtle.generateKey;
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            globalThis.crypto.subtle.generateKey = undefined;
+        });
+        afterEach(() => {
+            globalThis.crypto.subtle.generateKey = oldGenerateKey;
+        });
+        it('rejects', async () => {
+            expect.assertions(1);
+            await expect(assertKeyGenerationIsAvailable()).rejects.toThrow();
+        });
+    });
+    describe('when the Ed25519 curve is not available', () => {
+        beforeEach(() => {
+            const oldGenerateKey = globalThis.crypto.subtle.generateKey;
+            jest.spyOn(globalThis.crypto.subtle, 'generateKey').mockImplementation(async (algorithm, ...rest) => {
+                if (algorithm === 'Ed25519') {
+                    throw new Error('Ed25519 not supported');
+                }
+                return await oldGenerateKey.call(globalThis.crypto.subtle, algorithm, ...rest);
+            });
+        });
+        it('rejects', async () => {
+            expect.assertions(1);
+            await expect(assertKeyGenerationIsAvailable()).rejects.toThrow();
+        });
+        it('remembers the result from the first time it is called (parallel checks)', async () => {
+            expect.assertions(1);
+            try {
+                await Promise.all([assertKeyGenerationIsAvailable(), assertKeyGenerationIsAvailable()]);
+            } catch {
+                /* empty */
+            }
+            expect(globalThis.crypto.subtle.generateKey).toHaveBeenCalledTimes(1);
+        });
+        it('remembers the result from the first time it is called (serial checks)', async () => {
+            expect.assertions(1);
+            try {
+                await assertKeyGenerationIsAvailable();
+                await assertKeyGenerationIsAvailable();
+            } catch {
+                /* empty */
+            }
+            expect(globalThis.crypto.subtle.generateKey).toHaveBeenCalledTimes(1);
+        });
+    });
+});
+
+describe('assertSigningCapabilityIsAvailable()', () => {
+    let cachedIsSecureContext: boolean;
+    beforeEach(async () => {
+        cachedIsSecureContext = globalThis.isSecureContext;
+        globalThis.isSecureContext = true;
+    });
+    afterEach(() => {
+        globalThis.isSecureContext = cachedIsSecureContext;
+    });
+    it('resolves to `undefined` without throwing', async () => {
+        expect.assertions(1);
+        await expect(assertSigningCapabilityIsAvailable()).resolves.toBeUndefined();
+    });
+    if (__BROWSER__) {
+        describe('when in an insecure browser context', () => {
+            beforeEach(() => {
+                globalThis.isSecureContext = false;
+            });
+            it('rejects', async () => {
+                expect.assertions(1);
+                await expect(() => assertSigningCapabilityIsAvailable()).rejects.toThrow();
+            });
+        });
+    }
+    describe('when `SubtleCrypto::sign` is not available', () => {
+        let oldSign: InstanceType<typeof SubtleCrypto>['sign'];
+        beforeEach(() => {
+            oldSign = globalThis.crypto.subtle.sign;
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            globalThis.crypto.subtle.sign = undefined;
+        });
+        afterEach(() => {
+            globalThis.crypto.subtle.sign = oldSign;
+        });
+        it('rejects', async () => {
+            expect.assertions(1);
+            await expect(assertSigningCapabilityIsAvailable()).rejects.toThrow();
+        });
+    });
+});
+
+describe('assertVerificationCapabilityIsAvailable()', () => {
+    let cachedIsSecureContext: boolean;
+    beforeEach(async () => {
+        cachedIsSecureContext = globalThis.isSecureContext;
+        globalThis.isSecureContext = true;
+    });
+    afterEach(() => {
+        globalThis.isSecureContext = cachedIsSecureContext;
+    });
+    it('resolves to `undefined` without throwing', async () => {
+        expect.assertions(1);
+        await expect(assertVerificationCapabilityIsAvailable()).resolves.toBeUndefined();
+    });
+    if (__BROWSER__) {
+        describe('when in an insecure browser context', () => {
+            beforeEach(() => {
+                globalThis.isSecureContext = false;
+            });
+            it('rejects', async () => {
+                expect.assertions(1);
+                await expect(() => assertVerificationCapabilityIsAvailable()).rejects.toThrow();
+            });
+        });
+    }
+    describe('when `SubtleCrypto::sign` is not available', () => {
+        let oldVerify: InstanceType<typeof SubtleCrypto>['verify'];
+        beforeEach(() => {
+            oldVerify = globalThis.crypto.subtle.verify;
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            globalThis.crypto.subtle.verify = undefined;
+        });
+        afterEach(() => {
+            globalThis.crypto.subtle.verify = oldVerify;
+        });
+        it('rejects', async () => {
+            expect.assertions(1);
+            await expect(assertVerificationCapabilityIsAvailable()).rejects.toThrow();
+        });
+    });
+});

--- a/packages/keys/src/guard.ts
+++ b/packages/keys/src/guard.ts
@@ -1,0 +1,66 @@
+function assertIsSecureContext() {
+    if (__BROWSER__ && !globalThis.isSecureContext) {
+        // TODO: Coded error.
+        throw new Error(
+            'Cryptographic operations are only allowed in secure browser contexts. Read more ' +
+                'here: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts'
+        );
+    }
+}
+
+let cachedEd25519Decision: PromiseLike<boolean> | boolean | undefined;
+async function isEd25519CurveSupported(subtle: SubtleCrypto): Promise<boolean> {
+    if (cachedEd25519Decision === undefined) {
+        cachedEd25519Decision = new Promise(resolve => {
+            subtle
+                .generateKey('Ed25519', /* extractable */ false, ['sign', 'verify'])
+                .catch(() => {
+                    resolve((cachedEd25519Decision = false));
+                })
+                .then(() => {
+                    resolve((cachedEd25519Decision = true));
+                });
+        });
+    }
+    if (typeof cachedEd25519Decision === 'boolean') {
+        return cachedEd25519Decision;
+    } else {
+        return await cachedEd25519Decision;
+    }
+}
+
+export async function assertKeyGenerationIsAvailable() {
+    assertIsSecureContext();
+    if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.generateKey !== 'function') {
+        // TODO: Coded error.
+        throw new Error('No key generation implementation could be found');
+    }
+    if (!(await isEd25519CurveSupported(globalThis.crypto.subtle))) {
+        // TODO: Coded error.
+        throw new Error('This runtime does not support the generation of Ed25519 keypairs');
+    }
+}
+
+export async function assertKeyExporterIsAvailable() {
+    assertIsSecureContext();
+    if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.exportKey !== 'function') {
+        // TODO: Coded error.
+        throw new Error('No key export implementation could be found');
+    }
+}
+
+export async function assertSigningCapabilityIsAvailable() {
+    assertIsSecureContext();
+    if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.sign !== 'function') {
+        // TODO: Coded error.
+        throw new Error('No signing implementation could be found');
+    }
+}
+
+export async function assertVerificationCapabilityIsAvailable() {
+    assertIsSecureContext();
+    if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.verify !== 'function') {
+        // TODO: Coded error.
+        throw new Error('No signature verification implementation could be found');
+    }
+}

--- a/packages/keys/tsconfig.json
+++ b/packages/keys/tsconfig.json
@@ -4,6 +4,6 @@
     "extends": "tsconfig/base.json",
     "include": ["src"],
     "compilerOptions": {
-        "lib": ["ES2015", "ES2022.Error"]
+        "lib": ["DOM", "ES2015", "ES2022.Error"]
     }
 }

--- a/packages/test-config/jest-unit.config.common.ts
+++ b/packages/test-config/jest-unit.config.common.ts
@@ -8,6 +8,7 @@ const config: Partial<Config.InitialProjectOptions> = {
         path.resolve(__dirname, 'setup-dev-mode.ts'),
         path.resolve(__dirname, 'setup-define-version-constant.ts'),
         path.resolve(__dirname, 'setup-fetch-mock.ts'),
+        path.resolve(__dirname, 'setup-webcrypto.ts'),
     ],
     transform: {
         '^.+\\.(ts|js)$': [

--- a/packages/test-config/jest-unit.config.node.ts
+++ b/packages/test-config/jest-unit.config.node.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { Config } from '@jest/types';
 
 import commonConfig from './jest-unit.config.common';
@@ -16,7 +14,6 @@ const config: Partial<Config.InitialProjectOptions> = {
         __NODEJS__: true,
         __REACTNATIVE__: false,
     },
-    setupFilesAfterEnv: [...(commonConfig.setupFilesAfterEnv ?? []), path.resolve(__dirname, 'setup-node-crypto.ts')],
 };
 
 export default config;

--- a/packages/test-config/setup-node-crypto.ts
+++ b/packages/test-config/setup-node-crypto.ts
@@ -1,5 +1,0 @@
-import crypto from 'node:crypto';
-
-if (typeof globalThis.crypto === 'undefined') {
-    globalThis.crypto = crypto as Crypto;
-}

--- a/packages/test-config/setup-webcrypto.ts
+++ b/packages/test-config/setup-webcrypto.ts
@@ -1,0 +1,13 @@
+import crypto from 'node:crypto';
+
+if (typeof globalThis.crypto === 'undefined') {
+    Object.defineProperty(globalThis, 'crypto', {
+        value: crypto.webcrypto,
+        writable: true, // Allow tests to delete it.
+    });
+}
+if (typeof globalThis.crypto.subtle === 'undefined') {
+    Object.defineProperty(globalThis.crypto, 'subtle', {
+        value: crypto.webcrypto.subtle,
+    });
+}


### PR DESCRIPTION
refactor(experimental): assertion functions that you can use to determine whether Ed25519 is supported

## Summary

It's just nice to have these well tested, and all in one place. These will only become more complicated, so it's best to get them out of the code.

Only thing is, I wish that TypeScript could assert about globals: https://stackoverflow.com/q/76657623/802047

## Test Plan

```
cd packages/keys/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1393).
* #1400
* #1399
* #1398
* #1397
* #1396
* #1395
* #1394
* #1379
* __->__ #1393
* #1392