### PR TITLE
refactor(experimental): add `getIdentity` API method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-identity-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-identity-test.ts
@@ -1,0 +1,30 @@
+import { base58 } from '@metaplex-foundation/umi-serializers';
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import validatorIdentityBytes from '../../../../../test-ledger/validator-keypair.json';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getIdentity', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    it('returns the identity of the currently running local validator', async () => {
+        expect.assertions(1);
+        const secretKey = new Uint8Array(validatorIdentityBytes);
+        const publicKey = secretKey.slice(32, 64);
+        const expectedAddress = base58.deserialize(publicKey)[0];
+        const identityPromise = rpc.getIdentity().send();
+        await expect(identityPromise).resolves.toMatchObject({
+            identity: expectedAddress,
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getIdentity.ts
+++ b/packages/rpc-core/src/rpc-methods/getIdentity.ts
@@ -1,0 +1,15 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+type GetIdentityApiResponse = Readonly<{
+    identity: Base58EncodedAddress;
+}>;
+
+export interface GetIdentityApi {
+    /**
+     * Returns the identity pubkey for the current node
+     */
+    getIdentity(
+        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
+        NO_CONFIG?: Record<string, never>
+    ): GetIdentityApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -18,6 +18,7 @@ import { GetFirstAvailableBlockApi } from './getFirstAvailableBlock';
 import { GetGenesisHashApi } from './getGenesisHash';
 import { GetHealthApi } from './getHealth';
 import { GetHighestSnapshotSlotApi } from './getHighestSnapshotSlot';
+import { GetIdentityApi } from './getIdentity';
 import { GetInflationGovernorApi } from './getInflationGovernor';
 import { GetInflationRateApi } from './getInflationRate';
 import { GetInflationRewardApi } from './getInflationReward';
@@ -67,6 +68,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetGenesisHashApi &
     GetHealthApi &
     GetHighestSnapshotSlotApi &
+    GetIdentityApi &
     GetInflationGovernorApi &
     GetInflationRateApi &
     GetInflationRewardApi &

--- a/packages/rpc-core/tsconfig.json
+++ b/packages/rpc-core/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
-        "lib": ["DOM", "ES2017", "ES2020.BigInt", "ES2022.Error"]
+        "lib": ["DOM", "ES2017", "ES2020.BigInt", "ES2022.Error"],
+        "resolveJsonModule": true
     },
     "display": "@solana/rpc-core",
     "extends": "tsconfig/base.json",


### PR DESCRIPTION
This PR adds the `getIdentity` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 