### PR TITLE
chore: make style:fix also fix package.json

### DIFF
--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/fetch-impl/package.json
+++ b/packages/fetch-impl/package.json
@@ -30,7 +30,7 @@
         "compile:js": "tsup",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -41,7 +41,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "sed -i 's/@solana\\/web3\\.js-experimental/@solana\\/web3\\.js/g' package.json && sed -i 's/@solana\\/web3\\.js/@solana\\/web3\\.js-bak/g' ../library-legacy/package.json && pnpm publish --tag experimental --access public --no-git-checks && git reset --hard",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --globalSetup test-config/test-validator-setup.js --globalTeardown test-config/test-validator-teardown.js --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --globalSetup test-config/test-validator-setup.js --globalTeardown test-config/test-validator-teardown.js --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-transport/package.json
+++ b/packages/rpc-transport/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/text-encoding-impl/package.json
+++ b/packages/text-encoding-impl/package.json
@@ -31,7 +31,7 @@
         "compile:js": "tsup",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:typecheck": "tsc --noEmit",

--- a/packages/ws-impl/package.json
+++ b/packages/ws-impl/package.json
@@ -30,7 +30,7 @@
         "compile:js": "tsup",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/*",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
         "test:lint": "jest -c node_modules/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c node_modules/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",


### PR DESCRIPTION
I keep getting a mismatch between an editor setting and prettier styling for package.json

We run prettier on package.json so our `style:fix` should also fix it

Note that we don't run eslint on package.json and it makes a huge mess of it and complains about ordering of objects, so I've deliberately only added it to the prettier calls 