### PR TITLE
refactor(experimental): Fix getClusterNodes test

### DIFF
--- a/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
@@ -59,6 +59,10 @@ export const ALLOWED_NUMERIC_KEYPATHS: Partial<
         ['value', 'data', 'parsed', 'info', 'votes', KEYPATH_WILDCARD, 'confirmationCount'],
     ],
     getBlockTime: [[]],
+    getClusterNodes: [
+        [KEYPATH_WILDCARD, 'featureSet'],
+        [KEYPATH_WILDCARD, 'shredVersion'],
+    ],
     getInflationGovernor: [['initial'], ['foundation'], ['foundationTerm'], ['taper'], ['terminal']],
     getInflationRate: [['foundation'], ['total'], ['validator']],
     getInflationReward: [[KEYPATH_WILDCARD, 'commission']],

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-cluster-nodes-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-cluster-nodes-test.ts
@@ -15,18 +15,19 @@ describe('getClusterNodes', () => {
         });
     });
 
-    it('returns the cluster nodes', async () => {
-        expect.assertions(1);
-        const res = await rpc.getClusterNodes().send();
-        // Check that the array contains the expected nodes
-        expect(res).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    gossip: '127.0.0.1:1024',
-                    rpc: '127.0.0.1:8899',
-                    tpu: '127.0.0.1:1026',
-                }),
-            ])
-        );
+    describe('when run against the test validator', () => {
+        it('returns RPC and validator info', async () => {
+            expect.assertions(1);
+            const res = await rpc.getClusterNodes().send();
+            expect(res).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        gossip: expect.any(String),
+                        rpc: expect.any(String),
+                        tpu: expect.any(String),
+                    }),
+                ])
+            );
+        });
     });
 });


### PR DESCRIPTION
Turns out these ports change!

Also added the `number` response fields to the bigint exemptions