### PR TITLE
refactor(experimental): add `getInflationRate` API method

### DIFF
--- a/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
@@ -60,6 +60,7 @@ export const ALLOWED_NUMERIC_KEYPATHS: Partial<
     ],
     getBlockTime: [[]],
     getInflationGovernor: [['initial'], ['foundation'], ['foundationTerm'], ['taper'], ['terminal']],
+    getInflationRate: [['foundation'], ['total'], ['validator']],
     getInflationReward: [[KEYPATH_WILDCARD, 'commission']],
     getRecentPerformanceSamples: [[KEYPATH_WILDCARD, 'samplePeriodSecs']],
     getTokenLargestAccounts: [

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-rate-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-rate-test.ts
@@ -1,0 +1,30 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getInflationRate', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+    // TODO: I honestly have no clue how to test this
+    describe(`when called`, () => {
+        it('returns the inflation rate result with expected formatting', async () => {
+            expect.assertions(1);
+            const result = await rpc.getInflationRate().send();
+            expect(result).toMatchObject({
+                epoch: expect.any(BigInt),
+                foundation: expect.any(Number),
+                total: expect.any(Number),
+                validator: expect.any(Number),
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getInflationRate.ts
+++ b/packages/rpc-core/src/rpc-methods/getInflationRate.ts
@@ -1,0 +1,22 @@
+import { U64UnsafeBeyond2Pow53Minus1 } from './common';
+
+type GetInflationRateApiResponse = Readonly<{
+    /** Epoch for which these values are valid */
+    epoch: U64UnsafeBeyond2Pow53Minus1;
+    /** Inflation allocated to the foundation */
+    foundation: number; // Until we land on best type for `f64`
+    /** Total inflation */
+    total: number; // Until we land on best type for `f64`
+    /** Inflation allocated to validators */
+    validator: number; // Until we land on best type for `f64`
+}>;
+
+export interface GetInflationRateApi {
+    /**
+     * Returns the current block height of the node
+     */
+    getInflationRate(
+        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
+        NO_CONFIG?: Record<string, never>
+    ): GetInflationRateApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -18,6 +18,7 @@ import { GetGenesisHashApi } from './getGenesisHash';
 import { GetHealthApi } from './getHealth';
 import { GetHighestSnapshotSlotApi } from './getHighestSnapshotSlot';
 import { GetInflationGovernorApi } from './getInflationGovernor';
+import { GetInflationRateApi } from './getInflationRate';
 import { GetInflationRewardApi } from './getInflationReward';
 import { GetLatestBlockhashApi } from './getLatestBlockhash';
 import { GetMaxRetransmitSlotApi } from './getMaxRetransmitSlot';
@@ -58,6 +59,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetHealthApi &
     GetHighestSnapshotSlotApi &
     GetInflationGovernorApi &
+    GetInflationRateApi &
     GetInflationRewardApi &
     GetLatestBlockhashApi &
     GetMaxRetransmitSlotApi &


### PR DESCRIPTION
This PR adds the `getInflationRate` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 

---

Hyper-relevant to this PR is #1488. You can see I'm using number in place of what would be an ideal floating-point number handler for `f64`