### PR TITLE
refactor(experimental): add `ws` and `fetch-impl` peer dependencies to `rpc-transport`

### DIFF
--- a/packages/rpc-transport/package.json
+++ b/packages/rpc-transport/package.json
@@ -88,6 +88,10 @@
         "version-from-git": "^1.1.1",
         "ws-impl": "workspace:*"
     },
+    "peerDependencies": {
+        "node-fetch": "^2.6.7",
+        "ws": "^8.14.0"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/ws-impl/package.json
+++ b/packages/ws-impl/package.json
@@ -63,6 +63,6 @@
         "typescript": "^5.1.6"
     },
     "peerDependencies": {
-        "ws": "^8.13.0"
+        "ws": "^8.14.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,13 @@ importers:
         version: 1.1.1
 
   packages/rpc-transport:
+    dependencies:
+      node-fetch:
+        specifier: ^2.6.7
+        version: 2.6.12
+      ws:
+        specifier: ^8.14.0
+        version: 8.14.0
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
@@ -1015,8 +1022,8 @@ importers:
   packages/ws-impl:
     dependencies:
       ws:
-        specifier: ^8.13.0
-        version: 8.13.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+        specifier: ^8.14.0
+        version: 8.14.0
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
@@ -11871,6 +11878,19 @@ packages:
     dependencies:
       bufferutil: 4.0.7
       utf-8-validate: 5.0.10
+
+  /ws@8.14.0:
+    resolution: {integrity: sha512-WR0RJE9Ehsio6U4TuM+LmunEsjQ5ncHlw4sn9ihD6RoJKZrVyH9FWV3dmnwu8B2aNib1OvG2X6adUCyFpQyWcg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}


### PR DESCRIPTION
refactor(experimental): add `ws` and `fetch-impl` peer dependencies to `rpc-transport`

# Summary

Because these get built _in_ to `rpc-transport`, the `peerDependencies` config needs to be in `rpc-transport` in order to propagate to downstream dependencies.


# Test Plan

```ts
require('@solana/web3.js/dist/index.node.cjs'); // No more missing deps
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1580).
* #1586
* #1585
* #1584
* #1583
* #1582
* #1581
* __->__ #1580