### PR TITLE
refactor(experimental): a function to compute program derived addresses

### DIFF
--- a/packages/addresses/README.md
+++ b/packages/addresses/README.md
@@ -60,3 +60,24 @@ import { getBase58EncodedAddressFromPublicKey } from '@solana/addresses';
 
 const address = await getBase58EncodedAddressFromPublicKey(publicKey);
 ```
+
+### `getProgramDerivedAddress()`
+
+Given a program's `Base58EncodedAddress` and up to 16 `Seeds`, this method will return the program derived address (PDA) associated with each.
+
+```ts
+import { getBase58EncodedAddressCodec, getProgramDerivedAddress } from '@solana/addresses';
+
+const { serialize } = getBase58EncodedAddressCodec();
+const { bumpSeed, pda } = await getProgramDerivedAddress({
+    programAddress: 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Base58EncodedAddress,
+    seeds: [
+        // Owner
+        serialize('9fYLFVoVqwH37C3dyPi6cpeobfbQ2jtLpN5HgAYDDdkm' as Base58EncodedAddress),
+        // Token program
+        serialize('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Base58EncodedAddress),
+        // Mint
+        serialize('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' as Base58EncodedAddress),
+    ],
+});
+```

--- a/packages/addresses/src/__tests__/program-derived-address-test.ts
+++ b/packages/addresses/src/__tests__/program-derived-address-test.ts
@@ -1,0 +1,141 @@
+import { Base58EncodedAddress } from '../base58';
+import { getProgramDerivedAddress } from '../program-derived-address';
+
+describe('getProgramDerivedAddress()', () => {
+    it('fatals when supplied more than 16 seeds', async () => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: 'FN2R9R724eb4WaxeDmDYrUtmJgoSzkBiQMEHELV3ocyg' as Base58EncodedAddress,
+                seeds: Array(17).fill(''),
+            })
+        ).rejects.toThrow(/A maximum of 16 seeds/);
+    });
+    it.each([
+        new Uint8Array(Array(33).fill(0)),
+        'a'.repeat(33),
+        '\uD83D\uDC68\u200D\uD83D\uDC68\u200D\uD83D\uDC67\u200D\uD83D\uDC66\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC66\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC66',
+    ])('fatals when supplied a seed that is 33 bytes long', async oversizedSeed => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: '5eUi55m4FVaDqKubGH9r6ca1TxjmimmXEU9v1WUZJ47Z' as Base58EncodedAddress,
+                seeds: [oversizedSeed],
+            })
+        ).rejects.toThrow(/exceeds the maximum length of 32 bytes/);
+    });
+    it('returns a program derived address given a program address and no seeds', async () => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: 'CZ3TbkgUYpDAJVEWpujQhDSgzNTeqbokrJmYa1j4HAZc' as Base58EncodedAddress,
+                seeds: [],
+            })
+        ).resolves.toStrictEqual({
+            bumpSeed: 255,
+            pda: '9tVtkyCGAHSDDBPwz7895aC3p2gJRjpu2v26o35FTUco',
+        });
+    });
+    it('returns a program derived address after having tried multiple bump seeds given a program address and no seeds', async () => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: 'EfTbwNBrSqSuCNBhWUHsBoBdSMWgRU1S47daqRNgW7aK' as Base58EncodedAddress,
+                seeds: [],
+            })
+        ).resolves.toStrictEqual({
+            bumpSeed: 251,
+            pda: 'CKWT8KZ5GMzKpVRiAULWKPg1LiHt9U3NdAtbuTErHCTq',
+        });
+    });
+    it('returns a program derived address given a program address and a byte-array seed', async () => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: 'FD3PDEvpQ9JXq8tv7FpJPyZrCjWkCnAaTju16gFPdpqP' as Base58EncodedAddress,
+                seeds: [new Uint8Array([1, 2, 3])],
+            })
+        ).resolves.toStrictEqual({
+            bumpSeed: 255,
+            pda: '9Tj3hpMWacDiZoBe94sjwJQ72zsUVvEQYsrqyy2CfHky',
+        });
+    });
+    it('returns a program derived address after having tried multiple bump seeds given a program address and a byte-array seed', async () => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: '9HT3iB4oX1aZPH5V8eNUGByKuwhfcKjBQ3x9rfEAuNeF' as Base58EncodedAddress,
+                seeds: [new Uint8Array([1, 2, 3])],
+            })
+        ).resolves.toStrictEqual({
+            bumpSeed: 251,
+            pda: 'EeTcRajHcPh74C5D4GqZePac1wYB7Dj9ChTaNHaTH77V',
+        });
+    });
+    it('returns a program derived address given a program address and a string seed', async () => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: 'EKaNRGA37uiGRyRPMap5EZg9cmbT5mt7KWrGwKwAQ3rK' as Base58EncodedAddress,
+                seeds: ['hello'],
+            })
+        ).resolves.toStrictEqual({
+            bumpSeed: 255,
+            pda: '6V76gtKMCmVVjrx4sxR9uB868HtZbL3piKEmadC7rSgf',
+        });
+    });
+    it('returns a program derived address after having tried multiple bump seeds given a program address and a string seed', async () => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: '9PyoV2rqNtoboSvg2JD7GWhM5RQvHGwgdDvK7MCfpgX1' as Base58EncodedAddress,
+                seeds: ['hello'],
+            })
+        ).resolves.toStrictEqual({
+            bumpSeed: 251,
+            pda: 'E6npEurFu1UEbQFh1DsqBvny17XxUK2QPMgxD3Edn3aG',
+        });
+    });
+    it('returns a program derived address given a program address and a UTF-8 string seed', async () => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: 'A5dcVPLJsE2vbf7hkqqyYkYDK9UjUfNxuwGtWF2m2vEz' as Base58EncodedAddress,
+                seeds: ['\uD83D\uDE80'],
+            })
+        ).resolves.toStrictEqual({
+            bumpSeed: 255,
+            pda: 'GYpAzW57Ex4Sw3rp4pq95QrjvtsDyqZsMhSZwqz3NMsE',
+        });
+    });
+    it('returns a program derived address after having tried multiple bump seeds given a program address and a UTF-8 string seed', async () => {
+        expect.assertions(1);
+        await expect(
+            getProgramDerivedAddress({
+                programAddress: 'H8gBP21L5ietkHgXcGbgQBCVVEdPUQyuP9Q5MPRLLSJu' as Base58EncodedAddress,
+                seeds: ['\uD83D\uDE80'],
+            })
+        ).resolves.toStrictEqual({
+            bumpSeed: 251,
+            pda: '46v3JvPtEPeQmH3euXydEbxYD6yfxeZjWSzkkYvvM5Pp',
+        });
+    });
+    it('returns the same result given a program address and two different seed inputs that concatenate to the same bytes', async () => {
+        expect.assertions(1);
+        const [pdaButterfly, pdaButterFly] = await Promise.all([
+            getProgramDerivedAddress({
+                programAddress: '9PyoV2rqNtoboSvg2JD7GWhM5RQvHGwgdDvK7MCfpgX1' as Base58EncodedAddress,
+                seeds: ['butterfly'],
+            }),
+            getProgramDerivedAddress({
+                programAddress: '9PyoV2rqNtoboSvg2JD7GWhM5RQvHGwgdDvK7MCfpgX1' as Base58EncodedAddress,
+                seeds: ['butter', 'fly'],
+            }),
+        ]);
+        expect(pdaButterfly).toStrictEqual(pdaButterFly);
+    });
+    // https://solana.stackexchange.com/questions/7253/what-combination-of-program-address-and-seeds-would-cause-findprogramaddress-t
+    it.todo(
+        'fatals when supplied a combination of program address and seeds for which no off-curve point can be found'
+    );
+});

--- a/packages/addresses/src/index.ts
+++ b/packages/addresses/src/index.ts
@@ -1,2 +1,3 @@
 export * from './base58';
+export * from './program-derived-address';
 export * from './public-key';

--- a/packages/addresses/src/program-derived-address.ts
+++ b/packages/addresses/src/program-derived-address.ts
@@ -1,0 +1,78 @@
+import { assertDigestCapabilityIsAvailable } from '@solana/assertions';
+
+import { Base58EncodedAddress, getBase58EncodedAddressCodec } from './base58';
+import { compressedPointBytesAreOnCurve } from './curve';
+
+type PDAInput = Readonly<{
+    programAddress: Base58EncodedAddress;
+    seeds: Seed[];
+}>;
+type Seed = string | Uint8Array;
+
+const MAX_SEED_LENGTH = 32;
+const MAX_SEEDS = 16;
+const PDA_MARKER_BYTES = [
+    // The string 'ProgramDerivedAddress'
+    80, 114, 111, 103, 114, 97, 109, 68, 101, 114, 105, 118, 101, 100, 65, 100, 100, 114, 101, 115, 115,
+] as const;
+
+// TODO: Coded error.
+class PointOnCurveError extends Error {}
+
+async function createProgramDerivedAddress({ programAddress, seeds }: PDAInput): Promise<Base58EncodedAddress> {
+    await assertDigestCapabilityIsAvailable();
+    if (seeds.length > MAX_SEEDS) {
+        // TODO: Coded error.
+        throw new Error(`A maximum of ${MAX_SEEDS} seeds may be supplied when creating an address`);
+    }
+    let textEncoder: TextEncoder;
+    const seedBytes = seeds.reduce((acc, seed, ii) => {
+        const bytes = typeof seed === 'string' ? (textEncoder ||= new TextEncoder()).encode(seed) : seed;
+        if (bytes.byteLength > MAX_SEED_LENGTH) {
+            // TODO: Coded error.
+            throw new Error(`The seed at index ${ii} exceeds the maximum length of 32 bytes`);
+        }
+        acc.push(...bytes);
+        return acc;
+    }, [] as number[]);
+    const base58EncodedAddressCodec = getBase58EncodedAddressCodec();
+    const programAddressBytes = base58EncodedAddressCodec.serialize(programAddress);
+    const addressBytesBuffer = await crypto.subtle.digest(
+        'SHA-256',
+        new Uint8Array([...seedBytes, ...programAddressBytes, ...PDA_MARKER_BYTES])
+    );
+    const addressBytes = new Uint8Array(addressBytesBuffer);
+    if (await compressedPointBytesAreOnCurve(addressBytes)) {
+        // TODO: Coded error.
+        throw new PointOnCurveError('Invalid seeds; point must fall off the Ed25519 curve');
+    }
+    return base58EncodedAddressCodec.deserialize(addressBytes)[0];
+}
+
+export async function getProgramDerivedAddress({ programAddress, seeds }: PDAInput): Promise<
+    Readonly<{
+        bumpSeed: number;
+        pda: Base58EncodedAddress;
+    }>
+> {
+    let bumpSeed = 255;
+    while (bumpSeed > 0) {
+        try {
+            return {
+                bumpSeed,
+                pda: await createProgramDerivedAddress({
+                    programAddress,
+                    seeds: [...seeds, new Uint8Array([bumpSeed])],
+                }),
+            };
+        } catch (e) {
+            if (e instanceof PointOnCurveError) {
+                bumpSeed--;
+            } else {
+                throw e;
+            }
+        }
+    }
+    // TODO: Coded error.
+    throw new Error('Unable to find a viable program address bump seed');
+}


### PR DESCRIPTION
refactor(experimental): a function to compute program derived addresses

# Summary

Given a program address and a series of string or bytearray seeds, this function will compute the off-chain program derived address (PDA) corresponding to both.

# Test Plan

```
cd packages/addresses
pnpm test:unit:browser
pnpm test:unit:node
```
