### PR TITLE
refactor(experimental): add `getSlotLeader` method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leader-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leader-test.ts
@@ -18,18 +18,18 @@ describe('getSlotLeader', () => {
 
     (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
         describe(`when called with \`${commitment}\` commitment`, () => {
-            describe('when called with no `mintContextSlot`', () => {
+            describe('when called with no `minContextSlot`', () => {
                 it('returns the node public key', async () => {
                     expect.assertions(1);
-                    const res = await rpc.getSlotLeader().send();
+                    const res = await rpc.getSlotLeader({ commitment }).send();
                     expect(res).toEqual(expect.any(String));
                 });
             });
 
-            describe('when called with a valid `mintContextSlot`', () => {
+            describe('when called with a valid `minContextSlot`', () => {
                 it('returns the node public key', async () => {
                     expect.assertions(1);
-                    const res = await rpc.getSlotLeader({ minContextSlot: 0n }).send();
+                    const res = await rpc.getSlotLeader({ commitment, minContextSlot: 0n }).send();
                     expect(res).toEqual(expect.any(String));
                 });
             });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leader-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leader-test.ts
@@ -1,0 +1,54 @@
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { Commitment, createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+describe('getSlotLeader', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            describe('when called with no `mintContextSlot`', () => {
+                it('returns the node public key', async () => {
+                    expect.assertions(1);
+                    const res = await rpc.getSlotLeader().send();
+                    expect(res).toEqual(expect.any(String));
+                });
+            });
+
+            describe('when called with a valid `mintContextSlot`', () => {
+                it('returns the node public key', async () => {
+                    expect.assertions(1);
+                    const res = await rpc.getSlotLeader({ minContextSlot: 0n }).send();
+                    expect(res).toEqual(expect.any(String));
+                });
+            });
+        });
+    });
+
+    describe('when called with a `minContextSlot` higher than the highest slot available', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const sendPromise = rpc
+                .getSlotLeader({
+                    minContextSlot: 2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
+                })
+                .send();
+            await expect(sendPromise).rejects.toMatchObject({
+                code: -32016 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getSlotLeader.ts
+++ b/packages/rpc-core/src/rpc-methods/getSlotLeader.ts
@@ -1,0 +1,15 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+import { Commitment, Slot } from './common';
+
+export interface GetSlotLeaderApi {
+    /**
+     * Returns the current slot leader
+     */
+    getSlotLeader(
+        config?: Readonly<{
+            commitment?: Commitment;
+            minContextSlot?: Slot;
+        }>
+    ): Base58EncodedAddress;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -24,6 +24,7 @@ import { GetMaxShredInsertSlotApi } from './getMaxShredInsertSlot';
 import { GetRecentPerformanceSamplesApi } from './getRecentPerformanceSamples';
 import { GetSignaturesForAddressApi } from './getSignaturesForAddress';
 import { GetSlotApi } from './getSlot';
+import { GetSlotLeaderApi } from './getSlotLeader';
 import { GetSlotLeadersApi } from './getSlotLeaders';
 import { GetStakeMinimumDelegationApi } from './getStakeMinimumDelegation';
 import { GetSupplyApi } from './getSupply';
@@ -62,6 +63,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetRecentPerformanceSamplesApi &
     GetSignaturesForAddressApi &
     GetSlotApi &
+    GetSlotLeaderApi &
     GetSlotLeadersApi &
     GetStakeMinimumDelegationApi &
     GetSupplyApi &


### PR DESCRIPTION
This PR adds`getSlotLeader` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 