### PR TITLE
refactor(experimental): create a deduplication key getter specifically for subscriptions

### DIFF
--- a/packages/library/src/__tests__/rpc-request-deduplication-test.ts
+++ b/packages/library/src/__tests__/rpc-request-deduplication-test.ts
@@ -1,4 +1,7 @@
-import { getSolanaRpcPayloadDeduplicationKey } from '../rpc-request-deduplication';
+import {
+    getSolanaRpcPayloadDeduplicationKey,
+    getSolanaRpcSubscriptionPayloadDeduplicationKey,
+} from '../rpc-request-deduplication';
 
 describe('getSolanaRpcPayloadDeduplicationKey', () => {
     it('produces no key for undefined payloads', () => {
@@ -45,6 +48,69 @@ describe('getSolanaRpcPayloadDeduplicationKey', () => {
             getSolanaRpcPayloadDeduplicationKey({
                 jsonrpc: '2.0',
                 method: 'getFoo',
+                params: { b: { d: 4, c: [2, 3] }, a: 1 },
+                id: 2,
+            })
+            /* eslint-enable sort-keys-fix/sort-keys-fix */
+        );
+    });
+});
+
+describe('getSolanaRpcSubscriptionPayloadDeduplicationKey', () => {
+    it('produces no key for undefined payloads', () => {
+        expect(getSolanaRpcSubscriptionPayloadDeduplicationKey(undefined)).toBeUndefined();
+    });
+    it('produces no key for null payloads', () => {
+        expect(getSolanaRpcSubscriptionPayloadDeduplicationKey(null)).toBeUndefined();
+    });
+    it('produces no key for array payloads', () => {
+        expect(getSolanaRpcSubscriptionPayloadDeduplicationKey([])).toBeUndefined();
+    });
+    it('produces no key for string payloads', () => {
+        expect(getSolanaRpcSubscriptionPayloadDeduplicationKey('o hai')).toBeUndefined();
+    });
+    it('produces no key for numeric payloads', () => {
+        expect(getSolanaRpcSubscriptionPayloadDeduplicationKey(123)).toBeUndefined();
+    });
+    it('produces no key for bigint payloads', () => {
+        expect(getSolanaRpcSubscriptionPayloadDeduplicationKey(123n)).toBeUndefined();
+    });
+    it('produces no key for object payloads that are not JSON-RPC payloads', () => {
+        expect(getSolanaRpcSubscriptionPayloadDeduplicationKey({})).toBeUndefined();
+    });
+    it("produces a key for a JSON-RPC payload whose method ends in 'Subscribe'", () => {
+        expect(
+            getSolanaRpcSubscriptionPayloadDeduplicationKey({
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'fooSubscribe',
+                params: 'foo',
+            })
+        ).toMatchInlineSnapshot(`"["fooSubscribe","foo"]"`);
+    });
+    it("produces no key for a JSON-RPC payload whose method does not end in 'Subscribe'", () => {
+        expect(
+            getSolanaRpcSubscriptionPayloadDeduplicationKey({
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'getFoo',
+                params: 'foo',
+            })
+        ).toBeUndefined();
+    });
+    it('produces identical keys for two materially identical JSON-RPC payloads', () => {
+        expect(
+            getSolanaRpcSubscriptionPayloadDeduplicationKey({
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'fooSubscribe',
+                params: { a: 1, b: { c: [2, 3], d: 4 } },
+            })
+        ).toEqual(
+            /* eslint-disable sort-keys-fix/sort-keys-fix */
+            getSolanaRpcSubscriptionPayloadDeduplicationKey({
+                jsonrpc: '2.0',
+                method: 'fooSubscribe',
                 params: { b: { d: 4, c: [2, 3] }, a: 1 },
                 id: 2,
             })


### PR DESCRIPTION
# Summary

We want to produce subscription dedupe keys, but only for subscription requests. If we get `"method": "ping"` or any other such thing, return an undefined key.
