### PR TITLE
refactor(experimental): export the transaction encoder

### DIFF
--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -3,6 +3,7 @@ export * from './create-transaction';
 export * from './durable-nonce';
 export * from './fee-payer';
 export * from './instructions';
+export * from './serializers';
 export * from './signatures';
 export * from './types';
 export * from './wire-transaction';

--- a/packages/transactions/src/serializers/index.ts
+++ b/packages/transactions/src/serializers/index.ts
@@ -1,0 +1,1 @@
+export * from './transaction';


### PR DESCRIPTION
This PR exports the `getTransactionEncoder` function from `@solana/transactions`

Currently only this encoder is exported, others can be added if required

