### PR TITLE
refactor(experimental): add `getLargestAccounts` API method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-largest-accounts-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-largest-accounts-test.ts
@@ -1,0 +1,64 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { Commitment } from '../common';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getLargestAccounts', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            describe('when called without filter', () => {
+                it('returns a list of the largest accounts', async () => {
+                    expect.assertions(1);
+                    const largestAcountsPromise = rpc.getLargestAccounts({ commitment }).send();
+                    await expect(largestAcountsPromise).resolves.toMatchObject({
+                        context: {
+                            slot: expect.any(BigInt),
+                        },
+                        value: expect.arrayContaining([
+                            {
+                                address: expect.any(String),
+                                lamports: expect.any(BigInt),
+                            },
+                        ]),
+                    });
+                });
+            });
+
+            describe('when called with the `circulating` filter', () => {
+                it('returns a list of the largest circulating accounts', async () => {
+                    expect.assertions(1);
+                    const largestAcountsPromise = rpc.getLargestAccounts({ commitment, filter: 'circulating' }).send();
+                    await expect(largestAcountsPromise).resolves.toMatchObject({
+                        context: {
+                            slot: expect.any(BigInt),
+                        },
+                        value: expect.arrayContaining([
+                            {
+                                address: expect.any(String),
+                                lamports: expect.any(BigInt),
+                            },
+                        ]),
+                    });
+                });
+            });
+
+            describe('when called with the `nonCirculating` filter', () => {
+                // TODO: This will always be an empty array until we can mock it
+                // with the test validator.
+                it.todo('returns a list of the largest non-circulating accounts');
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getLargestAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getLargestAccounts.ts
@@ -1,0 +1,26 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, RpcResponse } from './common';
+
+type GetLargestAccountsResponseItem = Readonly<{
+    /** Base-58 encoded address of the account */
+    address: Base58EncodedAddress;
+    /** Number of lamports in the account */
+    lamports: LamportsUnsafeBeyond2Pow53Minus1;
+}>;
+
+type GetLargestAccountsApiResponse = RpcResponse<GetLargestAccountsResponseItem[]>;
+
+export interface GetLargestAccountsApi {
+    /**
+     * Returns the 20 largest accounts, by lamport balance
+     * (results may be cached up to two hours)
+     */
+    getLargestAccounts(
+        config?: Readonly<{
+            commitment?: Commitment;
+            /** Filter results by account type */
+            filter?: 'circulating' | 'nonCirculating';
+        }>
+    ): GetLargestAccountsApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -18,6 +18,7 @@ import { GetGenesisHashApi } from './getGenesisHash';
 import { GetHealthApi } from './getHealth';
 import { GetHighestSnapshotSlotApi } from './getHighestSnapshotSlot';
 import { GetInflationRewardApi } from './getInflationReward';
+import { GetLargestAccountsApi } from './getLargestAccounts';
 import { GetLatestBlockhashApi } from './getLatestBlockhash';
 import { GetMaxRetransmitSlotApi } from './getMaxRetransmitSlot';
 import { GetMaxShredInsertSlotApi } from './getMaxShredInsertSlot';
@@ -56,6 +57,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetHealthApi &
     GetHighestSnapshotSlotApi &
     GetInflationRewardApi &
+    GetLargestAccountsApi &
     GetLatestBlockhashApi &
     GetMaxRetransmitSlotApi &
     GetMaxShredInsertSlotApi &


### PR DESCRIPTION
This PR adds the `getLargestAccounts` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 