### PR TITLE
refactor(experimental): add `getMultipleAccounts` API method 

### DIFF
--- a/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
@@ -66,6 +66,67 @@ export const ALLOWED_NUMERIC_KEYPATHS: Partial<
     getInflationGovernor: [['initial'], ['foundation'], ['foundationTerm'], ['taper'], ['terminal']],
     getInflationRate: [['foundation'], ['total'], ['validator']],
     getInflationReward: [[KEYPATH_WILDCARD, 'commission']],
+    getMultipleAccounts: [
+        // parsed AddressTableLookup account
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'lastExtendedSlotStartIndex'],
+        // parsed Config account
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'slashPenalty'],
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'warmupCooldownRate'],
+        // parsed Token/Token22 token account
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'tokenAmount', 'decimals'],
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'tokenAmount', 'uiAmount'],
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'rentExemptReserve', 'decimals'],
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'delegatedAmount', 'decimals'],
+        [
+            'value',
+            KEYPATH_WILDCARD,
+            'data',
+            'parsed',
+            'info',
+            'extensions',
+            KEYPATH_WILDCARD,
+            'state',
+            'olderTransferFee',
+            'transferFeeBasisPoints',
+        ],
+        [
+            'value',
+            KEYPATH_WILDCARD,
+            'data',
+            'parsed',
+            'info',
+            'extensions',
+            KEYPATH_WILDCARD,
+            'state',
+            'newerTransferFee',
+            'transferFeeBasisPoints',
+        ],
+        [
+            'value',
+            KEYPATH_WILDCARD,
+            'data',
+            'parsed',
+            'info',
+            'extensions',
+            KEYPATH_WILDCARD,
+            'state',
+            'preUpdateAverageRate',
+        ],
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'extensions', KEYPATH_WILDCARD, 'state', 'currentRate'],
+        // parsed Token/Token22 mint account
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'decimals'],
+        // parsed Token/Token22 multisig account
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'numRequiredSigners'],
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'numValidSigners'],
+        // parsed Stake account
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'stake', 'delegation', 'warmupCooldownRate'],
+        // parsed Sysvar rent account
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'exemptionThreshold'],
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'burnPercent'],
+        // parsed Vote account
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'commission'],
+        ['value', KEYPATH_WILDCARD, 'data', 'parsed', 'info', 'votes', KEYPATH_WILDCARD, 'confirmationCount'],
+    ],
     getRecentPerformanceSamples: [[KEYPATH_WILDCARD, 'samplePeriodSecs']],
     getTokenAccountBalance: [
         ['value', 'decimals'],

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-account-info-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-account-info-test.ts
@@ -64,6 +64,19 @@ describe('getAccountInfo', () => {
         });
     });
 
+    describe('when called with an account that does not exist', () => {
+        it('returns a null RPC response', async () => {
+            expect.assertions(1);
+            // randomly generated
+            const publicKey =
+                'Bb39jXh8b1rWHymSqM46kKXYwzA35ChNZAMCZ3wSDAMV' as Base58EncodedAddress<'Bb39jXh8b1rWHymSqM46kKXYwzA35ChNZAMCZ3wSDAMV'>;
+            const accountInfoPromise = rpc.getAccountInfo(publicKey).send();
+            await expect(accountInfoPromise).resolves.toMatchObject({
+                value: null,
+            });
+        });
+    });
+
     describe('when called with base58 encoding', () => {
         it('returns account info with annotated base58 encoding', async () => {
             expect.assertions(1);

--- a/packages/rpc-core/src/rpc-methods/getAccountInfo.ts
+++ b/packages/rpc-core/src/rpc-methods/getAccountInfo.ts
@@ -8,22 +8,18 @@ import {
     Commitment,
     DataSlice,
     LamportsUnsafeBeyond2Pow53Minus1,
+    RpcResponse,
     Slot,
     U64UnsafeBeyond2Pow53Minus1,
 } from './common';
 
-type GetAccountInfoApiResponseBase = Readonly<{
-    context: Readonly<{
-        slot: Slot;
-    }>;
-    value: Readonly<{
-        executable: boolean;
-        lamports: LamportsUnsafeBeyond2Pow53Minus1;
-        owner: Base58EncodedAddress;
-        rentEpoch: U64UnsafeBeyond2Pow53Minus1;
-        space: U64UnsafeBeyond2Pow53Minus1;
-    }> | null;
-}>;
+type GetAccountInfoApiResponseBase = RpcResponse<{
+    executable: boolean;
+    lamports: LamportsUnsafeBeyond2Pow53Minus1;
+    owner: Base58EncodedAddress;
+    rentEpoch: U64UnsafeBeyond2Pow53Minus1;
+    space: U64UnsafeBeyond2Pow53Minus1;
+} | null>;
 
 type GetAccountInfoApiResponseWithDefaultData = Readonly<{
     value: Readonly<{

--- a/packages/rpc-core/src/rpc-methods/getMultipleAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getMultipleAccounts.ts
@@ -1,0 +1,113 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+import {
+    Base58EncodedDataResponse,
+    Base64EncodedDataResponse,
+    Base64EncodedZStdCompressedDataResponse,
+    Commitment,
+    DataSlice,
+    LamportsUnsafeBeyond2Pow53Minus1,
+    RpcResponse,
+    Slot,
+    U64UnsafeBeyond2Pow53Minus1,
+} from './common';
+
+type GetMultipleAccountsApiResponseBase = {
+    /** indicates if the account contains a program (and is strictly read-only) */
+    executable: boolean;
+    /** number of lamports assigned to this account */
+    lamports: LamportsUnsafeBeyond2Pow53Minus1;
+    /** pubkey of the program this account has been assigned to */
+    owner: Base58EncodedAddress;
+    /** the epoch at which this account will next owe rent */
+    rentEpoch: U64UnsafeBeyond2Pow53Minus1;
+    /** the data size of the account */
+    space: U64UnsafeBeyond2Pow53Minus1;
+} | null;
+
+type GetMultipleAccountsApiResponseWithBase58EncodedData_DEPRECATED = Readonly<{
+    data: Base58EncodedDataResponse;
+}>;
+
+type GetMultipleAccountsApiResponseWithBase64EncodedData = Readonly<{
+    data: Base64EncodedDataResponse;
+}>;
+
+type GetMultipleAccountsApiResponseWithBase64EncodedZStdCompressedData = Readonly<{
+    data: Base64EncodedZStdCompressedDataResponse;
+}>;
+
+type GetMultipleAccountsApiResponseWithJsonData = Readonly<{
+    data:
+        | Readonly<{
+              /** Name of the program that owns this account. */
+              program: string;
+              parsed: unknown;
+              space: U64UnsafeBeyond2Pow53Minus1;
+          }>
+        // If `jsonParsed` encoding is requested but a parser cannot be found for the given
+        // account the `data` field falls back to `base64`.
+        | Base64EncodedDataResponse;
+}>;
+
+type GetMultipleAccountsApiCommonConfig = Readonly<{
+    /** Defaults to `finalized` */
+    commitment?: Commitment;
+    /** The minimum slot that the request can be evaluated at */
+    minContextSlot?: Slot;
+}>;
+
+type GetMultipleAccountsApiSliceableCommonConfig = Readonly<{
+    /** Limit the returned account data */
+    dataSlice?: DataSlice;
+}>;
+
+export interface GetMultipleAccountsApi {
+    /**
+     * Returns the account information for a list of Pubkeys.
+     */
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Base58EncodedAddress[],
+        config: GetMultipleAccountsApiCommonConfig &
+            GetMultipleAccountsApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base64';
+            }>
+    ): RpcResponse<(GetMultipleAccountsApiResponseBase & GetMultipleAccountsApiResponseWithBase64EncodedData)[]>;
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Base58EncodedAddress[],
+        config: GetMultipleAccountsApiCommonConfig &
+            GetMultipleAccountsApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base64+zstd';
+            }>
+    ): RpcResponse<
+        (GetMultipleAccountsApiResponseBase & GetMultipleAccountsApiResponseWithBase64EncodedZStdCompressedData)[]
+    >;
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Base58EncodedAddress[],
+        config: GetMultipleAccountsApiCommonConfig &
+            Readonly<{
+                encoding: 'jsonParsed';
+            }>
+    ): RpcResponse<(GetMultipleAccountsApiResponseBase & GetMultipleAccountsApiResponseWithJsonData)[]>;
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Base58EncodedAddress[],
+        config: GetMultipleAccountsApiCommonConfig &
+            GetMultipleAccountsApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base58';
+            }>
+    ): RpcResponse<
+        (GetMultipleAccountsApiResponseBase & GetMultipleAccountsApiResponseWithBase58EncodedData_DEPRECATED)[]
+    >;
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Base58EncodedAddress[],
+        config?: GetMultipleAccountsApiCommonConfig
+    ): RpcResponse<(GetMultipleAccountsApiResponseBase & GetMultipleAccountsApiResponseWithBase64EncodedData)[]>;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -26,6 +26,7 @@ import { GetLatestBlockhashApi } from './getLatestBlockhash';
 import { GetMaxRetransmitSlotApi } from './getMaxRetransmitSlot';
 import { GetMaxShredInsertSlotApi } from './getMaxShredInsertSlot';
 import { GetMinimumBalanceForRentExemptionApi } from './getMinimumBalanceForRentExemption';
+import { GetMultipleAccountsApi } from './getMultipleAccounts';
 import { GetRecentPerformanceSamplesApi } from './getRecentPerformanceSamples';
 import { GetRecentPrioritizationFeesApi } from './getRecentPrioritizationFees';
 import { GetSignaturesForAddressApi } from './getSignaturesForAddress';
@@ -76,6 +77,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetMaxRetransmitSlotApi &
     GetMaxShredInsertSlotApi &
     GetMinimumBalanceForRentExemptionApi &
+    GetMultipleAccountsApi &
     GetRecentPerformanceSamplesApi &
     GetRecentPrioritizationFeesApi &
     GetSignaturesForAddressApi &


### PR DESCRIPTION
This PR adds `getMultipleAccounts` to experimental web3js. The API code, numeric patcher exceptions and tests are based on `getAccountInfo`

Note that the change to `get-account-info-tests.ts` is just formatting: moving more tests into the when called with jsonParsed encoding > for an account with parse-able JSON data block 

Ref #1449 