### PR TITLE
refactor(experimental): an rpc method to request airdrops

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/request-airdrop-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/request-airdrop-test.ts
@@ -1,0 +1,38 @@
+import { base58 } from '@metaplex-foundation/umi-serializers';
+import { Base58EncodedAddress } from '@solana/keys';
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '../common';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('requestAirdrop', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            it('returns the signature of the airdrop', async () => {
+                expect.assertions(1);
+                const randomBytes = new Uint8Array(32);
+                crypto.getRandomValues(randomBytes);
+                const [publicKeyAddress] = base58.deserialize(randomBytes);
+                const resultPromise = rpc
+                    .requestAirdrop(
+                        publicKeyAddress as Base58EncodedAddress,
+                        5000000n as LamportsUnsafeBeyond2Pow53Minus1,
+                        { commitment }
+                    )
+                    .send();
+                await expect(resultPromise).resolves.toEqual(expect.any(String));
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -27,6 +27,7 @@ import { GetTransactionCountApi } from './getTransactionCount';
 import { GetVoteAccountsApi } from './getVoteAccounts';
 import { IsBlockhashValidApi } from './isBlockhashValid';
 import { MinimumLedgerSlotApi } from './minimumLedgerSlot';
+import { RequestAirdropApi } from './requestAirdrop';
 import { SendTransactionApi } from './sendTransaction';
 
 type Config = Readonly<{
@@ -58,6 +59,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetVoteAccountsApi &
     IsBlockhashValidApi &
     MinimumLedgerSlotApi &
+    RequestAirdropApi &
     SendTransactionApi;
 
 export function createSolanaRpcApi(config?: Config): IRpcApi<SolanaRpcMethods> {

--- a/packages/rpc-core/src/rpc-methods/requestAirdrop.ts
+++ b/packages/rpc-core/src/rpc-methods/requestAirdrop.ts
@@ -1,0 +1,20 @@
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { Base58EncodedTransactionSignature, Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from './common';
+
+type RequestAirdropConfig = Readonly<{
+    commitment?: Commitment;
+}>;
+
+type RequestAirdropResponse = Base58EncodedTransactionSignature;
+
+export interface RequestAirdropApi {
+    /**
+     * Requests an airdrop of lamports to a Pubkey
+     */
+    requestAirdrop(
+        recipientAccount: Base58EncodedAddress,
+        lamports: LamportsUnsafeBeyond2Pow53Minus1,
+        config?: RequestAirdropConfig
+    ): RequestAirdropResponse;
+}


### PR DESCRIPTION
refactor(experimental): an rpc method to request airdrops

## Summary

Use this method anywhere but mainnet to request that an account be credited with some small number of lamports.

## Test Plan

```
cd packages/rpc-core/
pnpm test:unit:browser
pnpm test:unit:node
```
