### PR TITLE
refactor(experimental): rename `getBase58AddressFromPublicKey` to `getAddressFromPublicKey`

### DIFF
--- a/packages/addresses/README.md
+++ b/packages/addresses/README.md
@@ -51,14 +51,14 @@ function handleSubmit() {
 }
 ```
 
-### `getBase58EncodedAddressFromPublicKey()`
+### `getAddressFromPublicKey()`
 
 Given a public `CryptoKey`, this method will return its associated `Base58EncodedAddress`.
 
 ```ts
-import { getBase58EncodedAddressFromPublicKey } from '@solana/addresses';
+import { getAddressFromPublicKey } from '@solana/addresses';
 
-const address = await getBase58EncodedAddressFromPublicKey(publicKey);
+const address = await getAddressFromPublicKey(publicKey);
 ```
 
 ### `getProgramDerivedAddress()`

--- a/packages/addresses/src/__tests__/public-key-test.ts
+++ b/packages/addresses/src/__tests__/public-key-test.ts
@@ -1,4 +1,4 @@
-import { getBase58EncodedAddressFromPublicKey } from '../public-key';
+import { getAddressFromPublicKey } from '../public-key';
 
 // Corresponds to address `DcESq8KFcdTdpjWtr2DoGcvu5McM3VJoBetgM1X1vVct`
 const MOCK_PUBLIC_KEY_BYTES = new Uint8Array([
@@ -6,7 +6,7 @@ const MOCK_PUBLIC_KEY_BYTES = new Uint8Array([
     0x0e, 0x36, 0x71, 0x74, 0x32, 0x8d, 0x1a, 0xf7, 0xee, 0x7e, 0x04, 0x76, 0x19,
 ]);
 
-describe('getBase58EncodedAddressFromPublicKey', () => {
+describe('getAddressFromPublicKey', () => {
     it('returns the public key that corresponds to a given secret key', async () => {
         expect.assertions(1);
         const publicKey = await crypto.subtle.importKey(
@@ -16,9 +16,7 @@ describe('getBase58EncodedAddressFromPublicKey', () => {
             /* extractable */ true,
             ['verify']
         );
-        await expect(getBase58EncodedAddressFromPublicKey(publicKey)).resolves.toBe(
-            'DcESq8KFcdTdpjWtr2DoGcvu5McM3VJoBetgM1X1vVct'
-        );
+        await expect(getAddressFromPublicKey(publicKey)).resolves.toBe('DcESq8KFcdTdpjWtr2DoGcvu5McM3VJoBetgM1X1vVct');
     });
     it('throws when the public key is non-extractable', async () => {
         expect.assertions(1);
@@ -29,7 +27,7 @@ describe('getBase58EncodedAddressFromPublicKey', () => {
             /* extractable */ false,
             ['verify']
         );
-        await expect(() => getBase58EncodedAddressFromPublicKey(publicKey)).rejects.toThrow();
+        await expect(() => getAddressFromPublicKey(publicKey)).rejects.toThrow();
     });
     it('throws when called with a secret', async () => {
         expect.assertions(1);
@@ -41,7 +39,7 @@ describe('getBase58EncodedAddressFromPublicKey', () => {
             true,
             ['encrypt', 'decrypt']
         );
-        await expect(() => getBase58EncodedAddressFromPublicKey(publicKey)).rejects.toThrow();
+        await expect(() => getAddressFromPublicKey(publicKey)).rejects.toThrow();
     });
     it.each([
         { __variant: 'P256', name: 'ECDSA', namedCurve: 'P-256' },
@@ -62,7 +60,7 @@ describe('getBase58EncodedAddressFromPublicKey', () => {
     ])('throws when called with a $name/$__variant public key', async algorithm => {
         expect.assertions(1);
         const { publicKey } = await crypto.subtle.generateKey(algorithm, true, ['sign', 'verify']);
-        await expect(() => getBase58EncodedAddressFromPublicKey(publicKey)).rejects.toThrow();
+        await expect(() => getAddressFromPublicKey(publicKey)).rejects.toThrow();
     });
     it('throws when called with a private key', async () => {
         expect.assertions(1);
@@ -77,6 +75,6 @@ describe('getBase58EncodedAddressFromPublicKey', () => {
             /* extractable */ false,
             ['sign']
         );
-        await expect(() => getBase58EncodedAddressFromPublicKey(mockPrivateKey)).rejects.toThrow();
+        await expect(() => getAddressFromPublicKey(mockPrivateKey)).rejects.toThrow();
     });
 });

--- a/packages/addresses/src/public-key.ts
+++ b/packages/addresses/src/public-key.ts
@@ -2,7 +2,7 @@ import { assertKeyExporterIsAvailable } from '@solana/assertions';
 
 import { Base58EncodedAddress, getBase58EncodedAddressCodec } from './base58';
 
-export async function getBase58EncodedAddressFromPublicKey(publicKey: CryptoKey): Promise<Base58EncodedAddress> {
+export async function getAddressFromPublicKey(publicKey: CryptoKey): Promise<Base58EncodedAddress> {
     await assertKeyExporterIsAvailable();
     if (publicKey.type !== 'public' || publicKey.algorithm.name !== 'Ed25519') {
         // TODO: Coded error.

--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -1,10 +1,6 @@
 import 'test-matchers/toBeFrozenObject';
 
-import {
-    Base58EncodedAddress,
-    getBase58EncodedAddressCodec,
-    getBase58EncodedAddressFromPublicKey,
-} from '@solana/addresses';
+import { Base58EncodedAddress, getAddressFromPublicKey, getBase58EncodedAddressCodec } from '@solana/addresses';
 import { signBytes } from '@solana/keys';
 
 import { Blockhash } from '../blockhash';
@@ -50,7 +46,7 @@ describe('signTransaction', () => {
             ],
             version: 0,
         } as CompiledMessage);
-        (getBase58EncodedAddressFromPublicKey as jest.Mock).mockImplementation(async publicKey => {
+        (getAddressFromPublicKey as jest.Mock).mockImplementation(async publicKey => {
             switch (publicKey) {
                 case mockKeyPairA.publicKey:
                     return mockPublicKeyAddressA;

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -1,4 +1,4 @@
-import { Base58EncodedAddress, getBase58EncodedAddressFromPublicKey } from '@solana/addresses';
+import { Base58EncodedAddress, getAddressFromPublicKey } from '@solana/addresses';
 import { Ed25519Signature, signBytes } from '@solana/keys';
 
 import { CompiledMessage, compileMessage } from './message';
@@ -23,7 +23,7 @@ export async function signTransaction<TTransaction extends Parameters<typeof com
 ): Promise<TTransaction & ITransactionWithSignatures> {
     const compiledMessage = compileMessage(transaction);
     const [signerPublicKey, signature] = await Promise.all([
-        getBase58EncodedAddressFromPublicKey(keyPair.publicKey),
+        getAddressFromPublicKey(keyPair.publicKey),
         getCompiledMessageSignature(compiledMessage, keyPair.privateKey),
     ]);
     const nextSignatures = {


### PR DESCRIPTION
refactor(experimental): rename `getBase58AddressFromPublicKey` to `getAddressFromPublicKey`

# Summary

@2501babe mentioned this being sort of unweildy to type for something that's going to be used a lot, so let's shorten it now.

Not changed:

* the `assertIs*` method
* the `get*Codec` method
* the `get*Comparator` method

# Test Plan

CI run
