### PR TITLE
refactor(experimental): drop messages the moment a socket connection is aborted

### DIFF
--- a/packages/rpc-transport/src/transports/websocket/__tests__/websocket-connection-test.ts
+++ b/packages/rpc-transport/src/transports/websocket/__tests__/websocket-connection-test.ts
@@ -129,6 +129,17 @@ describe('RpcWebSocketConnection', () => {
                 value: undefined,
             });
         });
+        it('drops messages received between the time a connection is aborted and the time it closes', async () => {
+            expect.assertions(1);
+            const iterator = connection[Symbol.asyncIterator]();
+            const resultPromise = iterator.next();
+            abortController.abort();
+            ws.send({ some: 'message' });
+            await expect(resultPromise).resolves.toMatchObject({
+                done: true,
+                value: undefined,
+            });
+        });
         it('throws from the iterator when the connection encounters an error', async () => {
             expect.assertions(1);
             const iterator = connection[Symbol.asyncIterator]();


### PR DESCRIPTION
# Summary

Previous to this PR, if you aborted a socket connection, it would keep publishing messages into its iterator until the socket disconnected.

Now it will tear down the iterators and return from them immediately upon you calling `abort()`

# Test Plan

```
cd packages/rpc-transport
pnpm turbo test:unit:browser
pnpm turbo test:unit:node
```
