### PR TITLE
refactor(experimental): export option codecs

### DIFF
--- a/packages/options/src/index.ts
+++ b/packages/options/src/index.ts
@@ -1,3 +1,4 @@
 export * from './option';
+export * from './option-codec';
 export * from './unwrap-option';
 export * from './unwrap-option-recursively';


### PR DESCRIPTION
My bad, I forgot to export the option codecs when writing the `options` package. This is needed for client generation.
