### PR TITLE
refactor(experimental): add keys to compat

### DIFF
--- a/packages/compat/src/__tests__/address.ts
+++ b/packages/compat/src/__tests__/address.ts
@@ -1,0 +1,10 @@
+import { Keypair } from '@solana/web3.js';
+
+import { fromLegacyPublicKey } from '../address';
+
+describe('address', () => {
+    it('should convert from a Legacy Web3 JS PublicKey to a Base58EncodedAddress', () => {
+        const publicKey = Keypair.generate().publicKey;
+        expect(publicKey.toBase58()).toEqual(fromLegacyPublicKey(publicKey));
+    });
+});

--- a/packages/compat/src/__tests__/keypair.ts
+++ b/packages/compat/src/__tests__/keypair.ts
@@ -1,0 +1,29 @@
+import { Keypair } from '@solana/web3.js';
+
+import { fromLegacyKeypair } from '../keypair';
+
+describe('keypair', () => {
+    const legacyKeypair = Keypair.generate();
+    let keyPair: CryptoKeyPair;
+    describe.each(['public', 'private'])('%s key', type => {
+        beforeEach(async () => {
+            keyPair = await fromLegacyKeypair(legacyKeypair);
+        });
+        it(`has the algorithm "Ed25519"`, () => {
+            expect(keyPair).toHaveProperty([`${type}Key`, 'algorithm', 'name'], 'Ed25519');
+        });
+        it('has the string tag "CryptoKey"', () => {
+            expect(keyPair).toHaveProperty([`${type}Key`, Symbol.toStringTag], 'CryptoKey');
+        });
+        it(`has the type "${type}"`, () => {
+            expect(keyPair).toHaveProperty([`${type}Key`, 'type'], type);
+        });
+    });
+    it.each([true, false])(
+        "sets the private key's `extractable` to `%s` when generating a key pair with the extractability `%s`",
+        async extractable => {
+            expect.assertions(1), (keyPair = await fromLegacyKeypair(legacyKeypair, extractable));
+            expect(keyPair.privateKey).toHaveProperty('extractable', extractable);
+        }
+    );
+});

--- a/packages/compat/src/__typetests__/address.ts
+++ b/packages/compat/src/__typetests__/address.ts
@@ -1,0 +1,24 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { PublicKey } from '@solana/web3.js';
+
+import { fromLegacyPublicKey } from '../address';
+
+{
+    const publicKey = null as unknown as PublicKey;
+    fromLegacyPublicKey(publicKey) satisfies Base58EncodedAddress;
+    const publicKeyBase58 = publicKey.toBase58();
+    fromLegacyPublicKey(publicKey) satisfies Base58EncodedAddress<typeof publicKeyBase58>;
+}
+
+{
+    const publicKey = { toBase58: () => 'test' } as unknown as PublicKey;
+    fromLegacyPublicKey(publicKey) satisfies Base58EncodedAddress;
+    fromLegacyPublicKey(publicKey) satisfies Base58EncodedAddress<'test'>;
+}
+
+{
+    // Randomly generated
+    const publicKey = new PublicKey('B3piXWBQLLRuk56XG5VihxR4oe2PSsDM8nTF6s1DeVF5');
+    fromLegacyPublicKey(publicKey) satisfies Base58EncodedAddress;
+    fromLegacyPublicKey(publicKey) satisfies Base58EncodedAddress<'B3piXWBQLLRuk56XG5VihxR4oe2PSsDM8nTF6s1DeVF5'>;
+}

--- a/packages/compat/src/__typetests__/keypair.ts
+++ b/packages/compat/src/__typetests__/keypair.ts
@@ -1,0 +1,10 @@
+import { Keypair } from '@solana/web3.js';
+
+import { fromLegacyKeypair } from '../keypair';
+
+async () => {
+    {
+        const keypair = null as unknown as Keypair;
+        (await fromLegacyKeypair(keypair)) satisfies CryptoKeyPair;
+    }
+};

--- a/packages/compat/src/address.ts
+++ b/packages/compat/src/address.ts
@@ -1,0 +1,11 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { PublicKey } from '@solana/web3.js';
+
+/**
+ * Convert from a Legacy Web3 JS PublicKey to a base58 encoded address
+ * @param publicKey The PublicKey to convert
+ * @returns         A Base58EncodedAddress
+ */
+export function fromLegacyPublicKey<TAddress extends string>(publicKey: PublicKey): Base58EncodedAddress<TAddress> {
+    return publicKey.toBase58() as Base58EncodedAddress<TAddress>;
+}

--- a/packages/compat/src/keypair.ts
+++ b/packages/compat/src/keypair.ts
@@ -1,0 +1,61 @@
+import { Keypair } from '@solana/web3.js';
+
+function addPkcs8Header(bytes: Uint8Array): Uint8Array {
+    // prettier-ignore
+    return new Uint8Array([
+        /**
+         * PKCS#8 header
+         */
+        0x30, // ASN.1 sequence tag
+        0x2e, // Length of sequence (46 more bytes)
+
+            0x02, // ASN.1 integer tag
+            0x01, // Length of integer
+                0x00, // Version number
+
+            0x30, // ASN.1 sequence tag
+            0x05, // Length of sequence
+                0x06, // ASN.1 object identifier tag
+                0x03, // Length of object identifier
+                    // Edwards curve algorithms identifier https://oid-rep.orange-labs.fr/get/1.3.101.112
+                        0x2b, // iso(1) / identified-organization(3) (The first node is multiplied by the decimal 40 and the result is added to the value of the second node)
+                        0x65, // thawte(101)
+                    // Ed25519 identifier
+                        0x70, // id-Ed25519(112)
+
+        /**
+         * Private key payload
+         */
+        0x04, // ASN.1 octet string tag
+        0x22, // String length (34 more bytes)
+
+            // Private key bytes as octet string
+            0x04, // ASN.1 octet string tag
+            0x20, // String length (32 bytes)
+
+        ...bytes
+    ]);
+}
+
+/**
+ * Convert from a Legacy Web3 JS Keypair to a CryptoKeyPair
+ * @param keypair   The Keypair to convert
+ * @returns         A CryptoKeyPair
+ */
+export async function fromLegacyKeypair(keypair: Keypair, extractable?: boolean): Promise<CryptoKeyPair> {
+    const publicKey: CryptoKey = await crypto.subtle.importKey('raw', keypair.publicKey.toBytes(), 'Ed25519', true, [
+        'verify',
+    ]);
+    const privateKeyBytesPkcs8 = addPkcs8Header(keypair.secretKey.slice(0, 32));
+    const privateKey: CryptoKey = await crypto.subtle.importKey(
+        'pkcs8',
+        privateKeyBytesPkcs8,
+        'Ed25519',
+        extractable ?? false,
+        ['sign']
+    );
+    return {
+        privateKey,
+        publicKey,
+    } as CryptoKeyPair;
+}


### PR DESCRIPTION
This PR adds `PublicKey` and `Keypair` compatibility helpers for the new API.
