### PR TITLE
refactor(experimental): a strategy for confirming a transaction when the signature commits

### DIFF
--- a/packages/library/src/__tests__/transaction-confirmation-strategy-signature-test.ts
+++ b/packages/library/src/__tests__/transaction-confirmation-strategy-signature-test.ts
@@ -1,0 +1,174 @@
+import { TransactionSignature } from '@solana/transactions';
+
+import { createSignatureConfirmationPromiseFactory } from '../transaction-confirmation-strategy-signature';
+
+const FOREVER_PROMISE = new Promise(() => {
+    /* never resolve */
+});
+
+describe('createSignatureConfirmationPromiseFactory', () => {
+    let signatureNotificationGenerator: jest.Mock;
+    let createPendingSubscription: jest.Mock;
+    let createSubscriptionIterable: jest.Mock;
+    let getSignatureStatusesMock: jest.Mock;
+    let getSignatureConfirmationPromise: ReturnType<typeof createSignatureConfirmationPromiseFactory>;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        signatureNotificationGenerator = jest.fn().mockImplementation(async function* () {
+            yield await FOREVER_PROMISE;
+        });
+        getSignatureStatusesMock = jest.fn().mockReturnValue(FOREVER_PROMISE);
+        const rpc = {
+            getSignatureStatuses: () => ({
+                send: getSignatureStatusesMock,
+            }),
+        };
+        createSubscriptionIterable = jest.fn().mockResolvedValue({
+            [Symbol.asyncIterator]: signatureNotificationGenerator,
+        });
+        createPendingSubscription = jest.fn().mockReturnValue({ subscribe: createSubscriptionIterable });
+        const rpcSubscriptions = {
+            signatureNotifications: createPendingSubscription,
+        };
+        getSignatureConfirmationPromise = createSignatureConfirmationPromiseFactory(rpc, rpcSubscriptions);
+    });
+    it('sets up a subscription for notifications about signature changes', async () => {
+        expect.assertions(2);
+        getSignatureConfirmationPromise({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            signature: 'abc' as TransactionSignature,
+        });
+        await jest.runAllTimersAsync();
+        expect(createPendingSubscription).toHaveBeenCalledWith('abc', {
+            commitment: 'finalized',
+        });
+        expect(createSubscriptionIterable).toHaveBeenCalled();
+    });
+    it('does not fire off the one shot query for the signature status until the subscription is set up', async () => {
+        expect.assertions(2);
+        let setupSubscription;
+        createSubscriptionIterable.mockReturnValue(
+            new Promise(resolve => {
+                setupSubscription = resolve;
+            })
+        );
+        getSignatureConfirmationPromise({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            signature: 'abc' as TransactionSignature,
+        });
+        await jest.runAllTimersAsync();
+        expect(getSignatureStatusesMock).not.toHaveBeenCalled();
+        // FIXME: https://github.com/microsoft/TypeScript/issues/11498
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        setupSubscription({
+            [Symbol.asyncIterator]: signatureNotificationGenerator,
+        });
+        await jest.runAllTimersAsync();
+        expect(getSignatureStatusesMock).toHaveBeenCalled();
+    });
+    it.each(['processed', 'confirmed'])(
+        'continues to pend when the signature status returned by the one-shot query is at a lower level of commitment (eg. `%s`)',
+        async achievedCommitment => {
+            expect.assertions(1);
+            getSignatureStatusesMock.mockResolvedValue({
+                value: [{ confirmationStatus: achievedCommitment }],
+            });
+            const signatureConfirmationPromise = getSignatureConfirmationPromise({
+                abortSignal: new AbortController().signal,
+                commitment: 'finalized',
+                signature: 'abc' as TransactionSignature,
+            });
+            await jest.runAllTimersAsync();
+            await expect(Promise.race([signatureConfirmationPromise, 'pending'])).resolves.toBe('pending');
+        }
+    );
+    it('continues to pend when no signature status is returned by the one-shot query', async () => {
+        expect.assertions(1);
+        getSignatureStatusesMock.mockResolvedValue({
+            value: [null],
+        });
+        const signatureConfirmationPromise = getSignatureConfirmationPromise({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            signature: 'abc' as TransactionSignature,
+        });
+        await jest.runAllTimersAsync();
+        await expect(Promise.race([signatureConfirmationPromise, 'pending'])).resolves.toBe('pending');
+    });
+    it('resolves when the signature status returned by the one-shot query is at the target level of commitment', async () => {
+        expect.assertions(1);
+        getSignatureStatusesMock.mockResolvedValue({
+            value: [{ confirmationStatus: 'finalized' }],
+        });
+        const signatureConfirmationPromise = getSignatureConfirmationPromise({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            signature: 'abc' as TransactionSignature,
+        });
+        await expect(signatureConfirmationPromise).resolves.toBeUndefined();
+    });
+    it('resolves when a signature status notification is returned by the signature subscription', async () => {
+        expect.assertions(1);
+        signatureNotificationGenerator.mockImplementation(async function* () {
+            yield {
+                value: { err: null },
+            };
+            yield FOREVER_PROMISE;
+        });
+        const signatureConfirmationPromise = getSignatureConfirmationPromise({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            signature: 'abc' as TransactionSignature,
+        });
+        await expect(signatureConfirmationPromise).resolves.toBeUndefined();
+    });
+    it('fatals when the signature subscription returns an error', async () => {
+        expect.assertions(1);
+        signatureNotificationGenerator.mockImplementation(async function* () {
+            yield { value: { err: 'o no' } };
+            yield FOREVER_PROMISE;
+        });
+        const signatureConfirmationPromise = getSignatureConfirmationPromise({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            signature: 'abc' as TransactionSignature,
+        });
+        await expect(signatureConfirmationPromise).rejects.toThrow('The transaction with signature `abc` failed.');
+    });
+    it('calls the abort signal passed to the signature statuses query when aborted', async () => {
+        expect.assertions(2);
+        const abortController = new AbortController();
+        getSignatureConfirmationPromise({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            signature: 'abc' as TransactionSignature,
+        });
+        await jest.runAllTimersAsync();
+        expect(getSignatureStatusesMock).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: false }),
+        });
+        abortController.abort();
+        expect(getSignatureStatusesMock).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: true }),
+        });
+    });
+    it('calls the abort signal passed to the signature subscription when aborted', async () => {
+        expect.assertions(2);
+        const abortController = new AbortController();
+        getSignatureConfirmationPromise({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            signature: 'abc' as TransactionSignature,
+        });
+        expect(createSubscriptionIterable).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: false }),
+        });
+        abortController.abort();
+        expect(createSubscriptionIterable).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: true }),
+        });
+    });
+});

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -7,3 +7,4 @@ export * from './rpc-transport';
 export * from './rpc-websocket-transport';
 export * from './transaction-confirmation-strategy-blockheight';
 export * from './transaction-confirmation-strategy-nonce';
+export * from './transaction-confirmation-strategy-signature';

--- a/packages/library/src/transaction-confirmation-strategy-signature.ts
+++ b/packages/library/src/transaction-confirmation-strategy-signature.ts
@@ -1,0 +1,67 @@
+import { Commitment, commitmentComparator } from '@solana/rpc-core';
+import { GetSignatureStatusesApi } from '@solana/rpc-core/dist/types/rpc-methods/getSignatureStatuses';
+import { SignatureNotificationsApi } from '@solana/rpc-core/dist/types/rpc-subscriptions/signature-notifications';
+import { Rpc, RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import { TransactionSignature } from '@solana/transactions';
+
+type GetSignatureConfirmationPromiseFn = (config: {
+    abortSignal: AbortSignal;
+    commitment: Commitment;
+    signature: TransactionSignature;
+}) => Promise<void>;
+
+export function createSignatureConfirmationPromiseFactory(
+    rpc: Rpc<GetSignatureStatusesApi>,
+    rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi>
+): GetSignatureConfirmationPromiseFn {
+    return async function getSignatureConfirmationPromise({ abortSignal: callerAbortSignal, commitment, signature }) {
+        const abortController = new AbortController();
+        function handleAbort() {
+            abortController.abort();
+        }
+        callerAbortSignal.addEventListener('abort', handleAbort, { signal: abortController.signal });
+        /**
+         * STEP 1: Set up a subscription for signature changes.
+         */
+        const signatureStatusNotifications = await rpcSubscriptions
+            .signatureNotifications(signature, { commitment })
+            .subscribe({ abortSignal: abortController.signal });
+        const signatureDidCommitPromise = (async () => {
+            for await (const signatureStatusNotification of signatureStatusNotifications) {
+                if (signatureStatusNotification.value.err) {
+                    // TODO: Coded error.
+                    throw new Error(`The transaction with signature \`${signature}\` failed.`, {
+                        cause: signatureStatusNotification.value.err,
+                    });
+                } else {
+                    return;
+                }
+            }
+        })();
+        /**
+         * STEP 2: Having subscribed for updates, make a one-shot request for the current status.
+         */
+        const signatureStatusLookupPromise = (async () => {
+            const { value: signatureStatusResults } = await rpc
+                .getSignatureStatuses([signature])
+                .send({ abortSignal: abortController.signal });
+            const signatureStatus = signatureStatusResults[0];
+            if (
+                signatureStatus &&
+                signatureStatus.confirmationStatus &&
+                commitmentComparator(signatureStatus.confirmationStatus, commitment) >= 0
+            ) {
+                return;
+            } else {
+                await new Promise(() => {
+                    /* never resolve */
+                });
+            }
+        })();
+        try {
+            return await Promise.race([signatureDidCommitPromise, signatureStatusLookupPromise]);
+        } finally {
+            abortController.abort();
+        }
+    };
+}


### PR DESCRIPTION
# Summary

A transaction can be thought of as ‘confirmed’ when its signature achieves the level of commitment desired. This strategy watches the status of a given signature and returns when the signature's commitment achieves at least the level configured by the confirmer.

# Test Plan

```
cd packages/library
pnpm test:unit:browser
pnpm test:unit:node
```
