### PR TITLE
refactor(experimental): add `getSignatureStatuses` method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-signature-statuses-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-signature-statuses-test.ts
@@ -1,0 +1,81 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { TransactionSignature } from '../../transaction-signature';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getSignatureStatuses', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    describe('when called with a valid transaction signature', () => {
+        [true, false].forEach(searchTransactionHistory => {
+            describe(`with \`searchTransactionHistory\`: ${searchTransactionHistory} and one signature provided`, () => {
+                // TODO: Cannot test this until we have a way to mock
+                // some transactions without RPC methods
+                it.todo('returns a signature status with the correct shape');
+            });
+
+            describe(`with \`searchTransactionHistory\`: ${searchTransactionHistory} and multiple signatures provided`, () => {
+                // TODO: Cannot test this until we have a way to mock
+                // some transactions without RPC methods
+                it.todo('returns a signature status with the correct shape');
+            });
+        });
+    });
+
+    describe('when called with no transaction signature provided', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const signatureStatusPromise = rpc
+                .getSignatureStatuses(['invalid_signature' as TransactionSignature])
+                .send();
+            await expect(signatureStatusPromise).rejects.toMatchObject({
+                code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+
+    describe('when called with an invalid transaction signature', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const signatureStatusPromise = rpc
+                .getSignatureStatuses(['invalid_signature' as TransactionSignature])
+                .send();
+            await expect(signatureStatusPromise).rejects.toMatchObject({
+                code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+
+    describe('when called with a transaction signature that does not exist', () => {
+        it('returns null for that signature', async () => {
+            expect.assertions(1);
+            const signatureStatusPromise = rpc
+                .getSignatureStatuses([
+                    // Randomly generated
+                    '4Vx3PAb665jCLRpbpgKshZuwKP6TUgoSDDAbKEsyvkKhwrNDT6CE5d7MT1vEPkgEo1cmr7zsM8h724wRnjyCAoR3' as TransactionSignature,
+                ])
+                .send();
+            await expect(signatureStatusPromise).resolves.toMatchObject({
+                context: {
+                    slot: expect.any(BigInt),
+                },
+                value: [null],
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getSignatureStatuses.ts
+++ b/packages/rpc-core/src/rpc-methods/getSignatureStatuses.ts
@@ -1,0 +1,62 @@
+import { TransactionError } from '../transaction-error';
+import { TransactionSignature } from '../transaction-signature';
+import { Commitment, RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+
+/** @deprecated */
+type TransactionStatusOk = Readonly<{
+    Ok: null;
+}>;
+
+/** @deprecated */
+type TransactionStatusErr = Readonly<{
+    Err: TransactionError;
+}>;
+
+type GetSignatureStatusesBase = Readonly<{
+    /**
+     * Number of blocks since signature confirmation, null if rooted,
+     * as well as finalized by a supermajority of the cluster
+     */
+    confirmations: U64UnsafeBeyond2Pow53Minus1 | null;
+    /**
+     * The transaction's cluster confirmation status; either `processed`,
+     * `confirmed`, or `finalized`.
+     */
+    confirmationStatus: Commitment | null;
+    /** Error if transaction failed, null if transaction succeeded */
+    err: TransactionError | null;
+    /** The slot the transaction was processed */
+    slot: Slot;
+    /**
+     * @deprecated Transaction status
+     */
+    status: TransactionStatusOk | TransactionStatusErr;
+}> | null;
+
+type GetSignatureStatusesApiResponse = RpcResponse<GetSignatureStatusesBase>;
+
+export interface GetSignatureStatusesApi {
+    /**
+     * Returns the statuses of a list of signatures.
+     * Each signature must be a txid, the first signature of a transaction.
+     *
+     * Note: Unless the `searchTransactionHistory` configuration parameter is
+     * included, this method only searches the recent status cache of
+     * signatures, which retains statuses for all active slots plus
+     * `MAX_RECENT_BLOCKHASHES` rooted slots.
+     */
+    getSignatureStatuses(
+        /**
+         * An array of transaction signatures to confirm,
+         * as base-58 encoded strings (up to a maximum of 256)
+         */
+        signatures?: TransactionSignature[],
+        config?: Readonly<{
+            /**
+             * if `true` - a Solana node will search its ledger cache for any
+             * signatures not found in the recent status cache
+             */
+            searchTransactionHistory?: boolean;
+        }>
+    ): GetSignatureStatusesApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -23,6 +23,7 @@ import { GetMaxRetransmitSlotApi } from './getMaxRetransmitSlot';
 import { GetMaxShredInsertSlotApi } from './getMaxShredInsertSlot';
 import { GetRecentPerformanceSamplesApi } from './getRecentPerformanceSamples';
 import { GetSignaturesForAddressApi } from './getSignaturesForAddress';
+import { GetSignatureStatusesApi } from './getSignatureStatuses';
 import { GetSlotApi } from './getSlot';
 import { GetSlotLeadersApi } from './getSlotLeaders';
 import { GetStakeMinimumDelegationApi } from './getStakeMinimumDelegation';
@@ -61,6 +62,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetMaxShredInsertSlotApi &
     GetRecentPerformanceSamplesApi &
     GetSignaturesForAddressApi &
+    GetSignatureStatusesApi &
     GetSlotApi &
     GetSlotLeadersApi &
     GetStakeMinimumDelegationApi &


### PR DESCRIPTION
This PR adds`getSignatureStatuses` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 