### PR TITLE
refactor(experimental): a strategy for expiring a transaction confirmation when the block height is exceeded

### DIFF
--- a/packages/library/src/__tests__/transaction-confirmation-strategy-blockheight-test.ts
+++ b/packages/library/src/__tests__/transaction-confirmation-strategy-blockheight-test.ts
@@ -1,0 +1,83 @@
+import { createBlockHeightExceedencePromiseFactory } from '../transaction-confirmation-strategy-blockheight';
+
+const FOREVER_PROMISE = new Promise(() => {
+    /* never resolve */
+});
+
+describe('createBlockHeightExceedencePromiseFactory', () => {
+    let createSubscriptionIterable: jest.Mock;
+    let getBlockHeightExceedencePromise: ReturnType<typeof createBlockHeightExceedencePromiseFactory>;
+    let slotNotificationsGenerator: jest.Mock;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        slotNotificationsGenerator = jest.fn().mockImplementation(async function* () {
+            yield await FOREVER_PROMISE;
+        });
+        createSubscriptionIterable = jest.fn().mockResolvedValue({
+            [Symbol.asyncIterator]: slotNotificationsGenerator,
+        });
+        const rpcSubscriptions = {
+            slotNotifications: () => ({
+                subscribe: createSubscriptionIterable,
+            }),
+        };
+        getBlockHeightExceedencePromise = createBlockHeightExceedencePromiseFactory(rpcSubscriptions);
+    });
+    it('continues to pend when the slot received is less than the last valid slot', async () => {
+        expect.assertions(1);
+        slotNotificationsGenerator.mockImplementation(async function* () {
+            yield { slot: 120n };
+            yield { slot: 121n };
+            yield { slot: 122n };
+            yield await FOREVER_PROMISE;
+        });
+        const exceedencePromise = getBlockHeightExceedencePromise({
+            abortSignal: new AbortController().signal,
+            lastValidBlockHeight: 123n,
+        });
+        await jest.runAllTimersAsync();
+        await expect(Promise.race([exceedencePromise, 'pending'])).resolves.toBe('pending');
+    });
+    it('continues to pend when the slot received is equal to the last valid slot', async () => {
+        expect.assertions(1);
+        slotNotificationsGenerator.mockImplementation(async function* () {
+            yield { slot: 123n };
+            yield await FOREVER_PROMISE;
+        });
+        const exceedencePromise = getBlockHeightExceedencePromise({
+            abortSignal: new AbortController().signal,
+            lastValidBlockHeight: 123n,
+        });
+        await jest.runAllTimersAsync();
+        await expect(Promise.race([exceedencePromise, 'pending'])).resolves.toBe('pending');
+    });
+    it('throws when the slot received is higher than the last valid slot', async () => {
+        expect.assertions(1);
+        slotNotificationsGenerator.mockImplementation(async function* () {
+            yield { slot: 124n };
+            yield await FOREVER_PROMISE;
+        });
+        const exceedencePromise = getBlockHeightExceedencePromise({
+            abortSignal: new AbortController().signal,
+            lastValidBlockHeight: 123n,
+        });
+        await expect(exceedencePromise).rejects.toThrow(
+            'The network has progressed past the last block for which this transaction could have committed.'
+        );
+    });
+    it('calls the abort signal passed to the slot subscription when aborted', async () => {
+        expect.assertions(2);
+        const abortController = new AbortController();
+        getBlockHeightExceedencePromise({
+            abortSignal: abortController.signal,
+            lastValidBlockHeight: 123n,
+        });
+        expect(createSubscriptionIterable).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: false }),
+        });
+        abortController.abort();
+        expect(createSubscriptionIterable).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: true }),
+        });
+    });
+});

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -5,3 +5,4 @@ export * from '@solana/transactions';
 export * from './rpc';
 export * from './rpc-transport';
 export * from './rpc-websocket-transport';
+export * from './transaction-confirmation-strategy-blockheight';

--- a/packages/library/src/transaction-confirmation-strategy-blockheight.ts
+++ b/packages/library/src/transaction-confirmation-strategy-blockheight.ts
@@ -1,0 +1,36 @@
+import { Slot } from '@solana/rpc-core/dist/types/rpc-methods/common';
+import type { SlotNotificationsApi } from '@solana/rpc-core/dist/types/rpc-subscriptions/slot-notifications';
+import { RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+
+type GetBlockHeightExceedencePromiseFn = (config: {
+    abortSignal: AbortSignal;
+    lastValidBlockHeight: Slot;
+}) => Promise<void>;
+
+export function createBlockHeightExceedencePromiseFactory(
+    rpcSubscriptions: RpcSubscriptions<SlotNotificationsApi>
+): GetBlockHeightExceedencePromiseFn {
+    return async function getBlockHeightExceedencePromise({ abortSignal: callerAbortSignal, lastValidBlockHeight }) {
+        const abortController = new AbortController();
+        function handleAbort() {
+            abortController.abort();
+        }
+        callerAbortSignal.addEventListener('abort', handleAbort, { signal: abortController.signal });
+        const slotNotifications = await rpcSubscriptions
+            .slotNotifications()
+            .subscribe({ abortSignal: abortController.signal });
+        try {
+            for await (const slotNotification of slotNotifications) {
+                if (slotNotification.slot > lastValidBlockHeight) {
+                    // TODO: Coded error.
+                    throw new Error(
+                        'The network has progressed past the last block for which this transaction ' +
+                            'could have committed.'
+                    );
+                }
+            }
+        } finally {
+            abortController.abort();
+        }
+    };
+}


### PR DESCRIPTION
# Summary

Transactions with a lifetime as long as their blockhash is valid can be thought to expire after that blockhash becomes invalid. This strategy watches the progression of slots and throws an error after exceeding the height for which the blockhash is valid.

# Test Plan

```
cd packages/library
pnpm test:unit:browser
pnpm test:unit:node
```
