### PR TITLE
refactor(experimental): Make signatures param for getSignaturesStatus required

### DIFF
--- a/packages/rpc-core/src/rpc-methods/getSignatureStatuses.ts
+++ b/packages/rpc-core/src/rpc-methods/getSignatureStatuses.ts
@@ -50,7 +50,7 @@ export interface GetSignatureStatusesApi {
          * An array of transaction signatures to confirm,
          * as base-58 encoded strings (up to a maximum of 256)
          */
-        signatures?: TransactionSignature[],
+        signatures: TransactionSignature[],
         config?: Readonly<{
             /**
              * if `true` - a Solana node will search its ledger cache for any


### PR DESCRIPTION
Sorry, this parameter should be required. It's labeled as optional in the docs, but I've changed it in my PR to the docs repo