### PR TITLE
refactor(experimental): update type of `signatures` record to `Record`

### DIFF
--- a/packages/transactions/src/blockhash.ts
+++ b/packages/transactions/src/blockhash.ts
@@ -3,6 +3,7 @@ import { base58 } from '@metaplex-foundation/umi-serializers';
 import { IDurableNonceTransaction } from './durable-nonce';
 import { ITransactionWithSignatures } from './signatures';
 import { BaseTransaction } from './types';
+import { getUnsignedTransaction } from './unsigned-transaction';
 
 export type Blockhash = string & { readonly __blockhash: unique symbol };
 
@@ -60,23 +61,10 @@ export function setTransactionLifetimeUsingBlockhash(
     ) {
         return transaction;
     }
-    let out;
-    if ('signatures' in transaction) {
-        // The implication of the lifetime constraint changing is that any existing signatures are invalid.
-        const {
-            signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
-            ...unsignedTransaction
-        } = transaction;
-        out = {
-            ...unsignedTransaction,
-            lifetimeConstraint: blockhashLifetimeConstraint,
-        };
-    } else {
-        out = {
-            ...transaction,
-            lifetimeConstraint: blockhashLifetimeConstraint,
-        };
-    }
+    const out = {
+        ...getUnsignedTransaction(transaction),
+        lifetimeConstraint: blockhashLifetimeConstraint,
+    };
     Object.freeze(out);
     return out;
 }

--- a/packages/transactions/src/fee-payer.ts
+++ b/packages/transactions/src/fee-payer.ts
@@ -2,6 +2,7 @@ import { Base58EncodedAddress } from '@solana/keys';
 
 import { ITransactionWithSignatures } from './signatures';
 import { BaseTransaction } from './types';
+import { getUnsignedTransaction } from './unsigned-transaction';
 
 export interface ITransactionWithFeePayer<TAddress extends string = string> {
     readonly feePayer: Base58EncodedAddress<TAddress>;
@@ -20,23 +21,10 @@ export function setTransactionFeePayer<TFeePayerAddress extends string, TTransac
     if ('feePayer' in transaction && feePayer === transaction.feePayer) {
         return transaction;
     }
-    let out;
-    if ('signatures' in transaction) {
-        // The implication of the fee payer changing is that any existing signatures are invalid.
-        const {
-            signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
-            ...unsignedTransaction
-        } = transaction;
-        out = {
-            ...unsignedTransaction,
-            feePayer,
-        };
-    } else {
-        out = {
-            ...transaction,
-            feePayer,
-        };
-    }
+    const out = {
+        ...getUnsignedTransaction(transaction),
+        feePayer,
+    };
     Object.freeze(out);
     return out;
 }

--- a/packages/transactions/src/instructions.ts
+++ b/packages/transactions/src/instructions.ts
@@ -1,36 +1,15 @@
 import { ITransactionWithSignatures } from './signatures';
 import { BaseTransaction } from './types';
-
-function replaceInstructions<TTransaction extends BaseTransaction, TInstructions>(
-    transaction: TTransaction | (TTransaction & ITransactionWithSignatures),
-    nextInstructions: TInstructions
-): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
-    let out;
-    if ('signatures' in transaction) {
-        // The implication of the instructions changing is that any existing signatures are invalid.
-        const {
-            signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
-            ...unsignedTransaction
-        } = transaction;
-        out = {
-            ...unsignedTransaction,
-            instructions: nextInstructions,
-        };
-    } else {
-        out = {
-            ...transaction,
-            instructions: nextInstructions,
-        };
-    }
-    return out;
-}
+import { getUnsignedTransaction } from './unsigned-transaction';
 
 export function appendTransactionInstruction<TTransaction extends BaseTransaction>(
     instruction: TTransaction['instructions'][number],
     transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
 ): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
-    const nextInstructions = [...transaction.instructions, instruction] as const;
-    const out = replaceInstructions(transaction, nextInstructions);
+    const out = {
+        ...getUnsignedTransaction(transaction),
+        instructions: [...transaction.instructions, instruction],
+    };
     Object.freeze(out);
     return out;
 }
@@ -39,8 +18,10 @@ export function prependTransactionInstruction<TTransaction extends BaseTransacti
     instruction: TTransaction['instructions'][number],
     transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
 ): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
-    const nextInstructions = [instruction, ...transaction.instructions] as const;
-    const out = replaceInstructions(transaction, nextInstructions);
+    const out = {
+        ...getUnsignedTransaction(transaction),
+        instructions: [instruction, ...transaction.instructions],
+    };
     Object.freeze(out);
     return out;
 }

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -7,7 +7,7 @@ export interface IFullySignedTransaction extends ITransactionWithSignatures {
     readonly __fullySignedTransaction: unique symbol;
 }
 export interface ITransactionWithSignatures {
-    readonly signatures: { readonly [publicKey: Base58EncodedAddress]: Ed25519Signature };
+    readonly signatures: Readonly<Record<Base58EncodedAddress, Ed25519Signature>>;
 }
 
 async function getCompiledMessageSignature(message: CompiledMessage, secretKey: CryptoKey) {

--- a/packages/transactions/src/unsigned-transaction.ts
+++ b/packages/transactions/src/unsigned-transaction.ts
@@ -1,0 +1,17 @@
+import { ITransactionWithSignatures } from '.';
+import { BaseTransaction } from './types';
+
+export function getUnsignedTransaction<TTransaction extends BaseTransaction>(
+    transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
+): TTransaction | Omit<TTransaction & ITransactionWithSignatures, keyof ITransactionWithSignatures> {
+    if ('signatures' in transaction) {
+        // The implication of the lifetime constraint changing is that any existing signatures are invalid.
+        const {
+            signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
+            ...unsignedTransaction
+        } = transaction;
+        return unsignedTransaction;
+    } else {
+        return transaction;
+    }
+}


### PR DESCRIPTION
refactor(experimental): update type of `signatures` record to `Record`

This is so that it can be indexed by `Base58EncodedAddress`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1434).
* #1436
* #1435
* __->__ #1434
* #1433