### PR TITLE
refactor(experimental): refactor the default subscriptions transport with `pipe` to make it more readable

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -66,6 +66,7 @@
     ],
     "dependencies": {
         "@solana/addresses": "workspace:*",
+        "@solana/functional": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
         "@solana/rpc-core": "workspace:*",

--- a/packages/library/src/rpc-transport.ts
+++ b/packages/library/src/rpc-transport.ts
@@ -1,3 +1,4 @@
+import { pipe } from '@solana/functional';
 import { createHttpTransport } from '@solana/rpc-transport';
 import { IRpcTransport } from '@solana/rpc-transport/dist/types/transports/transport-types';
 
@@ -18,7 +19,7 @@ function normalizeHeaders<T extends Record<string, string>>(
 }
 
 export function createDefaultRpcTransport(config: Parameters<typeof createHttpTransport>[0]): IRpcTransport {
-    return getRpcTransportWithRequestCoalescing(
+    return pipe(
         createHttpTransport({
             ...config,
             headers: {
@@ -29,6 +30,6 @@ export function createDefaultRpcTransport(config: Parameters<typeof createHttpTr
                 } as { [overrideHeader: string]: string }),
             },
         }),
-        getSolanaRpcPayloadDeduplicationKey
+        transport => getRpcTransportWithRequestCoalescing(transport, getSolanaRpcPayloadDeduplicationKey)
     );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/functional':
+        specifier: workspace:*
+        version: link:../functional
       '@solana/instructions':
         specifier: workspace:*
         version: link:../instructions


### PR DESCRIPTION
# Summary

Much nicer to read these linearly rather than inside-out.

# Test Plan

CI run
