### PR TITLE
refactor(experimental): Add the `getClusterNodes` RPC method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-cluster-nodes-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-cluster-nodes-test.ts
@@ -1,0 +1,32 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getClusterNodes', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    it('returns the cluster nodes', async () => {
+        expect.assertions(1);
+        const res = await rpc.getClusterNodes().send();
+        // Check that the array contains the expected nodes
+        expect(res).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    gossip: '127.0.0.1:1024',
+                    rpc: '127.0.0.1:8899',
+                    tpu: '127.0.0.1:1026',
+                }),
+            ])
+        );
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getClusterNodes.ts
+++ b/packages/rpc-core/src/rpc-methods/getClusterNodes.ts
@@ -1,0 +1,37 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+type GetClusterNodesNode = Readonly<{
+    /** The unique identifier of the node's feature set */
+    featureSet: number | null;
+    /** Gossip network address for the node */
+    gossip: string | null;
+    /** Node public key, as base-58 encoded string */
+    pubkey: Base58EncodedAddress;
+    /**
+     * JSON RPC network address for the node,
+     * or `null` if the JSON RPC service is not enabled
+     */
+    rpc: string | null;
+    /** The shred version the node has been configured to use */
+    shredVersion: number | null;
+    /** TPU network address for the node */
+    tpu: string | null;
+    /**
+     * The software version of the node,
+     * or `null` if the version information is not available
+     */
+    version: string | null;
+}>;
+
+type GetClusterNodesApiResponse = readonly GetClusterNodesNode[];
+
+export interface GetClusterNodesApi {
+    /**
+     * Returns information about all the nodes participating in the cluster
+     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
+     */
+    getClusterNodes(
+        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
+        NO_CONFIG?: Record<string, never>
+    ): GetClusterNodesApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -8,6 +8,7 @@ import { GetBlockHeightApi } from './getBlockHeight';
 import { GetBlockProductionApi } from './getBlockProduction';
 import { GetBlocksApi } from './getBlocks';
 import { GetBlockTimeApi } from './getBlockTime';
+import { GetClusterNodesApi } from './getClusterNodes';
 import { GetEpochInfoApi } from './getEpochInfo';
 import { GetEpochScheduleApi } from './getEpochSchedule';
 import { GetFirstAvailableBlockApi } from './getFirstAvailableBlock';
@@ -40,6 +41,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetBlockProductionApi &
     GetBlocksApi &
     GetBlockTimeApi &
+    GetClusterNodesApi &
     GetEpochInfoApi &
     GetEpochScheduleApi &
     GetFirstAvailableBlockApi &


### PR DESCRIPTION
This PR adds the getBlockCommitment RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 