### PR TITLE
Export Commitment type to consumers

### DIFF
--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -58,6 +58,8 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     IsBlockhashValidApi &
     MinimumLedgerSlotApi;
 
+export type { Commitment } from './common';
+
 export function createSolanaRpcApi(config?: Config): IRpcApi<SolanaRpcMethods> {
     return new Proxy({} as IRpcApi<SolanaRpcMethods>, {
         defineProperty() {


### PR DESCRIPTION
- We use `Commitment` as part of the input config for many calls, so it's useful to export it so that consumers can pass it around/create it in their code. Otherwise you need to hardcode a compliant string value in code for each RPC call
- It's not feasible to use `Parameters ` or similar to obtain this type because it's usually optional and nested in a config object

I've also checked the other inputs for RPC methods and I can't see anything else likely to cause issues.

Tested by compiling `@packages/rpc-core` and then seeing `import type { Commitment } from '@solana/rpc-core` in a dependent package no longer errors. 