### PR TITLE
refactor(experimental): fix codecs-data-structures typecheck

### DIFF
--- a/packages/codecs-data-structures/src/scalar-enum.ts
+++ b/packages/codecs-data-structures/src/scalar-enum.ts
@@ -18,7 +18,7 @@ import { getU8Decoder, getU8Encoder, NumberCodec, NumberDecoder, NumberEncoder }
  * type DirectionType = ScalarEnum<Direction>;
  * ```
  */
-export type ScalarEnum<T> = ({ [key: number | string]: string | number | T } | number | T) & object;
+export type ScalarEnum<T> = ({ [key: number | string]: string | number | T } | number | T) & NonNullable<unknown>;
 
 /** Defines the options for scalar enum codecs. */
 export type ScalarEnumCodecOptions<TDiscriminator extends NumberCodec | NumberEncoder | NumberDecoder> =


### PR DESCRIPTION
Currently, running `pnpm test:typecheck` on the `codecs-data-structures` package fails, this PR fixes this by transforming `& object` to `& NonNullable<unknown>` (more famously known as `& {}`) to the `ScalarEnum` type. Umi previously used `& {}` and, when migrating the library to web3.js, I tried to make that type stronger but it seems only `& {}` can make this work.
