### PR TITLE
test: close file descriptors after reading data in tests

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
@@ -12,13 +12,17 @@ const genesisHashPattern = /genesis hash: ([\d\w]{32,})/;
 
 async function getGenesisHashFromLogFile() {
     const file = await open(logFilePath);
-    for await (const line of file.readLines({ encoding: 'utf-8' })) {
-        const match = line.match(genesisHashPattern);
-        if (match) {
-            return match[1];
+    try {
+        for await (const line of file.readLines({ encoding: 'utf-8' })) {
+            const match = line.match(genesisHashPattern);
+            if (match) {
+                return match[1];
+            }
         }
+        throw new Error(`Genesis hash not found in logfile \`${logFilePath}\``);
+    } finally {
+        await file.close();
     }
-    throw new Error(`Genesis hash not found in logfile \`${logFilePath}\``);
 }
 
 describe('getGenesisHash', () => {

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
@@ -14,17 +14,21 @@ const validatorKeypairPath = path.resolve(__dirname, '../../../../../test-ledger
 
 async function getValidatorAddress() {
     const file = await open(validatorKeypairPath);
-    let secretKey: Uint8Array | undefined;
-    for await (const line of file.readLines({ encoding: 'binary' })) {
-        secretKey = new Uint8Array(JSON.parse(line));
-        break; // Only need the first line
+    try {
+        let secretKey: Uint8Array | undefined;
+        for await (const line of file.readLines({ encoding: 'binary' })) {
+            secretKey = new Uint8Array(JSON.parse(line));
+            break; // Only need the first line
+        }
+        if (secretKey) {
+            const publicKey = secretKey.slice(32, 64);
+            const expectedAddress = base58.deserialize(publicKey)[0];
+            return expectedAddress as Base58EncodedAddress;
+        }
+        throw new Error(`Failed to read keypair file \`${validatorKeypairPath}\``);
+    } finally {
+        await file.close();
     }
-    if (secretKey) {
-        const publicKey = secretKey.slice(32, 64);
-        const expectedAddress = base58.deserialize(publicKey)[0];
-        return expectedAddress as Base58EncodedAddress;
-    }
-    throw new Error(`Failed to read keypair file \`${validatorKeypairPath}\``);
 }
 
 describe('getLeaderSchedule', () => {

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-version-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-version-test.ts
@@ -13,22 +13,26 @@ const versionPattern = /solana-validator ([\d.]+)/;
 
 async function getVersionFromLogFile() {
     const file = await open(logFilePath);
-    let version: string | undefined;
-    let featureSet: number | undefined;
-    for await (const line of file.readLines({ encoding: 'utf-8' })) {
-        const featureSetMatch = line.match(featureSetPattern);
-        if (featureSetMatch) {
-            featureSet = parseInt(featureSetMatch[1]);
+    try {
+        let version: string | undefined;
+        let featureSet: number | undefined;
+        for await (const line of file.readLines({ encoding: 'utf-8' })) {
+            const featureSetMatch = line.match(featureSetPattern);
+            if (featureSetMatch) {
+                featureSet = parseInt(featureSetMatch[1]);
+            }
+            const versionMatch = line.match(versionPattern);
+            if (versionMatch) {
+                version = versionMatch[1];
+            }
+            if (version && featureSet) {
+                return [featureSet, version];
+            }
         }
-        const versionMatch = line.match(versionPattern);
-        if (versionMatch) {
-            version = versionMatch[1];
-        }
-        if (version && featureSet) {
-            return [featureSet, version];
-        }
+        throw new Error(`Version info not found in logfile \`${logFilePath}\``);
+    } finally {
+        await file.close();
     }
-    throw new Error(`Version info not found in logfile \`${logFilePath}\``);
 }
 
 describe('getVersion', () => {


### PR DESCRIPTION
test: close file descriptors after reading data in tests

Prevents:
```
(node:3268) Warning: Closing file descriptor 22 on garbage collection
```
