### PR TITLE
refactor(experimental): revise `setFeePayer` overloads

### DIFF
--- a/packages/transactions/src/blockhash.ts
+++ b/packages/transactions/src/blockhash.ts
@@ -44,12 +44,14 @@ export function setTransactionLifetimeUsingBlockhash<TTransaction extends BaseTr
     blockhashLifetimeConstraint: BlockhashLifetimeConstraint,
     transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
 ): Omit<TTransaction, keyof ITransactionWithSignatures | 'lifetimeConstraint'> & ITransactionWithBlockhashLifetime;
+
 export function setTransactionLifetimeUsingBlockhash<
     TTransaction extends BaseTransaction | (BaseTransaction & ITransactionWithBlockhashLifetime)
 >(
     blockhashLifetimeConstraint: BlockhashLifetimeConstraint,
     transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
 ): Omit<TTransaction, keyof ITransactionWithSignatures> & ITransactionWithBlockhashLifetime;
+
 export function setTransactionLifetimeUsingBlockhash(
     blockhashLifetimeConstraint: BlockhashLifetimeConstraint,
     transaction: BaseTransaction | (BaseTransaction & ITransactionWithBlockhashLifetime)

--- a/packages/transactions/src/fee-payer.ts
+++ b/packages/transactions/src/fee-payer.ts
@@ -11,13 +11,23 @@ export interface ITransactionWithFeePayer<TAddress extends string = string> {
 export function setTransactionFeePayer<TFeePayerAddress extends string, TTransaction extends BaseTransaction>(
     feePayer: Base58EncodedAddress<TFeePayerAddress>,
     transaction:
+        | (TTransaction & ITransactionWithSignatures)
+        | (TTransaction & ITransactionWithFeePayer<TFeePayerAddress> & ITransactionWithSignatures)
+): Omit<TTransaction, keyof ITransactionWithSignatures> & ITransactionWithFeePayer<TFeePayerAddress>;
+
+export function setTransactionFeePayer<TFeePayerAddress extends string, TTransaction extends BaseTransaction>(
+    feePayer: Base58EncodedAddress<TFeePayerAddress>,
+    transaction: TTransaction | (TTransaction & ITransactionWithFeePayer<TFeePayerAddress>)
+): TTransaction & ITransactionWithFeePayer<TFeePayerAddress>;
+
+export function setTransactionFeePayer<TFeePayerAddress extends string, TTransaction extends BaseTransaction>(
+    feePayer: Base58EncodedAddress<TFeePayerAddress>,
+    transaction:
         | TTransaction
         | (TTransaction & ITransactionWithFeePayer<TFeePayerAddress>)
         | (TTransaction & ITransactionWithSignatures)
         | (TTransaction & ITransactionWithFeePayer<TFeePayerAddress> & ITransactionWithSignatures)
-):
-    | (TTransaction & ITransactionWithFeePayer<TFeePayerAddress>)
-    | (Omit<TTransaction, keyof ITransactionWithSignatures> & ITransactionWithFeePayer<TFeePayerAddress>) {
+) {
     if ('feePayer' in transaction && feePayer === transaction.feePayer) {
         return transaction;
     }


### PR DESCRIPTION
This PR introduces some changes to `setTransactionFeePayer` because the original type configuration was always returning a union for a provided base transaction.

With separated overloads, TypeScript can successfully resolve the return type based on the transaction provided.