### PR TITLE
refactor(experimental): an account GraphQL query

### DIFF
--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -45,8 +45,8 @@
         "test:treeshakability:native": "agadoo dist/index.native.js",
         "test:treeshakability:node": "agadoo dist/index.node.js",
         "test:typecheck": "tsc --noEmit",
-        "test:unit:browser": "jest -c node_modules/test-config/jest-unit.config.browser.ts --globalSetup test-config/test-validator-setup.js --globalTeardown test-config/test-validator-teardown.js --rootDir . --silent --passWithNoTests",
-        "test:unit:node": "jest -c node_modules/test-config/jest-unit.config.node.ts --globalSetup test-config/test-validator-setup.js --globalTeardown test-config/test-validator-teardown.js --rootDir . --silent --passWithNoTests"
+        "test:unit:browser": "jest -c node_modules/test-config/jest-unit.config.browser.ts --globalSetup test-config/test-validator-setup.js --globalTeardown test-config/test-validator-teardown.js --rootDir . --silent",
+        "test:unit:node": "jest -c node_modules/test-config/jest-unit.config.node.ts --globalSetup test-config/test-validator-setup.js --globalTeardown test-config/test-validator-teardown.js --rootDir . --silent"
     },
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "license": "MIT",

--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1,0 +1,649 @@
+import { createSolanaRpcApi, SolanaRpcMethods } from '@solana/rpc-core';
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createRpcGraphQL, RpcGraphQL } from '../rpc';
+
+describe('account', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    let rpcGraphQL: RpcGraphQL;
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+        rpcGraphQL = createRpcGraphQL(rpc);
+    });
+
+    describe('basic queries', () => {
+        // See scripts/fixtures/spl-token-token-account.json
+        const variableValues = {
+            address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+            commitment: 'confirmed',
+        };
+        it("can query an account's lamports balance", async () => {
+            expect.assertions(1);
+            const source = `
+            query testQuery($address: String!) {
+                account(address: $address) {
+                    lamports
+                }
+            }
+        `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        lamports: 10290815n,
+                    },
+                },
+            });
+        });
+        it("can query an account's executable value", async () => {
+            expect.assertions(1);
+            const source = `
+            query testQuery($address: String!, $commitment: Commitment) {
+                account(address: $address, commitment: $commitment) {
+                    executable
+                }
+            }
+        `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        executable: false,
+                    },
+                },
+            });
+        });
+        it('can query multiple fields', async () => {
+            expect.assertions(1);
+            const source = `
+            query testQuery($address: String!, $commitment: Commitment) {
+                account(address: $address, commitment: $commitment) {
+                    executable
+                    lamports
+                    rentEpoch
+                }
+            }
+        `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        executable: false,
+                        lamports: 10290815n,
+                        rentEpoch: 0n,
+                    },
+                },
+            });
+        });
+    });
+    describe('nested basic queries', () => {
+        // See scripts/fixtures/spl-token-token-account.json
+        const variableValues = {
+            address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+            commitment: 'confirmed',
+        };
+        it("can perform a nested query for the account's owner", async () => {
+            expect.assertions(1);
+            const source = `
+            query testQuery($address: String!, $commitment: Commitment) {
+                account(address: $address, commitment: $commitment) {
+                    owner {
+                        executable
+                        lamports
+                        rentEpoch
+                    }
+                }
+            }
+        `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        owner: {
+                            executable: true,
+                            lamports: expect.any(BigInt),
+                            rentEpoch: expect.any(BigInt),
+                        },
+                    },
+                },
+            });
+        });
+    });
+    describe('double nested basic queries', () => {
+        // See scripts/fixtures/spl-token-token-account.json
+        const variableValues = {
+            address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+            commitment: 'confirmed',
+        };
+        it("can perform a double nested query for each account's owner", async () => {
+            expect.assertions(1);
+            const source = `
+            query testQuery($address: String!, $commitment: Commitment) {
+                account(address: $address, commitment: $commitment) {
+                    owner {
+                        owner {
+                            executable
+                            lamports
+                            rentEpoch
+                        }
+                    }
+                }
+            }
+        `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        owner: {
+                            owner: {
+                                executable: true,
+                                lamports: expect.any(BigInt),
+                                rentEpoch: expect.any(BigInt),
+                            },
+                        },
+                    },
+                },
+            });
+        });
+    });
+    describe('account data queries', () => {
+        it('can get account data as base58', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/gpa1.json
+            const variableValues = {
+                address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
+                encoding: 'base58',
+            };
+            const source = `
+                query testQuery($address: String!, $encoding: AccountEncoding) {
+                    account(address: $address, encoding: $encoding) {
+                        ... on AccountBase58 {
+                            data
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: '2Uw1bpnsXxu3e',
+                    },
+                },
+            });
+        });
+        it('can get account data as base64', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/gpa1.json
+            const variableValues = {
+                address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
+                encoding: 'base64',
+            };
+            const source = `
+                query testQuery($address: String!, $encoding: AccountEncoding) {
+                    account(address: $address, encoding: $encoding) {
+                        ... on AccountBase64 {
+                            data
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: 'dGVzdCBkYXRh',
+                    },
+                },
+            });
+        });
+        it('can get account data as base64+zstd', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/gpa1.json
+            const variableValues = {
+                address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
+                encoding: 'base64Zstd',
+            };
+            const source = `
+                query testQuery($address: String!, $encoding: AccountEncoding) {
+                    account(address: $address, encoding: $encoding) {
+                        ... on AccountBase64Zstd {
+                            data
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: 'KLUv/QBYSQAAdGVzdCBkYXRh',
+                    },
+                },
+            });
+        });
+    });
+    describe('nested account data queries', () => {
+        it('can get nested account data as base64', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/spl-token-token-account.json
+            const variableValues = {
+                address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                encoding: 'base64',
+            };
+            const source = `
+                    query testQuery($address: String!, $encoding: AccountEncoding) {
+                        account(address: $address, encoding: $encoding) {
+                            ... on AccountBase64 {
+                                data
+                                owner(encoding: $encoding) {
+                                    ... on AccountBase64 {
+                                        data
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: '6Sg5VQll/9TWSsqvRtRd9zGOW09XyQxIfWBiXYKbg3tRbfSo3iE5g7lQFUZzej7dXNBFemsx9mHsHQF64UlEQ+BvnGLyhiMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                        owner: {
+                            data: expect.any(String),
+                        },
+                    },
+                },
+            });
+        });
+    });
+    describe('specific account type queries', () => {
+        it('can get a mint account', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/spl-token-mint-account.json
+            const variableValues = {
+                address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+            };
+            const source = `
+                query testQuery($address: String!) {
+                    account(address: $address) {
+                        ... on MintAccount {
+                            data {
+                                parsed {
+                                    info {
+                                        decimals
+                                        isInitialized
+                                        mintAuthority
+                                        supply
+                                    }
+                                    type
+                                }
+                                program
+                                space
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: {
+                            parsed: {
+                                info: {
+                                    decimals: expect.any(Number),
+                                    isInitialized: expect.any(Boolean),
+                                    mintAuthority: expect.any(String),
+                                    supply: expect.any(String),
+                                },
+                                type: 'mint',
+                            },
+                            program: 'spl-token',
+                            space: 82n,
+                        },
+                    },
+                },
+            });
+        });
+        it('can get a token account', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/spl-token-token-account.json
+            const variableValues = {
+                address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+            };
+            const source = `
+                query testQuery($address: String!) {
+                    account(address: $address) {
+                        ... on TokenAccount {
+                            data {
+                                parsed {
+                                    info {
+                                        isNative
+                                        mint
+                                        owner
+                                        state
+                                        tokenAmount {
+                                            amount
+                                            decimals
+                                            uiAmount
+                                            uiAmountString
+                                        }
+                                    }
+                                    type
+                                }
+                                program
+                                space
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: {
+                            parsed: {
+                                info: {
+                                    isNative: expect.any(Boolean),
+                                    mint: expect.any(String),
+                                    owner: expect.any(String),
+                                    state: expect.any(String),
+                                    tokenAmount: {
+                                        amount: expect.any(String),
+                                        decimals: expect.any(Number),
+                                        uiAmountString: expect.any(String),
+                                    },
+                                },
+                                type: 'account',
+                            },
+                            program: 'spl-token',
+                            space: 165n,
+                        },
+                    },
+                },
+            });
+        });
+        it('can get a nonce account', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/nonce-account.json
+            const variableValues = {
+                address: 'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
+            };
+            const source = `
+                query testQuery($address: String!) {
+                    account(address: $address) {
+                        ... on NonceAccount {
+                            data {
+                                parsed {
+                                    info {
+                                        authority
+                                        blockhash
+                                        feeCalculator {
+                                            lamportsPerSignature
+                                        }
+                                    }
+                                    type
+                                }
+                                program
+                                space
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: {
+                            parsed: {
+                                info: {
+                                    authority: expect.any(String),
+                                    blockhash: expect.any(String),
+                                    feeCalculator: {
+                                        lamportsPerSignature: expect.any(String),
+                                    },
+                                },
+                                type: 'initialized',
+                            },
+                            program: 'nonce',
+                            space: 80n,
+                        },
+                    },
+                },
+            });
+        });
+        it('can get a stake account', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/stake-account.json
+            const variableValues = {
+                address: 'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN',
+            };
+            const source = `
+                query testQuery($address: String!) {
+                    account(address: $address) {
+                        ... on StakeAccount {
+                            data {
+                                parsed {
+                                    info {
+                                        meta {
+                                            authorized {
+                                                staker
+                                                withdrawer
+                                            }
+                                            lockup {
+                                                custodian
+                                                epoch
+                                                unixTimestamp
+                                            }
+                                            rentExemptReserve
+                                        }
+                                        stake {
+                                            creditsObserved
+                                            delegation {
+                                                activationEpoch
+                                                deactivationEpoch
+                                                stake
+                                                voter
+                                            }
+                                        }
+                                    }
+                                    type
+                                }
+                                program
+                                space
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: {
+                            parsed: {
+                                info: {
+                                    meta: {
+                                        authorized: {
+                                            staker: expect.any(String),
+                                            withdrawer: expect.any(String),
+                                        },
+                                        lockup: {
+                                            custodian: expect.any(String),
+                                            epoch: expect.any(BigInt),
+                                            unixTimestamp: expect.any(BigInt),
+                                        },
+                                        rentExemptReserve: expect.any(String),
+                                    },
+                                    stake: {
+                                        creditsObserved: expect.any(BigInt),
+                                        delegation: {
+                                            activationEpoch: expect.any(BigInt),
+                                            deactivationEpoch: expect.any(BigInt),
+                                            stake: expect.any(String),
+                                            voter: expect.any(String),
+                                        },
+                                    },
+                                },
+                                type: 'delegated',
+                            },
+                            program: 'stake',
+                            space: 200n,
+                        },
+                    },
+                },
+            });
+        });
+        it('can get a vote account', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/vote-account.json
+            const variableValues = {
+                address: '4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp',
+            };
+            const source = `
+                query testQuery($address: String!) {
+                    account(address: $address) {
+                        ... on VoteAccount {
+                            data {
+                                parsed {
+                                    info {
+                                        authorizedVoters {
+                                            authorizedVoter
+                                            epoch
+                                        }
+                                        authorizedWithdrawer
+                                        commission
+                                        epochCredits {
+                                            credits
+                                            epoch
+                                            previousCredits
+                                        }
+                                        lastTimestamp {
+                                            slot
+                                            timestamp
+                                        }
+                                        nodePubkey
+                                        priorVoters
+                                        rootSlot
+                                        votes {
+                                            confirmationCount
+                                            slot
+                                        }
+                                    }
+                                    type
+                                }
+                                program
+                                space
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: {
+                            parsed: {
+                                info: {
+                                    authorizedVoters: expect.arrayContaining([
+                                        {
+                                            authorizedVoter: expect.any(String),
+                                            epoch: expect.any(BigInt),
+                                        },
+                                    ]),
+                                    authorizedWithdrawer: expect.any(String),
+                                    commission: expect.any(Number),
+                                    epochCredits: expect.arrayContaining([
+                                        {
+                                            credits: expect.any(String),
+                                            epoch: expect.any(BigInt),
+                                            previousCredits: expect.any(String),
+                                        },
+                                    ]),
+                                    lastTimestamp: {
+                                        slot: expect.any(BigInt),
+                                        timestamp: expect.any(BigInt),
+                                    },
+                                    nodePubkey: expect.any(String),
+                                    priorVoters: expect.any(Array),
+                                    rootSlot: expect.any(BigInt),
+                                    votes: expect.arrayContaining([
+                                        {
+                                            confirmationCount: expect.any(Number),
+                                            slot: expect.any(BigInt),
+                                        },
+                                    ]),
+                                },
+                                type: 'vote',
+                            },
+                            program: 'vote',
+                            space: expect.any(BigInt),
+                        },
+                    },
+                },
+            });
+        });
+        it('can get an address lookup table account', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/address-lookup-table-account.json
+            const variableValues = {
+                address: '2JPQuT3dHtPjrdcbUQyrrT4XYRYaWpWfmAJ54SUapg6n',
+            };
+            const source = `
+                query testQuery($address: String!) {
+                    account(address: $address) {
+                        ... on LookupTableAccount {
+                            data {
+                                parsed {
+                                    info {
+                                        addresses
+                                        authority
+                                        deactivationSlot
+                                        lastExtendedSlot
+                                        lastExtendedSlotStartIndex
+                                    }
+                                    type
+                                }
+                                program
+                                space
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        data: {
+                            parsed: {
+                                info: {
+                                    addresses: expect.any(Array),
+                                    authority: expect.any(String),
+                                    deactivationSlot: expect.any(String),
+                                    lastExtendedSlot: expect.any(String),
+                                    lastExtendedSlotStartIndex: expect.any(Number),
+                                },
+                                type: 'lookupTable',
+                            },
+                            program: 'address-lookup-table',
+                            space: 1304n,
+                        },
+                    },
+                },
+            });
+        });
+    });
+});

--- a/packages/rpc-graphql/src/rpc.ts
+++ b/packages/rpc-graphql/src/rpc.ts
@@ -3,6 +3,7 @@ import { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
 import { graphql, GraphQLObjectType, GraphQLSchema, Source } from 'graphql';
 
 import { createSolanaGraphQLContext, RpcGraphQLContext } from './context';
+import { accountQuery, accountTypes } from './schema/account';
 
 export interface RpcGraphQL {
     context: RpcGraphQLContext;
@@ -18,11 +19,11 @@ export function createRpcGraphQL(rpc: Rpc<SolanaRpcMethods>): RpcGraphQL {
     const schema = new GraphQLSchema({
         query: new GraphQLObjectType({
             fields: {
-                /** Root queries */
+                ...accountQuery,
             },
             name: 'RootQuery',
         }),
-        types: [],
+        types: [...accountTypes],
     });
     return {
         context,

--- a/packages/rpc-graphql/src/schema/account/index.ts
+++ b/packages/rpc-graphql/src/schema/account/index.ts
@@ -1,1 +1,2 @@
 export * from './query';
+export * from './types';

--- a/packages/rpc-graphql/src/schema/account/query.ts
+++ b/packages/rpc-graphql/src/schema/account/query.ts
@@ -2,10 +2,32 @@ import { Base58EncodedAddress } from '@solana/addresses';
 import { Commitment } from '@solana/rpc-core';
 import { DataSlice, Slot } from '@solana/rpc-core/dist/types/rpc-methods/common';
 
+import { RpcGraphQLContext } from '../../context';
+import { accountEncodingInputType, commitmentInputType, dataSliceInputType } from '../inputs';
+import { bigint, nonNull, string, type } from '../picks';
+import { accountInterface } from './types';
+
 export type AccountQueryArgs = {
     address: Base58EncodedAddress;
     commitment?: Commitment;
     dataSlice?: DataSlice;
     encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
     minContextSlot?: Slot;
+};
+
+/**
+ * Account root query for GraphQL
+ */
+export const accountQuery = {
+    account: {
+        args: {
+            address: nonNull(string()),
+            commitment: type(commitmentInputType),
+            dataSlice: type(dataSliceInputType),
+            encoding: type(accountEncodingInputType),
+            minContextSlot: bigint(),
+        },
+        resolve: (_parent: unknown, args: AccountQueryArgs, context: RpcGraphQLContext) => context.resolveAccount(args),
+        type: accountInterface,
+    },
 };

--- a/packages/rpc-graphql/src/schema/account/types.ts
+++ b/packages/rpc-graphql/src/schema/account/types.ts
@@ -1,0 +1,246 @@
+import { GraphQLInterfaceType, GraphQLObjectType, GraphQLScalarType } from 'graphql';
+
+import { accountEncodingInputType, commitmentInputType, dataSliceInputType } from '../inputs';
+import { bigint, boolean, list, number, object, string, type } from '../picks';
+
+export const tokenAmountType = new GraphQLObjectType({
+    fields: {
+        amount: string(),
+        decimals: number(),
+        uiAmount: bigint(),
+        uiAmountString: string(),
+    },
+    name: 'TokenAmount',
+});
+
+/**
+ * The fields of the account interface
+ */
+const accountInterfaceFields = {
+    encoding: string(),
+    executable: boolean(),
+    lamports: bigint(),
+    rentEpoch: bigint(),
+};
+
+/**
+ * An account interface for GraphQL
+ */
+export const accountInterface: GraphQLInterfaceType = new GraphQLInterfaceType({
+    description: 'A Solana account',
+    fields: () => ({
+        ...accountInterfaceFields,
+        owner: type(accountInterface),
+    }),
+    name: 'Account',
+    resolveType(account) {
+        if (account.encoding === 'base58') {
+            return 'AccountBase58';
+        }
+        if (account.encoding === 'base64') {
+            return 'AccountBase64';
+        }
+        if (account.encoding === 'base64+zstd') {
+            return 'AccountBase64Zstd';
+        }
+        if (account.encoding === 'jsonParsed') {
+            if (account.data.parsed.type === 'mint' && account.data.program === 'spl-token') {
+                return 'MintAccount';
+            }
+            if (account.data.parsed.type === 'account' && account.data.program === 'spl-token') {
+                return 'TokenAccount';
+            }
+            if (account.data.program === 'nonce') {
+                return 'NonceAccount';
+            }
+            if (account.data.program === 'stake') {
+                return 'StakeAccount';
+            }
+            if (account.data.parsed.type === 'vote' && account.data.program === 'vote') {
+                return 'VoteAccount';
+            }
+            if (account.data.parsed.type === 'lookupTable' && account.data.program === 'address-lookup-table') {
+                return 'LookupTableAccount';
+            }
+        }
+        return 'AccountBase64';
+    },
+});
+
+/**
+ * An account type implementing the account interface with a
+ * specified data encoding structure
+ * @param name          The name of the account type
+ * @param description   The description of the account type
+ * @param data          The data structure of the account type
+ * @returns             The account type as a GraphQL object implementing the account interface
+ */
+const accountType = (
+    name: string,
+    description: string,
+    data: { type: GraphQLScalarType | GraphQLObjectType }
+): GraphQLObjectType =>
+    new GraphQLObjectType({
+        description,
+        fields: {
+            ...accountInterfaceFields,
+            data,
+            owner: {
+                args: {
+                    commitment: type(commitmentInputType),
+                    dataSlice: type(dataSliceInputType),
+                    encoding: type(accountEncodingInputType),
+                    minContextSlot: bigint(),
+                },
+                resolve: (parent, args, context) => context.resolveAccount({ ...args, address: parent.owner }),
+                type: accountInterface,
+            },
+        },
+        interfaces: [accountInterface],
+        name,
+    });
+
+/**
+ * Builds JSON parsed account data
+ * Note: JSON parsed data is only available for account types with known schemas.
+ * Any account with an unknown schema will return base64 encoded data.
+ * @see https://docs.solana.com/api/http#parsed-responses
+ * @param name              The name of the account type
+ * @param parsedInfoFields  The fields of the parsed info object
+ * @returns                 The JSON parsed account data as a GraphQL object
+ */
+const accountDataJsonParsed = (name: string, parsedInfoFields: Parameters<typeof object>[1]) =>
+    object(name + 'Data', {
+        parsed: object(name + 'DataParsed', {
+            info: object(name + 'DataParsedInfo', parsedInfoFields),
+            type: string(),
+        }),
+        program: string(),
+        space: bigint(),
+    });
+
+const accountBase58 = accountType('AccountBase58', 'A Solana account with base58 encoded data', string());
+const accountBase64 = accountType('AccountBase64', 'A Solana account with base64 encoded data', string());
+const accountBase64Zstd = accountType(
+    'AccountBase64Zstd',
+    'A Solana account with base64 encoded data compressed with zstd',
+    string()
+);
+const accountNonceAccount = accountType(
+    'NonceAccount',
+    'A nonce account',
+    accountDataJsonParsed('Nonce', {
+        authority: string(),
+        blockhash: string(),
+        feeCalculator: object('NonceFeeCalculator', {
+            lamportsPerSignature: string(),
+        }),
+    })
+);
+const accountLookupTable = accountType(
+    'LookupTableAccount',
+    'An address lookup table account',
+    accountDataJsonParsed('LookupTable', {
+        addresses: list(string()),
+        authority: string(),
+        deactivationSlot: string(),
+        lastExtendedSlot: string(),
+        lastExtendedSlotStartIndex: number(),
+    })
+);
+const accountMint = accountType(
+    'MintAccount',
+    'An SPL mint',
+    accountDataJsonParsed('Mint', {
+        decimals: number(),
+        freezeAuthority: string(),
+        isInitialized: boolean(),
+        mintAuthority: string(),
+        supply: string(),
+    })
+);
+const accountTokenAccount = accountType(
+    'TokenAccount',
+    'An SPL token account',
+    accountDataJsonParsed('TokenAccount', {
+        isNative: boolean(),
+        mint: string(),
+        owner: string(),
+        state: string(),
+        tokenAmount: type(tokenAmountType),
+    })
+);
+const accountStakeAccount = accountType(
+    'StakeAccount',
+    'A stake account',
+    accountDataJsonParsed('Stake', {
+        meta: object('StakeMeta', {
+            authorized: object('StakeMetaAuthorized', {
+                staker: string(),
+                withdrawer: string(),
+            }),
+            lockup: object('StakeMetaLockup', {
+                custodian: string(),
+                epoch: bigint(),
+                unixTimestamp: bigint(),
+            }),
+            rentExemptReserve: string(),
+        }),
+        stake: object('StakeStake', {
+            creditsObserved: bigint(),
+            delegation: object('StakeStakeDelegation', {
+                activationEpoch: bigint(),
+                deactivationEpoch: bigint(),
+                stake: string(),
+                voter: string(),
+                warmupCooldownRate: number(),
+            }),
+        }),
+    })
+);
+const accountVoteAccount = accountType(
+    'VoteAccount',
+    'A vote account',
+    accountDataJsonParsed('Vote', {
+        authorizedVoters: list(
+            object('VoteAuthorizedVoter', {
+                authorizedVoter: string(),
+                epoch: bigint(),
+            })
+        ),
+        authorizedWithdrawer: string(),
+        commission: number(),
+        epochCredits: list(
+            object('VoteEpochCredits', {
+                credits: string(),
+                epoch: bigint(),
+                previousCredits: string(),
+            })
+        ),
+        lastTimestamp: object('VoteLastTimestamp', {
+            slot: bigint(),
+            timestamp: bigint(),
+        }),
+        nodePubkey: string(),
+        priorVoters: list(string()),
+        rootSlot: bigint(),
+        votes: list(
+            object('VoteVote', {
+                confirmationCount: number(),
+                slot: bigint(),
+            })
+        ),
+    })
+);
+
+export const accountTypes = [
+    accountBase58,
+    accountBase64,
+    accountBase64Zstd,
+    accountNonceAccount,
+    accountLookupTable,
+    accountMint,
+    accountTokenAccount,
+    accountStakeAccount,
+    accountVoteAccount,
+];

--- a/packages/rpc-graphql/src/schema/inputs.ts
+++ b/packages/rpc-graphql/src/schema/inputs.ts
@@ -1,0 +1,44 @@
+import { GraphQLEnumType, GraphQLInputObjectType } from 'graphql';
+
+import { number } from './picks';
+
+export const accountEncodingInputType = new GraphQLEnumType({
+    name: 'AccountEncoding',
+    values: {
+        base58: {
+            value: 'base58',
+        },
+        base64: {
+            value: 'base64',
+        },
+        base64Zstd: {
+            value: 'base64+zstd',
+        },
+        jsonParsed: {
+            value: 'jsonParsed',
+        },
+    },
+});
+
+export const commitmentInputType = new GraphQLEnumType({
+    name: 'Commitment',
+    values: {
+        confirmed: {
+            value: 'confirmed',
+        },
+        finalized: {
+            value: 'finalized',
+        },
+        processed: {
+            value: 'processed',
+        },
+    },
+});
+
+export const dataSliceInputType = new GraphQLInputObjectType({
+    fields: {
+        length: number(),
+        offset: number(),
+    },
+    name: 'DataSliceConfig',
+});


### PR DESCRIPTION
The `Account` query and schema for querying on-chain Solana accounts and their potentially parsed data.
