### PR TITLE
refactor(experimental): install the autopinger by default

### DIFF
--- a/packages/library/src/__tests__/rpc-websocket-autopinger-test.ts
+++ b/packages/library/src/__tests__/rpc-websocket-autopinger-test.ts
@@ -1,0 +1,145 @@
+import { IRpcWebSocketTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
+
+import { getWebSocketTransportWithAutoping } from '../rpc-websocket-autopinger';
+
+jest.mock('@solana/rpc-transport');
+
+const MOCK_INTERVAL_MS = 60_000;
+
+describe('getWebSocketTransportWithAutoping', () => {
+    let killConnection: () => void;
+    let mockInnerTransport: jest.Mock;
+    let receiveMessage: (value: unknown) => void;
+    let returnFromConnection: () => void;
+    let send: jest.Mock;
+    let transport: IRpcWebSocketTransport;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        send = jest.fn();
+        let resultPromise;
+        mockInnerTransport = jest.fn(() => ({
+            async *[Symbol.asyncIterator]() {
+                try {
+                    while (true) {
+                        yield (resultPromise ||= new Promise((resolve, reject) => {
+                            killConnection = () => {
+                                reject('error');
+                            };
+                            receiveMessage = resolve;
+                            returnFromConnection = () => {
+                                reject();
+                            };
+                        }));
+                        resultPromise = null;
+                    }
+                } catch (e) {
+                    if (e === 'error') {
+                        throw e;
+                    }
+                    return;
+                }
+            },
+            send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: send,
+        }));
+        transport = getWebSocketTransportWithAutoping({
+            intervalMs: MOCK_INTERVAL_MS,
+            transport: mockInnerTransport,
+        });
+    });
+    it('sends a ping message to the active connection at the specified interval', async () => {
+        expect.assertions(4);
+        await transport({ payload: 'hi', signal: new AbortController().signal });
+        // First ping.
+        jest.advanceTimersByTime(MOCK_INTERVAL_MS - 1);
+        expect(send).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1);
+        expect(send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                jsonrpc: '2.0',
+                method: 'ping',
+            })
+        );
+        // Second ping.
+        send.mockClear();
+        jest.advanceTimersByTime(MOCK_INTERVAL_MS - 1);
+        expect(send).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1);
+        expect(send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                jsonrpc: '2.0',
+                method: 'ping',
+            })
+        );
+    });
+    it('does not send a ping until interval milliseconds after the last sent message', async () => {
+        expect.assertions(3);
+        const connection = await transport({ payload: 'hi', signal: new AbortController().signal });
+        jest.advanceTimersByTime(500);
+        expect(send).not.toHaveBeenCalled();
+        connection.send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED('hi');
+        send.mockClear();
+        jest.advanceTimersByTime(MOCK_INTERVAL_MS - 1);
+        expect(send).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1);
+        expect(send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                jsonrpc: '2.0',
+                method: 'ping',
+            })
+        );
+    });
+    it('does not send a ping until interval milliseconds after the last received message', async () => {
+        expect.assertions(3);
+        await transport({ payload: 'hi', signal: new AbortController().signal });
+        jest.advanceTimersByTime(500);
+        expect(send).not.toHaveBeenCalled();
+        receiveMessage('hi');
+        await Promise.resolve(); // Flush Promise queue.
+        await Promise.resolve(); // Flush Promise queue.
+        jest.advanceTimersByTime(MOCK_INTERVAL_MS - 1);
+        expect(send).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1);
+        expect(send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                jsonrpc: '2.0',
+                method: 'ping',
+            })
+        );
+    });
+    it('does not send a ping after the connection throws', async () => {
+        expect.assertions(2);
+        await transport({ payload: 'hi', signal: new AbortController().signal });
+        // First ping.
+        jest.advanceTimersByTime(MOCK_INTERVAL_MS);
+        expect(send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                jsonrpc: '2.0',
+                method: 'ping',
+            })
+        );
+        killConnection();
+        await jest.runAllTimersAsync();
+        // No more pings.
+        send.mockClear();
+        jest.advanceTimersByTime(MOCK_INTERVAL_MS);
+        expect(send).not.toHaveBeenCalled();
+    });
+    it('does not send a ping after the connection returns', async () => {
+        expect.assertions(2);
+        await transport({ payload: 'hi', signal: new AbortController().signal });
+        // First ping.
+        jest.advanceTimersByTime(MOCK_INTERVAL_MS);
+        expect(send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                jsonrpc: '2.0',
+                method: 'ping',
+            })
+        );
+        returnFromConnection();
+        await jest.runAllTimersAsync();
+        // No more pings.
+        send.mockClear();
+        jest.advanceTimersByTime(MOCK_INTERVAL_MS);
+        expect(send).not.toHaveBeenCalled();
+    });
+});

--- a/packages/library/src/rpc-websocket-autopinger.ts
+++ b/packages/library/src/rpc-websocket-autopinger.ts
@@ -1,0 +1,54 @@
+import { IRpcWebSocketTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
+
+type Config = Readonly<{
+    intervalMs: number;
+    transport: IRpcWebSocketTransport;
+}>;
+
+const PING_PAYLOAD = {
+    jsonrpc: '2.0',
+    method: 'ping',
+} as const;
+
+export function getWebSocketTransportWithAutoping({ intervalMs, transport }: Config): IRpcWebSocketTransport {
+    const pingableConnections = new Map<
+        Awaited<ReturnType<IRpcWebSocketTransport>>,
+        Awaited<ReturnType<IRpcWebSocketTransport>>
+    >();
+    return async (...args) => {
+        const connection = await transport(...args);
+        let intervalId: string | number | NodeJS.Timeout | undefined;
+        function restartPingTimer() {
+            clearInterval(intervalId);
+            intervalId = setInterval(() => {
+                connection.send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(PING_PAYLOAD);
+            }, intervalMs);
+        }
+        if (pingableConnections.has(connection) === false) {
+            pingableConnections.set(connection, {
+                [Symbol.asyncIterator]: connection[Symbol.asyncIterator].bind(connection),
+                send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: (
+                    ...args: Parameters<typeof connection.send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED>
+                ) => {
+                    restartPingTimer();
+                    return connection.send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(...args);
+                },
+            });
+            (async () => {
+                try {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    for await (const _ of connection) {
+                        restartPingTimer();
+                    }
+                } catch {
+                    /* empty */
+                } finally {
+                    pingableConnections.delete(connection);
+                    clearInterval(intervalId);
+                }
+            })();
+            restartPingTimer();
+        }
+        return pingableConnections.get(connection)!;
+    };
+}

--- a/packages/library/src/rpc-websocket-transport.ts
+++ b/packages/library/src/rpc-websocket-transport.ts
@@ -1,16 +1,23 @@
 import { createWebSocketTransport } from '@solana/rpc-transport';
 import { IRpcWebSocketTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
 
+import { getWebSocketTransportWithAutoping } from './rpc-websocket-autopinger';
+
 export function createDefaultRpcSubscriptionsTransport(
     config: Omit<Parameters<typeof createWebSocketTransport>[0], 'sendBufferHighWatermark'> & {
+        intervalMs?: number;
         sendBufferHighWatermark?: number;
     }
 ): IRpcWebSocketTransport {
-    return createWebSocketTransport({
-        ...config,
-        sendBufferHighWatermark:
-            config.sendBufferHighWatermark ??
-            // Let 128KB of data into the WebSocket buffer before buffering it in the app.
-            131_072,
+    const { intervalMs, ...rest } = config;
+    return getWebSocketTransportWithAutoping({
+        intervalMs: intervalMs ?? 5_000,
+        transport: createWebSocketTransport({
+            ...rest,
+            sendBufferHighWatermark:
+                config.sendBufferHighWatermark ??
+                // Let 128KB of data into the WebSocket buffer before buffering it in the app.
+                131_072,
+        }),
     });
 }

--- a/packages/library/src/rpc.ts
+++ b/packages/library/src/rpc.ts
@@ -19,8 +19,6 @@ export function createSolanaRpc(config: Omit<Parameters<typeof createJsonRpc>[0]
 export function createSolanaRpcSubscriptions(
     config: Omit<Parameters<typeof createJsonSubscriptionRpc>[0], 'api'>
 ): RpcSubscriptions<SolanaRpcSubscriptions> {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
     return createJsonSubscriptionRpc({
         ...config,
         api: createSolanaRpcSubscriptionsApi(DEFAULT_RPC_CONFIG),

--- a/packages/rpc-core/src/response-patcher.ts
+++ b/packages/rpc-core/src/response-patcher.ts
@@ -57,7 +57,7 @@ export function patchResponseForSolanaLabsRpc<T>(
 
 export function patchResponseForSolanaLabsRpcSubscriptions<T>(
     rawResponse: unknown,
-    methodName?: keyof (ReturnType<typeof createSolanaRpcApi> & ReturnType<typeof createSolanaRpcSubscriptionsApi>)
+    methodName?: keyof ReturnType<typeof createSolanaRpcSubscriptionsApi>
 ): T {
     const allowedKeypaths = methodName ? getAllowedNumericKeypathsForNotification()[methodName] : undefined;
     return visitNode(rawResponse, allowedKeypaths ?? []);

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
@@ -1,0 +1,34 @@
+import { createJsonSubscriptionRpc, createWebSocketTransport } from '@solana/rpc-transport';
+import type { RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createSolanaRpcSubscriptionsApi, SolanaRpcSubscriptions } from '../index';
+
+describe('slotNotifications', () => {
+    let rpc: RpcSubscriptions<SolanaRpcSubscriptions>;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonSubscriptionRpc<SolanaRpcSubscriptions>({
+            api: createSolanaRpcSubscriptionsApi(),
+            transport: createWebSocketTransport({
+                sendBufferHighWatermark: Number.POSITIVE_INFINITY,
+                url: 'ws://127.0.0.1:8900',
+            }),
+        });
+    });
+
+    it('produces slot notifications', async () => {
+        expect.assertions(1);
+        const slotNotifications = await rpc.slotNotifications().subscribe();
+        const iterator = slotNotifications[Symbol.asyncIterator]();
+        await expect(iterator.next()).resolves.toHaveProperty(
+            'value',
+            expect.objectContaining({
+                parent: expect.any(BigInt),
+                root: expect.any(BigInt),
+                slot: expect.any(BigInt),
+            })
+        );
+    });
+});

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/slot-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/slot-notifications-type-test.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import { RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+
+import { U64UnsafeBeyond2Pow53Minus1 } from '../../rpc-methods/common';
+import { SolanaRpcSubscriptions } from '../index';
+
+async () => {
+    const rpcSubcriptions = null as unknown as RpcSubscriptions<SolanaRpcSubscriptions>;
+    const slotNotifications = await rpcSubcriptions.slotNotifications().subscribe();
+
+    slotNotifications satisfies AsyncIterable<
+        Readonly<{
+            parent: U64UnsafeBeyond2Pow53Minus1;
+            root: U64UnsafeBeyond2Pow53Minus1;
+            slot: U64UnsafeBeyond2Pow53Minus1;
+        }>
+    >;
+
+    // @ts-expect-error Takes no params.
+    rpcSubcriptions.slotNotifications({ commitment: 'finalized' });
+};

--- a/packages/rpc-core/src/rpc-subscriptions/index.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/index.ts
@@ -2,12 +2,13 @@ import { IRpcSubscriptionsApi, RpcSubscription } from '@solana/rpc-transport/dis
 
 import { patchParamsForSolanaLabsRpc } from '../params-patcher';
 import { patchResponseForSolanaLabsRpcSubscriptions } from '../response-patcher';
+import { SlotNotificationsApi } from './slot-notifications';
 
 type Config = Readonly<{
     onIntegerOverflow?: (methodName: string, keyPath: (number | string)[], value: bigint) => void;
 }>;
 
-export type SolanaRpcSubscriptions = never;
+export type SolanaRpcSubscriptions = SlotNotificationsApi;
 
 export function createSolanaRpcSubscriptionsApi(config?: Config): IRpcSubscriptionsApi<SolanaRpcSubscriptions> {
     return new Proxy({} as IRpcSubscriptionsApi<SolanaRpcSubscriptions>, {
@@ -21,7 +22,7 @@ export function createSolanaRpcSubscriptionsApi(config?: Config): IRpcSubscripti
             ...args: Parameters<NonNullable<ProxyHandler<IRpcSubscriptionsApi<SolanaRpcSubscriptions>>['get']>>
         ) {
             const [_, p] = args;
-            const notificationName = p.toString() as string;
+            const notificationName = p.toString() as keyof SolanaRpcSubscriptions;
             return function (
                 ...rawParams: Parameters<
                     SolanaRpcSubscriptions[TNotificationName] extends CallableFunction

--- a/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
@@ -1,0 +1,17 @@
+import { U64UnsafeBeyond2Pow53Minus1 } from '../rpc-methods/common';
+
+type SlotNotificationsApiNotification = Readonly<{
+    parent: U64UnsafeBeyond2Pow53Minus1;
+    root: U64UnsafeBeyond2Pow53Minus1;
+    slot: U64UnsafeBeyond2Pow53Minus1;
+}>;
+
+export interface SlotNotificationsApi {
+    /**
+     * Subscribe to receive notification anytime a slot is processed by the validator
+     */
+    slotNotifications(
+        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
+        NO_CONFIG?: Record<string, never>
+    ): SlotNotificationsApiNotification;
+}


### PR DESCRIPTION
refactor(experimental): install the autopinger by default

# Summary

Creating a default subscriptions transport now comes with the auto-pinger by default.

# Test Plan

Load up the browser bundle and run this test case.

```ts
const rpc = solanaWeb3.createSolanaRpcSubscriptions({transport: solanaWeb3.createDefaultRpcSubscriptionsTransport({url :'wss://api.devnet.solana.com'})});
const notifications = await rpc.accountNotifications('CXPeim1wQMkcTvEHx9QdhgKREYYJD8bnaCCqPRwJ1to1').subscribe();
for await (const notif of notifications) {
  console.log(notif);
}
```

Observe pings every 5 seconds.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1603).
* #1604
* __->__ #1603
* #1598
* #1586