### PR TITLE
refactor(experimental): an assertion function that refines the type of a transaction to `IDurableNonceTransaction`

### DIFF
--- a/packages/transactions/src/__tests__/durable-nonce-test.ts
+++ b/packages/transactions/src/__tests__/durable-nonce-test.ts
@@ -1,0 +1,126 @@
+import 'test-matchers/toBeFrozenObject';
+
+import { AccountRole, ReadonlySignerAccount, WritableAccount } from '@solana/instructions';
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { Blockhash, ITransactionWithBlockhashLifetime } from '../blockhash';
+import { assertIsDurableNonceTransaction, IDurableNonceTransaction, Nonce } from '../durable-nonce';
+import { BaseTransaction } from '../types';
+
+function createMockAdvanceNonceAccountInstruction<
+    TNonceAccountAddress extends string = string,
+    TNonceAuthorityAddress extends string = string
+>({
+    nonceAccountAddress,
+    nonceAuthorityAddress,
+}: {
+    nonceAccountAddress: Base58EncodedAddress<TNonceAccountAddress>;
+    nonceAuthorityAddress: Base58EncodedAddress<TNonceAuthorityAddress>;
+}): IDurableNonceTransaction['instructions'][0] {
+    return {
+        accounts: [
+            { address: nonceAccountAddress, role: AccountRole.WRITABLE } as WritableAccount<TNonceAccountAddress>,
+            {
+                address:
+                    'SysvarRecentB1ockHashes11111111111111111111' as Base58EncodedAddress<'SysvarRecentB1ockHashes11111111111111111111'>,
+                role: AccountRole.READONLY,
+            },
+            {
+                address: nonceAuthorityAddress,
+                role: AccountRole.READONLY_SIGNER,
+            } as ReadonlySignerAccount<TNonceAuthorityAddress>,
+        ],
+        data: new Uint8Array([4, 0, 0, 0]) as IDurableNonceTransaction['instructions'][0]['data'],
+        programAddress: '11111111111111111111111111111111' as Base58EncodedAddress<'11111111111111111111111111111111'>,
+    };
+}
+
+describe('assertIsDurableNonceTransaction()', () => {
+    let durableNonceTx: BaseTransaction & IDurableNonceTransaction;
+    const NONCE_CONSTRAINT = {
+        nonce: '123' as Nonce,
+        nonceAccountAddress: '123' as Base58EncodedAddress,
+        nonceAuthorityAddress: '123' as Base58EncodedAddress,
+    };
+    beforeEach(() => {
+        durableNonceTx = {
+            instructions: [createMockAdvanceNonceAccountInstruction(NONCE_CONSTRAINT)],
+            lifetimeConstraint: { nonce: NONCE_CONSTRAINT.nonce } as IDurableNonceTransaction['lifetimeConstraint'],
+            version: 0,
+        } as const;
+    });
+    it('throws when supplied a transaction with a nonce lifetime constraint but no instructions', () => {
+        expect(() => {
+            assertIsDurableNonceTransaction({
+                ...durableNonceTx,
+                instructions: [],
+            });
+        }).toThrow();
+    });
+    it('throws when supplied a transaction with a nonce lifetime constraint but an instruction at index 0 for a program other than the system program', () => {
+        expect(() => {
+            assertIsDurableNonceTransaction({
+                ...durableNonceTx,
+                instructions: [
+                    {
+                        ...durableNonceTx.instructions[0],
+                        programAddress: '32JTd9jz5xGuLegzVouXxfzAVTiJYWMLrg6p8RxbV5xc' as Base58EncodedAddress,
+                    },
+                ],
+                lifetimeConstraint: { nonce: NONCE_CONSTRAINT.nonce } as IDurableNonceTransaction['lifetimeConstraint'],
+            });
+        }).toThrow();
+    });
+    it('throws when supplied a transaction with a nonce lifetime constraint but a system program instruction at index 0 for something other than the `AdvanceNonceAccount` instruction', () => {
+        expect(() => {
+            assertIsDurableNonceTransaction({
+                ...durableNonceTx,
+                instructions: [
+                    {
+                        ...durableNonceTx.instructions[0],
+                        data: new Uint8Array([2, 0, 0, 0]), // Transfer instruction
+                    },
+                ],
+                lifetimeConstraint: { nonce: NONCE_CONSTRAINT.nonce } as IDurableNonceTransaction['lifetimeConstraint'],
+            });
+        }).toThrow();
+    });
+    it('throws when supplied a transaction with a nonce lifetime constraint but a system program instruction at index 0 with malformed accounts', () => {
+        expect(() => {
+            assertIsDurableNonceTransaction({
+                ...durableNonceTx,
+                instructions: [
+                    {
+                        ...durableNonceTx.instructions[0],
+                        accounts: [],
+                    },
+                ],
+                lifetimeConstraint: { nonce: NONCE_CONSTRAINT.nonce } as IDurableNonceTransaction['lifetimeConstraint'],
+            });
+        }).toThrow();
+    });
+    it('throws when supplied a transaction with an `AdvanceNonceAccount` instruction at index 0 but no lifetime constraint', () => {
+        expect(() => {
+            assertIsDurableNonceTransaction({
+                ...durableNonceTx,
+                lifetimeConstraint: undefined,
+            });
+        }).toThrow();
+    });
+    it('throws when supplied a transaction with an `AdvanceNonceAccount` instruction at index 0 but a blockhash lifetime constraint', () => {
+        expect(() => {
+            assertIsDurableNonceTransaction({
+                ...durableNonceTx,
+                lifetimeConstraint: {
+                    blockhash: '123' as Blockhash,
+                    lastValidBlockHeight: 123n,
+                } as ITransactionWithBlockhashLifetime['lifetimeConstraint'],
+            } as BaseTransaction);
+        }).toThrow();
+    });
+    it('does not throw when supplied a durable nonce transaction', () => {
+        expect(() => {
+            assertIsDurableNonceTransaction({ ...durableNonceTx });
+        }).not.toThrow();
+    });
+});

--- a/packages/transactions/src/blockhash.ts
+++ b/packages/transactions/src/blockhash.ts
@@ -3,6 +3,7 @@ import { base58 } from '@metaplex-foundation/umi-serializers';
 import { IDurableNonceTransaction } from './durable-nonce';
 import { ITransactionWithSignatures } from './signatures';
 import { BaseTransaction } from './types';
+import { getUnsignedTransaction } from './unsigned-transaction';
 
 export type Blockhash = string & { readonly __blockhash: unique symbol };
 
@@ -60,23 +61,10 @@ export function setTransactionLifetimeUsingBlockhash(
     ) {
         return transaction;
     }
-    let out;
-    if ('signatures' in transaction) {
-        // The implication of the lifetime constraint changing is that any existing signatures are invalid.
-        const {
-            signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
-            ...unsignedTransaction
-        } = transaction;
-        out = {
-            ...unsignedTransaction,
-            lifetimeConstraint: blockhashLifetimeConstraint,
-        };
-    } else {
-        out = {
-            ...transaction,
-            lifetimeConstraint: blockhashLifetimeConstraint,
-        };
-    }
+    const out = {
+        ...getUnsignedTransaction(transaction),
+        lifetimeConstraint: blockhashLifetimeConstraint,
+    };
     Object.freeze(out);
     return out;
 }

--- a/packages/transactions/src/durable-nonce.ts
+++ b/packages/transactions/src/durable-nonce.ts
@@ -1,12 +1,15 @@
-import { IInstruction, IInstructionWithAccounts, IInstructionWithData } from '@solana/instructions';
+import { AccountRole, IInstruction, IInstructionWithAccounts, IInstructionWithData } from '@solana/instructions';
 import { ReadonlyAccount, ReadonlySignerAccount, WritableAccount } from '@solana/instructions/dist/types/accounts';
+import { Base58EncodedAddress } from '@solana/keys';
+
+import { BaseTransaction } from './types';
 
 type AdvanceNonceAccountInstruction<
     TNonceAccountAddress extends string = string,
     TNonceAuthorityAddress extends string = string
 > = IInstruction<'11111111111111111111111111111111'> &
     IInstructionWithAccounts<
-        [
+        readonly [
             WritableAccount<TNonceAccountAddress>,
             ReadonlyAccount<'SysvarRecentB1ockHashes11111111111111111111'>,
             ReadonlySignerAccount<TNonceAuthorityAddress>
@@ -21,15 +24,65 @@ type NonceLifetimeConstraint<TNonceValue extends string = string> = Readonly<{
     nonce: Nonce<TNonceValue>;
 }>;
 
+const RECENT_BLOCKHASHES_SYSVAR_ADDRESS =
+    'SysvarRecentB1ockHashes11111111111111111111' as Base58EncodedAddress<'SysvarRecentB1ockHashes11111111111111111111'>;
+const SYSTEM_PROGRAM_ADDRESS =
+    '11111111111111111111111111111111' as Base58EncodedAddress<'11111111111111111111111111111111'>;
+
 export interface IDurableNonceTransaction<
     TNonceAccountAddress extends string = string,
     TNonceAuthorityAddress extends string = string,
     TNonceValue extends string = string
 > {
-    readonly instructions: [
+    readonly instructions: readonly [
         // The first instruction *must* be the system program's `AdvanceNonceAccount` instruction.
         AdvanceNonceAccountInstruction<TNonceAccountAddress, TNonceAuthorityAddress>,
         ...IInstruction[]
     ];
     readonly lifetimeConstraint: NonceLifetimeConstraint<TNonceValue>;
+}
+
+export function assertIsDurableNonceTransaction(
+    transaction: BaseTransaction | (BaseTransaction & IDurableNonceTransaction)
+): asserts transaction is BaseTransaction & IDurableNonceTransaction {
+    if (!isDurableNonceTransaction(transaction)) {
+        // TODO: Coded error.
+        throw new Error('Transaction is not a durable nonce transaction');
+    }
+}
+
+function isAdvanceNonceAccountInstruction(instruction: IInstruction): instruction is AdvanceNonceAccountInstruction {
+    return (
+        instruction.programAddress === SYSTEM_PROGRAM_ADDRESS &&
+        // Test for `AdvanceNonceAccount` instruction data
+        instruction.data != null &&
+        isAdvanceNonceAccountInstructionData(instruction.data) &&
+        // Test for exactly 3 accounts
+        instruction.accounts?.length === 3 &&
+        // First account is nonce account address
+        instruction.accounts[0].address != null &&
+        instruction.accounts[0].role === AccountRole.WRITABLE &&
+        // Second account is recent blockhashes sysvar
+        instruction.accounts[1].address === RECENT_BLOCKHASHES_SYSVAR_ADDRESS &&
+        instruction.accounts[1].role === AccountRole.READONLY &&
+        // Third account is nonce authority account
+        instruction.accounts[2].address != null &&
+        instruction.accounts[2].role === AccountRole.READONLY_SIGNER
+    );
+}
+
+function isAdvanceNonceAccountInstructionData(data: Uint8Array): data is AdvanceNonceAccountInstructionData {
+    // AdvanceNonceAccount is the fifth instruction in the System Program (index 4)
+    return data.byteLength === 4 && data[0] === 4 && data[1] === 0 && data[2] === 0 && data[3] === 0;
+}
+
+function isDurableNonceTransaction(
+    transaction: BaseTransaction | (BaseTransaction & IDurableNonceTransaction)
+): transaction is BaseTransaction & IDurableNonceTransaction {
+    return (
+        'lifetimeConstraint' in transaction &&
+        typeof transaction.lifetimeConstraint.nonce === 'string' &&
+        transaction.instructions[0] != null &&
+        isAdvanceNonceAccountInstruction(transaction.instructions[0])
+    );
 }

--- a/packages/transactions/src/fee-payer.ts
+++ b/packages/transactions/src/fee-payer.ts
@@ -2,6 +2,7 @@ import { Base58EncodedAddress } from '@solana/keys';
 
 import { ITransactionWithSignatures } from './signatures';
 import { BaseTransaction } from './types';
+import { getUnsignedTransaction } from './unsigned-transaction';
 
 export interface ITransactionWithFeePayer<TAddress extends string = string> {
     readonly feePayer: Base58EncodedAddress<TAddress>;
@@ -20,23 +21,10 @@ export function setTransactionFeePayer<TFeePayerAddress extends string, TTransac
     if ('feePayer' in transaction && feePayer === transaction.feePayer) {
         return transaction;
     }
-    let out;
-    if ('signatures' in transaction) {
-        // The implication of the fee payer changing is that any existing signatures are invalid.
-        const {
-            signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
-            ...unsignedTransaction
-        } = transaction;
-        out = {
-            ...unsignedTransaction,
-            feePayer,
-        };
-    } else {
-        out = {
-            ...transaction,
-            feePayer,
-        };
-    }
+    const out = {
+        ...getUnsignedTransaction(transaction),
+        feePayer,
+    };
     Object.freeze(out);
     return out;
 }

--- a/packages/transactions/src/instructions.ts
+++ b/packages/transactions/src/instructions.ts
@@ -1,36 +1,15 @@
 import { ITransactionWithSignatures } from './signatures';
 import { BaseTransaction } from './types';
-
-function replaceInstructions<TTransaction extends BaseTransaction, TInstructions>(
-    transaction: TTransaction | (TTransaction & ITransactionWithSignatures),
-    nextInstructions: TInstructions
-): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
-    let out;
-    if ('signatures' in transaction) {
-        // The implication of the instructions changing is that any existing signatures are invalid.
-        const {
-            signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
-            ...unsignedTransaction
-        } = transaction;
-        out = {
-            ...unsignedTransaction,
-            instructions: nextInstructions,
-        };
-    } else {
-        out = {
-            ...transaction,
-            instructions: nextInstructions,
-        };
-    }
-    return out;
-}
+import { getUnsignedTransaction } from './unsigned-transaction';
 
 export function appendTransactionInstruction<TTransaction extends BaseTransaction>(
     instruction: TTransaction['instructions'][number],
     transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
 ): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
-    const nextInstructions = [...transaction.instructions, instruction] as const;
-    const out = replaceInstructions(transaction, nextInstructions);
+    const out = {
+        ...getUnsignedTransaction(transaction),
+        instructions: [...transaction.instructions, instruction],
+    };
     Object.freeze(out);
     return out;
 }
@@ -39,8 +18,10 @@ export function prependTransactionInstruction<TTransaction extends BaseTransacti
     instruction: TTransaction['instructions'][number],
     transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
 ): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
-    const nextInstructions = [instruction, ...transaction.instructions] as const;
-    const out = replaceInstructions(transaction, nextInstructions);
+    const out = {
+        ...getUnsignedTransaction(transaction),
+        instructions: [instruction, ...transaction.instructions],
+    };
     Object.freeze(out);
     return out;
 }

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -7,7 +7,7 @@ export interface IFullySignedTransaction extends ITransactionWithSignatures {
     readonly __fullySignedTransaction: unique symbol;
 }
 export interface ITransactionWithSignatures {
-    readonly signatures: { readonly [publicKey: Base58EncodedAddress]: Ed25519Signature };
+    readonly signatures: Readonly<Record<Base58EncodedAddress, Ed25519Signature>>;
 }
 
 async function getCompiledMessageSignature(message: CompiledMessage, secretKey: CryptoKey) {

--- a/packages/transactions/src/unsigned-transaction.ts
+++ b/packages/transactions/src/unsigned-transaction.ts
@@ -1,0 +1,17 @@
+import { ITransactionWithSignatures } from '.';
+import { BaseTransaction } from './types';
+
+export function getUnsignedTransaction<TTransaction extends BaseTransaction>(
+    transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
+): TTransaction | Omit<TTransaction & ITransactionWithSignatures, keyof ITransactionWithSignatures> {
+    if ('signatures' in transaction) {
+        // The implication of the lifetime constraint changing is that any existing signatures are invalid.
+        const {
+            signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
+            ...unsignedTransaction
+        } = transaction;
+        return unsignedTransaction;
+    } else {
+        return transaction;
+    }
+}


### PR DESCRIPTION
refactor(experimental): an assertion function that refines the type of a transaction to `IDurableNonceTransaction`

## Summary

Given a transaction of an unknown shape, use this Typescript assertion method to narrow its type to `IDurableNonceTransaction` or throw.


## Test Plan

```
cd packages/transactions/
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1435).
* #1436
* __->__ #1435
* #1434
* #1433