### PR TITLE
refactor(experimental): a function that tells you whether a `CryptoKey` belongs to the polyfill or not

### DIFF
--- a/packages/webcrypto-ed25519-polyfill/src/__tests__/secrets-test.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/__tests__/secrets-test.ts
@@ -1,4 +1,4 @@
-import { generateKeyPolyfill } from '../secrets';
+import { generateKeyPolyfill, isPolyfilledKey } from '../secrets';
 
 describe('generateKeyPolyfill', () => {
     it('stores secret key bytes in an internal cache', () => {
@@ -86,5 +86,32 @@ describe('generateKeyPolyfill', () => {
                 generateKeyPolyfill(/* extractable */ false, ['sign', 'verify']);
             }).toThrow();
         });
+    });
+});
+
+describe('isPolyfilledKey', () => {
+    it('returns true when given a public key produced with generateKeyPolyfill()', () => {
+        const key = generateKeyPolyfill(/* extractable */ false, ['sign', 'verify']);
+        expect(isPolyfilledKey(key.publicKey)).toBe(true);
+    });
+    it('returns true when given a private key produced with generateKeyPolyfill()', () => {
+        const key = generateKeyPolyfill(/* extractable */ false, ['sign', 'verify']);
+        expect(isPolyfilledKey(key.privateKey)).toBe(true);
+    });
+    it('returns false when given a public key produced with the native keygen', async () => {
+        expect.assertions(1);
+        const key = (await crypto.subtle.generateKey('Ed25519', /* extractable */ false, [
+            'sign',
+            'verify',
+        ])) as CryptoKeyPair;
+        expect(isPolyfilledKey(key.publicKey)).toBe(false);
+    });
+    it('returns false when given a private key produced with the native keygen', async () => {
+        expect.assertions(1);
+        const key = (await crypto.subtle.generateKey('Ed25519', /* extractable */ false, [
+            'sign',
+            'verify',
+        ])) as CryptoKeyPair;
+        expect(isPolyfilledKey(key.privateKey)).toBe(false);
     });
 });

--- a/packages/webcrypto-ed25519-polyfill/src/secrets.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/secrets.ts
@@ -80,3 +80,7 @@ export function generateKeyPolyfill(extractable: boolean, keyUsages: readonly Ke
     const keyPair = createKeyPairFromBytes(privateKeyBytes, extractable, keyUsages);
     return keyPair;
 }
+
+export function isPolyfilledKey(key: CryptoKey): boolean {
+    return !!storageKeyBySecretKey_INTERNAL_ONLY_DO_NOT_EXPORT?.has(key);
+}


### PR DESCRIPTION
refactor(experimental): a function that tells you whether a `CryptoKey` belongs to the polyfill or not

## Summary

Only keys produced with the polyfill's `generateKey` method are usable with its other methods. Having been produced with the polyfill keygen is the same as ‘being present in the key store,’ hence this simple test.

## Test Plan


```
cd packages/webcrypto-ed25519-polyfill
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1396).
* #1416
* #1415
* #1414
* #1413
* #1412
* #1400
* #1399
* #1398
* #1397
* __->__ #1396