### PR TITLE
fix: use the native `fetch()` in Node wherever supported

### DIFF
--- a/packages/fetch-impl/src/index.node.ts
+++ b/packages/fetch-impl/src/index.node.ts
@@ -1,4 +1,8 @@
 // When building the browser bundle, this import gets replaced by `globalThis.fetch`.
 import fetchImpl from 'node-fetch';
 
-export default fetchImpl;
+export default typeof globalThis.fetch === 'function'
+    ? // The Fetch API is supported experimentally in Node 17.5+ and natively in Node 18+.
+      globalThis.fetch
+    : // Otherwise use the polyfill.
+      fetchImpl;

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -31,7 +31,7 @@ import {JSONRPCError} from 'jayson';
 
 import {EpochSchedule} from './epoch-schedule';
 import {SendTransactionError, SolanaJSONRPCError} from './errors';
-import fetchImpl, {Response} from './fetch-impl';
+import fetchImpl from './fetch-impl';
 import {DurableNonce, NonceAccount} from './nonce-account';
 import {PublicKey} from './publickey';
 import {Signer} from './keypair';

--- a/packages/library-legacy/src/fetch-impl.ts
+++ b/packages/library-legacy/src/fetch-impl.ts
@@ -1,13 +1,16 @@
 import * as nodeFetch from 'node-fetch';
 
-export * from 'node-fetch';
-export default async function (
-  input: nodeFetch.RequestInfo,
-  init?: nodeFetch.RequestInit,
-): Promise<nodeFetch.Response> {
-  const processedInput =
-    typeof input === 'string' && input.slice(0, 2) === '//'
-      ? 'https:' + input
-      : input;
-  return await nodeFetch.default(processedInput, init);
-}
+export default (typeof globalThis.fetch === 'function'
+  ? // The Fetch API is supported experimentally in Node 17.5+ and natively in Node 18+.
+    globalThis.fetch
+  : // Otherwise use the polyfill.
+    async function (
+      input: nodeFetch.RequestInfo,
+      init?: nodeFetch.RequestInit,
+    ): Promise<nodeFetch.Response> {
+      const processedInput =
+        typeof input === 'string' && input.slice(0, 2) === '//'
+          ? 'https:' + input
+          : input;
+      return await nodeFetch.default(processedInput, init);
+    }) as typeof globalThis.fetch;


### PR DESCRIPTION
fix: use the native `fetch()` in Node wherever supported

# Summary

Folks are having trouble using the `node-fetch` polyfill with certain RPC providers that:

* use chunked-transfer encoding
* don't send a zero-sized chunk before closing the socket

`node-fetch` doesn't like this, and fatals.

One easy thing we can do while we figure this all out is to use the _native_ `fetch()` API included in Node 18+ by default and 17.5+ behind an experimental flag.

Fixes #1418 in Node 18+.

# Test Plan

CI run.
