### PR TITLE
refactor: fix throw message in stake activation test

### DIFF
--- a/packages/library-legacy/test/connection.test.ts
+++ b/packages/library-legacy/test/connection.test.ts
@@ -5060,7 +5060,7 @@ describe('Connection', function () {
           LARGE_EPOCH,
         ),
       ).to.be.rejectedWith(
-        `failed to get Stake Activation ${newStakeAccount.publicKey.toBase58()}: Invalid param: epoch ${LARGE_EPOCH} has not yet started`,
+        `failed to get Stake Activation ${newStakeAccount.publicKey.toBase58()}: Invalid param: epoch ${LARGE_EPOCH}. Only the current epoch (0) is supported`,
       );
 
       const activationState = await connection.getStakeActivation(


### PR DESCRIPTION
This was broken by the change to a 1.17 validator, which changes this error message
