### PR TITLE
Export LamportsUnsafe type and add an assertion function

### DIFF
--- a/packages/rpc-core/src/__tests__/lamports-test.ts
+++ b/packages/rpc-core/src/__tests__/lamports-test.ts
@@ -1,0 +1,32 @@
+import { assertIsLamports } from '../lamports';
+
+describe('assertIsLamports()', () => {
+    it('throws when supplied a negative number', () => {
+        expect(() => {
+            assertIsLamports(-1n);
+        }).toThrow();
+        expect(() => {
+            assertIsLamports(-1000n);
+        }).toThrow();
+    });
+    it('throws when supplied a too large number', () => {
+        expect(() => {
+            assertIsLamports(2n ** 64n);
+        }).toThrow();
+    });
+    it('does not throw when supplied zero lamports', () => {
+        expect(() => {
+            assertIsLamports(0n);
+        }).not.toThrow();
+    });
+    it('does not throw when supplied a valid non-zero number of lamports', () => {
+        expect(() => {
+            assertIsLamports(1_000_000_000n);
+        }).not.toThrow();
+    });
+    it('does not throw when supplied the max valid number of lamports', () => {
+        expect(() => {
+            assertIsLamports(2n ** 64n - 1n);
+        }).not.toThrow();
+    });
+});

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lamports';
 export * from './rpc-methods';
 export * from './stringified-bigint';
 export * from './transaction-signature';

--- a/packages/rpc-core/src/lamports.ts
+++ b/packages/rpc-core/src/lamports.ts
@@ -1,0 +1,21 @@
+// FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
+// truncated or rounded because of a downcast to JavaScript `number` between your calling code and
+// the JSON-RPC transport.
+export type LamportsUnsafeBeyond2Pow53Minus1 = bigint & { readonly __brand: unique symbol };
+
+// Largest possible value to be represented by a u64
+const maxU64Value = 18446744073709551615n; // 2n ** 64n - 1n
+
+export function assertIsLamports(
+    putativeLamports: bigint
+): asserts putativeLamports is LamportsUnsafeBeyond2Pow53Minus1 {
+    if (putativeLamports < 0) {
+        // TODO: Coded error.
+        throw new Error('Input for 64-bit unsigned integer cannot be negative');
+    }
+
+    if (putativeLamports > maxU64Value) {
+        // TODO: Coded error.
+        throw new Error('Input number is too large to be represented as a 64-bit unsigned integer');
+    }
+}

--- a/packages/rpc-core/src/rpc-methods/__tests__/request-airdrop-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/request-airdrop-test.ts
@@ -4,7 +4,8 @@ import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '../common';
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../../lamports';
+import { Commitment } from '../common';
 import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
 
 describe('requestAirdrop', () => {

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-block-type-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-block-type-test.ts
@@ -2,13 +2,13 @@ import { Base58EncodedAddress } from '@solana/addresses';
 import { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
 import { Blockhash, TransactionVersion } from '@solana/transactions';
 
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../../lamports';
 import { TransactionError } from '../../transaction-error';
 import { SolanaRpcMethods } from '..';
 import {
     Base58EncodedBytes,
     Base58EncodedDataResponse,
     Base64EncodedDataResponse,
-    LamportsUnsafeBeyond2Pow53Minus1,
     Reward,
     TokenBalance,
     TransactionStatus,

--- a/packages/rpc-core/src/rpc-methods/common.ts
+++ b/packages/rpc-core/src/rpc-methods/common.ts
@@ -1,5 +1,6 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
 import { StringifiedBigInt } from '../stringified-bigint';
 import { StringifiedNumber } from '../stringified-number';
 import { TransactionError } from '../transaction-error';
@@ -10,11 +11,6 @@ export type DataSlice = Readonly<{
     offset: number;
     length: number;
 }>;
-
-// FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
-// truncated or rounded because of a downcast to JavaScript `number` between your calling code and
-// the JSON-RPC transport.
-export type LamportsUnsafeBeyond2Pow53Minus1 = bigint & { readonly __brand: unique symbol };
 
 // FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
 // truncated or rounded because of a downcast to JavaScript `number` between your calling code and

--- a/packages/rpc-core/src/rpc-methods/getBalance.ts
+++ b/packages/rpc-core/src/rpc-methods/getBalance.ts
@@ -1,6 +1,7 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, RpcResponse, Slot } from './common';
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
+import { Commitment, RpcResponse, Slot } from './common';
 
 type GetBalanceApiResponse = RpcResponse<LamportsUnsafeBeyond2Pow53Minus1>;
 

--- a/packages/rpc-core/src/rpc-methods/getBlock.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlock.ts
@@ -1,6 +1,7 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 import { Blockhash, TransactionVersion } from '@solana/transactions';
 
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
 import { TransactionError } from '../transaction-error';
 import { UnixTimestamp } from '../unix-timestamp';
 import {
@@ -8,7 +9,6 @@ import {
     Base58EncodedDataResponse,
     Base64EncodedDataResponse,
     Commitment,
-    LamportsUnsafeBeyond2Pow53Minus1,
     Reward,
     Slot,
     TokenBalance,

--- a/packages/rpc-core/src/rpc-methods/getBlockCommitment.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockCommitment.ts
@@ -1,4 +1,5 @@
-import { LamportsUnsafeBeyond2Pow53Minus1, Slot } from './common';
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
+import { Slot } from './common';
 
 type GetBlockCommitmentApiResponse = Readonly<{
     commitment: LamportsUnsafeBeyond2Pow53Minus1[] | null;

--- a/packages/rpc-core/src/rpc-methods/getInflationReward.ts
+++ b/packages/rpc-core/src/rpc-methods/getInflationReward.ts
@@ -1,6 +1,7 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
+import { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type GetInflationRewardApiResponse = Readonly<{
     // Reward amount in lamports

--- a/packages/rpc-core/src/rpc-methods/getLargestAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getLargestAccounts.ts
@@ -1,6 +1,7 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, RpcResponse } from './common';
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
+import { Commitment, RpcResponse } from './common';
 
 type GetLargestAccountsResponseItem = Readonly<{
     /** Base-58 encoded address of the account */

--- a/packages/rpc-core/src/rpc-methods/getMinimumBalanceForRentExemption.ts
+++ b/packages/rpc-core/src/rpc-methods/getMinimumBalanceForRentExemption.ts
@@ -1,4 +1,5 @@
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
+import { Commitment, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type GetMinimumBalanceForRentExemptionApiResponse = LamportsUnsafeBeyond2Pow53Minus1;
 

--- a/packages/rpc-core/src/rpc-methods/getStakeMinimumDelegation.ts
+++ b/packages/rpc-core/src/rpc-methods/getStakeMinimumDelegation.ts
@@ -1,4 +1,5 @@
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, RpcResponse } from './common';
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
+import { Commitment, RpcResponse } from './common';
 
 type GetStakeMinimumDelegationApiResponse = RpcResponse<LamportsUnsafeBeyond2Pow53Minus1>;
 

--- a/packages/rpc-core/src/rpc-methods/getSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getSupply.ts
@@ -1,6 +1,7 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, RpcResponse } from './common';
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
+import { Commitment, RpcResponse } from './common';
 
 type GetSupplyConfig = Readonly<{
     commitment?: Commitment;

--- a/packages/rpc-core/src/rpc-methods/getTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/getTransaction.ts
@@ -1,6 +1,7 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 import { Blockhash, TransactionVersion } from '@solana/transactions';
 
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
 import { TransactionError } from '../transaction-error';
 import { UnixTimestamp } from '../unix-timestamp';
 import {
@@ -8,7 +9,6 @@ import {
     Base58EncodedDataResponse,
     Base64EncodedDataResponse,
     Commitment,
-    LamportsUnsafeBeyond2Pow53Minus1,
     Reward,
     Slot,
     TokenBalance,

--- a/packages/rpc-core/src/rpc-methods/requestAirdrop.ts
+++ b/packages/rpc-core/src/rpc-methods/requestAirdrop.ts
@@ -1,6 +1,7 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
-import { Base58EncodedTransactionSignature, Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from './common';
+import { LamportsUnsafeBeyond2Pow53Minus1 } from '../lamports';
+import { Base58EncodedTransactionSignature, Commitment } from './common';
 
 type RequestAirdropConfig = Readonly<{
     commitment?: Commitment;


### PR DESCRIPTION
This is required because the `requestAirdrop` RPC call requires it as an input.

So as with our other branded inputs we need to be able to write code like:

```ts
const address = 'abc' as Base58EncodedAddress
const lamports = 1_000_000n
assertIsLamports(lamports)
await rpc.requestAirdrop(address, lamports).send()

// or just cast it
await rpc.requestAirdrop(address, 1_000_000n as LamportsUnsafeBeyond2Pow53Minus1).send()
```

Any BigInt that is greater than zero and is less than u64::MAX is valid as a number of lamports and will succeed in `assertIsLamports`. 