### PR TITLE
refactor(experimental): add `getTokenSupply` API method

### DIFF
--- a/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
@@ -65,6 +65,10 @@ export const ALLOWED_NUMERIC_KEYPATHS: Partial<
         ['value', KEYPATH_WILDCARD, 'decimals'],
         ['value', KEYPATH_WILDCARD, 'uiAmount'],
     ],
+    getTokenSupply: [
+        ['value', 'decimals'],
+        ['value', 'uiAmount'],
+    ],
     getTransaction: [
         ['meta', 'preTokenBalances', KEYPATH_WILDCARD, 'accountIndex'],
         ['meta', 'preTokenBalances', KEYPATH_WILDCARD, 'uiTokenAmount', 'decimals'],

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-token-supply-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-token-supply-test.ts
@@ -33,7 +33,8 @@ describe('getTokenSupply', () => {
                     value: {
                         amount: expect.any(String),
                         decimals: expect.any(Number),
-                        uiAmount: expect.anything(), // Number or null
+                        // This can be Number or null, but we're using a fixture so it should be Number
+                        uiAmount: expect.any(Number),
                         uiAmountString: expect.any(String),
                     },
                 });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-token-supply-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-token-supply-test.ts
@@ -1,0 +1,60 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
+import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { Commitment } from '../common';
+import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+
+// See scripts/fixtures/spl-token-mint-account.json
+const tokenMintAddress = 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' as Base58EncodedAddress;
+
+describe('getTokenSupply', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+    });
+
+    (['confirmed', 'finalized', 'processed'] as Commitment[]).forEach(commitment => {
+        describe(`when called with \`${commitment}\` commitment`, () => {
+            it('returns total token supply', async () => {
+                expect.assertions(1);
+                const tokenAccountBalancePromise = rpc.getTokenSupply(tokenMintAddress, { commitment }).send();
+                await expect(tokenAccountBalancePromise).resolves.toMatchObject({
+                    context: {
+                        slot: expect.any(BigInt),
+                    },
+                    value: {
+                        amount: expect.any(String),
+                        decimals: expect.any(Number),
+                        uiAmount: expect.anything(), // Number or null
+                        uiAmountString: expect.any(String),
+                    },
+                });
+            });
+        });
+    });
+
+    describe('when called with an account that is not a token mint', () => {
+        it('throws an error', async () => {
+            expect.assertions(1);
+            const stakeActivationPromise = rpc
+                .getTokenSupply(
+                    // Randomly generated
+                    'BnWCFuxmi6uH3ceVx4R8qcbWBMPVVYVVFWtAiiTA1PAu' as Base58EncodedAddress
+                )
+                .send();
+            await expect(stakeActivationPromise).rejects.toMatchObject({
+                code: -32602 satisfies (typeof SolanaJsonRpcErrorCode)['JSON_RPC_INVALID_PARAMS'],
+                message: expect.any(String),
+                name: 'SolanaJsonRpcError',
+            });
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-methods/getTokenSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenSupply.ts
@@ -1,0 +1,30 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+
+import { Commitment, RpcResponse } from './common';
+
+type GetTokenSupplyApiResponse = RpcResponse<{
+    /**
+     * The raw total token supply without decimals,
+     * a string representation of u64
+     */
+    amount: string;
+    /** Number of base 10 digits to the right of the decimal place */
+    decimals: number;
+    /** @deprecated The total token supply, using mint-prescribed decimals */
+    uiAmount: number | null;
+    /** The total token supply as a string, using mint-prescribed decimals */
+    uiAmountString: string;
+}>;
+
+export interface GetTokenSupplyApi {
+    /**
+     * Returns the total supply of an SPL Token mint
+     */
+    getTokenSupply(
+        /** Pubkey of the token Mint to query, as base-58 encoded string */
+        address: Base58EncodedAddress,
+        config?: Readonly<{
+            commitment?: Commitment;
+        }>
+    ): GetTokenSupplyApiResponse;
+}

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -28,6 +28,7 @@ import { GetSlotLeadersApi } from './getSlotLeaders';
 import { GetStakeMinimumDelegationApi } from './getStakeMinimumDelegation';
 import { GetSupplyApi } from './getSupply';
 import { GetTokenLargestAccountsApi } from './getTokenLargestAccounts';
+import { GetTokenSupplyApi } from './getTokenSupply';
 import { GetTransactionApi } from './getTransaction';
 import { GetTransactionCountApi } from './getTransactionCount';
 import { GetVoteAccountsApi } from './getVoteAccounts';
@@ -66,6 +67,7 @@ export type SolanaRpcMethods = GetAccountInfoApi &
     GetStakeMinimumDelegationApi &
     GetSupplyApi &
     GetTokenLargestAccountsApi &
+    GetTokenSupplyApi &
     GetTransactionApi &
     GetTransactionCountApi &
     GetVoteAccountsApi &


### PR DESCRIPTION
This PR adds the `getTokenSupply` RPC method to the new experimental Web3 JS's arsenal.

Ref #1449 