### PR TITLE
refactor(experimental): better build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     ],
     "scripts": {
         "build": "turbo run build",
-        "compile": "turbo run compile:js && turbo run compile:typedefs",
+        "compile": "turbo run compile:js compile:typedefs",
         "lint": "turbo run test:lint",
         "publish-packages": "turbo run publish-packages",
         "test": "turbo run test:unit:browser test:unit:node",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     ],
     "scripts": {
         "build": "turbo run build",
+        "compile": "turbo run compile:js && turbo run compile:typedefs",
         "lint": "turbo run test:lint",
         "publish-packages": "turbo run publish-packages",
         "test": "turbo run test:unit:browser test:unit:node",


### PR DESCRIPTION
currently `pnpm build` runs the full test suite, which is very not conducive to working with the library as an external dependency. it makes it hard to tell when the compile is actually done and the rest can be aborted, and also it kills any `solana-test-validator` running and leaves behind its own after SIGINT

this changes the build command to just build