### PR TITLE
refactor(experimental): extract the request cache logic into a base implementation

### DIFF
--- a/packages/library/src/__tests__/cached-abortable-iterable-test.ts
+++ b/packages/library/src/__tests__/cached-abortable-iterable-test.ts
@@ -1,0 +1,300 @@
+import { getCachedAbortableIterableFactory } from '../cached-abortable-iterable';
+
+describe('getCachedAbortableIterableFactory', () => {
+    let asyncGenerator: jest.Mock<AsyncGenerator<unknown, void>>;
+    let factory: (...args: unknown[]) => Promise<AsyncIterable<unknown>>;
+    let getAbortSignalFromInputArgs: jest.Mock;
+    let getCacheKeyFromInputArgs: jest.Mock;
+    let getCacheEntryMissingError: jest.Mock;
+    let onCacheHit: jest.Mock;
+    let onCreateIterable: jest.Mock;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        asyncGenerator = jest.fn().mockImplementation(async function* () {
+            yield await new Promise(() => {
+                /* never resolve */
+            });
+        });
+        getAbortSignalFromInputArgs = jest.fn().mockImplementation(() => new AbortController().signal);
+        getCacheKeyFromInputArgs = jest.fn().mockReturnValue('cache-key');
+        getCacheEntryMissingError = jest.fn();
+        onCacheHit = jest.fn();
+        onCreateIterable = jest.fn().mockResolvedValue({
+            [Symbol.asyncIterator]: asyncGenerator,
+        });
+        factory = getCachedAbortableIterableFactory({
+            getAbortSignalFromInputArgs,
+            getCacheEntryMissingError,
+            getCacheKeyFromInputArgs,
+            onCacheHit,
+            onCreateIterable,
+        });
+    });
+    it('reuses the same iterable for multiple invocations in the same runloop', async () => {
+        expect.assertions(1);
+        await Promise.all([factory('A'), factory('B')]);
+        expect(onCreateIterable).toHaveBeenCalledTimes(1);
+    });
+    it('reuses the same iterable for multiple invocations in different runloops', async () => {
+        expect.assertions(1);
+        await factory('A');
+        await factory('B');
+        expect(onCreateIterable).toHaveBeenCalledTimes(1);
+    });
+    it('reuses the same iterable so long as there is at least one non-aborted consumer', async () => {
+        expect.assertions(1);
+        const abortControllerA = new AbortController();
+        getAbortSignalFromInputArgs.mockReturnValue(abortControllerA.signal);
+        await factory('A');
+        await factory('B');
+        abortControllerA.abort();
+        await jest.runAllTimersAsync();
+        await factory('C');
+        expect(onCreateIterable).toHaveBeenCalledTimes(1);
+    });
+    it('reuses the same iterable even if a single subscription was aborted as many times as there are subscriptions', async () => {
+        expect.assertions(1);
+        const abortControllerA = new AbortController();
+        getAbortSignalFromInputArgs.mockReturnValueOnce(abortControllerA.signal);
+        await factory('A');
+        await factory('B');
+        abortControllerA.abort();
+        abortControllerA.abort();
+        await jest.runAllTimersAsync();
+        await factory('C');
+        expect(onCreateIterable).toHaveBeenCalledTimes(1);
+    });
+    it('reuses the same iterable so long as there is at least one non-aborted consumer at the end of the runloop, even if all of the existing ones are aborted', async () => {
+        expect.assertions(1);
+        const abortControllerA = new AbortController();
+        const abortControllerB = new AbortController();
+        getAbortSignalFromInputArgs.mockReturnValueOnce(abortControllerA.signal);
+        await factory('A');
+        getAbortSignalFromInputArgs.mockReturnValueOnce(abortControllerB.signal);
+        await factory('B');
+        abortControllerA.abort();
+        abortControllerB.abort();
+        await factory('C');
+        await jest.runAllTimersAsync();
+        expect(onCreateIterable).toHaveBeenCalledTimes(1);
+    });
+    it('creates a new iterable when all of the prior subscriptions have been aborted in the same runloop', async () => {
+        expect.assertions(1);
+        const abortControllerA = new AbortController();
+        const abortControllerB = new AbortController();
+        getAbortSignalFromInputArgs.mockReturnValueOnce(abortControllerA.signal);
+        await factory('A');
+        getAbortSignalFromInputArgs.mockReturnValueOnce(abortControllerB.signal);
+        await factory('B');
+        abortControllerA.abort();
+        abortControllerB.abort();
+        // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+        jest.runAllTimers();
+        await factory('C');
+        expect(onCreateIterable).toHaveBeenCalledTimes(2);
+    });
+    it('creates a new iterable when all of the prior subscriptions have been aborted in different runloops', async () => {
+        expect.assertions(1);
+        const abortControllerA = new AbortController();
+        const abortControllerB = new AbortController();
+        getAbortSignalFromInputArgs.mockReturnValueOnce(abortControllerA.signal);
+        await factory('A');
+        getAbortSignalFromInputArgs.mockReturnValueOnce(abortControllerB.signal);
+        await factory('B');
+        abortControllerA.abort();
+        // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+        jest.runAllTimers();
+        abortControllerB.abort();
+        // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+        jest.runAllTimers();
+        await factory('C');
+        expect(onCreateIterable).toHaveBeenCalledTimes(2);
+    });
+    it('creates a new iterable for a message given that the prior one failed synchronously', async () => {
+        expect.assertions(2);
+        // First time fails synchronously.
+        onCreateIterable.mockImplementationOnce(() => {
+            throw new Error('o no');
+        });
+        try {
+            await factory('A');
+        } catch {
+            /* empty */
+        }
+        expect(onCreateIterable).toHaveBeenCalledTimes(1);
+        // Second time succeeds.
+        await factory('A');
+        expect(onCreateIterable).toHaveBeenCalledTimes(2);
+    });
+    it('creates a new iterable for a message given that the prior one failed asynchronously', async () => {
+        expect.assertions(2);
+        // First time fails asynchronously.
+        onCreateIterable.mockRejectedValueOnce(new Error('o no'));
+        try {
+            await factory('A');
+        } catch {
+            /* empty */
+        }
+        expect(onCreateIterable).toHaveBeenCalledTimes(1);
+        // Second time succeeds.
+        await factory('A');
+        expect(onCreateIterable).toHaveBeenCalledTimes(2);
+    });
+    it('creates a new iterable for a message given that the prior iterable threw', async () => {
+        expect.assertions(2);
+        let throwFromIterable;
+        asyncGenerator.mockImplementationOnce(async function* () {
+            yield await new Promise((_, reject) => {
+                throwFromIterable = reject;
+            });
+        });
+        await factory('A');
+        expect(onCreateIterable).toHaveBeenCalledTimes(1);
+        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        throwFromIterable();
+        await jest.runAllTimersAsync();
+        await factory('A');
+        expect(onCreateIterable).toHaveBeenCalledTimes(2);
+    });
+    it('creates a new iterable for a message given that prior iterable returned', async () => {
+        expect.assertions(1);
+        let returnFromIterable;
+        asyncGenerator.mockImplementationOnce(async function* () {
+            try {
+                yield await new Promise((_, reject) => {
+                    returnFromIterable = reject;
+                });
+            } catch {
+                return;
+            }
+        });
+        await factory('A');
+        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        returnFromIterable();
+        await jest.runAllTimersAsync();
+        await factory('A');
+        expect(onCreateIterable).toHaveBeenCalledTimes(2);
+    });
+    it('calls `onCreateIterable` with the input args when no cached iterable is found', async () => {
+        expect.assertions(1);
+        await factory('A');
+        expect(onCreateIterable).toHaveBeenCalledWith(expect.any(AbortSignal), 'A');
+    });
+    it('calls `onCreateIterable` with an `AbortSignal` different than the one passed in', async () => {
+        expect.assertions(1);
+        const signal = new AbortController().signal;
+        getAbortSignalFromInputArgs.mockReturnValue(signal);
+        await factory('A');
+        expect(onCreateIterable.mock.lastCall[0]).not.toBe(signal);
+    });
+    it('does not call `onCacheHit` in the same runloop until the cached iterable is resolved', async () => {
+        expect.assertions(2);
+        let resolve;
+        onCreateIterable.mockImplementation(
+            () =>
+                new Promise(r => {
+                    resolve = r;
+                })
+        );
+        Promise.all([factory('A'), factory('B')]);
+        expect(onCacheHit).not.toHaveBeenCalled();
+        await jest.runAllTimersAsync();
+        const iterable = asyncGenerator();
+        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        resolve(iterable);
+        await jest.runAllTimersAsync();
+        expect(onCacheHit).toHaveBeenCalledWith(iterable, 'B');
+    });
+    it('calls `onCacheHit` in the same runloop when the cached iterable is already resolved', async () => {
+        expect.assertions(1);
+        const iterable = asyncGenerator();
+        onCreateIterable.mockReturnValue(iterable);
+        Promise.all([factory('A'), factory('B')]);
+        expect(onCacheHit).toHaveBeenCalledWith(iterable, 'B');
+    });
+    it('does not call `onCacheHit` in different runloops until the cached iterable is resolved', async () => {
+        expect.assertions(2);
+        let resolve;
+        onCreateIterable.mockImplementation(
+            () =>
+                new Promise(r => {
+                    resolve = r;
+                })
+        );
+        factory('A');
+        await jest.runAllTimersAsync();
+        factory('B');
+        await jest.runAllTimersAsync();
+        expect(onCacheHit).not.toHaveBeenCalled();
+        const iterable = asyncGenerator();
+        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        resolve(iterable);
+        await jest.runAllTimersAsync();
+        expect(onCacheHit).toHaveBeenCalledWith(iterable, 'B');
+    });
+    it('calls `onCacheHit` in different runloops when the cached iterable is already resolved', async () => {
+        expect.assertions(1);
+        const iterable = asyncGenerator();
+        onCreateIterable.mockReturnValue(iterable);
+        await factory('A');
+        await factory('B');
+        expect(onCacheHit).toHaveBeenCalledWith(iterable, 'B');
+    });
+    describe('given payloads that produce the same cache key', () => {
+        beforeEach(() => {
+            getCacheKeyFromInputArgs.mockReturnValue('cache-key');
+        });
+        it('reuses the same iterable for all payloads in the same runloop', async () => {
+            expect.assertions(1);
+            await Promise.all([factory('A'), factory('B')]);
+            expect(onCreateIterable).toHaveBeenCalledTimes(1);
+        });
+        it('reuses the same iterable for all payloads in different runloops', async () => {
+            expect.assertions(1);
+            await factory('A');
+            await factory('B');
+            expect(onCreateIterable).toHaveBeenCalledTimes(1);
+        });
+    });
+    describe('given payloads that produce different cache keys', () => {
+        beforeEach(() => {
+            let shardKey = 0;
+            getCacheKeyFromInputArgs.mockImplementation(() => `${++shardKey}`);
+        });
+        it('creates an iterable for each payload in the same runloop', async () => {
+            expect.assertions(1);
+            await Promise.all([factory('A'), factory('B')]);
+            expect(onCreateIterable).toHaveBeenCalledTimes(2);
+        });
+        it('creates an iterable for each payload in different runloops', async () => {
+            expect.assertions(1);
+            await factory('A');
+            await factory('B');
+            expect(onCreateIterable).toHaveBeenCalledTimes(2);
+        });
+    });
+    describe('given payloads that produce the cache key `undefined`', () => {
+        beforeEach(() => {
+            getCacheKeyFromInputArgs.mockReturnValue(undefined);
+        });
+        it('creates an iterable for each payload in the same runloop', async () => {
+            expect.assertions(1);
+            await Promise.all([factory('A'), factory('B')]);
+            expect(onCreateIterable).toHaveBeenCalledTimes(2);
+        });
+        it('creates an iterable for each payload in different runloops', async () => {
+            expect.assertions(1);
+            await factory('A');
+            await factory('B');
+            expect(onCreateIterable).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/library/src/__tests__/rpc-websocket-connection-sharding-test.ts
+++ b/packages/library/src/__tests__/rpc-websocket-connection-sharding-test.ts
@@ -4,7 +4,6 @@ import { getWebSocketTransportWithConnectionSharding } from '../rpc-websocket-co
 
 describe('getWebSocketTransportWithConnectionSharding', () => {
     let getShard: jest.Mock;
-    let iterable: jest.Mock<AsyncGenerator<unknown, void>>;
     let mockInnerTransport: jest.MockedFn<IRpcWebSocketTransport>;
     let send: jest.Mock<(payload: unknown) => Promise<void>>;
     let transport: IRpcWebSocketTransport;
@@ -12,14 +11,13 @@ describe('getWebSocketTransportWithConnectionSharding', () => {
         jest.useFakeTimers();
         getShard = jest.fn();
         send = jest.fn().mockResolvedValue(undefined);
-        iterable = jest.fn().mockImplementation(async function* () {
-            yield await new Promise(() => {
-                /* never resolve */
-            });
-        });
         send = jest.fn().mockResolvedValue(undefined);
         mockInnerTransport = jest.fn().mockResolvedValue({
-            [Symbol.asyncIterator]: iterable,
+            async *[Symbol.asyncIterator]() {
+                yield await new Promise(() => {
+                    /* never resolve */
+                });
+            },
             send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: send,
         });
         transport = getWebSocketTransportWithConnectionSharding({
@@ -27,166 +25,37 @@ describe('getWebSocketTransportWithConnectionSharding', () => {
             transport: mockInnerTransport,
         });
     });
-    it('reuses the same connection for multiple messages sent in the same runloop', async () => {
-        expect.assertions(1);
-        await Promise.all([
-            transport({ payload: 'hello', signal: new AbortController().signal }),
-            transport({ payload: 'world', signal: new AbortController().signal }),
-        ]);
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-    });
-    it('reuses the same connection for multiple messages sent in different runloops', async () => {
-        expect.assertions(1);
-        await transport({ payload: 'hello', signal: new AbortController().signal });
-        await transport({ payload: 'world', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-    });
-    it('reuses the same connection so long as there is at least one non-aborted subscription', async () => {
-        expect.assertions(1);
-        const abortControllerA = new AbortController();
-        await transport({ payload: 'A', signal: abortControllerA.signal });
-        await transport({ payload: 'B', signal: new AbortController().signal });
-        abortControllerA.abort();
-        await jest.runAllTimersAsync();
-        await transport({ payload: 'C', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-    });
-    it('reuses the same connection even if a single subscription was aborted as many times as there are subscriptions', async () => {
-        expect.assertions(1);
-        const abortControllerA = new AbortController();
-        await transport({ payload: 'A', signal: abortControllerA.signal });
-        await transport({ payload: 'B', signal: new AbortController().signal });
-        abortControllerA.abort();
-        abortControllerA.abort();
-        await jest.runAllTimersAsync();
-        await transport({ payload: 'C', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-    });
-    it('reuses the same connection so long as there is at least one non-aborted subscription at the end of the runloop, even if all of the existing ones are aborted', async () => {
-        expect.assertions(1);
-        const abortControllerA = new AbortController();
-        const abortControllerB = new AbortController();
-        await transport({ payload: 'A', signal: abortControllerA.signal });
-        await transport({ payload: 'B', signal: abortControllerB.signal });
-        abortControllerA.abort();
-        abortControllerB.abort();
-        await transport({ payload: 'C', signal: new AbortController().signal });
-        await jest.runAllTimersAsync();
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-    });
-    it('creates a new connection when all of the prior subscriptions have been aborted', async () => {
-        expect.assertions(1);
-        const abortControllerA = new AbortController();
-        const abortControllerB = new AbortController();
-        await transport({ payload: 'A', signal: abortControllerA.signal });
-        await transport({ payload: 'B', signal: abortControllerB.signal });
-        abortControllerA.abort();
-        abortControllerB.abort();
-        // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
-        jest.runAllTimers();
-        await transport({ payload: 'C', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
-    });
-    it('creates a new connection for a message given that the prior one failed synchronously', async () => {
-        expect.assertions(2);
-        // First time fails synchronously.
-        mockInnerTransport.mockImplementationOnce(() => {
-            throw new Error('o no');
-        });
-        try {
-            await transport({ payload: 'hello', signal: new AbortController().signal });
-        } catch {
-            /* empty */
-        }
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-        // Second time succeeds.
-        await transport({ payload: 'hello', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
-    });
-    it('creates a new connection for a message given that the prior one failed asynchronously', async () => {
-        expect.assertions(2);
-        // First time fails asynchronously.
-        mockInnerTransport.mockRejectedValueOnce(new Error('o no'));
-        try {
-            await transport({ payload: 'hello', signal: new AbortController().signal });
-        } catch {
-            /* empty */
-        }
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-        // Second time succeeds.
-        await transport({ payload: 'hello', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
-    });
-    it('creates a new connection for a message given that the prior connection threw', async () => {
-        expect.assertions(2);
-        let killConnection;
-        iterable.mockImplementationOnce(async function* () {
-            yield await new Promise((_, reject) => {
-                killConnection = reject;
-            });
-        });
-        await transport({ payload: 'hello', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        killConnection();
-        await jest.runAllTimersAsync();
-        await transport({ payload: 'hello', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
-    });
-    it('creates a new connection for a message given that prior connection returned', async () => {
-        expect.assertions(1);
-        let returnFromConnection;
-        iterable.mockImplementationOnce(async function* () {
-            try {
-                yield await new Promise((_, reject) => {
-                    returnFromConnection = reject;
-                });
-            } catch {
-                return;
-            }
-        });
-        await transport({ payload: 'hello', signal: new AbortController().signal });
-        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        returnFromConnection();
-        await jest.runAllTimersAsync();
-        await transport({ payload: 'hello', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
-    });
-    it('sends the initial message when constructing a new connection', async () => {
-        expect.assertions(1);
-        await Promise.all([
-            transport({ payload: 'hello', signal: new AbortController().signal }),
-            transport({ payload: 'world', signal: new AbortController().signal }),
-        ]);
-        expect(mockInnerTransport).toHaveBeenCalledWith(
-            expect.objectContaining({
-                payload: 'hello',
-            })
-        );
-    });
-    it('sends subsequent messages over the cached connection in the same runloop', async () => {
-        expect.assertions(2);
-        await Promise.all([
-            transport({ payload: 'hello', signal: new AbortController().signal }),
-            transport({ payload: 'world', signal: new AbortController().signal }),
-        ]);
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-        expect(send).toHaveBeenCalledWith('world');
-    });
-    it('sends subsequent messages over the cached connection in different runloops', async () => {
-        expect.assertions(2);
-        await transport({ payload: 'hello', signal: new AbortController().signal });
-        await transport({ payload: 'world', signal: new AbortController().signal });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
-        expect(send).toHaveBeenCalledWith('world');
-    });
     describe('given payloads that shard to the same key', () => {
         beforeEach(() => {
             getShard.mockReturnValue('shard-key');
+        });
+        it('sends the initial message when constructing a new connection', async () => {
+            expect.assertions(1);
+            await Promise.all([
+                transport({ payload: 'hello', signal: new AbortController().signal }),
+                transport({ payload: 'world', signal: new AbortController().signal }),
+            ]);
+            expect(mockInnerTransport).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    payload: 'hello',
+                })
+            );
+        });
+        it('sends subsequent messages over the cached connection in the same runloop', async () => {
+            expect.assertions(2);
+            await Promise.all([
+                transport({ payload: 'hello', signal: new AbortController().signal }),
+                transport({ payload: 'world', signal: new AbortController().signal }),
+            ]);
+            expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+            expect(send).toHaveBeenCalledWith('world');
+        });
+        it('sends subsequent messages over the cached connection in different runloops', async () => {
+            expect.assertions(2);
+            await transport({ payload: 'hello', signal: new AbortController().signal });
+            await transport({ payload: 'world', signal: new AbortController().signal });
+            expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+            expect(send).toHaveBeenCalledWith('world');
         });
         it('reuses the same connection for all payloads in the same runloop', async () => {
             expect.assertions(1);

--- a/packages/library/src/cached-abortable-iterable.ts
+++ b/packages/library/src/cached-abortable-iterable.ts
@@ -1,0 +1,102 @@
+type CacheEntry<TIterable extends AsyncIterable<unknown>> = {
+    abortController: AbortController;
+    iterable: Promise<TIterable> | TIterable;
+    purgeScheduled: boolean;
+    referenceCount: number;
+};
+type CacheKey = string | symbol;
+type Config<TInput extends unknown[], TIterable extends AsyncIterable<unknown>> = Readonly<{
+    getAbortSignalFromInputArgs: (...args: TInput) => AbortSignal;
+    getCacheEntryMissingError: (cacheKey: CacheKey) => Error;
+    getCacheKeyFromInputArgs: (...args: TInput) =>
+        | CacheKey
+        // `undefined` implies 'do not cache'
+        | undefined;
+    onCacheHit: (iterable: TIterable, ...args: TInput) => Promise<void>;
+    onCreateIterable: (abortSignal: AbortSignal, ...args: TInput) => Promise<TIterable>;
+}>;
+
+function registerIterableCleanup(iterable: AsyncIterable<unknown>, cleanupFn: CallableFunction) {
+    (async () => {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for await (const _ of iterable);
+        } catch {
+            /* empty */
+        } finally {
+            // Run the cleanup function.
+            cleanupFn();
+        }
+    })();
+}
+
+export function getCachedAbortableIterableFactory<TInput extends unknown[], TIterable extends AsyncIterable<unknown>>({
+    getAbortSignalFromInputArgs,
+    getCacheEntryMissingError,
+    getCacheKeyFromInputArgs,
+    onCacheHit,
+    onCreateIterable,
+}: Config<TInput, TIterable>): (...args: TInput) => Promise<TIterable> {
+    const cache = new Map<CacheKey, CacheEntry<TIterable>>();
+    function getCacheEntryOrThrow(cacheKey: CacheKey) {
+        const currentCacheEntry = cache.get(cacheKey);
+        if (!currentCacheEntry) {
+            throw getCacheEntryMissingError(cacheKey);
+        }
+        return currentCacheEntry;
+    }
+    return async (...args: TInput) => {
+        const cacheKey = getCacheKeyFromInputArgs(...args);
+        const signal = getAbortSignalFromInputArgs(...args);
+        if (cacheKey === undefined) {
+            return await onCreateIterable(signal, ...args);
+        }
+        const cleanup = () => {
+            cache.delete(cacheKey);
+            signal.removeEventListener('abort', handleAbort);
+        };
+        const handleAbort = () => {
+            const cacheEntry = getCacheEntryOrThrow(cacheKey);
+            if (cacheEntry.purgeScheduled !== true) {
+                cacheEntry.purgeScheduled = true;
+                globalThis.queueMicrotask(() => {
+                    cacheEntry.purgeScheduled = false;
+                    if (cacheEntry.referenceCount === 0) {
+                        cacheEntry.abortController.abort();
+                        cleanup();
+                    }
+                });
+            }
+            cacheEntry.referenceCount--;
+        };
+        signal.addEventListener('abort', handleAbort);
+        try {
+            const cacheEntry = cache.get(cacheKey);
+            if (!cacheEntry) {
+                const singletonAbortController = new AbortController();
+                const newIterablePromise = onCreateIterable(singletonAbortController.signal, ...args);
+                const newCacheEntry: CacheEntry<TIterable> = {
+                    abortController: singletonAbortController,
+                    iterable: newIterablePromise,
+                    purgeScheduled: false,
+                    referenceCount: 1,
+                };
+                cache.set(cacheKey, newCacheEntry);
+                const newIterable = await newIterablePromise;
+                registerIterableCleanup(newIterable, cleanup);
+                newCacheEntry.iterable = newIterable;
+                return newIterable;
+            } else {
+                cacheEntry.referenceCount++;
+                const iterableOrIterablePromise = cacheEntry.iterable;
+                const cachedIterable =
+                    'then' in iterableOrIterablePromise ? await iterableOrIterablePromise : iterableOrIterablePromise;
+                await onCacheHit(cachedIterable, ...args);
+                return cachedIterable;
+            }
+        } catch (e) {
+            cleanup();
+            throw e;
+        }
+    };
+}

--- a/packages/library/src/rpc-websocket-connection-sharding.ts
+++ b/packages/library/src/rpc-websocket-connection-sharding.ts
@@ -1,19 +1,14 @@
 import { IRpcWebSocketTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
 
-type CacheEntry = Readonly<{
-    abortController: AbortController;
-    connection: Awaited<ReturnType<IRpcWebSocketTransport>> | ReturnType<IRpcWebSocketTransport>;
-    purgeScheduled: boolean;
-    referenceCount: number;
-}>;
-type CacheKey = string | typeof NULL_SHARD_CACHE_KEY;
+import { getCachedAbortableIterableFactory } from './cached-abortable-iterable';
+
 type Config = Readonly<{
     /**
      * You might like to open more subscriptions per connection than your RPC provider allows for.
      * Using the initial payload as input, return a shard key from this method to assign
      * subscriptions to separate connections. One socket will be opened per shard key.
      */
-    getShard?: (payload: unknown) => string;
+    getShard?: (payload: unknown) => string | symbol;
     transport: IRpcWebSocketTransport;
 }>;
 
@@ -21,102 +16,19 @@ const NULL_SHARD_CACHE_KEY = Symbol(
     __DEV__ ? 'Cache key to use when there is no connection sharding strategy' : undefined
 );
 
-function registerIterableCleanup(iterable: AsyncIterable<unknown>, cleanupFn: CallableFunction) {
-    (async () => {
-        try {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            for await (const _ of iterable);
-        } catch {
-            /* empty */
-        } finally {
-            // Run the cleanup function.
-            cleanupFn();
-        }
-    })();
-}
-
 export function getWebSocketTransportWithConnectionSharding({ getShard, transport }: Config): IRpcWebSocketTransport {
-    const cache = new Map<CacheKey, CacheEntry>();
-    function updateCache(shardKey: CacheKey, updater: (currentCacheEntry: CacheEntry) => CacheEntry) {
-        const currentCacheEntry = cache.get(shardKey);
-        if (!currentCacheEntry) {
+    return getCachedAbortableIterableFactory({
+        getAbortSignalFromInputArgs: ({ signal }) => signal,
+        getCacheEntryMissingError(shardKey) {
             // TODO: Coded error.
-            throw new Error(`Found no cache entry for connection with shard key \`${shardKey.toString()}\``);
-        }
-        const nextCacheEntry = updater(currentCacheEntry);
-        cache.set(shardKey, nextCacheEntry);
-        return nextCacheEntry;
-    }
-    return async (...args) => {
-        const { payload, signal, ...rest } = args[0];
-        const shardKey = getShard ? getShard(payload) : NULL_SHARD_CACHE_KEY;
-        function cleanup() {
-            cache.delete(shardKey);
-            signal.removeEventListener('abort', handleAbort);
-        }
-        function handleAbort() {
-            if (cache.get(shardKey)?.purgeScheduled !== true) {
-                updateCache(shardKey, currentCacheEntry => ({
-                    ...currentCacheEntry,
-                    purgeScheduled: true,
-                }));
-                globalThis.queueMicrotask(() => {
-                    const cacheEntryAtEndOfRunloop = cache.get(shardKey);
-                    if (!cacheEntryAtEndOfRunloop) {
-                        return;
-                    }
-                    if (cacheEntryAtEndOfRunloop.referenceCount === 0) {
-                        cacheEntry.abortController.abort();
-                        cleanup();
-                    }
-                });
-            }
-            const cacheEntry = updateCache(shardKey, currentCacheEntry => ({
-                ...currentCacheEntry,
-                referenceCount: currentCacheEntry.referenceCount - 1,
-            }));
-        }
-        signal.addEventListener('abort', handleAbort);
-        try {
-            const cacheEntry = cache.get(shardKey);
-            if (!cacheEntry) {
-                const connectionAbortController = new AbortController();
-                const newConnectionPromise = transport({
-                    payload,
-                    signal: connectionAbortController.signal,
-                    ...rest,
-                });
-                const newCacheEntry = {
-                    abortController: connectionAbortController,
-                    connection: newConnectionPromise,
-                    purgeScheduled: false,
-                    referenceCount: 1,
-                };
-                cache.set(shardKey, newCacheEntry);
-                const newConnection = await newConnectionPromise;
-                registerIterableCleanup(newConnection, cleanup);
-                updateCache(shardKey, currentCacheEntry => ({
-                    ...currentCacheEntry,
-                    connection: newConnection,
-                }));
-                return newConnection;
-            } else {
-                updateCache(shardKey, currentCacheEntry => ({
-                    ...currentCacheEntry,
-                    referenceCount: currentCacheEntry.referenceCount + 1,
-                }));
-                const connectionOrConnectionPromise = cacheEntry.connection;
-                const cachedConnection =
-                    'then' in connectionOrConnectionPromise
-                        ? await connectionOrConnectionPromise
-                        : connectionOrConnectionPromise;
-                registerIterableCleanup(cachedConnection, cleanup);
-                await cachedConnection.send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(payload);
-                return cachedConnection;
-            }
-        } catch (e) {
-            cleanup();
-            throw e;
-        }
-    };
+            return new Error(`Found no cache entry for connection with shard key \`${shardKey?.toString()}\``);
+        },
+        getCacheKeyFromInputArgs: ({ payload }) => (getShard ? getShard(payload) : NULL_SHARD_CACHE_KEY),
+        onCacheHit: (connection, { payload }) => connection.send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(payload),
+        onCreateIterable: (abortSignal, config) =>
+            transport({
+                ...config,
+                signal: abortSignal,
+            }),
+    });
 }


### PR DESCRIPTION
# Summary

It turns out that this logic is _really_ similar to the logic that we're going to need for the subscription coalescing transport, so lets extract it into a base implementation now, and give it all the bells and whistles that it needs to support both use cases.

# Test Plan

```
cd packages/library
pnpm test:unit:browser
pnpm test:unit:node
```
