### PR TITLE
refactor(experimental): The slot notifications API

### DIFF
--- a/packages/library/src/rpc.ts
+++ b/packages/library/src/rpc.ts
@@ -19,8 +19,6 @@ export function createSolanaRpc(config: Omit<Parameters<typeof createJsonRpc>[0]
 export function createSolanaRpcSubscriptions(
     config: Omit<Parameters<typeof createJsonSubscriptionRpc>[0], 'api'>
 ): RpcSubscriptions<SolanaRpcSubscriptions> {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
     return createJsonSubscriptionRpc({
         ...config,
         api: createSolanaRpcSubscriptionsApi(DEFAULT_RPC_CONFIG),

--- a/packages/rpc-core/src/response-patcher.ts
+++ b/packages/rpc-core/src/response-patcher.ts
@@ -57,7 +57,7 @@ export function patchResponseForSolanaLabsRpc<T>(
 
 export function patchResponseForSolanaLabsRpcSubscriptions<T>(
     rawResponse: unknown,
-    methodName?: keyof (ReturnType<typeof createSolanaRpcApi> & ReturnType<typeof createSolanaRpcSubscriptionsApi>)
+    methodName?: keyof ReturnType<typeof createSolanaRpcSubscriptionsApi>
 ): T {
     const allowedKeypaths = methodName ? getAllowedNumericKeypathsForNotification()[methodName] : undefined;
     return visitNode(rawResponse, allowedKeypaths ?? []);

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
@@ -1,0 +1,34 @@
+import { createJsonSubscriptionRpc, createWebSocketTransport } from '@solana/rpc-transport';
+import type { RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcSubscriptionsApi, SolanaRpcSubscriptions } from '../index';
+
+describe('slotNotifications', () => {
+    let rpc: RpcSubscriptions<SolanaRpcSubscriptions>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonSubscriptionRpc<SolanaRpcSubscriptions>({
+            api: createSolanaRpcSubscriptionsApi(),
+            transport: createWebSocketTransport({
+                sendBufferHighWatermark: Number.POSITIVE_INFINITY,
+                url: 'ws://127.0.0.1:8900',
+            }),
+        });
+    });
+
+    it('produces slot notifications', async () => {
+        expect.assertions(1);
+        const slotNotifications = await rpc.slotNotifications().subscribe();
+        const iterator = slotNotifications[Symbol.asyncIterator]();
+        await expect(iterator.next()).resolves.toHaveProperty(
+            'value',
+            expect.objectContaining({
+                parent: expect.any(BigInt),
+                root: expect.any(BigInt),
+                slot: expect.any(BigInt),
+            })
+        );
+    });
+});

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/slot-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/slot-notifications-type-test.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import { RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+
+import { U64UnsafeBeyond2Pow53Minus1 } from '../../rpc-methods/common';
+import { SolanaRpcSubscriptions } from '../index';
+
+async () => {
+    const rpcSubcriptions = null as unknown as RpcSubscriptions<SolanaRpcSubscriptions>;
+    const slotNotifications = await rpcSubcriptions.slotNotifications().subscribe();
+
+    slotNotifications satisfies AsyncIterable<
+        Readonly<{
+            parent: U64UnsafeBeyond2Pow53Minus1;
+            root: U64UnsafeBeyond2Pow53Minus1;
+            slot: U64UnsafeBeyond2Pow53Minus1;
+        }>
+    >;
+
+    // @ts-expect-error Takes no params.
+    rpcSubcriptions.slotNotifications({ commitment: 'finalized' });
+};

--- a/packages/rpc-core/src/rpc-subscriptions/index.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/index.ts
@@ -2,12 +2,13 @@ import { IRpcSubscriptionsApi, RpcSubscription } from '@solana/rpc-transport/dis
 
 import { patchParamsForSolanaLabsRpc } from '../params-patcher';
 import { patchResponseForSolanaLabsRpcSubscriptions } from '../response-patcher';
+import { SlotNotificationsApi } from './slot-notifications';
 
 type Config = Readonly<{
     onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;
 }>;
 
-export type SolanaRpcSubscriptions = never;
+export type SolanaRpcSubscriptions = SlotNotificationsApi;
 
 export function createSolanaRpcSubscriptionsApi(config?: Config): IRpcSubscriptionsApi<SolanaRpcSubscriptions> {
     return new Proxy({} as IRpcSubscriptionsApi<SolanaRpcSubscriptions>, {
@@ -21,7 +22,7 @@ export function createSolanaRpcSubscriptionsApi(config?: Config): IRpcSubscripti
             ...args: Parameters<NonNullable<ProxyHandler<IRpcSubscriptionsApi<SolanaRpcSubscriptions>>['get']>>
         ) {
             const [_, p] = args;
-            const notificationName = p.toString() as string;
+            const notificationName = p.toString() as keyof SolanaRpcSubscriptions;
             return function (
                 ...rawParams: Parameters<
                     SolanaRpcSubscriptions[TNotificationName] extends CallableFunction

--- a/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
@@ -1,0 +1,17 @@
+import { U64UnsafeBeyond2Pow53Minus1 } from '../rpc-methods/common';
+
+type SlotNotificationsApiNotification = Readonly<{
+    parent: U64UnsafeBeyond2Pow53Minus1;
+    root: U64UnsafeBeyond2Pow53Minus1;
+    slot: U64UnsafeBeyond2Pow53Minus1;
+}>;
+
+export interface SlotNotificationsApi {
+    /**
+     * Subscribe to receive notification anytime a slot is processed by the validator
+     */
+    slotNotifications(
+        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
+        NO_CONFIG?: Record<string, never>
+    ): SlotNotificationsApiNotification;
+}


### PR DESCRIPTION
refactor(experimental): The slot notifications API

# Summary

Use this method to subscribe for a notification every time the slot advances.


# Test Plan

```
cd packages/rpc-core
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1586).
* #1604
* #1603
* #1598
* __->__ #1586