### PR TITLE
refactor(experimental): make graphql a dependency

### DIFF
--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -61,6 +61,9 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
+    "dependencies": {
+        "graphql": "^16.8.0"
+    },
     "devDependencies": {
         "@solana/addresses": "workspace:*",
         "@solana/eslint-config-solana": "^1.0.2",
@@ -75,7 +78,6 @@
         "eslint": "^8.45.0",
         "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
-        "graphql": "^16.8.0",
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^29.6.2",
         "jest-fetch-mock-fork": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1098,6 +1098,10 @@ importers:
         version: 1.1.1
 
   packages/rpc-graphql:
+    dependencies:
+      graphql:
+        specifier: ^16.8.0
+        version: 16.8.1
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1138,9 +1142,6 @@ importers:
       eslint-plugin-sort-keys-fix:
         specifier: ^1.1.2
         version: 1.1.2
-      graphql:
-        specifier: ^16.8.0
-        version: 16.8.1
       jest:
         specifier: ^29.6.1
         version: 29.7.0(@types/node@20.6.3)(ts-node@10.9.1)
@@ -7887,7 +7888,7 @@ packages:
   /graphql@16.8.1:
     resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: true
+    dev: false
 
   /handlebars@4.7.7:
     resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}


### PR DESCRIPTION
This PR should solve the tree-shakability problem. I've made `graphql` a direct dependency for `@solana/rpc-graphql`, as we've done with other external libraries required by a package - like the usage of `@metaplex-foundation/umi-serializers` in `@solana/addresses`.
