### PR TITLE
refactor(experimental): a strategy for expiring a transaction confirmation when a nonce advances

### DIFF
--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -6,3 +6,4 @@ export * from './rpc';
 export * from './rpc-transport';
 export * from './rpc-websocket-transport';
 export * from './transaction-confirmation-strategy-blockheight';
+export * from './transaction-confirmation-strategy-nonce';

--- a/packages/library/src/transaction-confirmation-strategy-nonce.ts
+++ b/packages/library/src/transaction-confirmation-strategy-nonce.ts
@@ -1,0 +1,95 @@
+import { base58, base64 } from '@metaplex-foundation/umi-serializers';
+import { Base58EncodedAddress } from '@solana/addresses';
+import { Commitment } from '@solana/rpc-core';
+import { Base64EncodedDataResponse } from '@solana/rpc-core/dist/types/rpc-methods/common';
+import { GetAccountInfoApi } from '@solana/rpc-core/dist/types/rpc-methods/getAccountInfo';
+import { AccountNotificationsApi } from '@solana/rpc-core/dist/types/rpc-subscriptions/account-notifications';
+import { Rpc, RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import { Nonce } from '@solana/transactions';
+
+type GetNonceInvalidationPromiseFn = (config: {
+    abortSignal: AbortSignal;
+    commitment: Commitment;
+    currentNonceValue: Nonce;
+    nonceAccountAddress: Base58EncodedAddress;
+}) => Promise<void>;
+
+const NONCE_VALUE_OFFSET =
+    4 + // version(u32)
+    4 + // state(u32)
+    32; // nonce authority(pubkey)
+// Then comes the nonce value.
+
+export function createNonceInvalidationPromiseFactory(
+    rpc: Rpc<GetAccountInfoApi>,
+    rpcSubscriptions: RpcSubscriptions<AccountNotificationsApi>
+): GetNonceInvalidationPromiseFn {
+    return async function getNonceInvalidationPromise({
+        abortSignal: callerAbortSignal,
+        commitment,
+        currentNonceValue,
+        nonceAccountAddress,
+    }) {
+        const abortController = new AbortController();
+        function handleAbort() {
+            abortController.abort();
+        }
+        callerAbortSignal.addEventListener('abort', handleAbort, { signal: abortController.signal });
+        /**
+         * STEP 1: Set up a subscription for nonce account changes.
+         */
+        const accountNotifications = await rpcSubscriptions
+            .accountNotifications(nonceAccountAddress, { commitment, encoding: 'base64' })
+            .subscribe({ abortSignal: abortController.signal });
+        function getNonceFromAccountData([base64EncodedBytes]: Base64EncodedDataResponse): Nonce {
+            const data = base64.serialize(base64EncodedBytes);
+            const nonceValueBytes = data.slice(NONCE_VALUE_OFFSET, NONCE_VALUE_OFFSET + 32);
+            return base58.deserialize(nonceValueBytes)[0] as Nonce;
+        }
+        const nonceAccountDidAdvancePromise = (async () => {
+            for await (const accountNotification of accountNotifications) {
+                const nonceValue = getNonceFromAccountData(accountNotification.value.data);
+                if (nonceValue !== currentNonceValue) {
+                    throw new Error(
+                        `The nonce \`${currentNonceValue}\` is no longer valid. It has advanced ` +
+                            `to \`${nonceValue}\`.`
+                    );
+                }
+            }
+        })();
+        /**
+         * STEP 2: Having subscribed for updates, make a one-shot request for the current nonce
+         *         value to check if it has already been advanced.
+         */
+        const nonceIsAlreadyInvalidPromise = (async () => {
+            const { value: nonceAccount } = await rpc
+                .getAccountInfo(nonceAccountAddress, {
+                    commitment,
+                    dataSlice: { length: 32, offset: NONCE_VALUE_OFFSET },
+                    encoding: 'base58',
+                })
+                .send({ abortSignal: abortController.signal });
+            if (!nonceAccount) {
+                throw new Error(`No nonce account could be found at address \`${nonceAccountAddress}\`.`);
+            }
+            const nonceValue =
+                // This works because we asked for the exact slice of data representing the nonce
+                // value, and furthermore asked for it in `base58` encoding.
+                nonceAccount.data[0] as unknown as Nonce;
+            if (nonceValue !== currentNonceValue) {
+                throw new Error(
+                    `The nonce \`${currentNonceValue}\` is no longer valid. It has advanced to \`${nonceValue}\`.`
+                );
+            } else {
+                await new Promise(() => {
+                    /* never resolve */
+                });
+            }
+        })();
+        try {
+            return await Promise.race([nonceAccountDidAdvancePromise, nonceIsAlreadyInvalidPromise]);
+        } finally {
+            abortController.abort();
+        }
+    };
+}


### PR DESCRIPTION
# Summary

Transactions with a lifetime tied to a nonce can be thought to expire after that nonce is ‘advanced’. This strategy watches a nonce's account and throws an error if the nonce changes from the expected value (ie. it was advanced in a different transaction).

# Test Plan

```
cd packages/library
pnpm test:unit:browser
pnpm test:unit:node
```
