### PR TITLE
refactor(experimental): export the subscriptions API from the main web3.js library

### DIFF
--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -4,3 +4,4 @@ export * from '@solana/keys';
 export * from '@solana/transactions';
 export * from './rpc';
 export * from './rpc-transport';
+export * from './rpc-websocket-transport';

--- a/packages/library/src/rpc-websocket-transport.ts
+++ b/packages/library/src/rpc-websocket-transport.ts
@@ -1,0 +1,16 @@
+import { createWebSocketTransport } from '@solana/rpc-transport';
+import { IRpcWebSocketTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
+
+export function createDefaultRpcSubscriptionsTransport(
+    config: Omit<Parameters<typeof createWebSocketTransport>[0], 'sendBufferHighWatermark'> & {
+        sendBufferHighWatermark?: number;
+    }
+): IRpcWebSocketTransport {
+    return createWebSocketTransport({
+        ...config,
+        sendBufferHighWatermark:
+            config.sendBufferHighWatermark ??
+            // Let 128KB of data into the WebSocket buffer before buffering it in the app.
+            131_072,
+    });
+}

--- a/packages/library/src/rpc.ts
+++ b/packages/library/src/rpc.ts
@@ -1,12 +1,28 @@
-import { createSolanaRpcApi, SolanaRpcMethods } from '@solana/rpc-core';
-import { createJsonRpc } from '@solana/rpc-transport';
-import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import {
+    createSolanaRpcApi,
+    createSolanaRpcSubscriptionsApi,
+    SolanaRpcMethods,
+    SolanaRpcSubscriptions,
+} from '@solana/rpc-core';
+import { createJsonRpc, createJsonSubscriptionRpc } from '@solana/rpc-transport';
+import type { Rpc, RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
 
 import { DEFAULT_RPC_CONFIG } from './rpc-default-config';
 
 export function createSolanaRpc(config: Omit<Parameters<typeof createJsonRpc>[0], 'api'>): Rpc<SolanaRpcMethods> {
-    return createJsonRpc<SolanaRpcMethods>({
+    return createJsonRpc({
         ...config,
         api: createSolanaRpcApi(DEFAULT_RPC_CONFIG),
+    });
+}
+
+export function createSolanaRpcSubscriptions(
+    config: Omit<Parameters<typeof createJsonSubscriptionRpc>[0], 'api'>
+): RpcSubscriptions<SolanaRpcSubscriptions> {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    return createJsonSubscriptionRpc({
+        ...config,
+        api: createSolanaRpcSubscriptionsApi(DEFAULT_RPC_CONFIG),
     });
 }

--- a/packages/rpc-core/src/__tests__/response-patcher-test.ts
+++ b/packages/rpc-core/src/__tests__/response-patcher-test.ts
@@ -1,5 +1,5 @@
 import { patchResponseForSolanaLabsRpc } from '../response-patcher';
-import { getAllowedNumericKeypaths } from '../response-patcher-allowed-numeric-values';
+import { getAllowedNumericKeypathsForResponse } from '../response-patcher-allowed-numeric-values';
 import { KEYPATH_WILDCARD } from '../response-patcher-types';
 
 jest.mock('../response-patcher-allowed-numeric-values');
@@ -86,7 +86,7 @@ describe('patchResponseForSolanaLabsRpc', () => {
             it(`performs no \`bigint\` upcasts on ${description} when the allowlist is of the form \`${JSON.stringify(
                 allowedKeyPaths
             )}\``, () => {
-                jest.mocked(getAllowedNumericKeypaths).mockReturnValue({ getBlocks: allowedKeyPaths });
+                jest.mocked(getAllowedNumericKeypathsForResponse).mockReturnValue({ getBlocks: allowedKeyPaths });
                 expect(patchResponseForSolanaLabsRpc(input, 'getBlocks')).toStrictEqual(expectation);
             });
         });

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lamports';
 export * from './rpc-methods';
+export * from './rpc-subscriptions';
 export * from './stringified-bigint';
 export * from './transaction-signature';
 export * from './unix-timestamp';

--- a/packages/rpc-core/src/response-patcher.ts
+++ b/packages/rpc-core/src/response-patcher.ts
@@ -1,6 +1,10 @@
-import { getAllowedNumericKeypaths } from './response-patcher-allowed-numeric-values';
+import {
+    getAllowedNumericKeypathsForNotification,
+    getAllowedNumericKeypathsForResponse,
+} from './response-patcher-allowed-numeric-values';
 import { KEYPATH_WILDCARD, KeyPathWildcard } from './response-patcher-types';
 import { createSolanaRpcApi } from './rpc-methods';
+import { createSolanaRpcSubscriptionsApi } from './rpc-subscriptions';
 
 export type KeyPath = ReadonlyArray<KeyPathWildcard | number | string | KeyPath>;
 // FIXME(https://github.com/microsoft/TypeScript/issues/33014)
@@ -47,6 +51,14 @@ export function patchResponseForSolanaLabsRpc<T>(
     rawResponse: unknown,
     methodName?: keyof ReturnType<typeof createSolanaRpcApi>
 ): T {
-    const allowedKeypaths = methodName ? getAllowedNumericKeypaths()[methodName] : undefined;
+    const allowedKeypaths = methodName ? getAllowedNumericKeypathsForResponse()[methodName] : undefined;
+    return visitNode(rawResponse, allowedKeypaths ?? []);
+}
+
+export function patchResponseForSolanaLabsRpcSubscriptions<T>(
+    rawResponse: unknown,
+    methodName?: keyof (ReturnType<typeof createSolanaRpcApi> & ReturnType<typeof createSolanaRpcSubscriptionsApi>)
+): T {
+    const allowedKeypaths = methodName ? getAllowedNumericKeypathsForNotification()[methodName] : undefined;
     return visitNode(rawResponse, allowedKeypaths ?? []);
 }

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/index-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/index-test.ts
@@ -1,0 +1,20 @@
+import { IRpcSubscriptionsApi } from '@solana/rpc-transport/dist/types/json-rpc-types';
+
+import { createSolanaRpcSubscriptionsApi } from '../index';
+
+interface TestRpcSubscriptionNotifications {
+    thingNotifications(...args: unknown[]): unknown;
+}
+
+describe('IRpcSubscriptionsApi', () => {
+    let api: IRpcSubscriptionsApi<TestRpcSubscriptionNotifications>;
+    beforeEach(() => {
+        api = createSolanaRpcSubscriptionsApi() as unknown as IRpcSubscriptionsApi<TestRpcSubscriptionNotifications>;
+    });
+    it('synthesizes subscribe/unsubscribe method names from the name of the notification', () => {
+        expect(api.thingNotifications()).toMatchObject({
+            subscribeMethodName: 'thingSubscribe',
+            unsubscribeMethodName: 'thingUnsubscribe',
+        });
+    });
+});

--- a/packages/rpc-core/src/rpc-subscriptions/index.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/index.ts
@@ -1,0 +1,49 @@
+import { IRpcSubscriptionsApi, RpcSubscription } from '@solana/rpc-transport/dist/types/json-rpc-types';
+
+import { patchParamsForSolanaLabsRpc } from '../params-patcher';
+import { patchResponseForSolanaLabsRpcSubscriptions } from '../response-patcher';
+
+type Config = Readonly<{
+    onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;
+}>;
+
+export type SolanaRpcSubscriptions = never;
+
+export function createSolanaRpcSubscriptionsApi(config?: Config): IRpcSubscriptionsApi<SolanaRpcSubscriptions> {
+    return new Proxy({} as IRpcSubscriptionsApi<SolanaRpcSubscriptions>, {
+        defineProperty() {
+            return false;
+        },
+        deleteProperty() {
+            return false;
+        },
+        get<TNotificationName extends keyof IRpcSubscriptionsApi<SolanaRpcSubscriptions>>(
+            ...args: Parameters<NonNullable<ProxyHandler<IRpcSubscriptionsApi<SolanaRpcSubscriptions>>['get']>>
+        ) {
+            const [_, p] = args;
+            const notificationName = p.toString() as string;
+            return function (
+                ...rawParams: Parameters<
+                    SolanaRpcSubscriptions[TNotificationName] extends CallableFunction
+                        ? SolanaRpcSubscriptions[TNotificationName]
+                        : never
+                >
+            ): RpcSubscription<ReturnType<SolanaRpcSubscriptions[TNotificationName]>> {
+                const handleIntegerOverflow = config?.onIntegerOverflow;
+                const params = patchParamsForSolanaLabsRpc(
+                    rawParams,
+                    handleIntegerOverflow
+                        ? (keyPath, value) => handleIntegerOverflow(notificationName, keyPath, value)
+                        : undefined
+                );
+                return {
+                    params,
+                    responseProcessor: rawResponse =>
+                        patchResponseForSolanaLabsRpcSubscriptions(rawResponse, notificationName),
+                    subscribeMethodName: notificationName.replace(/Notifications$/, 'Subscribe'),
+                    unsubscribeMethodName: notificationName.replace(/Notifications$/, 'Unsubscribe'),
+                };
+            };
+        },
+    });
+}

--- a/packages/rpc-transport/package.json
+++ b/packages/rpc-transport/package.json
@@ -73,6 +73,7 @@
         "eslint": "^8.45.0",
         "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
+        "fast-stable-stringify": "^1.0.0",
         "fetch-impl": "workspace:*",
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^29.6.4",

--- a/packages/rpc-transport/src/__tests__/json-rpc-subscription-test.ts
+++ b/packages/rpc-transport/src/__tests__/json-rpc-subscription-test.ts
@@ -1,0 +1,312 @@
+import { SolanaJsonRpcError } from '../json-rpc-errors';
+import { createJsonRpcMessage } from '../json-rpc-message';
+import { getNextMessageId } from '../json-rpc-message-id';
+import { createJsonSubscriptionRpc } from '../json-rpc-subscription';
+import { IRpcSubscriptionsApi, RpcSubscription, RpcSubscriptions } from '../json-rpc-types';
+import { IRpcWebSocketTransport } from '../transports/transport-types';
+
+jest.mock('../json-rpc-message-id');
+
+interface TestRpcSubscriptionNotifications {
+    nonConformingNotif(...args: unknown[]): unknown;
+    thingNotifications(...args: unknown[]): unknown;
+}
+
+describe('JSON-RPC 2.0 Subscriptions', () => {
+    let createWebSocketConnection: IRpcWebSocketTransport;
+    let rpc: RpcSubscriptions<TestRpcSubscriptionNotifications>;
+    beforeEach(() => {
+        jest.mocked(getNextMessageId).mockReturnValue(0);
+        createWebSocketConnection = jest.fn(
+            () =>
+                new Promise(() => {
+                    /* never resolve */
+                })
+        );
+        rpc = createJsonSubscriptionRpc({
+            api: {
+                // Note the lack of method implementations in the base case.
+            } as IRpcSubscriptionsApi<TestRpcSubscriptionNotifications>,
+            transport: createWebSocketConnection,
+        });
+    });
+    it('sends a subscription request to the transport', () => {
+        rpc.thingNotifications(123).subscribe();
+        expect(createWebSocketConnection).toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: {
+                    ...createJsonRpcMessage('thingSubscribe', [123]),
+                    id: expect.any(Number),
+                },
+            })
+        );
+    });
+    it('returns from the iterator when aborted', async () => {
+        expect.assertions(1);
+        jest.useFakeTimers();
+        const abortController = new AbortController();
+        jest.mocked(createWebSocketConnection).mockResolvedValueOnce({
+            send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: jest.fn(async () => {}),
+            async *[Symbol.asyncIterator]() {
+                yield { id: 0, result: 42 /* subscription id */ };
+            },
+        });
+        const thingNotifications = await rpc.thingNotifications(123).subscribe({ abortSignal: abortController.signal });
+        await jest.runAllTimersAsync();
+        const iterator = thingNotifications[Symbol.asyncIterator]();
+        const thingNotificationPromise = iterator.next();
+        abortController.abort();
+        await expect(thingNotificationPromise).resolves.toMatchObject({
+            done: true,
+            value: undefined,
+        });
+    });
+    it('sends an unsubscribe request to the transport when aborted given an established subscription', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        const send = jest.fn(async () => {});
+        jest.mocked(createWebSocketConnection).mockResolvedValueOnce({
+            send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: send,
+            async *[Symbol.asyncIterator]() {
+                yield { id: 0, result: 42 /* subscription id */ };
+            },
+        });
+        await rpc.thingNotifications(123).subscribe({ abortSignal: abortController.signal });
+        abortController.abort();
+        expect(send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'thingUnsubscribe',
+                params: [42],
+            })
+        );
+    });
+    it('does not send an unsubscribe request to the transport when aborted if the subscription has not yet been established', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        rpc.thingNotifications(123).subscribe({ abortSignal: abortController.signal });
+        abortController.abort();
+        expect(createWebSocketConnection).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({
+                    method: 'thingUnsubscribe',
+                }),
+            })
+        );
+    });
+    it('does not send an unsubscribe request to the transport when the server fatals given an established subscription', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        let killServer: () => void;
+        jest.mocked(createWebSocketConnection).mockResolvedValueOnce({
+            send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: jest.fn(async () => {}),
+            async *[Symbol.asyncIterator]() {
+                yield { id: 0, result: 42 /* subscription id */ };
+                yield new Promise((_, reject) => {
+                    killServer = reject;
+                });
+            },
+        });
+        await rpc.thingNotifications(123).subscribe({ abortSignal: abortController.signal });
+        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        killServer();
+        expect(createWebSocketConnection).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({
+                    method: 'thingUnsubscribe',
+                }),
+            })
+        );
+    });
+    it('delivers only messages destined for a particular subscription', async () => {
+        expect.assertions(1);
+        jest.mocked(createWebSocketConnection).mockResolvedValueOnce({
+            send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: jest.fn(async () => {}),
+            async *[Symbol.asyncIterator]() {
+                yield { id: 0, result: 42 /* subscription id */ };
+                yield { params: { result: 123, subscription: 41 } };
+                yield { params: { result: 456, subscription: 42 } };
+            },
+        });
+        const thingNotifications = await rpc.thingNotifications().subscribe();
+        const iterator = thingNotifications[Symbol.asyncIterator]();
+        await expect(iterator.next()).resolves.toHaveProperty('value', 456);
+    });
+    it.each([null, undefined])(
+        'fatals when the subscription id returned from the server is `%s`',
+        async subscriptionId => {
+            expect.assertions(1);
+            jest.mocked(createWebSocketConnection).mockResolvedValueOnce({
+                send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: jest.fn(async () => {}),
+                async *[Symbol.asyncIterator]() {
+                    yield { id: 0, result: subscriptionId /* subscription id */ };
+                },
+            });
+            const thingNotificationsPromise = rpc.thingNotifications().subscribe();
+            await expect(thingNotificationsPromise).rejects.toThrow('Failed to obtain a subscription id');
+        }
+    );
+    it("fatals when called with a method that does not end in 'Notifications'", () => {
+        expect(() => {
+            rpc.nonConformingNotif().subscribe();
+        }).toThrow();
+    });
+    it('fatals when called with an already aborted signal', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        abortController.abort();
+        const subscribePromise = rpc.thingNotifications().subscribe({ abortSignal: abortController.signal });
+        await expect(subscribePromise).rejects.toThrow(/operation was aborted/);
+    });
+    it('fatals when the server fails to respond with a subscription id', async () => {
+        expect.assertions(1);
+        jest.mocked(createWebSocketConnection).mockResolvedValueOnce({
+            send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: jest.fn(async () => {}),
+            async *[Symbol.asyncIterator]() {
+                yield { id: 0, result: undefined /* subscription id */ };
+            },
+        });
+        const subscribePromise = rpc.thingNotifications().subscribe();
+        await expect(subscribePromise).rejects.toThrow(/Failed to obtain a subscription id from the server/);
+    });
+    it('fatals when the server responds with an error', async () => {
+        expect.assertions(3);
+        jest.mocked(createWebSocketConnection).mockResolvedValueOnce({
+            send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: jest.fn(async () => {}),
+            async *[Symbol.asyncIterator]() {
+                yield {
+                    error: { code: 123, data: 'abc', message: 'o no' },
+                    id: 0,
+                };
+            },
+        });
+        const subscribePromise = rpc.thingNotifications().subscribe();
+        await expect(subscribePromise).rejects.toThrow(SolanaJsonRpcError);
+        await expect(subscribePromise).rejects.toThrow(/o no/);
+        await expect(subscribePromise).rejects.toMatchObject({ code: 123, data: 'abc' });
+    });
+    it('throws errors when the connection fails to construct', async () => {
+        expect.assertions(1);
+        jest.mocked(createWebSocketConnection).mockRejectedValue(new Error('o no'));
+        const subscribePromise = rpc.thingNotifications().subscribe();
+        await expect(subscribePromise).rejects.toThrow(/o no/);
+    });
+    it('passes thrown errors from the connection iterable through its own iterable', async () => {
+        expect.assertions(1);
+        jest.useFakeTimers();
+        let killServer: () => void;
+        jest.mocked(createWebSocketConnection).mockResolvedValue({
+            send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: jest.fn(async () => {}),
+            async *[Symbol.asyncIterator]() {
+                yield { id: 0, result: 42 /* subscription id */ };
+                yield await new Promise((_, reject) => {
+                    killServer = reject;
+                });
+            },
+        });
+        const thingNotifications = await rpc.thingNotifications(123).subscribe();
+        const thingNotificationsPromise = (async () => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for await (const _ of thingNotifications);
+        })();
+        await jest.runAllTimersAsync();
+        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        killServer(new Error('o no'));
+        await expect(thingNotificationsPromise).rejects.toThrow(/o no/);
+    });
+    describe('when calling a method having a concrete implementation', () => {
+        let rpc: RpcSubscriptions<TestRpcSubscriptionNotifications>;
+        beforeEach(() => {
+            rpc = createJsonSubscriptionRpc({
+                api: {
+                    nonConformingNotif(...params: unknown[]): RpcSubscription<unknown> {
+                        return {
+                            params: [...params, 'augmented', 'params'],
+                            subscribeMethodName: 'nonConformingSubscribeAugmented',
+                            unsubscribeMethodName: 'nonConformingUnsubscribeAugmented',
+                        };
+                    },
+                } as IRpcSubscriptionsApi<TestRpcSubscriptionNotifications>,
+                transport: createWebSocketConnection,
+            });
+        });
+        it('converts the returned subscription to a JSON-RPC 2.0 message and sends it to the transport', () => {
+            rpc.nonConformingNotif(123).subscribe();
+            expect(createWebSocketConnection).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    payload: {
+                        ...createJsonRpcMessage('nonConformingSubscribeAugmented', [123, 'augmented', 'params']),
+                        id: expect.any(Number),
+                    },
+                })
+            );
+        });
+        it('uses the returned unsubscribe method name when unsubscribing', async () => {
+            expect.assertions(1);
+            jest.useFakeTimers();
+            const abortController = new AbortController();
+            const send = jest.fn(async () => {});
+            jest.mocked(createWebSocketConnection).mockResolvedValue({
+                send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: send,
+                async *[Symbol.asyncIterator]() {
+                    yield { id: 0, result: 42 /* subscription id */ };
+                },
+            });
+            await rpc.nonConformingNotif(123).subscribe({ abortSignal: abortController.signal });
+            await jest.runAllTimersAsync();
+            abortController.abort();
+            expect(send).toHaveBeenCalledWith(createJsonRpcMessage('nonConformingUnsubscribeAugmented', [42]));
+        });
+    });
+    describe('when calling a method whose concrete implementation returns a response processor', () => {
+        let responseProcessor: jest.Mock;
+        let rpc: RpcSubscriptions<TestRpcSubscriptionNotifications>;
+        beforeEach(() => {
+            responseProcessor = jest.fn(response => `${response} processed response`);
+            rpc = createJsonSubscriptionRpc({
+                api: {
+                    thingNotifications(...params: unknown[]): RpcSubscription<unknown> {
+                        return {
+                            params,
+                            responseProcessor,
+                            subscribeMethodName: 'thingSubscribe',
+                            unsubscribeMethodName: 'thingUnsubscribe',
+                        };
+                    },
+                } as IRpcSubscriptionsApi<TestRpcSubscriptionNotifications>,
+                transport: createWebSocketConnection,
+            });
+        });
+        it('calls the response processor with the response from the JSON-RPC 2.0 endpoint', async () => {
+            expect.assertions(1);
+            jest.mocked(createWebSocketConnection).mockResolvedValueOnce({
+                send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: jest.fn(async () => {}),
+                async *[Symbol.asyncIterator]() {
+                    yield { id: 0, result: 42 /* subscription id */ };
+                    yield { params: { result: 123, subscription: 42 } };
+                },
+            });
+            const thingNotifications = await rpc.thingNotifications().subscribe();
+            await thingNotifications[Symbol.asyncIterator]().next();
+            expect(responseProcessor).toHaveBeenCalledWith(123);
+        });
+        it('returns the processed response', async () => {
+            expect.assertions(1);
+            jest.mocked(createWebSocketConnection).mockResolvedValueOnce({
+                send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: jest.fn(async () => {}),
+                async *[Symbol.asyncIterator]() {
+                    yield { id: 0, result: 42 /* subscription id */ };
+                    yield { params: { result: 123, subscription: 42 } };
+                },
+            });
+            const thingNotifications = await rpc.thingNotifications().subscribe();
+            await expect(thingNotifications[Symbol.asyncIterator]().next()).resolves.toHaveProperty(
+                'value',
+                '123 processed response'
+            );
+        });
+    });
+});

--- a/packages/rpc-transport/src/index.ts
+++ b/packages/rpc-transport/src/index.ts
@@ -1,3 +1,4 @@
 export * from './json-rpc';
+export * from './json-rpc-subscription';
 export * from './transports/http/http-transport';
 export * from './transports/websocket/websocket-transport';

--- a/packages/rpc-transport/src/json-rpc-subscription.ts
+++ b/packages/rpc-transport/src/json-rpc-subscription.ts
@@ -1,0 +1,142 @@
+import { JsonRpcResponse } from './json-rpc';
+import { SolanaJsonRpcError } from './json-rpc-errors';
+import { createJsonRpcMessage } from './json-rpc-message';
+import {
+    PendingRpcSubscription,
+    RpcSubscription,
+    RpcSubscriptionConfig,
+    RpcSubscriptions,
+    SubscribeOptions,
+} from './json-rpc-types';
+
+type JsonRpcNotification<TNotification> = Readonly<{
+    params: Readonly<{
+        result: TNotification;
+        subscription: number;
+    }>;
+}>;
+type SubscriptionId = number;
+
+function registerIterableFatal(iterable: AsyncIterable<unknown>, catchFn: CallableFunction) {
+    (async () => {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for await (const _ of iterable);
+        } catch (e) {
+            // Run the catch function if the iterator throws.
+            catchFn(e);
+        }
+    })();
+}
+
+function createPendingRpcSubscription<TRpcSubscriptionMethods, TNotification>(
+    rpcConfig: RpcSubscriptionConfig<TRpcSubscriptionMethods>,
+    { params, subscribeMethodName, unsubscribeMethodName, responseProcessor }: RpcSubscription<TNotification>
+): PendingRpcSubscription<TNotification> {
+    return {
+        async subscribe(options?: SubscribeOptions): Promise<AsyncIterable<TNotification>> {
+            options?.abortSignal?.throwIfAborted();
+            let subscriptionId: number | undefined;
+            function handleCleanup() {
+                if (subscriptionId !== undefined) {
+                    const payload = createJsonRpcMessage(unsubscribeMethodName, [subscriptionId]);
+                    connection.send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(payload).finally(() => {
+                        connectionAbortController.abort();
+                    });
+                } else {
+                    connectionAbortController.abort();
+                }
+            }
+            options?.abortSignal?.addEventListener('abort', handleCleanup);
+            /**
+             * STEP 1: Send the subscribe message.
+             */
+            const connectionAbortController = new AbortController();
+            const subscribeMessage = createJsonRpcMessage(subscribeMethodName, params);
+            const connection = await rpcConfig.transport({
+                payload: subscribeMessage,
+                signal: connectionAbortController.signal,
+            });
+            function handleConnectionFatal() {
+                options?.abortSignal?.removeEventListener('abort', handleCleanup);
+            }
+            registerIterableFatal(connection, handleConnectionFatal);
+            /**
+             * STEP 2: Wait for the acknowledgement from the server with the subscription id.
+             */
+            for await (const message of connection as AsyncIterable<
+                JsonRpcNotification<unknown> | JsonRpcResponse<SubscriptionId>
+            >) {
+                if ('id' in message && message.id === subscribeMessage.id) {
+                    if ('error' in message) {
+                        throw new SolanaJsonRpcError(message.error);
+                    } else {
+                        subscriptionId = message.result as SubscriptionId;
+                        break;
+                    }
+                }
+            }
+            if (subscriptionId == null) {
+                // TODO: Coded error.
+                throw new Error('Failed to obtain a subscription id from the server');
+            }
+            /**
+             * STEP 3: Return an iterable that yields notifications for this subscription id.
+             */
+            return {
+                async *[Symbol.asyncIterator]() {
+                    for await (const message of connection as AsyncIterable<
+                        JsonRpcNotification<unknown> | JsonRpcResponse<SubscriptionId>
+                    >) {
+                        if (!('params' in message) || message.params.subscription !== subscriptionId) {
+                            continue;
+                        }
+                        const notification = message.params.result as TNotification;
+                        yield responseProcessor ? responseProcessor(notification) : notification;
+                    }
+                },
+            };
+        },
+    };
+}
+
+function makeProxy<TRpcSubscriptionMethods>(
+    rpcConfig: RpcSubscriptionConfig<TRpcSubscriptionMethods>
+): RpcSubscriptions<TRpcSubscriptionMethods> {
+    return new Proxy(rpcConfig.api, {
+        defineProperty() {
+            return false;
+        },
+        deleteProperty() {
+            return false;
+        },
+        get(target, p, receiver) {
+            return function (...rawParams: unknown[]) {
+                const methodName = p.toString();
+                const createRpcSubscription = Reflect.get(target, methodName, receiver);
+                if (p.toString().endsWith('Notifications') === false && !createRpcSubscription) {
+                    // TODO: Coded error.
+                    throw new Error(
+                        "Either the notification name must end in 'Notifications' or the API " +
+                            'must supply a subscription creator function to map between the ' +
+                            'notification name and the subscribe/unsubscribe method names.'
+                    );
+                }
+                const newRequest = createRpcSubscription
+                    ? createRpcSubscription(...rawParams)
+                    : {
+                          params: rawParams,
+                          subscribeMethodName: methodName.replace(/Notifications$/, 'Subscribe'),
+                          unsubscribeMethodName: methodName.replace(/Notifications$/, 'Unsubscribe'),
+                      };
+                return createPendingRpcSubscription(rpcConfig, newRequest);
+            };
+        },
+    }) as RpcSubscriptions<TRpcSubscriptionMethods>;
+}
+
+export function createJsonSubscriptionRpc<TRpcSubscriptionMethods>(
+    rpcConfig: RpcSubscriptionConfig<TRpcSubscriptionMethods>
+): RpcSubscriptions<TRpcSubscriptionMethods> {
+    return makeProxy(rpcConfig);
+}

--- a/packages/rpc-transport/src/json-rpc.ts
+++ b/packages/rpc-transport/src/json-rpc.ts
@@ -5,7 +5,7 @@ import { PendingRpcRequest, Rpc, RpcConfig, RpcRequest, SendOptions } from './js
 interface IHasIdentifier {
     readonly id: number;
 }
-type JsonRpcResponse<TResponse> = IHasIdentifier &
+export type JsonRpcResponse<TResponse> = IHasIdentifier &
     Readonly<{ result: TResponse } | { error: { code: number; message: string; data?: unknown } }>;
 
 function createPendingRpcRequest<TRpcMethods, TResponse>(

--- a/packages/rpc-transport/src/transports/websocket/__tests__/websocket-transport-test.ts
+++ b/packages/rpc-transport/src/transports/websocket/__tests__/websocket-transport-test.ts
@@ -59,6 +59,7 @@ describe('IRpcWebSocketTransport', () => {
     });
     it('suspends until the socket is connected', async () => {
         expect.assertions(2);
+        jest.useFakeTimers();
         let resolveConnection: CallableFunction;
         jest.mocked(createWebSocketConnection).mockReturnValue(
             new Promise(r => {
@@ -74,8 +75,7 @@ describe('IRpcWebSocketTransport', () => {
             [Symbol.asyncIterator]: iterator,
             send,
         });
-        await Promise.resolve(); // Advance past the connection promise.
-        await Promise.resolve(); // Advance past the `send()` promise.
+        await jest.runAllTimersAsync();
         await expect(Promise.race([transportPromise, 'pending'])).resolves.not.toBe('pending');
     });
     it('forwards messages to the underlying connection', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,6 +787,9 @@ importers:
       eslint-plugin-sort-keys-fix:
         specifier: ^1.1.2
         version: 1.1.2
+      fast-stable-stringify:
+        specifier: ^1.0.0
+        version: 1.0.0
       fetch-impl:
         specifier: workspace:*
         version: link:../fetch-impl


### PR DESCRIPTION
refactor(experimental): export the subscriptions API from the main web3.js library

# Summary

This code lets you create a subscriptions API object.

# Test Plan

```ts
const rpcSubscriptions = createSolanaRpcSubscriptions({
  transport: createDefaultRpcSubscriptionsTransport({
    url: 'https://api.devnet.solana.com',
  }),
});

const slotNotifications = await rpcSubscriptions
  .slotNotifications()
  .subscribe();
for await (const notif of slotNotifications) {
  console.log(notif);
}
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1585).
* #1604
* #1603
* #1598
* #1586
* __->__ #1585
* #1584
* #1583
* #1582