### PR TITLE
refactor(experimental): a bigint scalar for RPC GraphQL

### DIFF
--- a/packages/rpc-graphql/src/schema/scalars.ts
+++ b/packages/rpc-graphql/src/schema/scalars.ts
@@ -1,0 +1,20 @@
+import { GraphQLScalarType, Kind } from 'graphql';
+
+export const BigIntScalar = new GraphQLScalarType({
+    name: 'BigInt',
+
+    parseLiteral(ast): bigint | null {
+        if (ast.kind === Kind.STRING) {
+            return BigInt(ast.value);
+        }
+        return null;
+    },
+
+    parseValue(value): bigint {
+        return BigInt(value as string);
+    },
+
+    serialize(value): bigint {
+        return BigInt(value as string);
+    },
+});


### PR DESCRIPTION
This PR introduces a `bigint` GraphQL scalar, which allows for parsing and interpreting `bigint` values from the RPC. 

Note: I have decided to handle these values as strings on the client API, with a suffix `n` character. 
