### PR TITLE
fix: unclosed string literal in code example, async keyword for the function

### DIFF
--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -80,10 +80,10 @@ Client applications primarily deal with addresses and public keys in the form of
 From time to time you might acquire a string, that you expect to validate as an address, from an untrusted network API or user input. To assert that such an arbitrary string is a base58-encoded address, use the `assertIsBase58EncodedAddress` function.
 
 ```ts
-import { assertIsBase58EncodedAddress } from '@solana/web3.js`;
+import { assertIsBase58EncodedAddress } from '@solana/web3.js';
 
 // Imagine a function that fetches an account's balance when a user submits a form.
-function handleSubmit() {
+async function handleSubmit() {
     // We know only that what the user typed conforms to the `string` type.
     const address: string = accountAddressInput.value;
     try {


### PR DESCRIPTION
In the code example within `packages/library/README.md`:
1. Corrected an unclosed string literal that could cause confusion for readers or implementation issues.
2. Added the `async` keyword to the function to align with asynchronous operations.
