### PR TITLE
test: use Jest fake timers properly in WebSocket transport test

### DIFF
--- a/packages/rpc-transport/src/transports/websocket/__tests__/websocket-transport-test.ts
+++ b/packages/rpc-transport/src/transports/websocket/__tests__/websocket-transport-test.ts
@@ -59,6 +59,7 @@ describe('IRpcWebSocketTransport', () => {
     });
     it('suspends until the socket is connected', async () => {
         expect.assertions(2);
+        jest.useFakeTimers();
         let resolveConnection: CallableFunction;
         jest.mocked(createWebSocketConnection).mockReturnValue(
             new Promise(r => {
@@ -74,8 +75,7 @@ describe('IRpcWebSocketTransport', () => {
             [Symbol.asyncIterator]: iterator,
             send,
         });
-        await Promise.resolve(); // Advance past the connection promise.
-        await Promise.resolve(); // Advance past the `send()` promise.
+        await jest.runAllTimersAsync();
         await expect(Promise.race([transportPromise, 'pending'])).resolves.not.toBe('pending');
     });
     it('forwards messages to the underlying connection', async () => {


### PR DESCRIPTION
test: use Jest fake timers properly in WebSocket transport test

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1582).
* #1604
* #1603
* #1598
* #1586
* #1585
* #1584
* #1583
* __->__ #1582