### PR TITLE
refactor(experimental): add `getStakeActivation` API method

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-stake-activation-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-stake-activation-test.ts
@@ -1,0 +1,86 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { Commitment } from '../common';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+// See scripts/fixtures/stake-account.json
+const stakeAccountAddress = 'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN' as Base58EncodedAddress;
+
+describe('getStakeActivation', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            it('returns stake activation', async () => {
+                expect.assertions(1);
+                const stakeActivationPromise = rpc.getStakeActivation(stakeAccountAddress, { commitment }).send();
+                await expect(stakeActivationPromise).resolves.toMatchObject({
+                    active: expect.any(BigInt),
+                    inactive: expect.any(BigInt),
+                    state: expect.any(String),
+                });
+            });
+        });
+    });
+
+    describe('when called with an account that is not a stake account', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const stakeActivationPromise = rpc
+                .getStakeActivation(
+                    // Randomly generated
+                    'BnWCFuxmi6uH3ceVx4R8qcbWBMPVVYVVFWtAiiTA1PAu' as Base58EncodedAddress
+                )
+                .send();
+            await expect(stakeActivationPromise).rejects.toMatchObject({
+                code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+
+    describe('when called with a `minContextSlot` higher than the highest slot available', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const stakeActivationPromise = rpc
+                .getStakeActivation(stakeAccountAddress, {
+                    minContextSlot: 2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
+                })
+                .send();
+            await expect(stakeActivationPromise).rejects.toMatchObject({
+                code: -32016 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+
+    describe('when called with an `epoch` higher than the highest slot available', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const stakeActivationPromise = rpc
+                .getStakeActivation(stakeAccountAddress, {
+                    epoch: 2n ** 63n - 1n, // u64:MAX; safe bet it'll be too high.
+                })
+                .send();
+            await expect(stakeActivationPromise).rejects.toMatchObject({
+                code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getStakeActivation.ts
+++ b/packages/rpc-core/src/rpc-methods/getStakeActivation.ts
@@ -1,0 +1,27 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+import { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+
+type GetStakeActivationApiResponse = Readonly<{
+    /** Stake active during the epoch */
+    active: U64UnsafeBeyond2Pow53Minus1;
+    /** Stake inactive during the epoch */
+    inactive: U64UnsafeBeyond2Pow53Minus1;
+    /** The stake account's activation state */
+    state: 'active' | 'inactive' | 'activating' | 'deactivating';
+}>;
+
+export interface GetStakeActivationApi {
+    /**
+     * Returns epoch activation information for a stake account
+     */
+    getStakeActivation(
+        address: Base58EncodedAddress,
+        config?: Readonly<{
+            commitment?: Commitment;
+            minContextSlot?: Slot;
+            /** Defaults to current epoch */
+            epoch?: U64UnsafeBeyond2Pow53Minus1;
+        }>
+    ): GetStakeActivationApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -25,6 +25,7 @@ import { GetRecentPerformanceSamplesApi } from './getRecentPerformanceSamples';
 import { GetSignaturesForAddressApi } from './getSignaturesForAddress';
 import { GetSlotApi } from './getSlot';
 import { GetSlotLeadersApi } from './getSlotLeaders';
+import { GetStakeActivationApi } from './getStakeActivation';
 import { GetStakeMinimumDelegationApi } from './getStakeMinimumDelegation';
 import { GetSupplyApi } from './getSupply';
 import { GetTokenLargestAccountsApi } from './getTokenLargestAccounts';
@@ -63,6 +64,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetSignaturesForAddressApi &
     GetSlotApi &
     GetSlotLeadersApi &
+    GetStakeActivationApi &
     GetStakeMinimumDelegationApi &
     GetSupplyApi &
     GetTokenLargestAccountsApi &


### PR DESCRIPTION
This PR adds the `getStakeActivation` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 