### PR TITLE
refactor(experimental): tighten up types

### DIFF
--- a/packages/rpc-core/src/rpc-methods/common.ts
+++ b/packages/rpc-core/src/rpc-methods/common.ts
@@ -93,7 +93,7 @@ export type AccountInfoWithPubkey<TAccount extends AccountInfoBase> = Readonly<{
     pubkey: Base58EncodedAddress;
 }>;
 
-type TokenAmount = Readonly<{
+export type TokenAmount = Readonly<{
     amount: StringifiedBigInt;
     decimals: number;
     uiAmount: number | null;

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountBalance.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountBalance.ts
@@ -1,17 +1,8 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
-import { Commitment, RpcResponse } from './common';
+import { Commitment, RpcResponse, TokenAmount } from './common';
 
-type GetTokenAccountBalanceApiResponse = RpcResponse<{
-    /** The raw balance without decimals, a string representation of u64 */
-    amount: string;
-    /** Number of base 10 digits to the right of the decimal place */
-    decimals: number;
-    /** @deprecated The balance, using mint-prescribed decimals */
-    uiAmount: number | null;
-    /** The balance as a string, using mint-prescribed decimals */
-    uiAmountString: string;
-}>;
+type GetTokenAccountBalanceApiResponse = RpcResponse<TokenAmount>;
 
 export interface GetTokenAccountBalanceApi {
     /**

--- a/packages/rpc-core/src/rpc-methods/getTokenLargestAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenLargestAccounts.ts
@@ -1,25 +1,8 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
-import { StringifiedBigInt } from '../stringified-bigint';
-import { Commitment, RpcResponse } from './common';
+import { Commitment, RpcResponse, TokenAmount } from './common';
 
-type GetTokenLargestAccountsApiResponse = RpcResponse<
-    {
-        /** the address of the token account */
-        address: Base58EncodedAddress;
-        /** the raw token account balance without decimals, a string representation of u64 */
-        amount: StringifiedBigInt;
-        /** number of base 10 digits to the right of the decimal place */
-        decimals: number;
-        /**
-         * the token account balance, using mint-prescribed decimals
-         * @deprecated
-         */
-        uiAmount: number | null;
-        /** the token account balance as a string, using mint-prescribed decimals */
-        uiAmountString: string;
-    }[]
->;
+type GetTokenLargestAccountsApiResponse = RpcResponse<TokenAmount & { address: Base58EncodedAddress }[]>;
 
 export interface GetTokenLargestAccountsApi {
     /**

--- a/packages/rpc-core/src/rpc-methods/getTokenSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenSupply.ts
@@ -1,20 +1,8 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
-import { Commitment, RpcResponse } from './common';
+import { Commitment, RpcResponse, TokenAmount } from './common';
 
-type GetTokenSupplyApiResponse = RpcResponse<{
-    /**
-     * The raw total token supply without decimals,
-     * a string representation of u64
-     */
-    amount: string;
-    /** Number of base 10 digits to the right of the decimal place */
-    decimals: number;
-    /** @deprecated The total token supply, using mint-prescribed decimals */
-    uiAmount: number | null;
-    /** The total token supply as a string, using mint-prescribed decimals */
-    uiAmountString: string;
-}>;
+type GetTokenSupplyApiResponse = RpcResponse<TokenAmount>;
 
 export interface GetTokenSupplyApi {
     /**

--- a/packages/rpc-core/src/rpc-methods/getTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/getTransaction.ts
@@ -1,7 +1,6 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 import { Blockhash, TransactionVersion } from '@solana/transactions';
 
-import { StringifiedBigInt } from '../stringified-bigint';
 import { TransactionError } from '../transaction-error';
 import { UnixTimestamp } from '../unix-timestamp';
 import {
@@ -11,6 +10,7 @@ import {
     Commitment,
     LamportsUnsafeBeyond2Pow53Minus1,
     Slot,
+    TokenAmount,
     U64UnsafeBeyond2Pow53Minus1,
 } from './common';
 
@@ -23,19 +23,7 @@ type TokenBalance = Readonly<{
     owner?: Base58EncodedAddress;
     /** Pubkey of the Token program that owns the account. */
     programId?: Base58EncodedAddress;
-    uiTokenAmount: {
-        /** Raw amount of tokens as a string, ignoring decimals. */
-        amount: StringifiedBigInt;
-        /** Number of decimals configured for token's mint. */
-        decimals: number;
-        /**
-         * Token amount as a float, accounting for decimals.
-         * @deprecated
-         */
-        uiAmount: number | null;
-        /** Token amount as a string, accounting for decimals. */
-        uiAmountString: string;
-    };
+    uiTokenAmount: TokenAmount;
 }>;
 
 type TransactionRewardBase = Readonly<{

--- a/packages/rpc-core/src/rpc-methods/getVersion.ts
+++ b/packages/rpc-core/src/rpc-methods/getVersion.ts
@@ -1,6 +1,6 @@
 type GetVersionApiResponse = Readonly<{
     /** Unique identifier of the current software's feature set */
-    'feature-set': number;
+    'feature-set': number; // `u32`
     /** Software version of `solana-core` */
     'solana-core': string;
 }>;


### PR DESCRIPTION
This PR tightens up use of common types such as `TokenAmount` from `rpc-methods/common.ts`