### PR TITLE
refactor(experimental): a function that you can use to apply a blockhash to a transaction

### DIFF
--- a/packages/transactions/src/__tests__/compile-lifetime-token-test.ts
+++ b/packages/transactions/src/__tests__/compile-lifetime-token-test.ts
@@ -1,5 +1,6 @@
 import { Blockhash } from '../blockhash';
 import { getCompiledLifetimeToken } from '../compile-lifetime-token';
+import { Nonce } from '../durable-nonce';
 
 describe('getCompiledLifetimeToken', () => {
     it('compiles a recent blockhash lifetime constraint', () => {
@@ -11,7 +12,7 @@ describe('getCompiledLifetimeToken', () => {
     });
     it('compiles a nonce lifetime constraint', () => {
         const token = getCompiledLifetimeToken({
-            nonce: 'abc',
+            nonce: 'abc' as Nonce,
         });
         expect(token).toBe('abc');
     });

--- a/packages/transactions/src/durable-nonce.ts
+++ b/packages/transactions/src/durable-nonce.ts
@@ -16,18 +16,20 @@ type AdvanceNonceAccountInstruction<
 type AdvanceNonceAccountInstructionData = Uint8Array & {
     readonly __advanceNonceAccountInstructionData: unique symbol;
 };
-type NonceLifetimeConstraint = Readonly<{
-    nonce: string;
+export type Nonce<TNonceValue extends string = string> = TNonceValue & { readonly __nonce: unique symbol };
+type NonceLifetimeConstraint<TNonceValue extends string = string> = Readonly<{
+    nonce: Nonce<TNonceValue>;
 }>;
 
 export interface IDurableNonceTransaction<
     TNonceAccountAddress extends string = string,
-    TNonceAuthorityAddress extends string = string
+    TNonceAuthorityAddress extends string = string,
+    TNonceValue extends string = string
 > {
     readonly instructions: [
         // The first instruction *must* be the system program's `AdvanceNonceAccount` instruction.
         AdvanceNonceAccountInstruction<TNonceAccountAddress, TNonceAuthorityAddress>,
         ...IInstruction[]
     ];
-    readonly lifetimeConstraint: NonceLifetimeConstraint;
+    readonly lifetimeConstraint: NonceLifetimeConstraint<TNonceValue>;
 }


### PR DESCRIPTION
refactor(experimental): a function that you can use to apply a blockhash to a transaction

## Summary

Use this function to apply a blockhash lifetime constraint to a transaction, unsetting the signatures if there are any and widening the type in case the transaction used to be a durable nonce transaction.


## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1432).
* #1436
* #1435
* #1434
* #1433
* __->__ #1432