### PR TITLE
refactor(experimental): add `getGenesisHash` API method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
@@ -1,0 +1,41 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+// TODO: We may want to replace the higher clusters with just the local
+// validator, since this is within the live test suite anyhow.
+// Also, with further manipulation capabilities over the local validator,
+// we can explore error testing as well
+const genesisHashMap: [string, Base58EncodedAddress][] = [
+    ['https://api.devnet.solana.com', 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' as Base58EncodedAddress],
+    ['https://api.testnet.solana.com', '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY' as Base58EncodedAddress],
+    ['https://api.mainnet-beta.solana.com', '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d' as Base58EncodedAddress],
+];
+
+describe('getGenesisHash', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    const createRpcForTest = (url: string) => {
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url }),
+        });
+    };
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+    });
+
+    genesisHashMap.forEach(([url, expectedGenesisHash]) => {
+        describe(`when sent to ${url}`, () => {
+            it(`returns ${expectedGenesisHash}`, async () => {
+                expect.assertions(1);
+                createRpcForTest(url);
+                const genesisHashPromise = rpc.getGenesisHash().send();
+                await expect(genesisHashPromise).resolves.toBe(expectedGenesisHash);
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
@@ -1,41 +1,32 @@
-import { Base58EncodedAddress } from '@solana/addresses';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fs from 'fs';
 import fetchMock from 'jest-fetch-mock-fork';
+import path from 'path';
 
 import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
 
-// TODO: We may want to replace the higher clusters with just the local
-// validator, since this is within the live test suite anyhow.
-// Also, with further manipulation capabilities over the local validator,
-// we can explore error testing as well
-const genesisHashMap: [string, Base58EncodedAddress][] = [
-    ['https://api.devnet.solana.com', 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' as Base58EncodedAddress],
-    ['https://api.testnet.solana.com', '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY' as Base58EncodedAddress],
-    ['https://api.mainnet-beta.solana.com', '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d' as Base58EncodedAddress],
-];
+const logFilePath = path.resolve(__dirname, '../../../../../test-ledger/validator.log');
+const genesisHashPattern = /genesis hash: ([\d\w]{44})/;
 
 describe('getGenesisHash', () => {
     let rpc: Rpc<SolanaRpcMethods>;
-    const createRpcForTest = (url: string) => {
-        rpc = createJsonRpc<SolanaRpcMethods>({
-            api: createSolanaRpcApi(),
-            transport: createHttpTransport({ url }),
-        });
-    };
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
     });
 
-    genesisHashMap.forEach(([url, expectedGenesisHash]) => {
-        describe(`when sent to ${url}`, () => {
-            it(`returns ${expectedGenesisHash}`, async () => {
-                expect.assertions(1);
-                createRpcForTest(url);
-                const genesisHashPromise = rpc.getGenesisHash().send();
-                await expect(genesisHashPromise).resolves.toBe(expectedGenesisHash);
-            });
+    describe('when sent to a local validator', () => {
+        it('returns the genesis hash', async () => {
+            expect.assertions(1);
+            const logFile = fs.readFileSync(logFilePath, 'utf-8');
+            const expectedGenesisHash = logFile.match(genesisHashPattern)?.[1];
+            const genesisHashPromise = rpc.getGenesisHash().send();
+            await expect(genesisHashPromise).resolves.toBe(expectedGenesisHash);
         });
     });
 });

--- a/packages/rpc-core/src/rpc-methods/getGenesisHash.ts
+++ b/packages/rpc-core/src/rpc-methods/getGenesisHash.ts
@@ -1,0 +1,13 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+type GetGenesisHashApiResponse = Base58EncodedAddress;
+
+export interface GetGenesisHashApi {
+    /**
+     * Returns the genesis hash
+     */
+    getGenesisHash(
+        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
+        NO_CONFIG?: Record<string, never>
+    ): GetGenesisHashApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -11,6 +11,7 @@ import { GetBlockTimeApi } from './getBlockTime';
 import { GetEpochInfoApi } from './getEpochInfo';
 import { GetEpochScheduleApi } from './getEpochSchedule';
 import { GetFirstAvailableBlockApi } from './getFirstAvailableBlock';
+import { GetGenesisHashApi } from './getGenesisHash';
 import { GetHealthApi } from './getHealth';
 import { GetInflationRewardApi } from './getInflationReward';
 import { GetLatestBlockhashApi } from './getLatestBlockhash';
@@ -44,6 +45,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetEpochInfoApi &
     GetEpochScheduleApi &
     GetFirstAvailableBlockApi &
+    GetGenesisHashApi &
     GetHealthApi &
     GetInflationRewardApi &
     GetLatestBlockhashApi &


### PR DESCRIPTION
This PR adds the `getGenesisHash` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 