### PR TITLE
Don't Merge - CI: change matrix fail-fast to false

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node:
           - 'current'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "packages/*"
     ],
     "scripts": {
-        "build": "turbo run build",
+        "build": "turbo run build --concurrency=5",
         "lint": "turbo run test:lint",
         "publish-packages": "turbo run publish-packages",
         "test": "turbo run test:unit:browser test:unit:node",


### PR DESCRIPTION
This should allow both Node jobs to complete even if one fails

I want to see if there's a difference between the success of the current and LTS jobs, with fail-fast one failing kills the other so I can't see if it'd complete successfully or not 