### PR TITLE
refactor(experimental): isolate test validator install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ yarn-error.log*
 # Sapling SCM
 .sl
 
-# `solana-test-validator` ledger location
+# `solana-test-validator`
+.solana/
 test-ledger/

--- a/scripts/setup-test-validator.sh
+++ b/scripts/setup-test-validator.sh
@@ -2,10 +2,11 @@
 
 set -ex
 
+TARGET_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )/.solana
+
 # setup environment
 version=$(curl -s -N https://api.github.com/repos/solana-labs/solana/releases/latest \
     | grep -m 1 \"tag_name\" \
     | sed -ne 's/^ *"tag_name": "\([^"]*\)",$/\1/p')
-sh -c "$(curl -sSfL https://release.solana.com/$version/install)"
-PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
-solana --version
+sh -c "$(curl -sSfL https://release.solana.com/$version/install)" init $version --data-dir $TARGET_DIR --no-modify-path
+$TARGET_DIR/active_release/bin/solana --version

--- a/scripts/start-shared-test-validator.sh
+++ b/scripts/start-shared-test-validator.sh
@@ -7,7 +7,7 @@
 LOCK_DIR="/tmp/lock"
 EXCLUSIVE_LOCK_FILE="$LOCK_DIR/.solanatestvalidator.exclusivelock"
 SHARED_LOCK_FILE="$LOCK_DIR/.solanatestvalidator.sharedlock"
-TEST_VALIDATOR=$HOME/.local/share/solana/install/active_release/bin/solana-test-validator
+TEST_VALIDATOR=$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )/.solana/active_release/bin/solana-test-validator
 TEST_VALIDATOR_LEDGER="$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )/test-ledger"
 FIXTURE_ACCOUNTS_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")/fixtures" ; pwd -P)"
 


### PR DESCRIPTION
This PR isolates the install for the test validator we use to run the test suite. 

This way, it won't override any local install you might have already.