### PR TITLE
test: fix genesis hash regex

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
 
 const logFilePath = path.resolve(__dirname, '../../../../../test-ledger/validator.log');
-const genesisHashPattern = /genesis hash: ([\d\w]{44})/;
+const genesisHashPattern = /genesis hash: ([\d\w]{32,})/;
 
 describe('getGenesisHash', () => {
     let rpc: Rpc<SolanaRpcMethods>;


### PR DESCRIPTION
This PR fixes the regex for grabbing the genesis hash from the validator logs. The length specifier previously used (44) is likely to fail whenever the raw bytes produce a shorter base58 encoding 