### PR TITLE
refactor(experimental): bring the HTTP transport and the WebSocket closer together, spiritually

### DIFF
--- a/packages/rpc-transport/package.json
+++ b/packages/rpc-transport/package.json
@@ -88,6 +88,10 @@
         "version-from-git": "^1.1.1",
         "ws-impl": "workspace:*"
     },
+    "peerDependencies": {
+        "node-fetch": "^2.6.7",
+        "ws": "^8.14.0"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-transport/src/transports/transport-types.ts
+++ b/packages/rpc-transport/src/transports/transport-types.ts
@@ -10,9 +10,16 @@ export interface IRpcTransport {
 }
 
 type RpcWebSocketTransportConfig = Readonly<{
+    payload: unknown;
     signal: AbortSignal;
 }>;
 
 export interface IRpcWebSocketTransport {
-    (config: RpcWebSocketTransportConfig): Promise<RpcWebSocketConnection>;
+    (config: RpcWebSocketTransportConfig): Promise<
+        Readonly<
+            Omit<RpcWebSocketConnection, 'send'> & {
+                send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: RpcWebSocketConnection['send'];
+            }
+        >
+    >;
 }

--- a/packages/rpc-transport/src/transports/websocket/__tests__/websocket-connection-test.ts
+++ b/packages/rpc-transport/src/transports/websocket/__tests__/websocket-connection-test.ts
@@ -5,9 +5,51 @@ import { createWebSocketConnection, RpcWebSocketConnection } from '../websocket-
 
 const MOCK_SEND_BUFFER_HIGH_WATERMARK = 42069;
 
+describe('createWebSocketConnection', () => {
+    let ws: WS;
+    function getLatestClient() {
+        const clients = ws.server.clients();
+        return clients[clients.length - 1];
+    }
+    beforeEach(async () => {
+        ws = new WS('wss://fake', {
+            jsonProtocol: true,
+        });
+    });
+    afterEach(() => {
+        WS.clean();
+    });
+    it('does not resolve until the socket is open', async () => {
+        expect.assertions(2);
+        const connectionPromise = createWebSocketConnection({
+            sendBufferHighWatermark: 0,
+            signal: new AbortController().signal,
+            url: 'wss://fake',
+        });
+        const client = getLatestClient();
+        expect(client).toHaveProperty('readyState', WebSocket.CONNECTING);
+        await connectionPromise;
+        expect(client).toHaveProperty('readyState', WebSocket.OPEN);
+    });
+    // https://github.com/thoov/mock-socket/issues/384
+    it.failing('throws when the connection is aborted before the connection is established', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        const connectionPromise = createWebSocketConnection({
+            sendBufferHighWatermark: 0,
+            signal: abortController.signal,
+            url: 'wss://fake',
+        });
+        const client = getLatestClient();
+        expect(client).toHaveProperty('readyState', WebSocket.CONNECTING);
+        abortController.abort();
+        await expect(connectionPromise).rejects.toThrow();
+    });
+});
+
 describe('RpcWebSocketConnection', () => {
     let abortController: AbortController;
-    let connection: RpcWebSocketConnection;
+    let connectionPromise: Promise<RpcWebSocketConnection>;
     let ws: WS;
     function getLatestClient() {
         const clients = ws.server.clients();
@@ -18,150 +60,156 @@ describe('RpcWebSocketConnection', () => {
         ws = new WS('wss://fake', {
             jsonProtocol: true,
         });
-        connection = await createWebSocketConnection({
+        connectionPromise = createWebSocketConnection({
             sendBufferHighWatermark: MOCK_SEND_BUFFER_HIGH_WATERMARK,
             signal: abortController.signal,
             url: 'wss://fake',
         });
-        await ws.connected;
     });
     afterEach(() => {
         WS.clean();
     });
-    it('does not resolve until the socket is open', async () => {
+    it('vends messages received immediately after the open event in the same runloop', async () => {
         expect.assertions(2);
-        const freshConnectionPromise = createWebSocketConnection({
-            sendBufferHighWatermark: 0,
-            signal: abortController.signal,
-            url: 'wss://fake',
-        });
-        const client = getLatestClient();
-        expect(client).toHaveProperty('readyState', WebSocket.CONNECTING);
-        await freshConnectionPromise;
-        expect(client).toHaveProperty('readyState', WebSocket.OPEN);
-    });
-    it('vends a message to consumers who have already polled for a result', async () => {
-        expect.assertions(2);
-        const iteratorA = connection[Symbol.asyncIterator]();
-        const iteratorB = connection[Symbol.asyncIterator]();
-        const resultPromiseA = iteratorA.next();
-        const resultPromiseB = iteratorB.next();
-        const expectedMessage = { some: 'message' };
-        ws.send(expectedMessage);
-        await expect(resultPromiseA).resolves.toMatchObject({ done: false, value: expectedMessage });
-        await expect(resultPromiseB).resolves.toMatchObject({ done: false, value: expectedMessage });
-    });
-    it('does not queue messsages for a consumer until it has started to poll', async () => {
-        expect.assertions(3);
-        const iterator = connection[Symbol.asyncIterator]();
-        ws.send({ some: 'lost message' });
-        const resultPromise = iterator.next();
-        ws.send({ some: 'immediately delivered message' });
-        await expect(resultPromise).resolves.toMatchObject({
-            done: false,
-            value: { some: 'immediately delivered message' },
-        });
-        ws.send({ some: 'queued message 1' });
-        ws.send({ some: 'queued message 2' });
-        await expect(iterator.next()).resolves.toMatchObject({
-            done: false,
-            value: { some: 'queued message 1' },
-        });
-        await expect(iterator.next()).resolves.toMatchObject({
-            done: false,
-            value: { some: 'queued message 2' },
-        });
-    });
-    it('returns from the iterator when the connection is aborted', async () => {
-        expect.assertions(1);
-        const iterator = connection[Symbol.asyncIterator]();
-        const resultPromise = iterator.next();
-        abortController.abort();
-        await expect(resultPromise).resolves.toMatchObject({
-            done: true,
-            value: undefined,
-        });
-    });
-    it('throws from the iterator when the connection encounters an error', async () => {
-        expect.assertions(1);
-        const iterator = connection[Symbol.asyncIterator]();
-        const resultPromise = iterator.next();
-        ws.error({
-            code: 1006 /* abnormal closure */,
-            reason: 'o no',
-            wasClean: false,
-        });
-        await expect(resultPromise).rejects.toThrow();
-    });
-    it('sends a message to the websocket', async () => {
-        expect.assertions(1);
-        connection.send({ some: 'message' });
-        await expect(ws).toReceiveMessage({ some: 'message' });
-    });
-    it('does not fatal when sending a message to a closing connection', async () => {
-        expect.assertions(2);
-        const client = getLatestClient();
-        abortController.abort();
-        expect(client).toHaveProperty('readyState', WebSocket.CLOSING);
-        await expect(connection.send({ some: 'message' })).resolves.toBeUndefined();
-    });
-    it('does not fatal when sending a message to a closed connection', async () => {
-        expect.assertions(2);
-        const client = getLatestClient();
-        abortController.abort();
-        await ws.closed;
-        expect(client).toHaveProperty('readyState', WebSocket.CLOSED);
-        await expect(connection.send({ some: 'message' })).resolves.toBeUndefined();
-    });
-    describe('given the send buffer is filled past the high watermark', () => {
-        let client: Client;
-        let oldBufferedAmount: number;
-        beforeEach(async () => {
-            client = await ws.connected;
-            oldBufferedAmount = client.bufferedAmount;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (client as any).bufferedAmount = MOCK_SEND_BUFFER_HIGH_WATERMARK + 1;
-        });
-        afterEach(() => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (client as any).bufferedAmount = oldBufferedAmount;
-        });
-        it('queues messages until the buffer falls to the high watermark', async () => {
-            expect.assertions(2);
-            let resolved = false;
-            connection.send({ some: 'message' }).then(() => {
-                resolved = true;
+        expect(getLatestClient()).toHaveProperty('readyState', WebSocket.CONNECTING);
+        ws.on('connection', socket => {
+            // Simulate a message event coming in right behind the open event in the event queue.
+            setTimeout(() => {
+                socket.send(JSON.stringify({ some: 'message' }));
             });
-            await Promise.resolve(); // Flush Promise queue.
-            expect(resolved).toBe(false);
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (client as any).bufferedAmount = MOCK_SEND_BUFFER_HIGH_WATERMARK;
-            await expect(ws).toReceiveMessage({ some: 'message' });
         });
-        it('protects against modification of the message while queued', async () => {
-            expect.assertions(1);
-            const message = { some: 'message' };
-            connection.send(message);
-            message.some = 'modified message';
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (client as any).bufferedAmount = MOCK_SEND_BUFFER_HIGH_WATERMARK;
-            await expect(ws).toReceiveMessage({ some: 'message' });
+        const connection = await connectionPromise;
+        const iterator = connection[Symbol.asyncIterator]();
+        await expect(iterator.next()).resolves.toHaveProperty('value', { some: 'message' });
+    });
+    describe('given an open connection', () => {
+        let connection: RpcWebSocketConnection;
+        beforeEach(async () => {
+            connection = await connectionPromise;
         });
-        it('fatals when the connection is closed while a message is queued', async () => {
+        it('vends a message to consumers who have already polled for a result', async () => {
+            expect.assertions(2);
+            const iteratorA = connection[Symbol.asyncIterator]();
+            const iteratorB = connection[Symbol.asyncIterator]();
+            const resultPromiseA = iteratorA.next();
+            const resultPromiseB = iteratorB.next();
+            const expectedMessage = { some: 'message' };
+            ws.send(expectedMessage);
+            await expect(resultPromiseA).resolves.toMatchObject({ done: false, value: expectedMessage });
+            await expect(resultPromiseB).resolves.toMatchObject({ done: false, value: expectedMessage });
+        });
+        it('does not queue messsages for a consumer until it has started to poll', async () => {
+            expect.assertions(3);
+            const iterator = connection[Symbol.asyncIterator]();
+            ws.send({ some: 'lost message' });
+            const resultPromise = iterator.next();
+            ws.send({ some: 'immediately delivered message' });
+            await expect(resultPromise).resolves.toMatchObject({
+                done: false,
+                value: { some: 'immediately delivered message' },
+            });
+            ws.send({ some: 'queued message 1' });
+            ws.send({ some: 'queued message 2' });
+            await expect(iterator.next()).resolves.toMatchObject({
+                done: false,
+                value: { some: 'queued message 1' },
+            });
+            await expect(iterator.next()).resolves.toMatchObject({
+                done: false,
+                value: { some: 'queued message 2' },
+            });
+        });
+        it('returns from the iterator when the connection is aborted', async () => {
             expect.assertions(1);
-            const sendPromise = connection.send({ some: 'message' });
+            const iterator = connection[Symbol.asyncIterator]();
+            const resultPromise = iterator.next();
             abortController.abort();
-            await expect(sendPromise).rejects.toThrow();
+            await expect(resultPromise).resolves.toMatchObject({
+                done: true,
+                value: undefined,
+            });
         });
-        it('fatals when the connection encounters an error while a message is queued', async () => {
+        it('throws from the iterator when the connection encounters an error', async () => {
             expect.assertions(1);
-            const sendPromise = connection.send({ some: 'message' });
+            const iterator = connection[Symbol.asyncIterator]();
+            const resultPromise = iterator.next();
             ws.error({
                 code: 1006 /* abnormal closure */,
                 reason: 'o no',
                 wasClean: false,
             });
-            await expect(sendPromise).rejects.toThrow();
+            await expect(resultPromise).rejects.toThrow();
+        });
+        it('sends a message to the websocket', async () => {
+            expect.assertions(1);
+            connection.send({ some: 'message' });
+            await expect(ws).toReceiveMessage({ some: 'message' });
+        });
+        it('does not fatal when sending a message to a closing connection', async () => {
+            expect.assertions(2);
+            const client = getLatestClient();
+            abortController.abort();
+            expect(client).toHaveProperty('readyState', WebSocket.CLOSING);
+            await expect(connection.send({ some: 'message' })).resolves.toBeUndefined();
+        });
+        it('does not fatal when sending a message to a closed connection', async () => {
+            expect.assertions(2);
+            const client = getLatestClient();
+            abortController.abort();
+            await ws.closed;
+            expect(client).toHaveProperty('readyState', WebSocket.CLOSED);
+            await expect(connection.send({ some: 'message' })).resolves.toBeUndefined();
+        });
+        describe('given the send buffer is filled past the high watermark', () => {
+            let client: Client;
+            let oldBufferedAmount: number;
+            beforeEach(async () => {
+                client = await ws.connected;
+                oldBufferedAmount = client.bufferedAmount;
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (client as any).bufferedAmount = MOCK_SEND_BUFFER_HIGH_WATERMARK + 1;
+            });
+            afterEach(() => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (client as any).bufferedAmount = oldBufferedAmount;
+            });
+            it('queues messages until the buffer falls to the high watermark', async () => {
+                expect.assertions(2);
+                let resolved = false;
+                connection.send({ some: 'message' }).then(() => {
+                    resolved = true;
+                });
+                await Promise.resolve(); // Flush Promise queue.
+                expect(resolved).toBe(false);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (client as any).bufferedAmount = MOCK_SEND_BUFFER_HIGH_WATERMARK;
+                await expect(ws).toReceiveMessage({ some: 'message' });
+            });
+            it('protects against modification of the message while queued', async () => {
+                expect.assertions(1);
+                const message = { some: 'message' };
+                connection.send(message);
+                message.some = 'modified message';
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (client as any).bufferedAmount = MOCK_SEND_BUFFER_HIGH_WATERMARK;
+                await expect(ws).toReceiveMessage({ some: 'message' });
+            });
+            it('fatals when the connection is closed while a message is queued', async () => {
+                expect.assertions(1);
+                const sendPromise = connection.send({ some: 'message' });
+                abortController.abort();
+                await expect(sendPromise).rejects.toThrow();
+            });
+            it('fatals when the connection encounters an error while a message is queued', async () => {
+                expect.assertions(1);
+                const sendPromise = connection.send({ some: 'message' });
+                ws.error({
+                    code: 1006 /* abnormal closure */,
+                    reason: 'o no',
+                    wasClean: false,
+                });
+                await expect(sendPromise).rejects.toThrow();
+            });
         });
     });
 });

--- a/packages/ws-impl/package.json
+++ b/packages/ws-impl/package.json
@@ -63,6 +63,6 @@
         "typescript": "^5.1.6"
     },
     "peerDependencies": {
-        "ws": "^8.13.0"
+        "ws": "^8.14.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,13 @@ importers:
         version: 1.1.1
 
   packages/rpc-transport:
+    dependencies:
+      node-fetch:
+        specifier: ^2.6.7
+        version: 2.6.12
+      ws:
+        specifier: ^8.14.0
+        version: 8.14.0
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
@@ -1015,8 +1022,8 @@ importers:
   packages/ws-impl:
     dependencies:
       ws:
-        specifier: ^8.13.0
-        version: 8.13.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+        specifier: ^8.14.0
+        version: 8.14.0
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
@@ -11871,6 +11878,19 @@ packages:
     dependencies:
       bufferutil: 4.0.7
       utf-8-validate: 5.0.10
+
+  /ws@8.14.0:
+    resolution: {integrity: sha512-WR0RJE9Ehsio6U4TuM+LmunEsjQ5ncHlw4sn9ihD6RoJKZrVyH9FWV3dmnwu8B2aNib1OvG2X6adUCyFpQyWcg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}


### PR DESCRIPTION
refactor(experimental): bring the HTTP transport and the WebSocket closer together, spiritually

# Summary

The HTTP transport returns a method that you can call to perform requests and to return responses. My initial version of the WebSocket transport did not fit this interface; instead it returned an object that encapsulated a send method and an iterator of the connection's messages.

Let's bring these spiritually closer together. After this PR you will instead get a method that behaves like a ‘one shot’ request function. When you call it, it creates a WebSocket connectio, sends your payload down it, then returns the connection iterator _and_ the send method.

Now you can more easily write wrapper transports around it that do stuff like:

* Connection persistence
* Auto-pinging
* Payload/response transformations


# Test Plan

```
cd packages/rpc-transport
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1581).
* #1598
* #1586
* #1585
* #1584
* #1583
* #1582
* __->__ #1581
* #1580