### PR TITLE
refactor(experimental): a WebSocket transport that shards payloads amongst a pool of shared socket connections

### DIFF
--- a/packages/library/src/__tests__/rpc-websocket-connection-sharding-test.ts
+++ b/packages/library/src/__tests__/rpc-websocket-connection-sharding-test.ts
@@ -1,0 +1,226 @@
+import { IRpcWebSocketTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
+
+import { getWebSocketTransportWithConnectionSharding } from '../rpc-websocket-connection-sharding';
+
+describe('getWebSocketTransportWithConnectionSharding', () => {
+    let getShard: jest.Mock;
+    let iterable: jest.Mock<AsyncGenerator<unknown, void>>;
+    let mockInnerTransport: jest.MockedFn<IRpcWebSocketTransport>;
+    let send: jest.Mock<(payload: unknown) => Promise<void>>;
+    let transport: IRpcWebSocketTransport;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        getShard = jest.fn();
+        send = jest.fn().mockResolvedValue(undefined);
+        iterable = jest.fn().mockImplementation(async function* () {
+            yield await new Promise(() => {
+                /* never resolve */
+            });
+        });
+        send = jest.fn().mockResolvedValue(undefined);
+        mockInnerTransport = jest.fn().mockResolvedValue({
+            [Symbol.asyncIterator]: iterable,
+            send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: send,
+        });
+        transport = getWebSocketTransportWithConnectionSharding({
+            getShard,
+            transport: mockInnerTransport,
+        });
+    });
+    it('reuses the same connection for multiple messages sent in the same runloop', async () => {
+        expect.assertions(1);
+        await Promise.all([
+            transport({ payload: 'hello', signal: new AbortController().signal }),
+            transport({ payload: 'world', signal: new AbortController().signal }),
+        ]);
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+    });
+    it('reuses the same connection for multiple messages sent in different runloops', async () => {
+        expect.assertions(1);
+        await transport({ payload: 'hello', signal: new AbortController().signal });
+        await transport({ payload: 'world', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+    });
+    it('reuses the same connection so long as there is at least one non-aborted subscription', async () => {
+        expect.assertions(1);
+        const abortControllerA = new AbortController();
+        await transport({ payload: 'A', signal: abortControllerA.signal });
+        await transport({ payload: 'B', signal: new AbortController().signal });
+        abortControllerA.abort();
+        await jest.runAllTimersAsync();
+        await transport({ payload: 'C', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+    });
+    it('reuses the same connection even if a single subscription was aborted as many times as there are subscriptions', async () => {
+        expect.assertions(1);
+        const abortControllerA = new AbortController();
+        await transport({ payload: 'A', signal: abortControllerA.signal });
+        await transport({ payload: 'B', signal: new AbortController().signal });
+        abortControllerA.abort();
+        abortControllerA.abort();
+        await jest.runAllTimersAsync();
+        await transport({ payload: 'C', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+    });
+    it('reuses the same connection so long as there is at least one non-aborted subscription at the end of the runloop, even if all of the existing ones are aborted', async () => {
+        expect.assertions(1);
+        const abortControllerA = new AbortController();
+        const abortControllerB = new AbortController();
+        await transport({ payload: 'A', signal: abortControllerA.signal });
+        await transport({ payload: 'B', signal: abortControllerB.signal });
+        abortControllerA.abort();
+        abortControllerB.abort();
+        await transport({ payload: 'C', signal: new AbortController().signal });
+        await jest.runAllTimersAsync();
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+    });
+    it('creates a new connection when all of the prior subscriptions have been aborted', async () => {
+        expect.assertions(1);
+        const abortControllerA = new AbortController();
+        const abortControllerB = new AbortController();
+        await transport({ payload: 'A', signal: abortControllerA.signal });
+        await transport({ payload: 'B', signal: abortControllerB.signal });
+        abortControllerA.abort();
+        abortControllerB.abort();
+        // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+        jest.runAllTimers();
+        await transport({ payload: 'C', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it('creates a new connection for a message given that the prior one failed synchronously', async () => {
+        expect.assertions(2);
+        // First time fails synchronously.
+        mockInnerTransport.mockImplementationOnce(() => {
+            throw new Error('o no');
+        });
+        try {
+            await transport({ payload: 'hello', signal: new AbortController().signal });
+        } catch {
+            /* empty */
+        }
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+        // Second time succeeds.
+        await transport({ payload: 'hello', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it('creates a new connection for a message given that the prior one failed asynchronously', async () => {
+        expect.assertions(2);
+        // First time fails asynchronously.
+        mockInnerTransport.mockRejectedValueOnce(new Error('o no'));
+        try {
+            await transport({ payload: 'hello', signal: new AbortController().signal });
+        } catch {
+            /* empty */
+        }
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+        // Second time succeeds.
+        await transport({ payload: 'hello', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it('creates a new connection for a message given that the prior connection threw', async () => {
+        expect.assertions(2);
+        let killConnection;
+        iterable.mockImplementationOnce(async function* () {
+            yield await new Promise((_, reject) => {
+                killConnection = reject;
+            });
+        });
+        await transport({ payload: 'hello', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        killConnection();
+        await jest.runAllTimersAsync();
+        await transport({ payload: 'hello', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it('creates a new connection for a message given that prior connection returned', async () => {
+        expect.assertions(1);
+        let returnFromConnection;
+        iterable.mockImplementationOnce(async function* () {
+            try {
+                yield await new Promise((_, reject) => {
+                    returnFromConnection = reject;
+                });
+            } catch {
+                return;
+            }
+        });
+        await transport({ payload: 'hello', signal: new AbortController().signal });
+        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        returnFromConnection();
+        await jest.runAllTimersAsync();
+        await transport({ payload: 'hello', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it('sends the initial message when constructing a new connection', async () => {
+        expect.assertions(1);
+        await Promise.all([
+            transport({ payload: 'hello', signal: new AbortController().signal }),
+            transport({ payload: 'world', signal: new AbortController().signal }),
+        ]);
+        expect(mockInnerTransport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: 'hello',
+            })
+        );
+    });
+    it('sends subsequent messages over the cached connection in the same runloop', async () => {
+        expect.assertions(2);
+        await Promise.all([
+            transport({ payload: 'hello', signal: new AbortController().signal }),
+            transport({ payload: 'world', signal: new AbortController().signal }),
+        ]);
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+        expect(send).toHaveBeenCalledWith('world');
+    });
+    it('sends subsequent messages over the cached connection in different runloops', async () => {
+        expect.assertions(2);
+        await transport({ payload: 'hello', signal: new AbortController().signal });
+        await transport({ payload: 'world', signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+        expect(send).toHaveBeenCalledWith('world');
+    });
+    describe('given payloads that shard to the same key', () => {
+        beforeEach(() => {
+            getShard.mockReturnValue('shard-key');
+        });
+        it('reuses the same connection for all payloads in the same runloop', async () => {
+            expect.assertions(1);
+            await Promise.all([
+                transport({ payload: 'hello', signal: new AbortController().signal }),
+                transport({ payload: 'world', signal: new AbortController().signal }),
+            ]);
+            expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+        });
+        it('reuses the same connection for all payloads in different runloops', async () => {
+            expect.assertions(1);
+            await transport({ payload: 'hello', signal: new AbortController().signal });
+            await transport({ payload: 'world', signal: new AbortController().signal });
+            expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+        });
+    });
+    describe('given payloads that shard to different keys', () => {
+        beforeEach(() => {
+            let shardKey = 0;
+            getShard.mockImplementation(() => `${++shardKey}`);
+        });
+        it('creates a connection for each payload in the same runloop', async () => {
+            expect.assertions(1);
+            await Promise.all([
+                transport({ payload: 'hello', signal: new AbortController().signal }),
+                transport({ payload: 'world', signal: new AbortController().signal }),
+            ]);
+            expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+        });
+        it('creates a connection for each payload in different runloops', async () => {
+            expect.assertions(1);
+            await transport({ payload: 'hello', signal: new AbortController().signal });
+            await transport({ payload: 'world', signal: new AbortController().signal });
+            expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/library/src/rpc-websocket-connection-sharding.ts
+++ b/packages/library/src/rpc-websocket-connection-sharding.ts
@@ -1,0 +1,122 @@
+import { IRpcWebSocketTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
+
+type CacheEntry = Readonly<{
+    abortController: AbortController;
+    connection: Awaited<ReturnType<IRpcWebSocketTransport>> | ReturnType<IRpcWebSocketTransport>;
+    purgeScheduled: boolean;
+    referenceCount: number;
+}>;
+type CacheKey = string | typeof NULL_SHARD_CACHE_KEY;
+type Config = Readonly<{
+    /**
+     * You might like to open more subscriptions per connection than your RPC provider allows for.
+     * Using the initial payload as input, return a shard key from this method to assign
+     * subscriptions to separate connections. One socket will be opened per shard key.
+     */
+    getShard?: (payload: unknown) => string;
+    transport: IRpcWebSocketTransport;
+}>;
+
+const NULL_SHARD_CACHE_KEY = Symbol(
+    __DEV__ ? 'Cache key to use when there is no connection sharding strategy' : undefined
+);
+
+function registerIterableCleanup(iterable: AsyncIterable<unknown>, cleanupFn: CallableFunction) {
+    (async () => {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for await (const _ of iterable);
+        } catch {
+            /* empty */
+        } finally {
+            // Run the cleanup function.
+            cleanupFn();
+        }
+    })();
+}
+
+export function getWebSocketTransportWithConnectionSharding({ getShard, transport }: Config): IRpcWebSocketTransport {
+    const cache = new Map<CacheKey, CacheEntry>();
+    function updateCache(shardKey: CacheKey, updater: (currentCacheEntry: CacheEntry) => CacheEntry) {
+        const currentCacheEntry = cache.get(shardKey);
+        if (!currentCacheEntry) {
+            // TODO: Coded error.
+            throw new Error(`Found no cache entry for connection with shard key \`${shardKey.toString()}\``);
+        }
+        const nextCacheEntry = updater(currentCacheEntry);
+        cache.set(shardKey, nextCacheEntry);
+        return nextCacheEntry;
+    }
+    return async (...args) => {
+        const { payload, signal, ...rest } = args[0];
+        const shardKey = getShard ? getShard(payload) : NULL_SHARD_CACHE_KEY;
+        function cleanup() {
+            cache.delete(shardKey);
+            signal.removeEventListener('abort', handleAbort);
+        }
+        function handleAbort() {
+            if (cache.get(shardKey)?.purgeScheduled !== true) {
+                updateCache(shardKey, currentCacheEntry => ({
+                    ...currentCacheEntry,
+                    purgeScheduled: true,
+                }));
+                globalThis.queueMicrotask(() => {
+                    const cacheEntryAtEndOfRunloop = cache.get(shardKey);
+                    if (!cacheEntryAtEndOfRunloop) {
+                        return;
+                    }
+                    if (cacheEntryAtEndOfRunloop.referenceCount === 0) {
+                        cacheEntry.abortController.abort();
+                        cleanup();
+                    }
+                });
+            }
+            const cacheEntry = updateCache(shardKey, currentCacheEntry => ({
+                ...currentCacheEntry,
+                referenceCount: currentCacheEntry.referenceCount - 1,
+            }));
+        }
+        signal.addEventListener('abort', handleAbort);
+        try {
+            const cacheEntry = cache.get(shardKey);
+            if (!cacheEntry) {
+                const connectionAbortController = new AbortController();
+                const newConnectionPromise = transport({
+                    payload,
+                    signal: connectionAbortController.signal,
+                    ...rest,
+                });
+                const newCacheEntry = {
+                    abortController: connectionAbortController,
+                    connection: newConnectionPromise,
+                    purgeScheduled: false,
+                    referenceCount: 1,
+                };
+                cache.set(shardKey, newCacheEntry);
+                const newConnection = await newConnectionPromise;
+                registerIterableCleanup(newConnection, cleanup);
+                updateCache(shardKey, currentCacheEntry => ({
+                    ...currentCacheEntry,
+                    connection: newConnection,
+                }));
+                return newConnection;
+            } else {
+                updateCache(shardKey, currentCacheEntry => ({
+                    ...currentCacheEntry,
+                    referenceCount: currentCacheEntry.referenceCount + 1,
+                }));
+                const connectionOrConnectionPromise = cacheEntry.connection;
+                const cachedConnection =
+                    'then' in connectionOrConnectionPromise
+                        ? await connectionOrConnectionPromise
+                        : connectionOrConnectionPromise;
+                registerIterableCleanup(cachedConnection, cleanup);
+                await cachedConnection.send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(payload);
+                return cachedConnection;
+            }
+        } catch (e) {
+            cleanup();
+            throw e;
+        }
+    };
+}


### PR DESCRIPTION
refactor(experimental): a WebSocket transport that shards payloads amongst a pool of shared socket connections

# Summary

Prior to this, the base WebSocket transport would open a separate connection for each and every subscription you would make. While this makes the API very easy to reason about, it's obviously inefficient.

In this PR we introduce a meta-transport that you can wrap around a base transport to add the following behaviours:

1. You can specify an optional `getShard` method to produce a shard key from a payload. You could use this to, for instance, shard subscriptions evenly across 20 socket connections, by hashing each payload to a number between 0-19.
2. The first request for a shard will open a connection
3. Subsequent requests for a shard will reuse the open connection

# Test Plan

```
cd packages/library
pnpm test:unit:browser
pnpm test:unit:node
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/solana-web3.js/pull/1612).
* #1613
* __->__ #1612
* #1611