### PR TITLE
refactor(experimental): refactor Address codec

### DIFF
--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -65,8 +65,9 @@
         "node": ">=17.4"
     },
     "dependencies": {
-        "@metaplex-foundation/umi-serializers": "^0.8.9",
-        "@solana/assertions": "workspace:*"
+        "@solana/assertions": "workspace:*",
+        "@solana/codecs-core": "workspace:*",
+        "@solana/codecs-strings": "workspace:*"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.2",

--- a/packages/addresses/src/__tests__/address-test.ts
+++ b/packages/addresses/src/__tests__/address-test.ts
@@ -1,71 +1,123 @@
-import { base58 } from '@metaplex-foundation/umi-serializers';
+import { Encoder } from '@solana/codecs-core';
+import { getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
 
-import { assertIsAddress, Base58EncodedAddress, getAddressCodec, getAddressComparator } from '../address';
+import { Base58EncodedAddress, getAddressCodec, getAddressComparator } from '../address';
+
+jest.mock('@solana/codecs-strings', () => ({
+    ...jest.requireActual('@solana/codecs-strings'),
+    getBase58Decoder: jest.fn(),
+    getBase58Encoder: jest.fn(),
+}));
+
+// real implementations
+const originalBase58Module = jest.requireActual('@solana/codecs-strings');
+const originalGetBase58Encoder = originalBase58Module.getBase58Encoder();
+const originalGetBase58Decoder = originalBase58Module.getBase58Decoder();
 
 describe('Base58EncodedAddress', () => {
     describe('assertIsAddress()', () => {
-        it('throws when supplied a non-base58 string', () => {
-            expect(() => {
-                assertIsAddress('not-a-base-58-encoded-string');
-            }).toThrow();
-        });
-        it('throws when the decoded byte array has a length other than 32 bytes', () => {
-            expect(() => {
-                assertIsAddress(
-                    // 31 bytes [128, ..., 128]
-                    '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM'
-                );
-            }).toThrow();
-        });
-        it('does not throw when supplied a base-58 encoded address', () => {
-            expect(() => {
-                assertIsAddress('11111111111111111111111111111111');
-            }).not.toThrow();
-        });
-        it('returns undefined when supplied a base-58 encoded address', () => {
-            expect(assertIsAddress('11111111111111111111111111111111')).toBeUndefined();
-        });
-        [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44].forEach(len => {
-            it(`attempts to decode input strings of exactly ${len} characters`, () => {
-                const decodeMethod = jest.spyOn(base58, 'serialize');
-                try {
-                    assertIsAddress('1'.repeat(len));
-                    // eslint-disable-next-line no-empty
-                } catch {}
-                expect(decodeMethod).toHaveBeenCalled();
+        let assertIsAddress: typeof import('../address').assertIsAddress;
+        // Reload `assertIsAddress` before each test to reset memoised state
+        beforeEach(async () => {
+            await jest.isolateModulesAsync(async () => {
+                const base58ModulePromise =
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    import('../address');
+                assertIsAddress = (await base58ModulePromise).assertIsAddress;
             });
         });
-        it('does not attempt to decode too-short input strings', () => {
-            const decodeMethod = jest.spyOn(base58, 'serialize');
-            try {
-                assertIsAddress(
-                    // 31 bytes [0, ..., 0]
-                    '1111111111111111111111111111111' // 31 characters
-                );
-                // eslint-disable-next-line no-empty
-            } catch {}
-            expect(decodeMethod).not.toHaveBeenCalled();
+
+        describe('using the real base58 implementation', () => {
+            beforeEach(() => {
+                // use real implementation
+                jest.mocked(getBase58Encoder).mockReturnValue(originalGetBase58Encoder);
+            });
+            it('throws when supplied a non-base58 string', () => {
+                expect(() => {
+                    assertIsAddress('not-a-base-58-encoded-string');
+                }).toThrow();
+            });
+            it('throws when the decoded byte array has a length other than 32 bytes', () => {
+                expect(() => {
+                    assertIsAddress(
+                        // 31 bytes [128, ..., 128]
+                        '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM'
+                    );
+                }).toThrow();
+            });
+            it('does not throw when supplied a base-58 encoded address', () => {
+                expect(() => {
+                    assertIsAddress('11111111111111111111111111111111');
+                }).not.toThrow();
+            });
+            it('returns undefined when supplied a base-58 encoded address', () => {
+                expect(assertIsAddress('11111111111111111111111111111111')).toBeUndefined();
+            });
         });
-        it('does not attempt to decode too-long input strings', () => {
-            const decodeMethod = jest.spyOn(base58, 'serialize');
-            try {
-                assertIsAddress(
-                    // 33 bytes [0, 255, ..., 255]
-                    '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG' // 45 characters
-                );
-                // eslint-disable-next-line no-empty
-            } catch {}
-            expect(decodeMethod).not.toHaveBeenCalled();
+        describe('using a mock base58 implementation', () => {
+            const mockEncode = jest.fn();
+            beforeEach(() => {
+                // use mock implementation
+                mockEncode.mockClear();
+                jest.mocked(getBase58Encoder).mockReturnValue({ encode: mockEncode } as unknown as Encoder<string>);
+            });
+
+            [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44].forEach(len => {
+                it(`attempts to encode input strings of exactly ${len} characters`, () => {
+                    try {
+                        assertIsAddress('1'.repeat(len));
+                        // eslint-disable-next-line no-empty
+                    } catch {}
+                    expect(mockEncode).toHaveBeenCalled();
+                });
+            });
+            it('does not attempt to decode too-short input strings', () => {
+                try {
+                    assertIsAddress(
+                        // 31 bytes [0, ..., 0]
+                        '1111111111111111111111111111111' // 31 characters
+                    );
+                    // eslint-disable-next-line no-empty
+                } catch {}
+                expect(mockEncode).not.toHaveBeenCalled();
+            });
+            it('does not attempt to decode too-long input strings', () => {
+                try {
+                    assertIsAddress(
+                        // 33 bytes [0, 255, ..., 255]
+                        '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG' // 45 characters
+                    );
+                    // eslint-disable-next-line no-empty
+                } catch {}
+                expect(mockEncode).not.toHaveBeenCalled();
+            });
+            it('memoises getBase58Encoder when called multiple times', () => {
+                try {
+                    assertIsAddress('1'.repeat(32));
+                    // eslint-disable-next-line no-empty
+                } catch {}
+                try {
+                    assertIsAddress('1'.repeat(32));
+                    // eslint-disable-next-line no-empty
+                } catch {}
+                expect(jest.mocked(getBase58Encoder)).toHaveBeenCalledTimes(1);
+            });
         });
     });
+
     describe('getAddressCodec', () => {
         let address: ReturnType<typeof getAddressCodec>;
         beforeEach(() => {
+            // use real implementations
+            jest.mocked(getBase58Encoder).mockReturnValue(originalGetBase58Encoder);
+            jest.mocked(getBase58Decoder).mockReturnValue(originalGetBase58Decoder);
+
             address = getAddressCodec();
         });
         it('serializes a base58 encoded address into a 32-byte buffer', () => {
             expect(
-                address.serialize(
+                address.encode(
                     '4wBqpZM9xaSheZzJSMawUHDgZ7miWfSsxmfVF5jJpYP' as Base58EncodedAddress<'4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw'>
                 )
             ).toEqual(
@@ -77,7 +129,7 @@ describe('Base58EncodedAddress', () => {
         });
         it('deserializes a byte buffer representing an address into a base58 encoded address', () => {
             expect(
-                address.deserialize(
+                address.decode(
                     new Uint8Array([
                         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
                         27, 28, 29, 30, 31, 32,
@@ -91,9 +143,36 @@ describe('Base58EncodedAddress', () => {
         });
         it('fatals when trying to deserialize a byte buffer shorter than 32-bytes', () => {
             const tooShortBuffer = new Uint8Array(Array(31).fill(0));
-            expect(() => address.deserialize(tooShortBuffer)).toThrow();
+            expect(() => address.decode(tooShortBuffer)).toThrow();
+        });
+        it('memoises getBase58Encoder and getBase58Decoder when called multiple times', async () => {
+            expect.assertions(2);
+
+            // reload the module to reset memoised state
+            let getAddressCodec: typeof import('../address').getAddressCodec;
+            await jest.isolateModulesAsync(async () => {
+                const base58ModulePromise =
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    import('../address');
+                getAddressCodec = (await base58ModulePromise).getAddressCodec;
+            });
+
+            address = getAddressCodec!();
+            address.encode(
+                '4wBqpZM9xaSheZzJSMawUHDgZ7miWfSsxmfVF5jJpYP' as Base58EncodedAddress<'4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw'>
+            );
+
+            address = getAddressCodec!();
+            address.encode(
+                '4wBqpZM9xaSheZzJSMawUHDgZ7miWfSsxmfVF5jJpYP' as Base58EncodedAddress<'4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw'>
+            );
+
+            expect(jest.mocked(getBase58Encoder)).toHaveBeenCalledTimes(1);
+            expect(jest.mocked(getBase58Decoder)).toHaveBeenCalledTimes(1);
         });
     });
+
     describe('getAddressComparator', () => {
         it('sorts base 58 addresses', () => {
             expect(

--- a/packages/addresses/src/address.ts
+++ b/packages/addresses/src/address.ts
@@ -1,8 +1,22 @@
-import { base58, Serializer, string } from '@metaplex-foundation/umi-serializers';
+import { Codec, combineCodec, Decoder, Encoder, mapEncoder } from '@solana/codecs-core';
+import { getBase58Decoder, getBase58Encoder, getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
 
 export type Base58EncodedAddress<TAddress extends string = string> = TAddress & {
     readonly __brand: unique symbol;
 };
+
+let memoisedBase58Encoder: Encoder<string> | undefined;
+let memoisedBase58Decoder: Decoder<string> | undefined;
+
+function getMemoisedBase58Encoder(): Encoder<string> {
+    if (!memoisedBase58Encoder) memoisedBase58Encoder = getBase58Encoder();
+    return memoisedBase58Encoder;
+}
+
+function getMemoisedBase58Decoder(): Decoder<string> {
+    if (!memoisedBase58Decoder) memoisedBase58Decoder = getBase58Decoder();
+    return memoisedBase58Decoder;
+}
 
 export function isAddress(
     putativeBase58EncodedAddress: string
@@ -17,7 +31,8 @@ export function isAddress(
         return false;
     }
     // Slow-path; actually attempt to decode the input string.
-    const bytes = base58.serialize(putativeBase58EncodedAddress);
+    const base58Encoder = getMemoisedBase58Encoder();
+    const bytes = base58Encoder.encode(putativeBase58EncodedAddress);
     const numBytes = bytes.byteLength;
     if (numBytes !== 32) {
         return false;
@@ -39,7 +54,8 @@ export function assertIsAddress(
             throw new Error('Expected input string to decode to a byte array of length 32.');
         }
         // Slow-path; actually attempt to decode the input string.
-        const bytes = base58.serialize(putativeBase58EncodedAddress);
+        const base58Encoder = getMemoisedBase58Encoder();
+        const bytes = base58Encoder.encode(putativeBase58EncodedAddress);
         const numBytes = bytes.byteLength;
         if (numBytes !== 32) {
             throw new Error(`Expected input string to decode to a byte array of length 32. Actual length: ${numBytes}`);
@@ -58,16 +74,27 @@ export function address<TAddress extends string = string>(
     return putativeBase58EncodedAddress as Base58EncodedAddress<TAddress>;
 }
 
-export function getAddressCodec(
-    config?: Readonly<{
-        description: string;
-    }>
-): Serializer<Base58EncodedAddress> {
-    return string({
-        description: config?.description ?? (__DEV__ ? 'A 32-byte account address' : ''),
-        encoding: base58,
+export function getAddressEncoder(config?: Readonly<{ description: string }>): Encoder<Base58EncodedAddress> {
+    return mapEncoder(
+        getStringEncoder({
+            description: config?.description ?? 'Base58EncodedAddress',
+            encoding: getMemoisedBase58Encoder(),
+            size: 32,
+        }),
+        putativeAddress => address(putativeAddress)
+    );
+}
+
+export function getAddressDecoder(config?: Readonly<{ description: string }>): Decoder<Base58EncodedAddress> {
+    return getStringDecoder({
+        description: config?.description ?? 'Base58EncodedAddress',
+        encoding: getMemoisedBase58Decoder(),
         size: 32,
-    }) as unknown as Serializer<Base58EncodedAddress>;
+    }) as Decoder<Base58EncodedAddress>;
+}
+
+export function getAddressCodec(config?: Readonly<{ description: string }>): Codec<Base58EncodedAddress> {
+    return combineCodec(getAddressEncoder(config), getAddressDecoder(config));
 }
 
 export function getAddressComparator(): (x: string, y: string) => number {

--- a/packages/addresses/src/public-key.ts
+++ b/packages/addresses/src/public-key.ts
@@ -1,6 +1,6 @@
 import { assertKeyExporterIsAvailable } from '@solana/assertions';
 
-import { Base58EncodedAddress, getAddressCodec } from './address';
+import { Base58EncodedAddress, getAddressDecoder } from './address';
 
 export async function getAddressFromPublicKey(publicKey: CryptoKey): Promise<Base58EncodedAddress> {
     await assertKeyExporterIsAvailable();
@@ -9,6 +9,6 @@ export async function getAddressFromPublicKey(publicKey: CryptoKey): Promise<Bas
         throw new Error('The `CryptoKey` must be an `Ed25519` public key');
     }
     const publicKeyBytes = await crypto.subtle.exportKey('raw', publicKey);
-    const [base58EncodedAddress] = getAddressCodec().deserialize(new Uint8Array(publicKeyBytes));
+    const [base58EncodedAddress] = getAddressDecoder().decode(new Uint8Array(publicKeyBytes));
     return base58EncodedAddress;
 }

--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -162,7 +162,7 @@ describe('signTransaction', () => {
             }
         });
         (getAddressCodec as jest.Mock).mockReturnValue({
-            serialize: jest.fn().mockReturnValue('fAkEbAsE58AdDrEsS'),
+            encode: jest.fn().mockReturnValue('fAkEbAsE58AdDrEsS'),
         });
         (signBytes as jest.Mock).mockImplementation(async secretKey => {
             switch (secretKey) {

--- a/packages/transactions/src/serializers/address-table-lookup.ts
+++ b/packages/transactions/src/serializers/address-table-lookup.ts
@@ -1,16 +1,28 @@
 import { array, Serializer, shortU16, struct, StructToSerializerTuple, u8 } from '@metaplex-foundation/umi-serializers';
-import { getAddressCodec } from '@solana/addresses';
+import { Base58EncodedAddress, getAddressCodec } from '@solana/addresses';
 
 import { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
 
 type AddressTableLookup = ReturnType<typeof getCompiledAddressTableLookups>[number];
+
+// Temporary, will use getAddressCodec directly when everything else is migrated
+function addressSerializerCompat(compat?: { description: string }): Serializer<Base58EncodedAddress> {
+    const codec = getAddressCodec();
+    return {
+        description: compat?.description ?? codec.description,
+        deserialize: codec.decode,
+        fixedSize: codec.fixedSize,
+        maxSize: codec.maxSize,
+        serialize: codec.encode,
+    };
+}
 
 export function getAddressTableLookupCodec(): Serializer<AddressTableLookup> {
     return struct(
         [
             [
                 'lookupTableAddress',
-                getAddressCodec(
+                addressSerializerCompat(
                     __DEV__
                         ? {
                               description:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   jsdom: ^22
   mock-socket: ^9.3.0
@@ -30,12 +34,15 @@ importers:
 
   packages/addresses:
     dependencies:
-      '@metaplex-foundation/umi-serializers':
-        specifier: ^0.8.9
-        version: 0.8.9
       '@solana/assertions':
         specifier: workspace:*
         version: link:../assertions
+      '@solana/codecs-core':
+        specifier: workspace:*
+        version: link:../codecs-core
+      '@solana/codecs-strings':
+        specifier: workspace:*
+        version: link:../codecs-strings
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
@@ -13110,7 +13117,3 @@ packages:
   /zstd-codec@0.1.4:
     resolution: {integrity: sha512-KYnWoFWgGtWyQEKNnUcb3u8ZtKO8dn5d8u+oGpxPlopqsPyv60U8suDyfk7Z7UtAO6Sk5i1aVcAs9RbaB1n36A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
- Use strings-codecs package
- Memoise created encoder/decoder

This should serve as a pattern for refactoring the other serializers related to transactions 