### PR TITLE
refactor(experimental): a polyfill for `SubtleCrypto#verify`

### DIFF
--- a/packages/webcrypto-ed25519-polyfill/README.md
+++ b/packages/webcrypto-ed25519-polyfill/README.md
@@ -35,4 +35,9 @@ const keyPair = await crypto.subtle.generateKey('Ed25519', false, ['sign']);
 const publicKeyBytes = await crypto.subtle.exportKey('raw', keyPair.publicKey);
 const data = new Uint8Array([1, 2, 3]);
 const signature = await crypto.subtle.sign('Ed25519', keyPair.privateKey, data);
+if (await crypto.subtle.verify('Ed25519', keyPair.publicKey, signature, data)) {
+    console.log('Data was signed using the private key associated with this public key');
+} else {
+    throw new Error('Signature verification error');
+}
 ```

--- a/packages/webcrypto-ed25519-polyfill/src/secrets.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/secrets.ts
@@ -126,3 +126,15 @@ export function signPolyfill(key: CryptoKey, data: BufferSource): ArrayBuffer {
     const signature = ed25519.sign(payload, privateKeyBytes);
     return signature;
 }
+
+export function verifyPolyfill(key: CryptoKey, signature: BufferSource, data: BufferSource): boolean {
+    if (key.type !== 'public' || !key.usages.includes('verify')) {
+        throw new DOMException('Unable to use this key to verify', 'InvalidAccessError');
+    }
+    const publicKeyBytes = ed25519.getPublicKey(getSecretKeyBytes_INTERNAL_ONLY_DO_NOT_EXPORT(key));
+    try {
+        return ed25519.verify(bufferSourceToUint8Array(signature), bufferSourceToUint8Array(data), publicKeyBytes);
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
refactor(experimental): a polyfill for `SubtleCrypto#verify`

## Summary

Given a key that was created with `generateKeyPolyfill`, this method will verify that the supplied signature was produced by sigining the supplied data with the private key associated with the supplied public key.

## Test Plan

```ts
cd packages/webcrypto-ed25519-polyfill
pnpm test:node:browser
pnpm test:node:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1400).
* #1422
* #1421
* #1424
* #1420
* #1419
* #1416
* #1415
* #1414
* #1413
* #1412
* __->__ #1400