### PR TITLE
refactor(experimental): add `getRecentPrioritizationFees` method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-recent-prioritization-fees-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-recent-prioritization-fees-test.ts
@@ -1,0 +1,98 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getRecentPrioritizationFees', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    describe('when called with no addresses provided', () => {
+        it('returns a list of prioritization fees', async () => {
+            expect.assertions(1);
+            const res = await rpc.getRecentPrioritizationFees().send();
+            expect(Array.isArray(res)).toBe(true);
+            // TODO: We have no way to reliably ensure at least one slot
+            // has passed at the time of this test, so we can't reliably
+            // expect an array that isn't empty.
+            //
+            // expect(res[0]).toMatchObject({
+            //     prioritizationFee: expect.any(BigInt),
+            //     slot: expect.any(BigInt),
+            // });
+        });
+    });
+
+    describe('when called with one address provided', () => {
+        // TODO: This test does not check whether the response is related to
+        // prioritization fees associated with locking the provided account
+        it('returns a list of prioritization fees', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/GQE2yjns7SKKuMc89tveBDpzYHwXfeuB2PGAbGaPWc6G.json
+            const addresses = ['GQE2yjns7SKKuMc89tveBDpzYHwXfeuB2PGAbGaPWc6G' as Base58EncodedAddress];
+            const res = await rpc.getRecentPrioritizationFees(addresses).send();
+            expect(Array.isArray(res)).toBe(true);
+            // TODO: We have no way to reliably ensure at least one slot
+            // has passed at the time of this test, so we can't reliably
+            // expect an array that isn't empty.
+            //
+            // expect(res[0]).toMatchObject({
+            //     prioritizationFee: expect.any(BigInt),
+            //     slot: expect.any(BigInt),
+            // });
+        });
+    });
+
+    describe('when called with multiple addresses provided', () => {
+        // TODO: This test does not check whether the response is related to
+        // prioritization fees associated with locking the provided accounts
+        it('returns a list of prioritization fees', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc.json
+            // See scripts/fixtures/GQE2yjns7SKKuMc89tveBDpzYHwXfeuB2PGAbGaPWc6G.json
+            const addresses = [
+                '4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc' as Base58EncodedAddress,
+                'GQE2yjns7SKKuMc89tveBDpzYHwXfeuB2PGAbGaPWc6G' as Base58EncodedAddress,
+            ];
+            const res = await rpc.getRecentPrioritizationFees(addresses).send();
+            expect(Array.isArray(res)).toBe(true);
+            // TODO: We have no way to reliably ensure at least one slot
+            // has passed at the time of this test, so we can't reliably
+            // expect an array that isn't empty.
+            //
+            // expect(res[0]).toMatchObject({
+            //     prioritizationFee: expect.any(BigInt),
+            //     slot: expect.any(BigInt),
+            // });
+        });
+    });
+
+    describe('when called with the address of an account that does not exist', () => {
+        // TODO: This test does not check whether the response is related to
+        // prioritization fees associated with locking the provided account
+        it('returns a list of prioritization fees', async () => {
+            expect.assertions(1);
+            // Randomly generated
+            const addresses = ['BnWCFuxmi6uH3ceVx4R8qcbWBMPVVYVVFWtAiiTA1PAu' as Base58EncodedAddress];
+            const res = await rpc.getRecentPrioritizationFees(addresses).send();
+            expect(Array.isArray(res)).toBe(true);
+            // TODO: We have no way to reliably ensure at least one slot
+            // has passed at the time of this test, so we can't reliably
+            // expect an array that isn't empty.
+            //
+            // expect(res[0]).toMatchObject({
+            //     prioritizationFee: expect.any(BigInt),
+            //     slot: expect.any(BigInt),
+            // });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/common.ts
+++ b/packages/rpc-core/src/rpc-methods/common.ts
@@ -10,6 +10,13 @@ export type DataSlice = Readonly<{
 // the JSON-RPC transport.
 export type LamportsUnsafeBeyond2Pow53Minus1 = bigint & { readonly __lamports: unique symbol };
 
+// FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
+// truncated or rounded because of a downcast to JavaScript `number` between your calling code and
+// the JSON-RPC transport.
+//
+// Spefically being used to denote micro-lamports, which are 0.000001 lamports.
+export type MicroLamportsUnsafeBeyond2Pow53Minus1 = bigint & { readonly __lamports: unique symbol };
+
 export type Slot = U64UnsafeBeyond2Pow53Minus1;
 
 // FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be

--- a/packages/rpc-core/src/rpc-methods/getRecentPrioritizationFees.ts
+++ b/packages/rpc-core/src/rpc-methods/getRecentPrioritizationFees.ts
@@ -1,0 +1,31 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+import { MicroLamportsUnsafeBeyond2Pow53Minus1, Slot } from './common';
+
+type GetRecentPrioritizationFeesApiResponse = Readonly<{
+    /**
+     * The per-compute-unit fee paid by at least one successfully
+     * landed transaction, specified in increments of
+     * micro-lamports (0.000001 lamports).
+     */
+    prioritizationFee: MicroLamportsUnsafeBeyond2Pow53Minus1;
+    /** Slot in which the fee was observed */
+    slot: Slot;
+}>[];
+
+export interface GetRecentPrioritizationFeesApi {
+    /**
+     * Returns the balance of the account of provided Pubkey
+     */
+    getRecentPrioritizationFees(
+        /**
+         * An array of Account addresses (up to a maximum of 128 addresses),
+         * as base-58 encoded strings.
+         *
+         * Note: If this parameter is provided, the response will reflect
+         * a fee to land a transaction locking all of the provided accounts
+         * as writable.
+         */
+        addresses?: Base58EncodedAddress[]
+    ): GetRecentPrioritizationFeesApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -22,6 +22,7 @@ import { GetLatestBlockhashApi } from './getLatestBlockhash';
 import { GetMaxRetransmitSlotApi } from './getMaxRetransmitSlot';
 import { GetMaxShredInsertSlotApi } from './getMaxShredInsertSlot';
 import { GetRecentPerformanceSamplesApi } from './getRecentPerformanceSamples';
+import { GetRecentPrioritizationFeesApi } from './getRecentPrioritizationFees';
 import { GetSignaturesForAddressApi } from './getSignaturesForAddress';
 import { GetSlotApi } from './getSlot';
 import { GetSlotLeadersApi } from './getSlotLeaders';
@@ -60,6 +61,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetMaxRetransmitSlotApi &
     GetMaxShredInsertSlotApi &
     GetRecentPerformanceSamplesApi &
+    GetRecentPrioritizationFeesApi &
     GetSignaturesForAddressApi &
     GetSlotApi &
     GetSlotLeadersApi &


### PR DESCRIPTION
This PR adds the`getRecentPrioritizationFees` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 