### PR TITLE
Revert "chore: bump @babel/plugin-transform-runtime from 7.22.9 to 7.…

### DIFF
--- a/packages/library-legacy/package.json
+++ b/packages/library-legacy/package.json
@@ -74,7 +74,7 @@
     "@babel/core": "^7.22.10",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-private-methods": "^7.18.6",
-    "@babel/plugin-transform-runtime": "^7.22.10",
+    "@babel/plugin-transform-runtime": "^7.22.9",
     "@babel/preset-env": "^7.22.4",
     "@babel/preset-typescript": "^7.22.5",
     "@rollup/plugin-alias": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,8 +506,8 @@ importers:
         specifier: ^7.18.6
         version: 7.18.6(@babel/core@7.22.10)
       '@babel/plugin-transform-runtime':
-        specifier: ^7.22.10
-        version: 7.22.10(@babel/core@7.22.10)
+        specifier: ^7.22.9
+        version: 7.22.9(@babel/core@7.22.10)
       '@babel/preset-env':
         specifier: ^7.22.4
         version: 7.22.4(@babel/core@7.22.10)
@@ -2078,8 +2078,8 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-runtime@7.22.10(@babel/core@7.22.10):
-    resolution: {integrity: sha512-RchI7HePu1eu0CYNKHHHQdfenZcM4nz8rew5B1VWqeRKdcwW5aQ5HeG9eTUbWiAS1UrmHVLmoxTWHt3iLD/NhA==}
+  /@babel/plugin-transform-runtime@7.22.9(@babel/core@7.22.10):
+    resolution: {integrity: sha512-9KjBH61AGJetCPYp/IEyLEp47SyybZb0nDRpBvmtEkm+rUIwxdlKpyNHI1TmsGkeuLclJdleQHRZ8XLBnnh8CQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0


### PR DESCRIPTION
…22.10 (#1561)"

This reverts commit d6c3cfe44a9c2f5a4be006035e85fdc813d158f0.