### PR TITLE
refactor(experimental): refactor Address codec

### DIFF
--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -65,8 +65,9 @@
         "node": ">=17.4"
     },
     "dependencies": {
-        "@metaplex-foundation/umi-serializers": "^0.8.9",
-        "@solana/assertions": "workspace:*"
+        "@solana/assertions": "workspace:*",
+        "@solana/codecs-core": "workspace:*",
+        "@solana/codecs-strings": "workspace:*"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.2",

--- a/packages/addresses/src/public-key.ts
+++ b/packages/addresses/src/public-key.ts
@@ -1,6 +1,6 @@
 import { assertKeyExporterIsAvailable } from '@solana/assertions';
 
-import { Base58EncodedAddress, getAddressCodec } from './address';
+import { Base58EncodedAddress, getAddressDecoder } from './address';
 
 export async function getAddressFromPublicKey(publicKey: CryptoKey): Promise<Base58EncodedAddress> {
     await assertKeyExporterIsAvailable();
@@ -9,6 +9,6 @@ export async function getAddressFromPublicKey(publicKey: CryptoKey): Promise<Bas
         throw new Error('The `CryptoKey` must be an `Ed25519` public key');
     }
     const publicKeyBytes = await crypto.subtle.exportKey('raw', publicKey);
-    const [base58EncodedAddress] = getAddressCodec().deserialize(new Uint8Array(publicKeyBytes));
+    const [base58EncodedAddress] = getAddressDecoder().decode(new Uint8Array(publicKeyBytes));
     return base58EncodedAddress;
 }

--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -162,7 +162,7 @@ describe('signTransaction', () => {
             }
         });
         (getAddressCodec as jest.Mock).mockReturnValue({
-            serialize: jest.fn().mockReturnValue('fAkEbAsE58AdDrEsS'),
+            encode: jest.fn().mockReturnValue('fAkEbAsE58AdDrEsS'),
         });
         (signBytes as jest.Mock).mockImplementation(async secretKey => {
             switch (secretKey) {

--- a/packages/transactions/src/serializers/address-table-lookup.ts
+++ b/packages/transactions/src/serializers/address-table-lookup.ts
@@ -1,16 +1,28 @@
 import { array, Serializer, shortU16, struct, StructToSerializerTuple, u8 } from '@metaplex-foundation/umi-serializers';
-import { getAddressCodec } from '@solana/addresses';
+import { Base58EncodedAddress, getAddressCodec } from '@solana/addresses';
 
 import { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
 
 type AddressTableLookup = ReturnType<typeof getCompiledAddressTableLookups>[number];
+
+// Temporary, will use getAddressCodec directly when everything else is migrated
+function addressSerializerCompat(compat?: { description: string }): Serializer<Base58EncodedAddress> {
+    const codec = getAddressCodec();
+    return {
+        description: compat?.description ?? codec.description,
+        deserialize: codec.decode,
+        fixedSize: codec.fixedSize,
+        maxSize: codec.maxSize,
+        serialize: codec.encode,
+    };
+}
 
 export function getAddressTableLookupCodec(): Serializer<AddressTableLookup> {
     return struct(
         [
             [
                 'lookupTableAddress',
-                getAddressCodec(
+                addressSerializerCompat(
                     __DEV__
                         ? {
                               description:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   jsdom: ^22
   mock-socket: ^9.3.0
@@ -30,12 +34,15 @@ importers:
 
   packages/addresses:
     dependencies:
-      '@metaplex-foundation/umi-serializers':
-        specifier: ^0.8.9
-        version: 0.8.9
       '@solana/assertions':
         specifier: workspace:*
         version: link:../assertions
+      '@solana/codecs-core':
+        specifier: workspace:*
+        version: link:../codecs-core
+      '@solana/codecs-strings':
+        specifier: workspace:*
+        version: link:../codecs-strings
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
@@ -13110,7 +13117,3 @@ packages:
   /zstd-codec@0.1.4:
     resolution: {integrity: sha512-KYnWoFWgGtWyQEKNnUcb3u8ZtKO8dn5d8u+oGpxPlopqsPyv60U8suDyfk7Z7UtAO6Sk5i1aVcAs9RbaB1n36A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
- Use strings-codecs package
- Memoise created encoder/decoder

This should serve as a pattern for refactoring the other serializers related to transactions


