### PR TITLE
refactor(experimental): add `getTokenAccountBalance` API method

### DIFF
--- a/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
@@ -61,6 +61,10 @@ export const ALLOWED_NUMERIC_KEYPATHS: Partial<
     getBlockTime: [[]],
     getInflationReward: [[KEYPATH_WILDCARD, 'commission']],
     getRecentPerformanceSamples: [[KEYPATH_WILDCARD, 'samplePeriodSecs']],
+    getTokenAccountBalance: [
+        ['value', 'decimals'],
+        ['value', 'uiAmount'],
+    ],
     getTokenLargestAccounts: [
         ['value', KEYPATH_WILDCARD, 'decimals'],
         ['value', KEYPATH_WILDCARD, 'uiAmount'],

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-token-account-balance-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-token-account-balance-test.ts
@@ -35,7 +35,8 @@ describe('getTokenAccountBalance', () => {
                     value: {
                         amount: expect.any(String),
                         decimals: expect.any(Number),
-                        uiAmount: expect.anything(), // Number or null
+                        // This can be Number or null, but we're using a fixture so it should be Number
+                        uiAmount: expect.any(Number),
                         uiAmountString: expect.any(String),
                     },
                 });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-token-account-balance-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-token-account-balance-test.ts
@@ -1,0 +1,62 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { Commitment } from '../common';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+// See scripts/fixtures/spl-token-token-account.json
+const tokenAccountAddress = 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca' as Base58EncodedAddress;
+
+describe('getTokenAccountBalance', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            it('returns token account balance', async () => {
+                expect.assertions(1);
+                const tokenAccountBalancePromise = rpc
+                    .getTokenAccountBalance(tokenAccountAddress, { commitment })
+                    .send();
+                await expect(tokenAccountBalancePromise).resolves.toMatchObject({
+                    context: {
+                        slot: expect.any(BigInt),
+                    },
+                    value: {
+                        amount: expect.any(String),
+                        decimals: expect.any(Number),
+                        uiAmount: expect.anything(), // Number or null
+                        uiAmountString: expect.any(String),
+                    },
+                });
+            });
+        });
+    });
+
+    describe('when called with an account that is not a token account', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const stakeActivationPromise = rpc
+                .getTokenAccountBalance(
+                    // Randomly generated
+                    'BnWCFuxmi6uH3ceVx4R8qcbWBMPVVYVVFWtAiiTA1PAu' as Base58EncodedAddress
+                )
+                .send();
+            await expect(stakeActivationPromise).rejects.toMatchObject({
+                code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountBalance.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountBalance.ts
@@ -1,0 +1,27 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+import { Commitment, RpcResponse } from './common';
+
+type GetTokenAccountBalanceApiResponse = RpcResponse<{
+    /** The raw balance without decimals, a string representation of u64 */
+    amount: string;
+    /** Number of base 10 digits to the right of the decimal place */
+    decimals: number;
+    /** @deprecated The balance, using mint-prescribed decimals */
+    uiAmount: number | null;
+    /** The balance as a string, using mint-prescribed decimals */
+    uiAmountString: string;
+}>;
+
+export interface GetTokenAccountBalanceApi {
+    /**
+     * Returns the token balance of an SPL Token account
+     */
+    getTokenAccountBalance(
+        /** Pubkey of Token account to query, as base-58 encoded string */
+        address: Base58EncodedAddress,
+        config?: Readonly<{
+            commitment?: Commitment;
+        }>
+    ): GetTokenAccountBalanceApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -27,6 +27,7 @@ import { GetSlotApi } from './getSlot';
 import { GetSlotLeadersApi } from './getSlotLeaders';
 import { GetStakeMinimumDelegationApi } from './getStakeMinimumDelegation';
 import { GetSupplyApi } from './getSupply';
+import { GetTokenAccountBalanceApi } from './getTokenAccountBalance';
 import { GetTokenLargestAccountsApi } from './getTokenLargestAccounts';
 import { GetTransactionApi } from './getTransaction';
 import { GetTransactionCountApi } from './getTransactionCount';
@@ -65,6 +66,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetSlotLeadersApi &
     GetStakeMinimumDelegationApi &
     GetSupplyApi &
+    GetTokenAccountBalanceApi &
     GetTokenLargestAccountsApi &
     GetTransactionApi &
     GetTransactionCountApi &


### PR DESCRIPTION
This PR adds the `getTokenAccountBalance` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 