### PR TITLE
refactor(experimental): rename Base58EncodedAddress helpers

### DIFF
--- a/packages/addresses/README.md
+++ b/packages/addresses/README.md
@@ -22,18 +22,18 @@ This package contains utilities for generating account addresses. It can be used
 
 This type represents a string that validates as a Solana address. Functions that require well-formed addresses should specify their inputs in terms of this type.
 
-Whenever you need to validate an arbitrary string as a base58-encoded address, use the `assertIsBase58EncodedAddress()` function in this package.
+Whenever you need to validate an arbitrary string as a base58-encoded address, use the `assertIsAddress()` function in this package.
 
 ## Functions
 
-### `assertIsBase58EncodedAddress()`
+### `assertIsAddress()`
 
 Client applications primarily deal with addresses and public keys in the form of base58-encoded strings. Addresses returned from the RPC API conform to the type `Base58EncodedAddress`. You can use a value of that type wherever a base58-encoded address is expected.
 
-From time to time you might acquire a string, that you expect to validate as an address, from an untrusted network API or user input. To assert that such an arbitrary string is a base58-encoded address, use the `assertIsBase58EncodedAddress` function.
+From time to time you might acquire a string, that you expect to validate as an address, from an untrusted network API or user input. To assert that such an arbitrary string is a base58-encoded address, use the `assertIsAddress` function.
 
 ```ts
-import { assertIsBase58EncodedAddress } from '@solana/addresses';
+import { assertIsAddress } from '@solana/addresses';
 
 // Imagine a function that fetches an account's balance when a user submits a form.
 function handleSubmit() {
@@ -42,7 +42,7 @@ function handleSubmit() {
     try {
         // If this type assertion function doesn't throw, then
         // Typescript will upcast `address` to `Base58EncodedAddress`.
-        assertIsBase58EncodedAddress(address);
+        assertIsAddress(address);
         // At this point, `address` is a `Base58EncodedAddress` that can be used with the RPC.
         const balanceInLamports = await rpc.getBalance(address).send();
     } catch (e) {
@@ -66,9 +66,9 @@ const address = await getAddressFromPublicKey(publicKey);
 Given a program's `Base58EncodedAddress` and up to 16 `Seeds`, this method will return the program derived address (PDA) associated with each.
 
 ```ts
-import { getBase58EncodedAddressCodec, getProgramDerivedAddress } from '@solana/addresses';
+import { getAddressCodec, getProgramDerivedAddress } from '@solana/addresses';
 
-const { serialize } = getBase58EncodedAddressCodec();
+const { serialize } = getAddressCodec();
 const { bumpSeed, pda } = await getProgramDerivedAddress({
     programAddress: 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Base58EncodedAddress,
     seeds: [

--- a/packages/addresses/src/__tests__/address-test.ts
+++ b/packages/addresses/src/__tests__/address-test.ts
@@ -1,22 +1,17 @@
 import { base58 } from '@metaplex-foundation/umi-serializers';
 
-import {
-    assertIsBase58EncodedAddress,
-    Base58EncodedAddress,
-    getBase58EncodedAddressCodec,
-    getBase58EncodedAddressComparator,
-} from '../base58';
+import { assertIsAddress, Base58EncodedAddress, getAddressCodec, getAddressComparator } from '../address';
 
-describe('base58', () => {
-    describe('assertIsBase58EncodedAddress()', () => {
+describe('Base58EncodedAddress', () => {
+    describe('assertIsAddress()', () => {
         it('throws when supplied a non-base58 string', () => {
             expect(() => {
-                assertIsBase58EncodedAddress('not-a-base-58-encoded-string');
+                assertIsAddress('not-a-base-58-encoded-string');
             }).toThrow();
         });
         it('throws when the decoded byte array has a length other than 32 bytes', () => {
             expect(() => {
-                assertIsBase58EncodedAddress(
+                assertIsAddress(
                     // 31 bytes [128, ..., 128]
                     '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM'
                 );
@@ -24,17 +19,17 @@ describe('base58', () => {
         });
         it('does not throw when supplied a base-58 encoded address', () => {
             expect(() => {
-                assertIsBase58EncodedAddress('11111111111111111111111111111111');
+                assertIsAddress('11111111111111111111111111111111');
             }).not.toThrow();
         });
         it('returns undefined when supplied a base-58 encoded address', () => {
-            expect(assertIsBase58EncodedAddress('11111111111111111111111111111111')).toBeUndefined();
+            expect(assertIsAddress('11111111111111111111111111111111')).toBeUndefined();
         });
         [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44].forEach(len => {
             it(`attempts to decode input strings of exactly ${len} characters`, () => {
                 const decodeMethod = jest.spyOn(base58, 'serialize');
                 try {
-                    assertIsBase58EncodedAddress('1'.repeat(len));
+                    assertIsAddress('1'.repeat(len));
                     // eslint-disable-next-line no-empty
                 } catch {}
                 expect(decodeMethod).toHaveBeenCalled();
@@ -43,7 +38,7 @@ describe('base58', () => {
         it('does not attempt to decode too-short input strings', () => {
             const decodeMethod = jest.spyOn(base58, 'serialize');
             try {
-                assertIsBase58EncodedAddress(
+                assertIsAddress(
                     // 31 bytes [0, ..., 0]
                     '1111111111111111111111111111111' // 31 characters
                 );
@@ -54,7 +49,7 @@ describe('base58', () => {
         it('does not attempt to decode too-long input strings', () => {
             const decodeMethod = jest.spyOn(base58, 'serialize');
             try {
-                assertIsBase58EncodedAddress(
+                assertIsAddress(
                     // 33 bytes [0, 255, ..., 255]
                     '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG' // 45 characters
                 );
@@ -63,10 +58,10 @@ describe('base58', () => {
             expect(decodeMethod).not.toHaveBeenCalled();
         });
     });
-    describe('getBase58EncodedAddressCodec', () => {
-        let address: ReturnType<typeof getBase58EncodedAddressCodec>;
+    describe('getAddressCodec', () => {
+        let address: ReturnType<typeof getAddressCodec>;
         beforeEach(() => {
-            address = getBase58EncodedAddressCodec();
+            address = getAddressCodec();
         });
         it('serializes a base58 encoded address into a 32-byte buffer', () => {
             expect(
@@ -99,7 +94,7 @@ describe('base58', () => {
             expect(() => address.deserialize(tooShortBuffer)).toThrow();
         });
     });
-    describe('getBase58EncodedAddressComparator', () => {
+    describe('getAddressComparator', () => {
         it('sorts base 58 addresses', () => {
             expect(
                 // These addresses were chosen such that sorting these conventionally (ie. using
@@ -117,7 +112,7 @@ describe('base58', () => {
                     'BKggsVVp7yLmXtPuBDtC3FXBzvLyyye3Q2tFKUUGCHLj',
                     'Ds72joawSKQ9nCDAAmGMKFiwiY6HR7PDzYDHDzZom3tj',
                     'F1zKr4ZUYo5UAnH1fvYaD6R7ne137NYfS1r5HrCb8NpF',
-                ].sort(getBase58EncodedAddressComparator())
+                ].sort(getAddressComparator())
             ).toEqual([
                 '6JYSQqSHY1E5JDwEfgWMieozqA1KCwiP2cH69to9eWKH',
                 '7grJ9YUAEHxckLFqCY7fq8cM1UrragNSuPH1dvwJ8EEK',

--- a/packages/addresses/src/__tests__/coercions-test.ts
+++ b/packages/addresses/src/__tests__/coercions-test.ts
@@ -1,4 +1,4 @@
-import { address, Base58EncodedAddress } from '../base58';
+import { address, Base58EncodedAddress } from '../address';
 
 describe('coercions', () => {
     describe('address', () => {

--- a/packages/addresses/src/__tests__/computed-address-test.ts
+++ b/packages/addresses/src/__tests__/computed-address-test.ts
@@ -1,4 +1,4 @@
-import { Base58EncodedAddress } from '../base58';
+import { Base58EncodedAddress } from '../address';
 import { createAddressWithSeed, getProgramDerivedAddress } from '../computed-address';
 
 describe('getProgramDerivedAddress()', () => {

--- a/packages/addresses/src/__typetests__/coercions-typetests.ts
+++ b/packages/addresses/src/__typetests__/coercions-typetests.ts
@@ -1,3 +1,3 @@
-import { address, Base58EncodedAddress } from '../base58';
+import { address, Base58EncodedAddress } from '../address';
 
 address('555555555555555555555555') satisfies Base58EncodedAddress<'555555555555555555555555'>;

--- a/packages/addresses/src/address.ts
+++ b/packages/addresses/src/address.ts
@@ -4,7 +4,7 @@ export type Base58EncodedAddress<TAddress extends string = string> = TAddress & 
     readonly __brand: unique symbol;
 };
 
-export function isBase58EncodedAddress(
+export function isAddress(
     putativeBase58EncodedAddress: string
 ): putativeBase58EncodedAddress is Base58EncodedAddress<typeof putativeBase58EncodedAddress> {
     // Fast-path; see if the input string is of an acceptable length.
@@ -25,7 +25,7 @@ export function isBase58EncodedAddress(
     return true;
 }
 
-export function assertIsBase58EncodedAddress(
+export function assertIsAddress(
     putativeBase58EncodedAddress: string
 ): asserts putativeBase58EncodedAddress is Base58EncodedAddress<typeof putativeBase58EncodedAddress> {
     try {
@@ -54,11 +54,11 @@ export function assertIsBase58EncodedAddress(
 export function address<TAddress extends string = string>(
     putativeBase58EncodedAddress: TAddress
 ): Base58EncodedAddress<TAddress> {
-    assertIsBase58EncodedAddress(putativeBase58EncodedAddress);
+    assertIsAddress(putativeBase58EncodedAddress);
     return putativeBase58EncodedAddress as Base58EncodedAddress<TAddress>;
 }
 
-export function getBase58EncodedAddressCodec(
+export function getAddressCodec(
     config?: Readonly<{
         description: string;
     }>
@@ -70,7 +70,7 @@ export function getBase58EncodedAddressCodec(
     }) as unknown as Serializer<Base58EncodedAddress>;
 }
 
-export function getBase58EncodedAddressComparator(): (x: string, y: string) => number {
+export function getAddressComparator(): (x: string, y: string) => number {
     return new Intl.Collator('en', {
         caseFirst: 'lower',
         ignorePunctuation: false,

--- a/packages/addresses/src/computed-address.ts
+++ b/packages/addresses/src/computed-address.ts
@@ -1,6 +1,6 @@
 import { assertDigestCapabilityIsAvailable } from '@solana/assertions';
 
-import { Base58EncodedAddress, getBase58EncodedAddressCodec } from './base58';
+import { Base58EncodedAddress, getAddressCodec } from './address';
 import { compressedPointBytesAreOnCurve } from './curve';
 
 type PDAInput = Readonly<{
@@ -42,7 +42,7 @@ async function createProgramDerivedAddress({ programAddress, seeds }: PDAInput):
         acc.push(...bytes);
         return acc;
     }, [] as number[]);
-    const base58EncodedAddressCodec = getBase58EncodedAddressCodec();
+    const base58EncodedAddressCodec = getAddressCodec();
     const programAddressBytes = base58EncodedAddressCodec.serialize(programAddress);
     const addressBytesBuffer = await crypto.subtle.digest(
         'SHA-256',
@@ -89,7 +89,7 @@ export async function createAddressWithSeed({
     programAddress,
     seed,
 }: SeedInput): Promise<Base58EncodedAddress> {
-    const { serialize, deserialize } = getBase58EncodedAddressCodec();
+    const { serialize, deserialize } = getAddressCodec();
 
     const seedBytes = typeof seed === 'string' ? new TextEncoder().encode(seed) : seed;
     if (seedBytes.byteLength > MAX_SEED_LENGTH) {

--- a/packages/addresses/src/index.ts
+++ b/packages/addresses/src/index.ts
@@ -1,3 +1,3 @@
-export * from './base58';
+export * from './address';
 export * from './computed-address';
 export * from './public-key';

--- a/packages/addresses/src/public-key.ts
+++ b/packages/addresses/src/public-key.ts
@@ -1,6 +1,6 @@
 import { assertKeyExporterIsAvailable } from '@solana/assertions';
 
-import { Base58EncodedAddress, getBase58EncodedAddressCodec } from './base58';
+import { Base58EncodedAddress, getAddressCodec } from './address';
 
 export async function getAddressFromPublicKey(publicKey: CryptoKey): Promise<Base58EncodedAddress> {
     await assertKeyExporterIsAvailable();
@@ -9,6 +9,6 @@ export async function getAddressFromPublicKey(publicKey: CryptoKey): Promise<Bas
         throw new Error('The `CryptoKey` must be an `Ed25519` public key');
     }
     const publicKeyBytes = await crypto.subtle.exportKey('raw', publicKey);
-    const [base58EncodedAddress] = getBase58EncodedAddressCodec().deserialize(new Uint8Array(publicKeyBytes));
+    const [base58EncodedAddress] = getAddressCodec().deserialize(new Uint8Array(publicKeyBytes));
     return base58EncodedAddress;
 }

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -77,10 +77,10 @@ Unimplemented.
 
 Client applications primarily deal with addresses and public keys in the form of base58-encoded strings. Addresses and public keys returned from the RPC API conform to the type `Base58EncodedAddress`. You can use a value of that type wherever a base58-encoded address or key is expected.
 
-From time to time you might acquire a string, that you expect to validate as an address, from an untrusted network API or user input. To assert that such an arbitrary string is a base58-encoded address, use the `assertIsBase58EncodedAddress` function.
+From time to time you might acquire a string, that you expect to validate as an address, from an untrusted network API or user input. To assert that such an arbitrary string is a base58-encoded address, use the `assertIsAddress` function.
 
 ```ts
-import { assertIsBase58EncodedAddress } from '@solana/web3.js';
+import { assertIsAddress } from '@solana/web3.js';
 
 // Imagine a function that fetches an account's balance when a user submits a form.
 async function handleSubmit() {
@@ -89,7 +89,7 @@ async function handleSubmit() {
     try {
         // If this type assertion function doesn't throw, then
         // Typescript will upcast `address` to `Base58EncodedAddress`.
-        assertIsBase58EncodedAddress(address);
+        assertIsAddress(address);
         // At this point, `address` is a `Base58EncodedAddress` that can be used with the RPC.
         const balanceInLamports = await rpc.getBalance(address).send();
     } catch (e) {

--- a/packages/transactions/src/__tests__/accounts-test.ts
+++ b/packages/transactions/src/__tests__/accounts-test.ts
@@ -1,4 +1,4 @@
-import { Base58EncodedAddress, getBase58EncodedAddressComparator } from '@solana/addresses';
+import { Base58EncodedAddress, getAddressComparator } from '@solana/addresses';
 import { AccountRole, IAccountLookupMeta, IInstruction } from '@solana/instructions';
 
 import {
@@ -410,7 +410,7 @@ describe('getAddressMapFromInstructions', () => {
         'creates one $endRole lut entry given matching $aRole and $bRole lut addresses from different lookup tables, preferring the table with the lower address when it $instructionOrder.0',
         ({ aRole, bRole, expectedEntry, instructionOrder: [_, orderInstructions] }) => {
             const commonAddress = getMockAddress();
-            const sortedAddresses = MOCK_ADDRESSES.slice(0, 2).sort(getBase58EncodedAddressComparator());
+            const sortedAddresses = MOCK_ADDRESSES.slice(0, 2).sort(getAddressComparator());
             const lowerLutMeta = {
                 addressIndex: 9,
                 lookupTableAddress: sortedAddresses[0], // Address which sorts lower.
@@ -440,7 +440,7 @@ describe('getAddressMapFromInstructions', () => {
 describe('getOrderedAccountsFromAddressMap', () => {
     let sortedAddresses: Base58EncodedAddress[];
     beforeEach(() => {
-        sortedAddresses = [...MOCK_ADDRESSES].sort(getBase58EncodedAddressComparator());
+        sortedAddresses = [...MOCK_ADDRESSES].sort(getAddressComparator());
     });
     it.each(['READONLY', 'WRITABLE', 'READONLY_SIGNER', 'WRITABLE_SIGNER'] as AccountRoleEnumName[])(
         'puts the fee payer before %s static addresses',

--- a/packages/transactions/src/__tests__/compile-address-table-lookups-test.ts
+++ b/packages/transactions/src/__tests__/compile-address-table-lookups-test.ts
@@ -1,4 +1,4 @@
-import { Base58EncodedAddress, getBase58EncodedAddressComparator } from '@solana/addresses';
+import { Base58EncodedAddress, getAddressComparator } from '@solana/addresses';
 import { AccountRole } from '@solana/instructions';
 
 import { OrderedAccounts } from '../accounts';
@@ -20,7 +20,7 @@ function getMockAddress() {
 
 describe('getCompiledAddressTableLookups', () => {
     it('returns address table lookups in lexical order', () => {
-        const sortedAddresses = [...MOCK_ADDRESSES].sort(getBase58EncodedAddressComparator());
+        const sortedAddresses = [...MOCK_ADDRESSES].sort(getAddressComparator());
         const orderedAccounts = [
             {
                 address: getMockAddress(),

--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -1,7 +1,7 @@
 import 'test-matchers/toBeFrozenObject';
 
 import { base58 } from '@metaplex-foundation/umi-serializers';
-import { Base58EncodedAddress, getAddressFromPublicKey, getBase58EncodedAddressCodec } from '@solana/addresses';
+import { Base58EncodedAddress, getAddressCodec, getAddressFromPublicKey } from '@solana/addresses';
 import { Ed25519Signature, signBytes } from '@solana/keys';
 
 import { Blockhash } from '../blockhash';
@@ -161,7 +161,7 @@ describe('signTransaction', () => {
                     return '99999999999999999999999999999999' as Base58EncodedAddress<'99999999999999999999999999999999'>;
             }
         });
-        (getBase58EncodedAddressCodec as jest.Mock).mockReturnValue({
+        (getAddressCodec as jest.Mock).mockReturnValue({
             serialize: jest.fn().mockReturnValue('fAkEbAsE58AdDrEsS'),
         });
         (signBytes as jest.Mock).mockImplementation(async secretKey => {

--- a/packages/transactions/src/accounts.ts
+++ b/packages/transactions/src/accounts.ts
@@ -1,4 +1,4 @@
-import { Base58EncodedAddress, getBase58EncodedAddressComparator } from '@solana/addresses';
+import { Base58EncodedAddress, getAddressComparator } from '@solana/addresses';
 import {
     AccountRole,
     IAccountLookupMeta,
@@ -85,7 +85,7 @@ export function getAddressMapFromInstructions(
             }
             return { [TYPE]: AddressMapEntryType.STATIC, role: AccountRole.READONLY };
         });
-        let addressComparator: ReturnType<typeof getBase58EncodedAddressComparator>;
+        let addressComparator: ReturnType<typeof getAddressComparator>;
         if (!instruction.accounts) {
             continue;
         }
@@ -109,7 +109,7 @@ export function getAddressMapFromInstructions(
                                     // Consider using the new LOOKUP_TABLE if its address is different...
                                     entry.lookupTableAddress !== accountMeta.lookupTableAddress &&
                                     // ...and sorts before the existing one.
-                                    (addressComparator ||= getBase58EncodedAddressComparator())(
+                                    (addressComparator ||= getAddressComparator())(
                                         accountMeta.lookupTableAddress,
                                         entry.lookupTableAddress
                                     ) < 0;
@@ -203,7 +203,7 @@ export function getAddressMapFromInstructions(
 }
 
 export function getOrderedAccountsFromAddressMap(addressMap: AddressMap): OrderedAccounts {
-    let addressComparator: ReturnType<typeof getBase58EncodedAddressComparator>;
+    let addressComparator: ReturnType<typeof getAddressComparator>;
     const orderedAccounts: (IAccountMeta | IAccountLookupMeta)[] = Object.entries(addressMap)
         .sort(([leftAddress, leftEntry], [rightAddress, rightEntry]) => {
             // STEP 1: Rapid precedence check. Fee payer, then static addresses, then lookups.
@@ -228,7 +228,7 @@ export function getOrderedAccountsFromAddressMap(addressMap: AddressMap): Ordere
                 return leftIsWritable ? -1 : 1;
             }
             // STEP 3: Sort by address.
-            addressComparator ||= getBase58EncodedAddressComparator();
+            addressComparator ||= getAddressComparator();
             if (
                 leftEntry[TYPE] === AddressMapEntryType.LOOKUP_TABLE &&
                 rightEntry[TYPE] === AddressMapEntryType.LOOKUP_TABLE &&

--- a/packages/transactions/src/compile-address-table-lookups.ts
+++ b/packages/transactions/src/compile-address-table-lookups.ts
@@ -1,4 +1,4 @@
-import { Base58EncodedAddress, getBase58EncodedAddressComparator } from '@solana/addresses';
+import { Base58EncodedAddress, getAddressComparator } from '@solana/addresses';
 import { AccountRole } from '@solana/instructions';
 
 import { OrderedAccounts } from './accounts';
@@ -29,7 +29,7 @@ export function getCompiledAddressTableLookups(orderedAccounts: OrderedAccounts)
         }
     }
     return Object.keys(index)
-        .sort(getBase58EncodedAddressComparator())
+        .sort(getAddressComparator())
         .map(lookupTableAddress => ({
             lookupTableAddress: lookupTableAddress as Base58EncodedAddress,
             ...index[lookupTableAddress as unknown as Base58EncodedAddress],

--- a/packages/transactions/src/serializers/address-table-lookup.ts
+++ b/packages/transactions/src/serializers/address-table-lookup.ts
@@ -1,5 +1,5 @@
 import { array, Serializer, shortU16, struct, StructToSerializerTuple, u8 } from '@metaplex-foundation/umi-serializers';
-import { getBase58EncodedAddressCodec } from '@solana/addresses';
+import { getAddressCodec } from '@solana/addresses';
 
 import { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
 
@@ -10,7 +10,7 @@ export function getAddressTableLookupCodec(): Serializer<AddressTableLookup> {
         [
             [
                 'lookupTableAddress',
-                getBase58EncodedAddressCodec(
+                getAddressCodec(
                     __DEV__
                         ? {
                               description:

--- a/packages/transactions/src/serializers/message.ts
+++ b/packages/transactions/src/serializers/message.ts
@@ -8,7 +8,7 @@ import {
     struct,
     StructToSerializerTuple,
 } from '@metaplex-foundation/umi-serializers';
-import { getBase58EncodedAddressCodec } from '@solana/addresses';
+import { getAddressCodec } from '@solana/addresses';
 
 import { CompiledMessage } from '../message';
 import { SerializedMessageBytes } from '../types';
@@ -71,7 +71,7 @@ function getPreludeStructSerializerTuple(): StructToSerializerTuple<CompiledMess
         ['header', getMessageHeaderCodec()],
         [
             'staticAccounts',
-            array(getBase58EncodedAddressCodec(), {
+            array(getAddressCodec(), {
                 description: __DEV__ ? 'A compact-array of static account addresses belonging to this transaction' : '',
                 size: shortU16(),
             }),


### PR DESCRIPTION
- Rename `isBase58EncodedAddress()` to `isAddress()`
- Rename `assertIsBase58EncodedAddress()` to `assertIsAddress()`
- Rename `getBase58EncodedAddressCodec()` to `getAddressCodec()`
- Rename `getBase58EncodedAddressComparator()` to `getAddressComparator()`
- Rename `base58.ts` and `base58-test.ts` files to `address.ts` and `address-test.ts`
