### PR TITLE
refactor(experimental): Add the `getBlocksWithLimit` RPC method

### DIFF
--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -64,8 +64,8 @@
         "@metaplex-foundation/umi-serializers": "^0.8.5"
     },
     "devDependencies": {
-        "@solana/eslint-config-solana": "^1.0.2",
         "@solana/addresses": "workspace:*",
+        "@solana/eslint-config-solana": "^1.0.2",
         "@solana/rpc-transport": "workspace:*",
         "@solana/transactions": "workspace:*",
         "@swc/jest": "^0.2.27",
@@ -77,6 +77,7 @@
         "eslint": "^8.45.0",
         "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
+        "fs": "0.0.1-security",
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^29.6.2",
         "jest-fetch-mock-fork": "^3.0.4",

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -64,8 +64,8 @@
         "@metaplex-foundation/umi-serializers": "^0.8.5"
     },
     "devDependencies": {
-        "@solana/addresses": "workspace:*",
         "@solana/eslint-config-solana": "^1.0.2",
+        "@solana/addresses": "workspace:*",
         "@solana/rpc-transport": "workspace:*",
         "@solana/transactions": "workspace:*",
         "@swc/jest": "^0.2.27",
@@ -77,7 +77,6 @@
         "eslint": "^8.45.0",
         "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
-        "fs": "0.0.1-security",
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^29.6.2",
         "jest-fetch-mock-fork": "^3.0.4",

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-blocks-with-limit-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-blocks-with-limit-test.ts
@@ -1,101 +1,32 @@
-import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
-import { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
-import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
-import fs from 'fs';
-import fetchMock from 'jest-fetch-mock-fork';
-import path from 'path';
-
-import { Commitment, createSolanaRpcApi, SolanaRpcMethods } from '../index';
-
-const logFilePath = path.resolve(__dirname, '../../../../../test-ledger/validator.log');
-const confirmedPattern = /My next leader slot is (\d+)/g;
-const finalizedPattern = /new root (\d+)/g;
-
-async function waitForBlock(slot: number, commitment: 'confirmed' | 'finalized') {
-    const pattern = commitment === 'confirmed' ? confirmedPattern : finalizedPattern;
-    let slotFound = false;
-    while (!slotFound) {
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        const logs = fs.readFileSync(logFilePath, 'utf8');
-        let match;
-        let latestSlot: number;
-        while ((match = pattern.exec(logs)) !== null) {
-            latestSlot = Number(match[1]);
-            console.log(`Found slot ${latestSlot}`);
-            if (latestSlot >= slot) {
-                slotFound = true;
-                return;
-            }
-        }
-        await new Promise(resolve => setTimeout(resolve, (slot - latestSlot) * 500));
-    }
-}
+import { Commitment } from '../index';
 
 describe('getBlocksWithLimit', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
-    beforeEach(() => {
-        fetchMock.resetMocks();
-        fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
-            api: createSolanaRpcApi(),
-            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
-        });
-    });
-
     (['confirmed', 'finalized'] as Exclude<Commitment, 'processed'>[]).forEach(commitment => {
-        describe(`when called with \`${commitment}\` commitment`, () => {});
-
-        describe('when called with a valid `startSlot` and a valid `limit`', () => {
-            // On the test validator, finalized blocks tend to be available ~35 slots
-            // after the current confirmed slot.
-            // So we'll have to wait for a few blocks to be confirmed before we can test this.
-            // That means we'll need _at least_ a 35 * 500 ms = 17,500 ms starting buffer
-            it('returns 5 blocks for a limit of 5', async () => {
-                expect.assertions(1);
-                await waitForBlock(5, commitment); // ~500 ms block time x 5 blocks = 2500 ms
-                const res = await rpc.getBlocksWithLimit(1n, 5, { commitment }).send();
-                expect(res).toHaveLength(5);
-            }, 17_500);
-        });
-
-        describe('when called with a valid `startSlot` and a `limit` of 0', () => {
-            it('returns an empty array', async () => {
-                expect.assertions(1);
-                await waitForBlock(2, commitment); // ~500 ms block time x 2 blocks = 1000 ms (< 500 ms default)
-                const res = await rpc.getBlocksWithLimit(2n, 0, { commitment }).send();
-                expect(res).toHaveLength(0);
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            describe('when called with a valid `startSlot` and a valid `limit`', () => {
+                // On the test validator, finalized blocks tend to be available ~35 slots
+                // after the current confirmed slot.
+                // So we'll have to wait for a few blocks to be confirmed before we can test this.
+                it.todo('returns 5 blocks for a limit of 5');
             });
-        });
 
-        describe('when called with a `limit` resulting in a slot higher than the highest slot available', () => {
-            // TODO: We need to be able to deterministically set the highest slot
-            // so we can test against it, but without making an RPC call like
-            // `getSlot` which would defeat the purpose of this test.
-            it.todo('returns up to the highest slot available');
-        });
-
-        describe('when called with a `startSlot` higher than the highest slot available', () => {
-            it('returns an empty array', async () => {
-                expect.assertions(1);
-                const res = await rpc
-                    .getBlocksWithLimit(
-                        2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
-                        3
-                    )
-                    .send();
-                expect(res).toHaveLength(0);
+            describe('when called with a valid `startSlot` and a `limit` of 0', () => {
+                it.todo('returns an empty array');
             });
-        });
 
-        describe('when called with a `limit` higher than 500,000', () => {
-            it('throws an error', async () => {
-                expect.assertions(1);
-                const sendPromise = rpc.getBlocksWithLimit(0n, 500_001).send();
-                await expect(sendPromise).rejects.toMatchObject({
-                    code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
-                    message: expect.any(String),
-                    name: 'SolanaJsonRpcError',
-                });
+            describe('when called with a `limit` resulting in a slot higher than the highest slot available', () => {
+                // TODO: We need to be able to deterministically set the highest slot
+                // so we can test against it, but without making an RPC call like
+                // `getSlot` which would defeat the purpose of this test.
+                it.todo('returns up to the highest slot available');
+            });
+
+            describe('when called with a `startSlot` higher than the highest slot available', () => {
+                it.todo('returns an empty array');
+            });
+
+            describe('when called with a `limit` higher than 500,000', () => {
+                it.todo('throws an error');
             });
         });
     });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-blocks-with-limit-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-blocks-with-limit-test.ts
@@ -1,0 +1,63 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getBlocksWithLimit', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    describe('when called with a valid `startSlot` and a valid `limit`', () => {
+        it('returns 8 blocks for a limit of 8', async () => {
+            expect.assertions(1);
+            const res = await rpc.getBlocksWithLimit(5n, 8).send();
+            expect(res).toHaveLength(8);
+        });
+
+        it('returns an empty array for a limit of 0', async () => {
+            expect.assertions(1);
+            const res = await rpc.getBlocksWithLimit(27n, 0).send();
+            expect(res).toHaveLength(0);
+        });
+    });
+
+    describe('when called with a `limit` resulting in a slot higher than the highest slot available', () => {
+        // TODO: We need to be able to deterministically set the highest slot
+        // so we can test against it, but without making an RPC call like
+        // `getSlot` which would defeat the purpose of this test.
+        it.todo('returns up to the highest slot available');
+    });
+
+    describe('when called with a `startSlot` higher than the highest slot available', () => {
+        it('returns an empty array', async () => {
+            expect.assertions(1);
+            const res = await rpc
+                .getBlocksWithLimit(
+                    2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
+                    3
+                )
+                .send();
+            expect(res).toHaveLength(0);
+        });
+    });
+
+    describe('when called with a `limit` higher than 500,000', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const sendPromise = rpc.getBlocksWithLimit(0n, 500_001).send();
+            await expect(sendPromise).rejects.toMatchObject({
+                code: -32602,
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-blocks-with-limit-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-blocks-with-limit-test.ts
@@ -1,8 +1,35 @@
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fs from 'fs';
 import fetchMock from 'jest-fetch-mock-fork';
+import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { Commitment, createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+const logFilePath = path.resolve(__dirname, '../../../../../test-ledger/validator.log');
+const confirmedPattern = /My next leader slot is (\d+)/g;
+const finalizedPattern = /new root (\d+)/g;
+
+async function waitForBlock(slot: number, commitment: 'confirmed' | 'finalized') {
+    const pattern = commitment === 'confirmed' ? confirmedPattern : finalizedPattern;
+    let slotFound = false;
+    while (!slotFound) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        const logs = fs.readFileSync(logFilePath, 'utf8');
+        let match;
+        let latestSlot: number;
+        while ((match = pattern.exec(logs)) !== null) {
+            latestSlot = Number(match[1]);
+            console.log(`Found slot ${latestSlot}`);
+            if (latestSlot >= slot) {
+                slotFound = true;
+                return;
+            }
+        }
+        await new Promise(resolve => setTimeout(resolve, (slot - latestSlot) * 500));
+    }
+}
 
 describe('getBlocksWithLimit', () => {
     let rpc: Rpc<SolanaRpcMethods>;
@@ -15,48 +42,60 @@ describe('getBlocksWithLimit', () => {
         });
     });
 
-    describe('when called with a valid `startSlot` and a valid `limit`', () => {
-        it('returns 8 blocks for a limit of 8', async () => {
-            expect.assertions(1);
-            const res = await rpc.getBlocksWithLimit(5n, 8).send();
-            expect(res).toHaveLength(8);
+    (['confirmed', 'finalized'] as Exclude<Commitment, 'processed'>[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {});
+
+        describe('when called with a valid `startSlot` and a valid `limit`', () => {
+            // On the test validator, finalized blocks tend to be available ~35 slots
+            // after the current confirmed slot.
+            // So we'll have to wait for a few blocks to be confirmed before we can test this.
+            // That means we'll need _at least_ a 35 * 500 ms = 17,500 ms starting buffer
+            it('returns 5 blocks for a limit of 5', async () => {
+                expect.assertions(1);
+                await waitForBlock(5, commitment); // ~500 ms block time x 5 blocks = 2500 ms
+                const res = await rpc.getBlocksWithLimit(1n, 5, { commitment }).send();
+                expect(res).toHaveLength(5);
+            }, 17_500);
         });
 
-        it('returns an empty array for a limit of 0', async () => {
-            expect.assertions(1);
-            const res = await rpc.getBlocksWithLimit(27n, 0).send();
-            expect(res).toHaveLength(0);
+        describe('when called with a valid `startSlot` and a `limit` of 0', () => {
+            it('returns an empty array', async () => {
+                expect.assertions(1);
+                await waitForBlock(2, commitment); // ~500 ms block time x 2 blocks = 1000 ms (< 500 ms default)
+                const res = await rpc.getBlocksWithLimit(2n, 0, { commitment }).send();
+                expect(res).toHaveLength(0);
+            });
         });
-    });
 
-    describe('when called with a `limit` resulting in a slot higher than the highest slot available', () => {
-        // TODO: We need to be able to deterministically set the highest slot
-        // so we can test against it, but without making an RPC call like
-        // `getSlot` which would defeat the purpose of this test.
-        it.todo('returns up to the highest slot available');
-    });
-
-    describe('when called with a `startSlot` higher than the highest slot available', () => {
-        it('returns an empty array', async () => {
-            expect.assertions(1);
-            const res = await rpc
-                .getBlocksWithLimit(
-                    2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
-                    3
-                )
-                .send();
-            expect(res).toHaveLength(0);
+        describe('when called with a `limit` resulting in a slot higher than the highest slot available', () => {
+            // TODO: We need to be able to deterministically set the highest slot
+            // so we can test against it, but without making an RPC call like
+            // `getSlot` which would defeat the purpose of this test.
+            it.todo('returns up to the highest slot available');
         });
-    });
 
-    describe('when called with a `limit` higher than 500,000', () => {
-        it('throws an error', async () => {
-            expect.assertions(1);
-            const sendPromise = rpc.getBlocksWithLimit(0n, 500_001).send();
-            await expect(sendPromise).rejects.toMatchObject({
-                code: -32602,
-                message: expect.any(String),
-                name: 'SolanaJsonRpcError',
+        describe('when called with a `startSlot` higher than the highest slot available', () => {
+            it('returns an empty array', async () => {
+                expect.assertions(1);
+                const res = await rpc
+                    .getBlocksWithLimit(
+                        2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
+                        3
+                    )
+                    .send();
+                expect(res).toHaveLength(0);
+            });
+        });
+
+        describe('when called with a `limit` higher than 500,000', () => {
+            it('throws an error', async () => {
+                expect.assertions(1);
+                const sendPromise = rpc.getBlocksWithLimit(0n, 500_001).send();
+                await expect(sendPromise).rejects.toMatchObject({
+                    code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
+                    message: expect.any(String),
+                    name: 'SolanaJsonRpcError',
+                });
             });
         });
     });

--- a/packages/rpc-core/src/rpc-methods/getBlocksWithLimit.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlocksWithLimit.ts
@@ -1,0 +1,20 @@
+import { Commitment, Slot } from './common';
+
+type GetBlocksWithLimitApiResponse = Slot[];
+
+export interface GetBlocksWithLimitApi {
+    /**
+     * Returns a list of confirmed blocks starting at the given slot
+     * for up to `limit` blocks
+     */
+    getBlocksWithLimit(
+        startSlot: Slot,
+        // The maximum number of blocks to return (between 0 and 500,000)
+        // Note: 0 will return an empty array
+        limit: number,
+        config?: Readonly<{
+            // Defaults to `finalized`
+            commitment?: Exclude<Commitment, 'processed'>;
+        }>
+    ): GetBlocksWithLimitApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -8,6 +8,7 @@ import { GetBlockCommitmentApi } from './getBlockCommitment';
 import { GetBlockHeightApi } from './getBlockHeight';
 import { GetBlockProductionApi } from './getBlockProduction';
 import { GetBlocksApi } from './getBlocks';
+import { GetBlocksWithLimitApi } from './getBlocksWithLimit';
 import { GetBlockTimeApi } from './getBlockTime';
 import { GetClusterNodesApi } from './getClusterNodes';
 import { GetEpochInfoApi } from './getEpochInfo';
@@ -44,6 +45,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetBlockHeightApi &
     GetBlockProductionApi &
     GetBlocksApi &
+    GetBlocksWithLimitApi &
     GetBlockTimeApi &
     GetClusterNodesApi &
     GetEpochInfoApi &

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -706,6 +710,9 @@ importers:
       eslint-plugin-sort-keys-fix:
         specifier: ^1.1.2
         version: 1.1.2
+      fs:
+        specifier: 0.0.1-security
+        version: 0.0.1-security
       jest:
         specifier: ^29.6.1
         version: 29.6.1(@types/node@20.4.4)(ts-node@10.9.1)
@@ -6723,6 +6730,10 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  /fs@0.0.1-security:
+    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
+    dev: true
+
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -11855,7 +11866,3 @@ packages:
   /zstd-codec@0.1.4:
     resolution: {integrity: sha512-KYnWoFWgGtWyQEKNnUcb3u8ZtKO8dn5d8u+oGpxPlopqsPyv60U8suDyfk7Z7UtAO6Sk5i1aVcAs9RbaB1n36A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,9 +710,6 @@ importers:
       eslint-plugin-sort-keys-fix:
         specifier: ^1.1.2
         version: 1.1.2
-      fs:
-        specifier: 0.0.1-security
-        version: 0.0.1-security
       jest:
         specifier: ^29.6.1
         version: 29.6.1(@types/node@20.4.4)(ts-node@10.9.1)
@@ -6729,10 +6726,6 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  /fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
-    dev: true
 
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}


### PR DESCRIPTION
This PR adds the `getBlocksWithLimit` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 

---

I will say adding this method pointed out some strange behavior with the RPC that I'm curious about:
- If you provide a valid slot number and a limit of `0`, you get an empty array
- If you provide a slot number greater than the current slot, you get an empty array

The behavior of getting an empty array rather than an error seems strange, no?