### PR TITLE
refactor(experimental): use slot type for all slots

### DIFF
--- a/packages/rpc-core/src/rpc-methods/getBlockProduction.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockProduction.ts
@@ -1,14 +1,14 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
 import { Commitment } from '../commitment';
-import { RpcResponse, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import { RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type NumberOfLeaderSlots = U64UnsafeBeyond2Pow53Minus1;
 type NumberOfBlocksProduced = U64UnsafeBeyond2Pow53Minus1;
 
 type SlotRange = Readonly<{
-    firstSlot: U64UnsafeBeyond2Pow53Minus1;
-    lastSlot: U64UnsafeBeyond2Pow53Minus1;
+    firstSlot: Slot;
+    lastSlot: Slot;
 }>;
 
 type GetBlockProductionApiConfigBase = Readonly<{

--- a/packages/rpc-core/src/rpc-methods/getVoteAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getVoteAccounts.ts
@@ -1,7 +1,7 @@
 import { Base58EncodedAddress } from '@solana/addresses';
 
 import { Commitment } from '../commitment';
-import { U64UnsafeBeyond2Pow53Minus1 } from './common';
+import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type Epoch = U64UnsafeBeyond2Pow53Minus1;
 type Credits = U64UnsafeBeyond2Pow53Minus1;
@@ -25,7 +25,7 @@ type VoteAccount<TVotePubkey extends Base58EncodedAddress> = Readonly<{
     /** Latest history of earned credits for up to five epochs */
     epochCredits: readonly EpochCredit[];
     /** Current root slot for this vote account */
-    rootSlot: U64UnsafeBeyond2Pow53Minus1;
+    rootSlot: Slot;
 }>;
 
 type GetVoteAccountsApiResponse<TVotePubkey extends Base58EncodedAddress> = Readonly<{


### PR DESCRIPTION
This PR replaces any `u64` types with `Slot` for fields that represent a slot.

Closes #1629
