### PR TITLE
refactor(experimental): Add the `getBlockCommitment` RPC method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-block-commitment-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-block-commitment-test.ts
@@ -1,0 +1,33 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getBlockCommitment', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    it('returns the block commitment for an older block, which has null commitment', async () => {
+        expect.assertions(1);
+        const getBlockCommitmentPromise = rpc.getBlockCommitment(0n).send();
+        await expect(getBlockCommitmentPromise).resolves.toMatchObject({
+            commitment: null,
+            totalStake: expect.any(BigInt),
+        });
+    });
+
+    // TODO: We need a good way to feed `getBlockCommitment` a recent block.
+    // This would actually return a value for commitment.
+    // This is tricky to do without `getSlot`, and we'll need some kind
+    // of manipulation capability over test-validator to pull it off without
+    // another RPC call.
+    it.todo('returns the block commitment for a recent block');
+});

--- a/packages/rpc-core/src/rpc-methods/getBlockCommitment.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockCommitment.ts
@@ -1,0 +1,14 @@
+import { LamportsUnsafeBeyond2Pow53Minus1, Slot } from './common';
+
+type GetBlockCommitmentApiResponse = Readonly<{
+    commitment: LamportsUnsafeBeyond2Pow53Minus1[] | null;
+    totalStake: LamportsUnsafeBeyond2Pow53Minus1;
+}>;
+
+export interface GetBlockCommitmentApi {
+    /**
+     * Returns the amount of cluster stake in lamports that has voted on
+     * a particular block, as well as the stake attributed to each vote account
+     */
+    getBlockCommitment(slot: Slot): GetBlockCommitmentApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -4,6 +4,7 @@ import { patchParamsForSolanaLabsRpc } from '../params-patcher';
 import { patchResponseForSolanaLabsRpc } from '../response-patcher';
 import { GetAccountInfoApi } from './getAccountInfo';
 import { GetBalanceApi } from './getBalance';
+import { GetBlockCommitmentApi } from './getBlockCommitment';
 import { GetBlockHeightApi } from './getBlockHeight';
 import { GetBlockProductionApi } from './getBlockProduction';
 import { GetBlocksApi } from './getBlocks';
@@ -36,6 +37,7 @@ type Config = Readonly<{
 
 export type SolanaRpcMethods = GetAccountInfoApi &
     GetBalanceApi &
+    GetBlockCommitmentApi &
     GetBlockHeightApi &
     GetBlockProductionApi &
     GetBlocksApi &


### PR DESCRIPTION
This PR adds the `getBlockCommitment` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 