### PR TITLE
refactor(experimental): add fromVersionedTransactionWithDurableNonce

### DIFF
--- a/packages/compat/src/__typetests__/transaction-typetests.ts
+++ b/packages/compat/src/__typetests__/transaction-typetests.ts
@@ -1,8 +1,23 @@
-import { ITransactionWithBlockhashLifetime, ITransactionWithFeePayer, Transaction } from '@solana/transactions';
+import {
+    IDurableNonceTransaction,
+    ITransactionWithBlockhashLifetime,
+    ITransactionWithFeePayer,
+    Transaction,
+} from '@solana/transactions';
 import { VersionedTransaction } from '@solana/web3.js';
 
-import { fromVersionedTransactionWithBlockhash } from '../transaction';
+import { fromVersionedTransactionWithBlockhash, fromVersionedTransactionWithDurableNonce } from '../transaction';
 
-const transaction = null as unknown as VersionedTransaction;
-const returned = fromVersionedTransactionWithBlockhash(transaction);
-returned satisfies Transaction & ITransactionWithFeePayer & ITransactionWithBlockhashLifetime;
+// Blockhash
+{
+    const transaction = null as unknown as VersionedTransaction;
+    const returned = fromVersionedTransactionWithBlockhash(transaction);
+    returned satisfies Transaction & ITransactionWithFeePayer & ITransactionWithBlockhashLifetime;
+}
+
+// Durable nonce
+{
+    const transaction = null as unknown as VersionedTransaction;
+    const returned = fromVersionedTransactionWithDurableNonce(transaction);
+    returned satisfies Transaction & ITransactionWithFeePayer & IDurableNonceTransaction;
+}

--- a/packages/compat/src/transaction.ts
+++ b/packages/compat/src/transaction.ts
@@ -186,7 +186,7 @@ export function fromVersionedTransactionWithDurableNonce(
         tx => setTransactionFeePayer(feePayer.toBase58() as Base58EncodedAddress, tx),
         tx => setTransactionLifetimeUsingDurableNonce(durableNonceLifetime, tx),
         tx =>
-            instructions.reduce((acc, instruction) => {
+            instructions.slice(1).reduce((acc, instruction) => {
                 return appendTransactionInstruction(instruction, acc);
             }, tx),
         tx => (transaction.signatures.length ? { ...tx, signatures } : tx)

--- a/packages/transactions/src/durable-nonce.ts
+++ b/packages/transactions/src/durable-nonce.ts
@@ -83,7 +83,9 @@ function createAdvanceNonceAccountInstruction<
     };
 }
 
-function isAdvanceNonceAccountInstruction(instruction: IInstruction): instruction is AdvanceNonceAccountInstruction {
+export function isAdvanceNonceAccountInstruction(
+    instruction: IInstruction
+): instruction is AdvanceNonceAccountInstruction {
     return (
         instruction.programAddress === SYSTEM_PROGRAM_ADDRESS &&
         // Test for `AdvanceNonceAccount` instruction data


### PR DESCRIPTION
This PR adds a new `@solana/compat` function to convert a versioned transaction that uses a durable nonce lifetime

This is similar to the blockhash version, with a few differences:

- It does not take `lastValidBlockHeight` since that is only used for blockhash lifetimes
- It errors if the input transaction does not have an advance durable nonce instruction as its first instruction
- It returns an `IDurableNonceTransaction`

Note that the instruction check is done on the modern instruction. I've just used the `isAdvanceNonceAccountInstruction` function that we already have

I opted for a separate function because I don't think there's an easy way to differentiate these types in the legacy library, since it puts the `nonce` value in the `blockhash` field

Callers will likely often already know which sort of transaction they're dealing with, so I'd rather they just tell us by using a different function and then we get clearer typing too
