### PR TITLE
refactor(experimental): add `getHighestSnapshotSlot` API method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-highest-snapshot-slot-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-highest-snapshot-slot-test.ts
@@ -1,0 +1,14 @@
+// TODO: Again, until we can manipulate the local validator more,
+// this test can't be implemented properly.
+describe('getHighestSnapshotSlot', () => {
+    describe('when there is at least one valid snapshot', () => {
+        it.todo('returns the highest snapshot slot information that the node has snapshots for');
+    });
+
+    describe('when there are no snapshots yet', () => {
+        // TODO:
+        //  Error code -32008
+        //  Message: "No snapshot"
+        it.todo('throws an error');
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getHighestSnapshotSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getHighestSnapshotSlot.ts
@@ -1,0 +1,20 @@
+import { Slot } from './common';
+
+type GetHighestSnapshotSlotApiResponse = Readonly<{
+    full: Slot;
+    incremental: Slot | null;
+}>;
+
+export interface GetHighestSnapshotSlotApi {
+    /**
+     * Returns the highest slot information that the node has snapshots for.
+     *
+     * This will find the highest full snapshot slot, and the highest
+     * incremental snapshot slot based on the full snapshot slot, if there
+     * is one.
+     */
+    getHighestSnapshotSlot(
+        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
+        NO_CONFIG?: Record<string, never>
+    ): GetHighestSnapshotSlotApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -12,6 +12,7 @@ import { GetEpochInfoApi } from './getEpochInfo';
 import { GetEpochScheduleApi } from './getEpochSchedule';
 import { GetFirstAvailableBlockApi } from './getFirstAvailableBlock';
 import { GetHealthApi } from './getHealth';
+import { GetHighestSnapshotSlotApi } from './getHighestSnapshotSlot';
 import { GetInflationRewardApi } from './getInflationReward';
 import { GetLatestBlockhashApi } from './getLatestBlockhash';
 import { GetMaxRetransmitSlotApi } from './getMaxRetransmitSlot';
@@ -45,6 +46,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetEpochScheduleApi &
     GetFirstAvailableBlockApi &
     GetHealthApi &
+    GetHighestSnapshotSlotApi &
     GetInflationRewardApi &
     GetLatestBlockhashApi &
     GetMaxRetransmitSlotApi &


### PR DESCRIPTION
This PR adds the `getHighestSnapshotSlot` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 