### PR TITLE
refactor(experimental): implement getBase58EncodedAddressForSeed

### DIFF
--- a/packages/addresses/src/__tests__/computed-address-test.ts
+++ b/packages/addresses/src/__tests__/computed-address-test.ts
@@ -167,6 +167,7 @@ describe('createAddressWithSeed', () => {
     it('fails with a malicious programAddress meant to produce an address that would collide with a PDA', async () => {
         expect.assertions(1);
         const baseAddress = 'Bh1uUDP3ApWLeccVNHwyQKpnfGQbuE2UECbGA6M4jiZJ' as Base58EncodedAddress;
+        // The ending bytes of this address decode to the ASCII string 'ProgramDerivedAddress'
         const programAddress = '4vJ9JU1bJJE96FbKdjWme2JfVK1knU936FHTDZV7AC2' as Base58EncodedAddress;
 
         await expect(createAddressWithSeed({ baseAddress, programAddress, seed: 'seed' })).rejects.toThrow(

--- a/packages/addresses/src/__tests__/computed-address-test.ts
+++ b/packages/addresses/src/__tests__/computed-address-test.ts
@@ -1,5 +1,5 @@
 import { Base58EncodedAddress } from '../base58';
-import { getProgramDerivedAddress } from '../program-derived-address';
+import { createAddressWithSeed, getProgramDerivedAddress } from '../computed-address';
 
 describe('getProgramDerivedAddress()', () => {
     it('fatals when supplied more than 16 seeds', async () => {
@@ -138,4 +138,39 @@ describe('getProgramDerivedAddress()', () => {
     it.todo(
         'fatals when supplied a combination of program address and seeds for which no off-curve point can be found'
     );
+});
+
+describe('createAddressWithSeed', () => {
+    it('returns an address that is the SHA-256 hash of the concatenated base address, seed, and program address', async () => {
+        expect.assertions(2);
+        const baseAddress = 'Bh1uUDP3ApWLeccVNHwyQKpnfGQbuE2UECbGA6M4jiZJ' as Base58EncodedAddress;
+        const programAddress = 'FGrddpvjBUAG6VdV4fR8Q2hEZTHS6w4SEveVBgfwbfdm' as Base58EncodedAddress;
+        const expectedAddress = 'HUKxCeXY6gZohFJFARbLE6L6C9wDEHz1SfK8ENM7QY7z' as Base58EncodedAddress;
+
+        await expect(createAddressWithSeed({ baseAddress, programAddress, seed: 'seed' })).resolves.toEqual(
+            expectedAddress
+        );
+
+        await expect(
+            createAddressWithSeed({ baseAddress, programAddress, seed: new Uint8Array([0x73, 0x65, 0x65, 0x64]) })
+        ).resolves.toEqual(expectedAddress);
+    });
+    it('fails when the seed is longer than 32 bytes', async () => {
+        expect.assertions(1);
+        const baseAddress = 'Bh1uUDP3ApWLeccVNHwyQKpnfGQbuE2UECbGA6M4jiZJ' as Base58EncodedAddress;
+        const programAddress = 'FGrddpvjBUAG6VdV4fR8Q2hEZTHS6w4SEveVBgfwbfdm' as Base58EncodedAddress;
+
+        await expect(createAddressWithSeed({ baseAddress, programAddress, seed: 'a'.repeat(33) })).rejects.toThrow(
+            'The seed exceeds the maximum length of 32 bytes'
+        );
+    });
+    it('fails with a malicious programAddress meant to produce an address that would collide with a PDA', async () => {
+        expect.assertions(1);
+        const baseAddress = 'Bh1uUDP3ApWLeccVNHwyQKpnfGQbuE2UECbGA6M4jiZJ' as Base58EncodedAddress;
+        const programAddress = '4vJ9JU1bJJE96FbKdjWme2JfVK1knU936FHTDZV7AC2' as Base58EncodedAddress;
+
+        await expect(createAddressWithSeed({ baseAddress, programAddress, seed: 'seed' })).rejects.toThrow(
+            'programAddress cannot end with the PDA marker'
+        );
+    });
 });

--- a/packages/addresses/src/index.ts
+++ b/packages/addresses/src/index.ts
@@ -1,3 +1,3 @@
 export * from './base58';
-export * from './program-derived-address';
+export * from './computed-address';
 export * from './public-key';


### PR DESCRIPTION
doing this now because its a blocker for me. straightforward reimpl of `createWithSeed`:

```
  static async createWithSeed(
    fromPublicKey: PublicKey,
    seed: string,
    programId: PublicKey,
  ): Promise<PublicKey> {
    const buffer = Buffer.concat([
      fromPublicKey.toBuffer(),
      Buffer.from(seed),
      programId.toBuffer(),
    ]);
    const publicKeyBytes = sha256(buffer);
    return new PublicKey(publicKeyBytes);
  }
```

not ready to merge as-is, pls let me know:
* how to run `lint:fix`, theres no command for it so i have no idea
* if you want this in a new file
* any style complaints, i tried to copy existing code as much as possible