### PR TITLE
refactor(experimental): update test validator with new vote account state

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-cluster-nodes-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-cluster-nodes-test.ts
@@ -12,7 +12,7 @@ const logFilePath = path.resolve(__dirname, '../../../../../test-ledger/validato
 // TPU does not seem to be reliably matchable from the log file
 const featureSetPattern = /feat:([\d]+)/;
 const gossipPattern = /local gossip address: [\d.]+:([\d]+)/;
-const pubkeyPattern = /identity: ([\w]{32,})/;
+const pubkeyPattern = /identity pubkey: ([\w]{32,})/;
 const rpcPattern = /rpc bound to [\d.]+:([\d]+)/;
 const shredVersionPattern = /shred_version: ([\d]+)/;
 const versionPattern = /solana-validator ([\d.]+)/;

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-program-accounts-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-program-accounts-test.ts
@@ -463,13 +463,13 @@ describe('getProgramAccounts', () => {
                                             type: 'programData',
                                         },
                                         program: 'bpf-upgradeable-loader',
-                                        space: 395693n,
+                                        space: 518437n,
                                     },
                                     executable: false,
-                                    lamports: 2754914160n,
+                                    lamports: 3609212400n,
                                     owner: 'BPFLoaderUpgradeab1e11111111111111111111111',
                                     rentEpoch: expect.any(BigInt),
-                                    space: 395693n,
+                                    space: 518437n,
                                 },
                                 // Token 2022 data account
                                 pubkey: 'DoU57AYuPFu2QU514RktNPG22QhApEjnKxnBcu4BHDTY',
@@ -1196,10 +1196,7 @@ describe('getProgramAccounts', () => {
                         })
                         .send();
 
-                    // FIXME: The legacy vote account tests add vote accounts to the local validator
-                    //        (which is shared with this test) in such a way that makes a
-                    //        `toStrictEqual()` assertion impossible here.
-                    await expect(accountInfosPromise).resolves.toMatchObject(
+                    await expect(accountInfosPromise).resolves.toStrictEqual(
                         // We can't guarantee ordering is preserved across test runs
                         expect.arrayContaining([
                             {
@@ -1269,13 +1266,13 @@ describe('getProgramAccounts', () => {
                                             type: 'vote',
                                         },
                                         program: 'vote',
-                                        space: 3731n,
+                                        space: 3762n,
                                     },
                                     executable: false,
                                     lamports: expect.any(BigInt), // Changes
                                     owner: 'Vote111111111111111111111111111111111111111',
                                     rentEpoch: expect.any(BigInt),
-                                    space: 3731n,
+                                    space: 3762n,
                                 },
                                 pubkey: voteAccountAddress,
                             },
@@ -1436,13 +1433,13 @@ describe('getProgramAccounts', () => {
                                             type: 'programData',
                                         },
                                         program: 'bpf-upgradeable-loader',
-                                        space: 395693n,
+                                        space: 518437n,
                                     },
                                     executable: false,
-                                    lamports: 2754914160n,
+                                    lamports: 3609212400n,
                                     owner: 'BPFLoaderUpgradeab1e11111111111111111111111',
                                     rentEpoch: expect.any(BigInt),
-                                    space: 395693n,
+                                    space: 518437n,
                                 },
                                 // Token 2022 data account
                                 pubkey: 'DoU57AYuPFu2QU514RktNPG22QhApEjnKxnBcu4BHDTY',
@@ -2175,10 +2172,7 @@ describe('getProgramAccounts', () => {
                         })
                         .send();
 
-                    // FIXME: The legacy vote account tests add vote accounts to the local validator
-                    //        (which is shared with this test) in such a way that makes a
-                    //        `toStrictEqual()` assertion impossible here.
-                    await expect(accountInfosPromise).resolves.toMatchObject({
+                    await expect(accountInfosPromise).resolves.toStrictEqual({
                         context: CONTEXT_MATCHER,
                         // We can't guarantee ordering is preserved across test runs
                         value: expect.arrayContaining([
@@ -2250,13 +2244,13 @@ describe('getProgramAccounts', () => {
                                             type: 'vote',
                                         },
                                         program: 'vote',
-                                        space: 3731n,
+                                        space: 3762n,
                                     },
                                     executable: false,
                                     lamports: expect.any(BigInt), // Changes
                                     owner: 'Vote111111111111111111111111111111111111111',
                                     rentEpoch: expect.any(BigInt),
-                                    space: 3731n,
+                                    space: 3762n,
                                 },
                                 pubkey: voteAccountAddress,
                             },

--- a/scripts/get-latest-validator-release-version.sh
+++ b/scripts/get-latest-validator-release-version.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 (
     set -e
-    version=$(curl -s -N https://api.github.com/repos/solana-labs/solana/releases/latest \
-      | grep -m 1 \"tag_name\" \
-      | sed -ne 's/^ *"tag_name": "\([^"]*\)",$/\1/p')
+    version=$(curl -s "https://api.github.com/repos/solana-labs/solana/releases" | \
+      grep '"tag_name": "v1.17.' | \
+      sort -t. -k3,3nr | \
+      head -n1 | \
+      awk -F\" '{print $4}')
     if [ -z $version ]; then
       exit 3
     fi

--- a/scripts/setup-test-validator.sh
+++ b/scripts/setup-test-validator.sh
@@ -5,8 +5,10 @@ set -ex
 TARGET_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )/.solana
 
 # setup environment
-version=$(curl -s -N https://api.github.com/repos/solana-labs/solana/releases/latest \
-    | grep -m 1 \"tag_name\" \
-    | sed -ne 's/^ *"tag_name": "\([^"]*\)",$/\1/p')
+version=$(curl -s "https://api.github.com/repos/solana-labs/solana/releases" | \
+      grep '"tag_name": "v1.17.' | \
+      sort -t. -k3,3nr | \
+      head -n1 | \
+      awk -F\" '{print $4}')
 sh -c "$(curl -sSfL https://release.solana.com/$version/install)" init $version --data-dir $TARGET_DIR --no-modify-path
 $TARGET_DIR/active_release/bin/solana --version


### PR DESCRIPTION
This PR makes a temporary fix for CI to enable using the `1.17.x` test validator, where the following change has been implemented: https://github.com/solana-labs/solana/pull/33531.

When `1.17` goes live on mainnet-beta, we can revert the changes to the test scripts, such as `scripts/setup-test-validator.sh`.

An issue has been created to remind us of this revert.
