### PR TITLE
refactor(experimental): an account resolver

### DIFF
--- a/packages/rpc-graphql/src/context.ts
+++ b/packages/rpc-graphql/src/context.ts
@@ -2,13 +2,62 @@ import { SolanaRpcMethods } from '@solana/rpc-core';
 import { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
 
 import { createGraphQLCache, GraphQLCache } from './cache';
+import { AccountQueryArgs } from './schema/account/query';
 
 export interface RpcGraphQLContext {
     cache: GraphQLCache;
+    resolveAccount(args: AccountQueryArgs): ReturnType<typeof resolveAccount>;
     rpc: Rpc<SolanaRpcMethods>;
+}
+
+// Default to jsonParsed encoding if none is provided
+async function resolveAccount(
+    { address, encoding = 'jsonParsed', ...config }: AccountQueryArgs,
+    cache: GraphQLCache,
+    rpc: Rpc<SolanaRpcMethods>
+) {
+    const requestConfig = { encoding, ...config };
+
+    const cached = cache.get(address, requestConfig);
+    if (cached !== null) {
+        return cached;
+    }
+
+    const account = await rpc
+        .getAccountInfo(address, requestConfig as Parameters<SolanaRpcMethods['getAccountInfo']>[1])
+        .send()
+        .then(res => res.value)
+        .catch(e => {
+            throw e;
+        });
+
+    if (account === null) {
+        return null;
+    }
+
+    const [data, responseEncoding] = Array.isArray(account.data)
+        ? encoding === 'jsonParsed'
+            ? [account.data[0], 'base64']
+            : [account.data[0], encoding]
+        : [account.data, 'jsonParsed'];
+    const queryResponse = {
+        ...account,
+        data,
+        encoding: responseEncoding,
+    };
+
+    cache.insert(address, requestConfig, queryResponse);
+
+    return queryResponse;
 }
 
 export function createSolanaGraphQLContext(rpc: Rpc<SolanaRpcMethods>): RpcGraphQLContext {
     const cache = createGraphQLCache();
-    return { cache, rpc };
+    return {
+        cache,
+        resolveAccount(args) {
+            return resolveAccount(args, this.cache, this.rpc);
+        },
+        rpc,
+    };
 }

--- a/packages/rpc-graphql/src/schema/account/index.ts
+++ b/packages/rpc-graphql/src/schema/account/index.ts
@@ -1,0 +1,1 @@
+export * from './query';

--- a/packages/rpc-graphql/src/schema/account/query.ts
+++ b/packages/rpc-graphql/src/schema/account/query.ts
@@ -1,0 +1,11 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { Commitment } from '@solana/rpc-core';
+import { DataSlice, Slot } from '@solana/rpc-core/dist/types/rpc-methods/common';
+
+export type AccountQueryArgs = {
+    address: Base58EncodedAddress;
+    commitment?: Commitment;
+    dataSlice?: DataSlice;
+    encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
+    minContextSlot?: Slot;
+};


### PR DESCRIPTION
A resolver to hit the Solana RPC for an `AccountInfo` from a GraphQL query.
