### PR TITLE
refactor(experimental): repair bad address index compilation

### DIFF
--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -37,7 +37,7 @@ describe('signTransaction', () => {
             },
             instructions: [
                 {
-                    addressIndices: [/* mockPublicKeyAddressB */ 1, /* mockPublicKeyAddressC */ 2],
+                    accountIndices: [/* mockPublicKeyAddressB */ 1, /* mockPublicKeyAddressC */ 2],
                     programAddressIndex: 3 /* system program */,
                 },
             ],

--- a/packages/transactions/src/__tests__/wire-transaction-test.ts
+++ b/packages/transactions/src/__tests__/wire-transaction-test.ts
@@ -40,7 +40,7 @@ describe('getBase64EncodedWireTransaction', () => {
         expect(getBase64EncodedWireTransaction(tx))
             // Copy and paste this string into the Solana Explorer at https://explorer.solana.com/tx/inspector
             .toBe(
-                'AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlyfqJ5qvbi2J5r1hDgkimf7xAsjcGduDtpu9zfTn8MGyAgMBmLTJ6VrW508Eg1xWkND+TiiPuCPuCPuCPuCPugAIBAQMPHmsUIcBKBwQxJlwZxbvuGZK66K/RzQeO+K9wR9wR9y1bQTxlQN4VDJNzFE1RM8pMuDC6D3VnFqzqDlDXlDXlPHmsUIcBKBwQxJlwZxbvuGZK66K/RzQeO+K9wR9wR9wePNYoQ4CUDghiTLgzi3fcMyV10V+jmg8d8V7gj7gj7gECAAAA'
+                'AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlyfqJ5qvbi2J5r1hDgkimf7xAsjcGduDtpu9zfTn8MGyAgMBmLTJ6VrW508Eg1xWkND+TiiPuCPuCPuCPuCPugAIBAQMPHmsUIcBKBwQxJlwZxbvuGZK66K/RzQeO+K9wR9wR9y1bQTxlQN4VDJNzFE1RM8pMuDC6D3VnFqzqDlDXlDXlPHmsUIcBKBwQxJlwZxbvuGZK66K/RzQeO+K9wR9wR9wePNYoQ4CUDghiTLgzi3fcMyV10V+jmg8d8V7gj7gj7gECAQEAAA=='
             );
     });
 });

--- a/packages/transactions/src/compile-instructions.ts
+++ b/packages/transactions/src/compile-instructions.ts
@@ -4,7 +4,7 @@ import { IInstruction } from '@solana/instructions';
 import { OrderedAccounts } from './accounts';
 
 type CompiledInstruction = Readonly<{
-    addressIndices?: number[];
+    accountIndices?: number[];
     data?: Uint8Array;
     programAddressIndex: number;
 }>;

--- a/packages/transactions/src/serializers/__tests__/instruction-test.ts
+++ b/packages/transactions/src/serializers/__tests__/instruction-test.ts
@@ -8,7 +8,7 @@ describe('Instruction codec', () => {
     it('serializes an instruction according to spec', () => {
         expect(
             instruction.serialize({
-                addressIndices: [1, 2],
+                accountIndices: [1, 2],
                 data: new Uint8Array([4, 5, 6]),
                 programAddressIndex: 7,
             })
@@ -28,7 +28,7 @@ describe('Instruction codec', () => {
             ])
         );
     });
-    it('serializes a zero-length compact array when `addressIndices` is `undefined`', () => {
+    it('serializes a zero-length compact array when `accountIndices` is `undefined`', () => {
         expect(
             instruction.serialize({
                 data: new Uint8Array([3, 4]),
@@ -50,7 +50,7 @@ describe('Instruction codec', () => {
     it('serializes a zero-length compact array when `data` is `undefined`', () => {
         expect(
             instruction.serialize({
-                addressIndices: [3, 4],
+                accountIndices: [3, 4],
                 programAddressIndex: 1,
             })
         ).toEqual(
@@ -86,12 +86,12 @@ describe('Instruction codec', () => {
                 ])
             )[0]
         ).toEqual({
-            addressIndices: [3, 4],
+            accountIndices: [3, 4],
             data: new Uint8Array([6, 7, 8, 9, 10]),
             programAddressIndex: 1,
         });
     });
-    it('omits the `addressIndices` property when the indices data is zero-length', () => {
+    it('omits the `accountIndices` property when the indices data is zero-length', () => {
         expect(
             instruction.deserialize(
                 new Uint8Array([
@@ -105,7 +105,7 @@ describe('Instruction codec', () => {
                     4,
                 ])
             )[0]
-        ).not.toHaveProperty('addressIndices');
+        ).not.toHaveProperty('accountIndices');
     });
     it('omits the `data` property when the instruction data is zero-length', () => {
         expect(

--- a/packages/transactions/src/serializers/__tests__/message-test.ts
+++ b/packages/transactions/src/serializers/__tests__/message-test.ts
@@ -27,7 +27,7 @@ describe.each([getCompiledMessageCodec, getCompiledMessageEncoder])(
                 },
                 instructions: [
                     { programAddressIndex: 44 },
-                    { addressIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
+                    { accountIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
                 ],
                 lifetimeToken: '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL', // decodes to [33{32}]
                 staticAccounts: [
@@ -259,7 +259,7 @@ describe.each([getCompiledMessageCodec, getCompiledMessageDecoder])(
                 },
                 instructions: [
                     { programAddressIndex: 44 },
-                    { addressIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
+                    { accountIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
                 ],
                 lifetimeToken: '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL', // decodes to [33{32}]
                 staticAccounts: [
@@ -337,7 +337,7 @@ describe.each([getCompiledMessageCodec, getCompiledMessageDecoder])(
                 },
                 instructions: [
                     { programAddressIndex: 44 },
-                    { addressIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
+                    { accountIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
                 ],
                 lifetimeToken: '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL', // decodes to [33{32}]
                 staticAccounts: [

--- a/packages/transactions/src/serializers/instruction.ts
+++ b/packages/transactions/src/serializers/instruction.ts
@@ -20,7 +20,7 @@ export function getInstructionCodec(): Serializer<Instruction> {
                 ),
             ],
             [
-                'addressIndices',
+                'accountIndices',
                 array(
                     u8({
                         description: __DEV__
@@ -47,23 +47,23 @@ export function getInstructionCodec(): Serializer<Instruction> {
             ],
         ]),
         (value: Instruction) => {
-            if (value.addressIndices !== undefined && value.data !== undefined) {
+            if (value.accountIndices !== undefined && value.data !== undefined) {
                 return value as Required<Instruction>;
             }
             return {
                 ...value,
-                addressIndices: value.addressIndices ?? [],
+                accountIndices: value.accountIndices ?? [],
                 data: value.data ?? new Uint8Array(0),
             } as Required<Instruction>;
         },
         (value: Required<Instruction>) => {
-            if (value.addressIndices.length && value.data.byteLength) {
+            if (value.accountIndices.length && value.data.byteLength) {
                 return value;
             }
-            const { addressIndices, data, ...rest } = value;
+            const { accountIndices, data, ...rest } = value;
             return {
                 ...rest,
-                ...(addressIndices.length ? { addressIndices } : null),
+                ...(accountIndices.length ? { accountIndices } : null),
                 ...(data.byteLength ? { data } : null),
             };
         }


### PR DESCRIPTION
refactor(experimental): repair bad address index compilation

# Summary

The code had `addressIndices` in some places and `accountIndices` in others, and I missed it in the wire serialization test. This consolidates on `accountIndices`

# Test Plan

```
cd packages/transactions
pnpm test:unit:browser
pnpm test:unit:node
```
