### PR TITLE
refactor(experimental): make `true` the default for `isSecureContext` in tests

### DIFF
--- a/packages/keys/src/__tests__/guard-test.ts
+++ b/packages/keys/src/__tests__/guard-test.ts
@@ -5,14 +5,6 @@ import {
 } from '../guard';
 
 describe('assertKeyExporterIsAvailable()', () => {
-    let cachedIsSecureContext: boolean;
-    beforeEach(async () => {
-        cachedIsSecureContext = globalThis.isSecureContext;
-        globalThis.isSecureContext = true;
-    });
-    afterEach(() => {
-        globalThis.isSecureContext = cachedIsSecureContext;
-    });
     it('resolves to `undefined` without throwing', async () => {
         expect.assertions(1);
         await expect(assertKeyExporterIsAvailable()).resolves.toBeUndefined();
@@ -48,10 +40,7 @@ describe('assertKeyExporterIsAvailable()', () => {
 
 describe('assertKeyGenerationIsAvailable()', () => {
     let assertKeyGenerationIsAvailable: typeof import('../guard').assertKeyGenerationIsAvailable;
-    let cachedIsSecureContext: boolean;
     beforeEach(async () => {
-        cachedIsSecureContext = globalThis.isSecureContext;
-        globalThis.isSecureContext = true;
         await jest.isolateModulesAsync(async () => {
             const guardModulePromise =
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -59,9 +48,6 @@ describe('assertKeyGenerationIsAvailable()', () => {
                 import('../guard');
             assertKeyGenerationIsAvailable = (await guardModulePromise).assertKeyGenerationIsAvailable;
         });
-    });
-    afterEach(() => {
-        globalThis.isSecureContext = cachedIsSecureContext;
     });
     it('resolves to `undefined` without throwing', async () => {
         expect.assertions(1);
@@ -131,14 +117,6 @@ describe('assertKeyGenerationIsAvailable()', () => {
 });
 
 describe('assertSigningCapabilityIsAvailable()', () => {
-    let cachedIsSecureContext: boolean;
-    beforeEach(async () => {
-        cachedIsSecureContext = globalThis.isSecureContext;
-        globalThis.isSecureContext = true;
-    });
-    afterEach(() => {
-        globalThis.isSecureContext = cachedIsSecureContext;
-    });
     it('resolves to `undefined` without throwing', async () => {
         expect.assertions(1);
         await expect(assertSigningCapabilityIsAvailable()).resolves.toBeUndefined();
@@ -173,14 +151,6 @@ describe('assertSigningCapabilityIsAvailable()', () => {
 });
 
 describe('assertVerificationCapabilityIsAvailable()', () => {
-    let cachedIsSecureContext: boolean;
-    beforeEach(async () => {
-        cachedIsSecureContext = globalThis.isSecureContext;
-        globalThis.isSecureContext = true;
-    });
-    afterEach(() => {
-        globalThis.isSecureContext = cachedIsSecureContext;
-    });
     it('resolves to `undefined` without throwing', async () => {
         expect.assertions(1);
         await expect(assertVerificationCapabilityIsAvailable()).resolves.toBeUndefined();

--- a/packages/keys/src/__tests__/key-pair-test.ts
+++ b/packages/keys/src/__tests__/key-pair-test.ts
@@ -1,22 +1,6 @@
 import { generateKeyPair } from '../key-pair';
 
 describe('generateKeyPair', () => {
-    let oldIsSecureContext: boolean;
-    beforeEach(() => {
-        if (__BROWSER__) {
-            // FIXME: JSDOM does not set `isSecureContext` or otherwise allow you to configure it.
-            // Some discussion: https://github.com/jsdom/jsdom/issues/2751#issuecomment-846613392
-            if (globalThis.isSecureContext !== undefined) {
-                oldIsSecureContext = globalThis.isSecureContext;
-            }
-            globalThis.isSecureContext = true;
-        }
-    });
-    afterEach(() => {
-        if (oldIsSecureContext !== undefined) {
-            globalThis.isSecureContext = oldIsSecureContext;
-        }
-    });
     it.each(['private', 'public'])('generates an ed25519 %s `CryptoKey`', async type => {
         expect.assertions(1);
         const keyPair = await generateKeyPair();

--- a/packages/keys/src/__tests__/pubkey-test.ts
+++ b/packages/keys/src/__tests__/pubkey-test.ts
@@ -7,14 +7,6 @@ const MOCK_PUBLIC_KEY_BYTES = new Uint8Array([
 ]);
 
 describe('getBase58EncodedAddressFromPublicKey', () => {
-    let oldIsSecureContext: boolean;
-    beforeEach(() => {
-        oldIsSecureContext = globalThis.isSecureContext;
-        globalThis.isSecureContext = true;
-    });
-    afterEach(() => {
-        globalThis.isSecureContext = oldIsSecureContext;
-    });
     it('returns the public key that corresponds to a given secret key', async () => {
         expect.assertions(1);
         const publicKey = await crypto.subtle.importKey(

--- a/packages/keys/src/__tests__/signatures-test.ts
+++ b/packages/keys/src/__tests__/signatures-test.ts
@@ -49,14 +49,6 @@ const MOCK_PUBLIC_KEY_BYTES = new Uint8Array([
 ]);
 
 describe('sign', () => {
-    let oldIsSecureContext: boolean;
-    beforeEach(() => {
-        oldIsSecureContext = globalThis.isSecureContext;
-        globalThis.isSecureContext = true;
-    });
-    afterEach(() => {
-        globalThis.isSecureContext = oldIsSecureContext;
-    });
     it('produces the expected signature given a private key', async () => {
         expect.assertions(1);
         const privateKey = await crypto.subtle.importKey(
@@ -81,7 +73,6 @@ describe('sign', () => {
 
 describe('verify', () => {
     let mockPublicKey: CryptoKey;
-    let oldIsSecureContext: boolean;
     beforeEach(async () => {
         mockPublicKey = await crypto.subtle.importKey(
             'raw',
@@ -90,11 +81,6 @@ describe('verify', () => {
             /* extractable */ false,
             ['verify']
         );
-        oldIsSecureContext = globalThis.isSecureContext;
-        globalThis.isSecureContext = true;
-    });
-    afterEach(() => {
-        globalThis.isSecureContext = oldIsSecureContext;
     });
     it('returns `true` when the correct signature is supplied for a given payload', async () => {
         expect.assertions(1);

--- a/packages/test-config/jest-unit.config.browser.ts
+++ b/packages/test-config/jest-unit.config.browser.ts
@@ -15,7 +15,11 @@ const config: Partial<Config.InitialProjectOptions> = {
         __NODEJS__: false,
         __REACTNATIVE__: false,
     },
-    setupFilesAfterEnv: [...(commonConfig.setupFilesAfterEnv ?? []), path.resolve(__dirname, 'setup-text-encoder.ts')],
+    setupFilesAfterEnv: [
+        ...(commonConfig.setupFilesAfterEnv ?? []),
+        path.resolve(__dirname, 'setup-secure-context.ts'),
+        path.resolve(__dirname, 'setup-text-encoder.ts'),
+    ],
     testEnvironment: 'jsdom',
     testEnvironmentOptions: {},
 };

--- a/packages/test-config/setup-secure-context.ts
+++ b/packages/test-config/setup-secure-context.ts
@@ -1,0 +1,4 @@
+globalThis.isSecureContext = true;
+beforeEach(() => {
+    globalThis.isSecureContext = true;
+});


### PR DESCRIPTION
refactor(experimental): make `true` the default for `isSecureContext` in tests

## Summary

This makes tests much more simple.

## Test Plan

```
pnpm turbo test:unit:node test:unit:browser
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1412).
* #1422
* #1421
* #1420
* #1419
* #1416
* #1415
* #1414
* #1413
* __->__ #1412