### PR TITLE
refactor(experimental): make rpc-graphql tree-shakable

### DIFF
--- a/packages/rpc-graphql/src/rpc.ts
+++ b/packages/rpc-graphql/src/rpc.ts
@@ -22,14 +22,14 @@ export function createRpcGraphQL(rpc: Rpc<SolanaRpcMethods>): RpcGraphQL {
     const schema = new GraphQLSchema({
         query: new GraphQLObjectType({
             fields: {
-                ...accountQuery,
-                ...blockQuery,
-                ...programAccountsQuery,
-                ...transactionQuery,
+                ...accountQuery(),
+                ...blockQuery(),
+                ...programAccountsQuery(),
+                ...transactionQuery(),
             },
             name: 'RootQuery',
         }),
-        types: [...accountTypes, ...blockTypes, ...transactionTypes],
+        types: [...accountTypes(), ...blockTypes(), ...transactionTypes()],
     });
     return {
         context,

--- a/packages/rpc-graphql/src/schema/account/query.ts
+++ b/packages/rpc-graphql/src/schema/account/query.ts
@@ -18,16 +18,16 @@ export type AccountQueryArgs = {
 /**
  * Account root query for GraphQL
  */
-export const accountQuery = {
+export const accountQuery = () => ({
     account: {
         args: {
             address: nonNull(string()),
-            commitment: type(commitmentInputType),
-            dataSlice: type(dataSliceInputType),
-            encoding: type(accountEncodingInputType),
+            commitment: type(commitmentInputType()),
+            dataSlice: type(dataSliceInputType()),
+            encoding: type(accountEncodingInputType()),
             minContextSlot: bigint(),
         },
         resolve: (_parent: unknown, args: AccountQueryArgs, context: RpcGraphQLContext) => context.resolveAccount(args),
-        type: accountInterface,
+        type: accountInterface(),
     },
-};
+});

--- a/packages/rpc-graphql/src/schema/account/types.ts
+++ b/packages/rpc-graphql/src/schema/account/types.ts
@@ -3,69 +3,71 @@ import { GraphQLInterfaceType, GraphQLObjectType, GraphQLScalarType } from 'grap
 import { accountEncodingInputType, commitmentInputType, dataSliceInputType } from '../inputs';
 import { bigint, boolean, list, number, object, string, type } from '../picks';
 
-export const tokenAmountType = new GraphQLObjectType({
-    fields: {
-        amount: string(),
-        decimals: number(),
-        uiAmount: bigint(),
-        uiAmountString: string(),
-    },
-    name: 'TokenAmount',
-});
+export const tokenAmountType = () =>
+    new GraphQLObjectType({
+        fields: {
+            amount: string(),
+            decimals: number(),
+            uiAmount: bigint(),
+            uiAmountString: string(),
+        },
+        name: 'TokenAmount',
+    });
 
 /**
  * The fields of the account interface
  */
-const accountInterfaceFields = {
+const accountInterfaceFields = () => ({
     encoding: string(),
     executable: boolean(),
     lamports: bigint(),
     rentEpoch: bigint(),
-};
+});
 
 /**
  * An account interface for GraphQL
  */
-export const accountInterface: GraphQLInterfaceType = new GraphQLInterfaceType({
-    description: 'A Solana account',
-    fields: () => ({
-        ...accountInterfaceFields,
-        owner: type(accountInterface),
-    }),
-    name: 'Account',
-    resolveType(account) {
-        if (account.encoding === 'base58') {
-            return 'AccountBase58';
-        }
-        if (account.encoding === 'base64') {
+export const accountInterface = (): GraphQLInterfaceType =>
+    new GraphQLInterfaceType({
+        description: 'A Solana account',
+        fields: () => ({
+            ...accountInterfaceFields(),
+            owner: type(accountInterface()),
+        }),
+        name: 'Account',
+        resolveType(account) {
+            if (account.encoding === 'base58') {
+                return 'AccountBase58';
+            }
+            if (account.encoding === 'base64') {
+                return 'AccountBase64';
+            }
+            if (account.encoding === 'base64+zstd') {
+                return 'AccountBase64Zstd';
+            }
+            if (account.encoding === 'jsonParsed') {
+                if (account.data.parsed.type === 'mint' && account.data.program === 'spl-token') {
+                    return 'MintAccount';
+                }
+                if (account.data.parsed.type === 'account' && account.data.program === 'spl-token') {
+                    return 'TokenAccount';
+                }
+                if (account.data.program === 'nonce') {
+                    return 'NonceAccount';
+                }
+                if (account.data.program === 'stake') {
+                    return 'StakeAccount';
+                }
+                if (account.data.parsed.type === 'vote' && account.data.program === 'vote') {
+                    return 'VoteAccount';
+                }
+                if (account.data.parsed.type === 'lookupTable' && account.data.program === 'address-lookup-table') {
+                    return 'LookupTableAccount';
+                }
+            }
             return 'AccountBase64';
-        }
-        if (account.encoding === 'base64+zstd') {
-            return 'AccountBase64Zstd';
-        }
-        if (account.encoding === 'jsonParsed') {
-            if (account.data.parsed.type === 'mint' && account.data.program === 'spl-token') {
-                return 'MintAccount';
-            }
-            if (account.data.parsed.type === 'account' && account.data.program === 'spl-token') {
-                return 'TokenAccount';
-            }
-            if (account.data.program === 'nonce') {
-                return 'NonceAccount';
-            }
-            if (account.data.program === 'stake') {
-                return 'StakeAccount';
-            }
-            if (account.data.parsed.type === 'vote' && account.data.program === 'vote') {
-                return 'VoteAccount';
-            }
-            if (account.data.parsed.type === 'lookupTable' && account.data.program === 'address-lookup-table') {
-                return 'LookupTableAccount';
-            }
-        }
-        return 'AccountBase64';
-    },
-});
+        },
+    });
 
 /**
  * An account type implementing the account interface with a
@@ -83,20 +85,20 @@ const accountType = (
     new GraphQLObjectType({
         description,
         fields: {
-            ...accountInterfaceFields,
+            ...accountInterfaceFields(),
             data,
             owner: {
                 args: {
-                    commitment: type(commitmentInputType),
-                    dataSlice: type(dataSliceInputType),
-                    encoding: type(accountEncodingInputType),
+                    commitment: type(commitmentInputType()),
+                    dataSlice: type(dataSliceInputType()),
+                    encoding: type(accountEncodingInputType()),
                     minContextSlot: bigint(),
                 },
                 resolve: (parent, args, context) => context.resolveAccount({ ...args, address: parent.owner }),
-                type: accountInterface,
+                type: accountInterface(),
             },
         },
-        interfaces: [accountInterface],
+        interfaces: [accountInterface()],
         name,
     });
 
@@ -119,128 +121,131 @@ const accountDataJsonParsed = (name: string, parsedInfoFields: Parameters<typeof
         space: bigint(),
     });
 
-const accountBase58 = accountType('AccountBase58', 'A Solana account with base58 encoded data', string());
-const accountBase64 = accountType('AccountBase64', 'A Solana account with base64 encoded data', string());
-const accountBase64Zstd = accountType(
-    'AccountBase64Zstd',
-    'A Solana account with base64 encoded data compressed with zstd',
-    string()
-);
-const accountNonceAccount = accountType(
-    'NonceAccount',
-    'A nonce account',
-    accountDataJsonParsed('Nonce', {
-        authority: string(),
-        blockhash: string(),
-        feeCalculator: object('NonceFeeCalculator', {
-            lamportsPerSignature: string(),
-        }),
-    })
-);
-const accountLookupTable = accountType(
-    'LookupTableAccount',
-    'An address lookup table account',
-    accountDataJsonParsed('LookupTable', {
-        addresses: list(string()),
-        authority: string(),
-        deactivationSlot: string(),
-        lastExtendedSlot: string(),
-        lastExtendedSlotStartIndex: number(),
-    })
-);
-const accountMint = accountType(
-    'MintAccount',
-    'An SPL mint',
-    accountDataJsonParsed('Mint', {
-        decimals: number(),
-        freezeAuthority: string(),
-        isInitialized: boolean(),
-        mintAuthority: string(),
-        supply: string(),
-    })
-);
-const accountTokenAccount = accountType(
-    'TokenAccount',
-    'An SPL token account',
-    accountDataJsonParsed('TokenAccount', {
-        isNative: boolean(),
-        mint: string(),
-        owner: string(),
-        state: string(),
-        tokenAmount: type(tokenAmountType),
-    })
-);
-const accountStakeAccount = accountType(
-    'StakeAccount',
-    'A stake account',
-    accountDataJsonParsed('Stake', {
-        meta: object('StakeMeta', {
-            authorized: object('StakeMetaAuthorized', {
-                staker: string(),
-                withdrawer: string(),
+const accountBase58 = () => accountType('AccountBase58', 'A Solana account with base58 encoded data', string());
+const accountBase64 = () => accountType('AccountBase64', 'A Solana account with base64 encoded data', string());
+const accountBase64Zstd = () =>
+    accountType('AccountBase64Zstd', 'A Solana account with base64 encoded data compressed with zstd', string());
+const accountNonceAccount = () =>
+    accountType(
+        'NonceAccount',
+        'A nonce account',
+        accountDataJsonParsed('Nonce', {
+            authority: string(),
+            blockhash: string(),
+            feeCalculator: object('NonceFeeCalculator', {
+                lamportsPerSignature: string(),
             }),
-            lockup: object('StakeMetaLockup', {
-                custodian: string(),
-                epoch: bigint(),
-                unixTimestamp: bigint(),
+        })
+    );
+const accountLookupTable = () =>
+    accountType(
+        'LookupTableAccount',
+        'An address lookup table account',
+        accountDataJsonParsed('LookupTable', {
+            addresses: list(string()),
+            authority: string(),
+            deactivationSlot: string(),
+            lastExtendedSlot: string(),
+            lastExtendedSlotStartIndex: number(),
+        })
+    );
+const accountMint = () =>
+    accountType(
+        'MintAccount',
+        'An SPL mint',
+        accountDataJsonParsed('Mint', {
+            decimals: number(),
+            freezeAuthority: string(),
+            isInitialized: boolean(),
+            mintAuthority: string(),
+            supply: string(),
+        })
+    );
+const accountTokenAccount = () =>
+    accountType(
+        'TokenAccount',
+        'An SPL token account',
+        accountDataJsonParsed('TokenAccount', {
+            isNative: boolean(),
+            mint: string(),
+            owner: string(),
+            state: string(),
+            tokenAmount: type(tokenAmountType()),
+        })
+    );
+const accountStakeAccount = () =>
+    accountType(
+        'StakeAccount',
+        'A stake account',
+        accountDataJsonParsed('Stake', {
+            meta: object('StakeMeta', {
+                authorized: object('StakeMetaAuthorized', {
+                    staker: string(),
+                    withdrawer: string(),
+                }),
+                lockup: object('StakeMetaLockup', {
+                    custodian: string(),
+                    epoch: bigint(),
+                    unixTimestamp: bigint(),
+                }),
+                rentExemptReserve: string(),
             }),
-            rentExemptReserve: string(),
-        }),
-        stake: object('StakeStake', {
-            creditsObserved: bigint(),
-            delegation: object('StakeStakeDelegation', {
-                activationEpoch: bigint(),
-                deactivationEpoch: bigint(),
-                stake: string(),
-                voter: string(),
-                warmupCooldownRate: number(),
+            stake: object('StakeStake', {
+                creditsObserved: bigint(),
+                delegation: object('StakeStakeDelegation', {
+                    activationEpoch: bigint(),
+                    deactivationEpoch: bigint(),
+                    stake: string(),
+                    voter: string(),
+                    warmupCooldownRate: number(),
+                }),
             }),
-        }),
-    })
-);
-const accountVoteAccount = accountType(
-    'VoteAccount',
-    'A vote account',
-    accountDataJsonParsed('Vote', {
-        authorizedVoters: list(
-            object('VoteAuthorizedVoter', {
-                authorizedVoter: string(),
-                epoch: bigint(),
-            })
-        ),
-        authorizedWithdrawer: string(),
-        commission: number(),
-        epochCredits: list(
-            object('VoteEpochCredits', {
-                credits: string(),
-                epoch: bigint(),
-                previousCredits: string(),
-            })
-        ),
-        lastTimestamp: object('VoteLastTimestamp', {
-            slot: bigint(),
-            timestamp: bigint(),
-        }),
-        nodePubkey: string(),
-        priorVoters: list(string()),
-        rootSlot: bigint(),
-        votes: list(
-            object('VoteVote', {
-                confirmationCount: number(),
+        })
+    );
+const accountVoteAccount = () =>
+    accountType(
+        'VoteAccount',
+        'A vote account',
+        accountDataJsonParsed('Vote', {
+            authorizedVoters: list(
+                object('VoteAuthorizedVoter', {
+                    authorizedVoter: string(),
+                    epoch: bigint(),
+                })
+            ),
+            authorizedWithdrawer: string(),
+            commission: number(),
+            epochCredits: list(
+                object('VoteEpochCredits', {
+                    credits: string(),
+                    epoch: bigint(),
+                    previousCredits: string(),
+                })
+            ),
+            lastTimestamp: object('VoteLastTimestamp', {
                 slot: bigint(),
-            })
-        ),
-    })
-);
+                timestamp: bigint(),
+            }),
+            nodePubkey: string(),
+            priorVoters: list(string()),
+            rootSlot: bigint(),
+            votes: list(
+                object('VoteVote', {
+                    confirmationCount: number(),
+                    slot: bigint(),
+                })
+            ),
+        })
+    );
 
-export const accountTypes = [
-    accountBase58,
-    accountBase64,
-    accountBase64Zstd,
-    accountNonceAccount,
-    accountLookupTable,
-    accountMint,
-    accountTokenAccount,
-    accountStakeAccount,
-    accountVoteAccount,
+export const accountTypes = () => [
+    accountBase58(),
+    accountBase64(),
+    accountBase64Zstd(),
+    accountNonceAccount(),
+    accountLookupTable(),
+    accountMint(),
+    accountTokenAccount(),
+    accountStakeAccount(),
+    accountVoteAccount(),
 ];

--- a/packages/rpc-graphql/src/schema/account/types.ts
+++ b/packages/rpc-graphql/src/schema/account/types.ts
@@ -3,71 +3,87 @@ import { GraphQLInterfaceType, GraphQLObjectType, GraphQLScalarType } from 'grap
 import { accountEncodingInputType, commitmentInputType, dataSliceInputType } from '../inputs';
 import { bigint, boolean, list, number, object, string, type } from '../picks';
 
-export const tokenAmountType = () =>
-    new GraphQLObjectType({
-        fields: {
-            amount: string(),
-            decimals: number(),
-            uiAmount: bigint(),
-            uiAmountString: string(),
-        },
-        name: 'TokenAmount',
-    });
+let memoisedTokenAmountType: GraphQLObjectType | undefined;
+export const tokenAmountType = () => {
+    if (!memoisedTokenAmountType) {
+        memoisedTokenAmountType = new GraphQLObjectType({
+            fields: {
+                amount: string(),
+                decimals: number(),
+                uiAmount: bigint(),
+                uiAmountString: string(),
+            },
+            name: 'TokenAmount',
+        });
+    }
+    return memoisedTokenAmountType;
+};
 
 /**
  * The fields of the account interface
  */
-const accountInterfaceFields = () => ({
-    encoding: string(),
-    executable: boolean(),
-    lamports: bigint(),
-    rentEpoch: bigint(),
-});
+let memoisedAccountInterfaceFields: object | undefined;
+const accountInterfaceFields = () => {
+    if (!memoisedAccountInterfaceFields) {
+        memoisedAccountInterfaceFields = {
+            encoding: string(),
+            executable: boolean(),
+            lamports: bigint(),
+            rentEpoch: bigint(),
+        };
+    }
+    return memoisedAccountInterfaceFields;
+};
 
 /**
  * An account interface for GraphQL
  */
-export const accountInterface = (): GraphQLInterfaceType =>
-    new GraphQLInterfaceType({
-        description: 'A Solana account',
-        fields: () => ({
-            ...accountInterfaceFields(),
-            owner: type(accountInterface()),
-        }),
-        name: 'Account',
-        resolveType(account) {
-            if (account.encoding === 'base58') {
-                return 'AccountBase58';
-            }
-            if (account.encoding === 'base64') {
+let memoisedAccountInterface: GraphQLInterfaceType | undefined;
+export const accountInterface = (): GraphQLInterfaceType => {
+    if (!memoisedAccountInterface) {
+        memoisedAccountInterface = new GraphQLInterfaceType({
+            description: 'A Solana account',
+            fields: () => ({
+                ...accountInterfaceFields(),
+                owner: type(accountInterface()),
+            }),
+            name: 'Account',
+            resolveType(account) {
+                if (account.encoding === 'base58') {
+                    return 'AccountBase58';
+                }
+                if (account.encoding === 'base64') {
+                    return 'AccountBase64';
+                }
+                if (account.encoding === 'base64+zstd') {
+                    return 'AccountBase64Zstd';
+                }
+                if (account.encoding === 'jsonParsed') {
+                    if (account.data.parsed.type === 'mint' && account.data.program === 'spl-token') {
+                        return 'MintAccount';
+                    }
+                    if (account.data.parsed.type === 'account' && account.data.program === 'spl-token') {
+                        return 'TokenAccount';
+                    }
+                    if (account.data.program === 'nonce') {
+                        return 'NonceAccount';
+                    }
+                    if (account.data.program === 'stake') {
+                        return 'StakeAccount';
+                    }
+                    if (account.data.parsed.type === 'vote' && account.data.program === 'vote') {
+                        return 'VoteAccount';
+                    }
+                    if (account.data.parsed.type === 'lookupTable' && account.data.program === 'address-lookup-table') {
+                        return 'LookupTableAccount';
+                    }
+                }
                 return 'AccountBase64';
-            }
-            if (account.encoding === 'base64+zstd') {
-                return 'AccountBase64Zstd';
-            }
-            if (account.encoding === 'jsonParsed') {
-                if (account.data.parsed.type === 'mint' && account.data.program === 'spl-token') {
-                    return 'MintAccount';
-                }
-                if (account.data.parsed.type === 'account' && account.data.program === 'spl-token') {
-                    return 'TokenAccount';
-                }
-                if (account.data.program === 'nonce') {
-                    return 'NonceAccount';
-                }
-                if (account.data.program === 'stake') {
-                    return 'StakeAccount';
-                }
-                if (account.data.parsed.type === 'vote' && account.data.program === 'vote') {
-                    return 'VoteAccount';
-                }
-                if (account.data.parsed.type === 'lookupTable' && account.data.program === 'address-lookup-table') {
-                    return 'LookupTableAccount';
-                }
-            }
-            return 'AccountBase64';
-        },
-    });
+            },
+        });
+    }
+    return memoisedAccountInterface;
+};
 
 /**
  * An account type implementing the account interface with a
@@ -121,131 +137,186 @@ const accountDataJsonParsed = (name: string, parsedInfoFields: Parameters<typeof
         space: bigint(),
     });
 
-const accountBase58 = () => accountType('AccountBase58', 'A Solana account with base58 encoded data', string());
-const accountBase64 = () => accountType('AccountBase64', 'A Solana account with base64 encoded data', string());
-const accountBase64Zstd = () =>
-    accountType('AccountBase64Zstd', 'A Solana account with base64 encoded data compressed with zstd', string());
-const accountNonceAccount = () =>
-    accountType(
-        'NonceAccount',
-        'A nonce account',
-        accountDataJsonParsed('Nonce', {
-            authority: string(),
-            blockhash: string(),
-            feeCalculator: object('NonceFeeCalculator', {
-                lamportsPerSignature: string(),
-            }),
-        })
-    );
-const accountLookupTable = () =>
-    accountType(
-        'LookupTableAccount',
-        'An address lookup table account',
-        accountDataJsonParsed('LookupTable', {
-            addresses: list(string()),
-            authority: string(),
-            deactivationSlot: string(),
-            lastExtendedSlot: string(),
-            lastExtendedSlotStartIndex: number(),
-        })
-    );
-const accountMint = () =>
-    accountType(
-        'MintAccount',
-        'An SPL mint',
-        accountDataJsonParsed('Mint', {
-            decimals: number(),
-            freezeAuthority: string(),
-            isInitialized: boolean(),
-            mintAuthority: string(),
-            supply: string(),
-        })
-    );
-const accountTokenAccount = () =>
-    accountType(
-        'TokenAccount',
-        'An SPL token account',
-        accountDataJsonParsed('TokenAccount', {
-            isNative: boolean(),
-            mint: string(),
-            owner: string(),
-            state: string(),
-            tokenAmount: type(tokenAmountType()),
-        })
-    );
-const accountStakeAccount = () =>
-    accountType(
-        'StakeAccount',
-        'A stake account',
-        accountDataJsonParsed('Stake', {
-            meta: object('StakeMeta', {
-                authorized: object('StakeMetaAuthorized', {
-                    staker: string(),
-                    withdrawer: string(),
-                }),
-                lockup: object('StakeMetaLockup', {
-                    custodian: string(),
-                    epoch: bigint(),
-                    unixTimestamp: bigint(),
-                }),
-                rentExemptReserve: string(),
-            }),
-            stake: object('StakeStake', {
-                creditsObserved: bigint(),
-                delegation: object('StakeStakeDelegation', {
-                    activationEpoch: bigint(),
-                    deactivationEpoch: bigint(),
-                    stake: string(),
-                    voter: string(),
-                    warmupCooldownRate: number(),
-                }),
-            }),
-        })
-    );
-const accountVoteAccount = () =>
-    accountType(
-        'VoteAccount',
-        'A vote account',
-        accountDataJsonParsed('Vote', {
-            authorizedVoters: list(
-                object('VoteAuthorizedVoter', {
-                    authorizedVoter: string(),
-                    epoch: bigint(),
-                })
-            ),
-            authorizedWithdrawer: string(),
-            commission: number(),
-            epochCredits: list(
-                object('VoteEpochCredits', {
-                    credits: string(),
-                    epoch: bigint(),
-                    previousCredits: string(),
-                })
-            ),
-            lastTimestamp: object('VoteLastTimestamp', {
-                slot: bigint(),
-                timestamp: bigint(),
-            }),
-            nodePubkey: string(),
-            priorVoters: list(string()),
-            rootSlot: bigint(),
-            votes: list(
-                object('VoteVote', {
-                    confirmationCount: number(),
-                    slot: bigint(),
-                })
-            ),
-        })
-    );
+let memoisedAccountBase58: GraphQLObjectType | undefined;
+const accountBase58 = () => {
+    if (!memoisedAccountBase58)
+        memoisedAccountBase58 = accountType('AccountBase58', 'A Solana account with base58 encoded data', string());
+    return memoisedAccountBase58;
+};
 
-export const accountTypes = () => [
-    accountBase58(),
-    accountBase64(),
-    accountBase64Zstd(),
-    accountNonceAccount(),
-    accountLookupTable(),
-    accountMint(),
-    accountTokenAccount(),
-    accountStakeAccount(),
-    accountVoteAccount(),
-];
+let memoisedAccountBase64: GraphQLObjectType | undefined;
+const accountBase64 = () => {
+    if (!memoisedAccountBase64)
+        memoisedAccountBase64 = accountType('AccountBase64', 'A Solana account with base64 encoded data', string());
+    return memoisedAccountBase64;
+};
+
+let memoisedAccountBase64Zstd: GraphQLObjectType | undefined;
+const accountBase64Zstd = () => {
+    if (!memoisedAccountBase64Zstd)
+        memoisedAccountBase64Zstd = accountType(
+            'AccountBase64Zstd',
+            'A Solana account with base64 encoded data compressed with zstd',
+            string()
+        );
+    return memoisedAccountBase64Zstd;
+};
+
+let memoisedAccountNonceAccount: GraphQLObjectType | undefined;
+const accountNonceAccount = () => {
+    if (!memoisedAccountNonceAccount)
+        memoisedAccountNonceAccount = accountType(
+            'NonceAccount',
+            'A nonce account',
+            accountDataJsonParsed('Nonce', {
+                authority: string(),
+                blockhash: string(),
+                feeCalculator: object('NonceFeeCalculator', {
+                    lamportsPerSignature: string(),
+                }),
+            })
+        );
+    return memoisedAccountNonceAccount;
+};
+
+let memoisedAccountLookupTable: GraphQLObjectType | undefined;
+const accountLookupTable = () => {
+    if (!memoisedAccountLookupTable)
+        memoisedAccountLookupTable = accountType(
+            'LookupTableAccount',
+            'An address lookup table account',
+            accountDataJsonParsed('LookupTable', {
+                addresses: list(string()),
+                authority: string(),
+                deactivationSlot: string(),
+                lastExtendedSlot: string(),
+                lastExtendedSlotStartIndex: number(),
+            })
+        );
+    return memoisedAccountLookupTable;
+};
+
+let memoisedAccountMint: GraphQLObjectType | undefined;
+const accountMint = () => {
+    if (!memoisedAccountMint)
+        memoisedAccountMint = accountType(
+            'MintAccount',
+            'An SPL mint',
+            accountDataJsonParsed('Mint', {
+                decimals: number(),
+                freezeAuthority: string(),
+                isInitialized: boolean(),
+                mintAuthority: string(),
+                supply: string(),
+            })
+        );
+    return memoisedAccountMint;
+};
+
+let memoisedAccountTokenAccount: GraphQLObjectType | undefined;
+const accountTokenAccount = () => {
+    if (!memoisedAccountTokenAccount)
+        memoisedAccountTokenAccount = accountType(
+            'TokenAccount',
+            'An SPL token account',
+            accountDataJsonParsed('TokenAccount', {
+                isNative: boolean(),
+                mint: string(),
+                owner: string(),
+                state: string(),
+                tokenAmount: type(tokenAmountType()),
+            })
+        );
+    return memoisedAccountTokenAccount;
+};
+
+let memoisedAccountStakeAccount: GraphQLObjectType | undefined;
+const accountStakeAccount = () => {
+    if (!memoisedAccountStakeAccount)
+        memoisedAccountStakeAccount = accountType(
+            'StakeAccount',
+            'A stake account',
+            accountDataJsonParsed('Stake', {
+                meta: object('StakeMeta', {
+                    authorized: object('StakeMetaAuthorized', {
+                        staker: string(),
+                        withdrawer: string(),
+                    }),
+                    lockup: object('StakeMetaLockup', {
+                        custodian: string(),
+                        epoch: bigint(),
+                        unixTimestamp: bigint(),
+                    }),
+                    rentExemptReserve: string(),
+                }),
+                stake: object('StakeStake', {
+                    creditsObserved: bigint(),
+                    delegation: object('StakeStakeDelegation', {
+                        activationEpoch: bigint(),
+                        deactivationEpoch: bigint(),
+                        stake: string(),
+                        voter: string(),
+                        warmupCooldownRate: number(),
+                    }),
+                }),
+            })
+        );
+    return memoisedAccountStakeAccount;
+};
+
+let memoisedAccountVoteAccount: GraphQLObjectType | undefined;
+const accountVoteAccount = () => {
+    if (!memoisedAccountVoteAccount)
+        memoisedAccountVoteAccount = accountType(
+            'VoteAccount',
+            'A vote account',
+            accountDataJsonParsed('Vote', {
+                authorizedVoters: list(
+                    object('VoteAuthorizedVoter', {
+                        authorizedVoter: string(),
+                        epoch: bigint(),
+                    })
+                ),
+                authorizedWithdrawer: string(),
+                commission: number(),
+                epochCredits: list(
+                    object('VoteEpochCredits', {
+                        credits: string(),
+                        epoch: bigint(),
+                        previousCredits: string(),
+                    })
+                ),
+                lastTimestamp: object('VoteLastTimestamp', {
+                    slot: bigint(),
+                    timestamp: bigint(),
+                }),
+                nodePubkey: string(),
+                priorVoters: list(string()),
+                rootSlot: bigint(),
+                votes: list(
+                    object('VoteVote', {
+                        confirmationCount: number(),
+                        slot: bigint(),
+                    })
+                ),
+            })
+        );
+    return memoisedAccountVoteAccount;
+};
+
+let memoisedAccountTypes: GraphQLObjectType[] | undefined;
+export const accountTypes = () => {
+    if (!memoisedAccountTypes)
+        memoisedAccountTypes = [
+            accountBase58(),
+            accountBase64(),
+            accountBase64Zstd(),
+            accountNonceAccount(),
+            accountLookupTable(),
+            accountMint(),
+            accountTokenAccount(),
+            accountStakeAccount(),
+            accountVoteAccount(),
+        ];
+    return memoisedAccountTypes;
+};

--- a/packages/rpc-graphql/src/schema/block/query.ts
+++ b/packages/rpc-graphql/src/schema/block/query.ts
@@ -19,17 +19,17 @@ export type BlockQueryArgs = {
 /**
  * Block root query for GraphQL
  */
-export const blockQuery = {
+export const blockQuery = () => ({
     block: {
         args: {
-            commitment: type(commitmentInputType),
-            encoding: type(transactionEncodingInputType),
+            commitment: type(commitmentInputType()),
+            encoding: type(transactionEncodingInputType()),
             maxSupportedTransactionVersion: string(),
             rewards: boolean(),
             slot: nonNull(bigint()),
-            transactionDetails: type(blockTransactionDetailsInputType),
+            transactionDetails: type(blockTransactionDetailsInputType()),
         },
         resolve: (_parent: unknown, args: BlockQueryArgs, context: RpcGraphQLContext) => context.resolveBlock(args),
-        type: blockInterface,
+        type: blockInterface(),
     },
-};
+});

--- a/packages/rpc-graphql/src/schema/block/types.ts
+++ b/packages/rpc-graphql/src/schema/block/types.ts
@@ -10,107 +10,141 @@ import {
     transactionStatus,
 } from '../transaction';
 
-const transactionForAccounts = () =>
-    new GraphQLObjectType({
-        fields: {
-            meta: object('TransactionMetaForAccounts', {
-                computeUnitsUsed: bigint(),
-                err: string(),
-                fee: bigint(),
-                format: string(),
-                loadedAddresses: type(transactionMetaLoadedAddresses()),
-                logMessages: list(string()),
-                postBalances: list(bigint()),
-                postTokenBalances: list(type(tokenBalance())),
-                preBalances: list(bigint()),
-                preTokenBalances: list(type(tokenBalance())),
-                returnData: type(returnData()),
-                rewards: list(type(reward())),
-                status: type(transactionStatus()),
-            }),
-            transaction: type(transactionInterface()), // TODO
-            version: string(),
-        },
-        name: 'TransactionForAccounts',
-    });
+let memoisedTransactionForAccounts: GraphQLObjectType | undefined;
+const transactionForAccounts = () => {
+    if (!memoisedTransactionForAccounts)
+        memoisedTransactionForAccounts = new GraphQLObjectType({
+            fields: {
+                meta: object('TransactionMetaForAccounts', {
+                    computeUnitsUsed: bigint(),
+                    err: string(),
+                    fee: bigint(),
+                    format: string(),
+                    loadedAddresses: type(transactionMetaLoadedAddresses()),
+                    logMessages: list(string()),
+                    postBalances: list(bigint()),
+                    postTokenBalances: list(type(tokenBalance())),
+                    preBalances: list(bigint()),
+                    preTokenBalances: list(type(tokenBalance())),
+                    returnData: type(returnData()),
+                    rewards: list(type(reward())),
+                    status: type(transactionStatus()),
+                }),
+                transaction: type(transactionInterface()), // TODO
+                version: string(),
+            },
+            name: 'TransactionForAccounts',
+        });
+    return memoisedTransactionForAccounts;
+};
 
+let memoisedBlockInterfaceFields: object | undefined;
 /**
  * The fields for the block interface
  */
-const blockInterfaceFields = () => ({
-    blockHeight: bigint(),
-    blockTime: bigint(),
-    blockhash: string(),
-    parentSlot: bigint(),
-    previousBlockhash: string(),
-    rewards: list(type(reward())),
-});
+const blockInterfaceFields = () => {
+    if (!memoisedBlockInterfaceFields)
+        memoisedBlockInterfaceFields = {
+            blockHeight: bigint(),
+            blockTime: bigint(),
+            blockhash: string(),
+            parentSlot: bigint(),
+            previousBlockhash: string(),
+            rewards: list(type(reward())),
+        };
+    return memoisedBlockInterfaceFields;
+};
 
+let memoisedBlockInterface: GraphQLInterfaceType | undefined;
 /**
  * Interface for a block
  */
-export const blockInterface = () =>
-    new GraphQLInterfaceType({
-        fields: {
-            ...blockInterfaceFields(),
-        },
-        name: 'Block',
-        resolveType(block) {
-            if (block.transactionDetails === 'signatures') {
-                return 'BlockWithSignatures';
-            }
-            if (block.transactionDetails === 'accounts') {
-                return 'BlockWithAccounts';
-            }
-            if (block.transactionDetails === 'none') {
-                return 'BlockWithNoTransactions';
-            }
-            return 'BlockWithTransactions';
-        },
-    });
+export const blockInterface = () => {
+    if (!memoisedBlockInterface)
+        memoisedBlockInterface = new GraphQLInterfaceType({
+            fields: {
+                ...blockInterfaceFields(),
+            },
+            name: 'Block',
+            resolveType(block) {
+                if (block.transactionDetails === 'signatures') {
+                    return 'BlockWithSignatures';
+                }
+                if (block.transactionDetails === 'accounts') {
+                    return 'BlockWithAccounts';
+                }
+                if (block.transactionDetails === 'none') {
+                    return 'BlockWithNoTransactions';
+                }
+                return 'BlockWithTransactions';
+            },
+        });
+    return memoisedBlockInterface;
+};
 
-const BlockWithNoTransactions = () =>
-    new GraphQLObjectType({
-        fields: {
-            ...blockInterfaceFields(),
-        },
-        interfaces: [blockInterface()],
-        name: 'BlockWithNoTransactions',
-    });
+let memoisedBlockWithNoTransactions: GraphQLObjectType | undefined;
+const blockWithNoTransactions = () => {
+    if (!memoisedBlockWithNoTransactions)
+        memoisedBlockWithNoTransactions = new GraphQLObjectType({
+            fields: {
+                ...blockInterfaceFields(),
+            },
+            interfaces: [blockInterface()],
+            name: 'BlockWithNoTransactions',
+        });
+    return memoisedBlockWithNoTransactions;
+};
 
-const blockWithSignatures = () =>
-    new GraphQLObjectType({
-        fields: {
-            ...blockInterfaceFields(),
-            signatures: list(string()),
-        },
-        interfaces: [blockInterface()],
-        name: 'BlockWithSignatures',
-    });
+let memoisedBlockWithSignatures: GraphQLObjectType | undefined;
+const blockWithSignatures = () => {
+    if (!memoisedBlockWithSignatures)
+        memoisedBlockWithSignatures = new GraphQLObjectType({
+            fields: {
+                ...blockInterfaceFields(),
+                signatures: list(string()),
+            },
+            interfaces: [blockInterface()],
+            name: 'BlockWithSignatures',
+        });
+    return memoisedBlockWithSignatures;
+};
 
-const blockWithAccounts = () =>
-    new GraphQLObjectType({
-        fields: {
-            ...blockInterfaceFields(),
-            transactions: list(type(transactionForAccounts())),
-        },
-        interfaces: [blockInterface()],
-        name: 'BlockWithAccounts',
-    });
+let memoisedBlockWithAccounts: GraphQLObjectType | undefined;
+const blockWithAccounts = () => {
+    if (!memoisedBlockWithAccounts)
+        memoisedBlockWithAccounts = new GraphQLObjectType({
+            fields: {
+                ...blockInterfaceFields(),
+                transactions: list(type(transactionForAccounts())),
+            },
+            interfaces: [blockInterface()],
+            name: 'BlockWithAccounts',
+        });
+    return memoisedBlockWithAccounts;
+};
 
-const blockWithTransactions = () =>
-    new GraphQLObjectType({
-        fields: {
-            ...blockInterfaceFields(),
-            transactions: list(type(transactionInterface())),
-        },
-        interfaces: [blockInterface()],
-        name: 'BlockWithTransactions',
-    });
+let memoisedBlockWithTransactions: GraphQLObjectType | undefined;
+const blockWithTransactions = () => {
+    if (!memoisedBlockWithTransactions)
+        memoisedBlockWithTransactions = new GraphQLObjectType({
+            fields: {
+                ...blockInterfaceFields(),
+                transactions: list(type(transactionInterface())),
+            },
+            interfaces: [blockInterface()],
+            name: 'BlockWithTransactions',
+        });
+    return memoisedBlockWithTransactions;
+};
 
-export const blockTypes = () => [
-    BlockWithNoTransactions(),
-    blockWithSignatures(),
-    blockWithAccounts(),
-    blockWithTransactions(),
-];
+let memoisedBlockTypes: GraphQLObjectType[] | undefined;
+export const blockTypes = () => {
+    if (!memoisedBlockTypes)
+        memoisedBlockTypes = [
+            blockWithNoTransactions(),
+            blockWithSignatures(),
+            blockWithAccounts(),
+            blockWithTransactions(),
+        ];
+    return memoisedBlockTypes;
+};

--- a/packages/rpc-graphql/src/schema/block/types.ts
+++ b/packages/rpc-graphql/src/schema/block/types.ts
@@ -10,96 +10,107 @@ import {
     transactionStatus,
 } from '../transaction';
 
-const transactionForAccounts = new GraphQLObjectType({
-    fields: {
-        meta: object('TransactionMetaForAccounts', {
-            computeUnitsUsed: bigint(),
-            err: string(),
-            fee: bigint(),
-            format: string(),
-            loadedAddresses: type(transactionMetaLoadedAddresses),
-            logMessages: list(string()),
-            postBalances: list(bigint()),
-            postTokenBalances: list(type(tokenBalance)),
-            preBalances: list(bigint()),
-            preTokenBalances: list(type(tokenBalance)),
-            returnData: type(returnData),
-            rewards: list(type(reward)),
-            status: type(transactionStatus),
-        }),
-        transaction: type(transactionInterface), // TODO
-        version: string(),
-    },
-    name: 'TransactionForAccounts',
-});
+const transactionForAccounts = () =>
+    new GraphQLObjectType({
+        fields: {
+            meta: object('TransactionMetaForAccounts', {
+                computeUnitsUsed: bigint(),
+                err: string(),
+                fee: bigint(),
+                format: string(),
+                loadedAddresses: type(transactionMetaLoadedAddresses()),
+                logMessages: list(string()),
+                postBalances: list(bigint()),
+                postTokenBalances: list(type(tokenBalance())),
+                preBalances: list(bigint()),
+                preTokenBalances: list(type(tokenBalance())),
+                returnData: type(returnData()),
+                rewards: list(type(reward())),
+                status: type(transactionStatus()),
+            }),
+            transaction: type(transactionInterface()), // TODO
+            version: string(),
+        },
+        name: 'TransactionForAccounts',
+    });
 
 /**
  * The fields for the block interface
  */
-const blockInterfaceFields = {
+const blockInterfaceFields = () => ({
     blockHeight: bigint(),
     blockTime: bigint(),
     blockhash: string(),
     parentSlot: bigint(),
     previousBlockhash: string(),
-    rewards: list(type(reward)),
-};
+    rewards: list(type(reward())),
+});
 
 /**
  * Interface for a block
  */
-export const blockInterface = new GraphQLInterfaceType({
-    fields: {
-        ...blockInterfaceFields,
-    },
-    name: 'Block',
-    resolveType(block) {
-        if (block.transactionDetails === 'signatures') {
-            return 'BlockWithSignatures';
-        }
-        if (block.transactionDetails === 'accounts') {
-            return 'BlockWithAccounts';
-        }
-        if (block.transactionDetails === 'none') {
-            return 'BlockWithNoTransactions';
-        }
-        return 'BlockWithTransactions';
-    },
-});
+export const blockInterface = () =>
+    new GraphQLInterfaceType({
+        fields: {
+            ...blockInterfaceFields(),
+        },
+        name: 'Block',
+        resolveType(block) {
+            if (block.transactionDetails === 'signatures') {
+                return 'BlockWithSignatures';
+            }
+            if (block.transactionDetails === 'accounts') {
+                return 'BlockWithAccounts';
+            }
+            if (block.transactionDetails === 'none') {
+                return 'BlockWithNoTransactions';
+            }
+            return 'BlockWithTransactions';
+        },
+    });
 
-const BlockWithNoTransactions = new GraphQLObjectType({
-    fields: {
-        ...blockInterfaceFields,
-    },
-    interfaces: [blockInterface],
-    name: 'BlockWithNoTransactions',
-});
+const BlockWithNoTransactions = () =>
+    new GraphQLObjectType({
+        fields: {
+            ...blockInterfaceFields(),
+        },
+        interfaces: [blockInterface()],
+        name: 'BlockWithNoTransactions',
+    });
 
-const blockWithSignatures = new GraphQLObjectType({
-    fields: {
-        ...blockInterfaceFields,
-        signatures: list(string()),
-    },
-    interfaces: [blockInterface],
-    name: 'BlockWithSignatures',
-});
+const blockWithSignatures = () =>
+    new GraphQLObjectType({
+        fields: {
+            ...blockInterfaceFields(),
+            signatures: list(string()),
+        },
+        interfaces: [blockInterface()],
+        name: 'BlockWithSignatures',
+    });
 
-const blockWithAccounts = new GraphQLObjectType({
-    fields: {
-        ...blockInterfaceFields,
-        transactions: list(type(transactionForAccounts)),
-    },
-    interfaces: [blockInterface],
-    name: 'BlockWithAccounts',
-});
+const blockWithAccounts = () =>
+    new GraphQLObjectType({
+        fields: {
+            ...blockInterfaceFields(),
+            transactions: list(type(transactionForAccounts())),
+        },
+        interfaces: [blockInterface()],
+        name: 'BlockWithAccounts',
+    });
 
-const blockWithTransactions = new GraphQLObjectType({
-    fields: {
-        ...blockInterfaceFields,
-        transactions: list(type(transactionInterface)),
-    },
-    interfaces: [blockInterface],
-    name: 'BlockWithTransactions',
-});
+const blockWithTransactions = () =>
+    new GraphQLObjectType({
+        fields: {
+            ...blockInterfaceFields(),
+            transactions: list(type(transactionInterface())),
+        },
+        interfaces: [blockInterface()],
+        name: 'BlockWithTransactions',
+    });
 
-export const blockTypes = [BlockWithNoTransactions, blockWithSignatures, blockWithAccounts, blockWithTransactions];
+export const blockTypes = () => [
+    BlockWithNoTransactions(),
+    blockWithSignatures(),
+    blockWithAccounts(),
+    blockWithTransactions(),
+];

--- a/packages/rpc-graphql/src/schema/inputs.ts
+++ b/packages/rpc-graphql/src/schema/inputs.ts
@@ -2,101 +2,108 @@ import { GraphQLEnumType, GraphQLInputObjectType } from 'graphql';
 
 import { bigint, number, string } from './picks';
 
-export const accountEncodingInputType = new GraphQLEnumType({
-    name: 'AccountEncoding',
-    values: {
-        base58: {
-            value: 'base58',
+export const accountEncodingInputType = () =>
+    new GraphQLEnumType({
+        name: 'AccountEncoding',
+        values: {
+            base58: {
+                value: 'base58',
+            },
+            base64: {
+                value: 'base64',
+            },
+            base64Zstd: {
+                value: 'base64+zstd',
+            },
+            jsonParsed: {
+                value: 'jsonParsed',
+            },
         },
-        base64: {
-            value: 'base64',
-        },
-        base64Zstd: {
-            value: 'base64+zstd',
-        },
-        jsonParsed: {
-            value: 'jsonParsed',
-        },
-    },
-});
+    });
 
-export const blockTransactionDetailsInputType = new GraphQLEnumType({
-    name: 'BlockTransactionDetails',
-    values: {
-        accounts: {
-            value: 'accounts',
+export const blockTransactionDetailsInputType = () =>
+    new GraphQLEnumType({
+        name: 'BlockTransactionDetails',
+        values: {
+            accounts: {
+                value: 'accounts',
+            },
+            full: {
+                value: 'full',
+            },
+            none: {
+                value: 'none',
+            },
+            signatures: {
+                value: 'signatures',
+            },
         },
-        full: {
-            value: 'full',
-        },
-        none: {
-            value: 'none',
-        },
-        signatures: {
-            value: 'signatures',
-        },
-    },
-});
+    });
 
-export const commitmentInputType = new GraphQLEnumType({
-    name: 'Commitment',
-    values: {
-        confirmed: {
-            value: 'confirmed',
+export const commitmentInputType = () =>
+    new GraphQLEnumType({
+        name: 'Commitment',
+        values: {
+            confirmed: {
+                value: 'confirmed',
+            },
+            finalized: {
+                value: 'finalized',
+            },
+            processed: {
+                value: 'processed',
+            },
         },
-        finalized: {
-            value: 'finalized',
-        },
-        processed: {
-            value: 'processed',
-        },
-    },
-});
+    });
 
-export const dataSliceInputType = new GraphQLInputObjectType({
-    fields: {
-        length: number(),
-        offset: number(),
-    },
-    name: 'DataSliceConfig',
-});
+export const dataSliceInputType = () =>
+    new GraphQLInputObjectType({
+        fields: {
+            length: number(),
+            offset: number(),
+        },
+        name: 'DataSliceConfig',
+    });
 
-export const maxSupportedTransactionVersionInputType = new GraphQLEnumType({
-    name: 'MaxSupportedTransactionVersion',
-    values: {
-        legacy: {
-            value: 'legacy',
+export const maxSupportedTransactionVersionInputType = () =>
+    new GraphQLEnumType({
+        name: 'MaxSupportedTransactionVersion',
+        values: {
+            legacy: {
+                value: 'legacy',
+            },
+            zero: {
+                value: '0',
+            },
         },
-        zero: {
-            value: '0',
-        },
-    },
-});
+    });
 
-export const programAccountFilterInputType = new GraphQLInputObjectType({
-    fields: {
-        bytes: bigint(),
-        dataSize: bigint(),
-        encoding: string(),
-        offset: bigint(),
-    },
-    name: 'ProgramAccountFilter',
-});
+export const programAccountFilterInputType = () =>
+    new GraphQLInputObjectType({
+        fields: {
+            bytes: bigint(),
+            dataSize: bigint(),
+            encoding: string(),
+            offset: bigint(),
+        },
+        name: 'ProgramAccountFilter',
+    });
 
-export const transactionEncodingInputType = new GraphQLEnumType({
-    name: 'TransactionEncoding',
-    values: {
-        base58: {
-            value: 'base58',
+export const transactionEncodingInputType = () =>
+    new GraphQLEnumType({
+        name: 'TransactionEncoding',
+        values: {
+            base58: {
+                value: 'base58',
+            },
+            base64: {
+                value: 'base64',
+            },
+            json: {
+                value: 'json',
+            },
+            jsonParsed: {
+                value: 'jsonParsed',
+            },
         },
-        base64: {
-            value: 'base64',
-        },
-        json: {
-            value: 'json',
-        },
-        jsonParsed: {
-            value: 'jsonParsed',
-        },
-    },
-});
+    });

--- a/packages/rpc-graphql/src/schema/inputs.ts
+++ b/packages/rpc-graphql/src/schema/inputs.ts
@@ -2,108 +2,136 @@ import { GraphQLEnumType, GraphQLInputObjectType } from 'graphql';
 
 import { bigint, number, string } from './picks';
 
-export const accountEncodingInputType = () =>
-    new GraphQLEnumType({
-        name: 'AccountEncoding',
-        values: {
-            base58: {
-                value: 'base58',
+let memoisedAccountEncodingInputType: GraphQLEnumType | undefined;
+export const accountEncodingInputType = () => {
+    if (!memoisedAccountEncodingInputType)
+        memoisedAccountEncodingInputType = new GraphQLEnumType({
+            name: 'AccountEncoding',
+            values: {
+                base58: {
+                    value: 'base58',
+                },
+                base64: {
+                    value: 'base64',
+                },
+                base64Zstd: {
+                    value: 'base64+zstd',
+                },
+                jsonParsed: {
+                    value: 'jsonParsed',
+                },
             },
-            base64: {
-                value: 'base64',
-            },
-            base64Zstd: {
-                value: 'base64+zstd',
-            },
-            jsonParsed: {
-                value: 'jsonParsed',
-            },
-        },
-    });
+        });
+    return memoisedAccountEncodingInputType;
+};
 
-export const blockTransactionDetailsInputType = () =>
-    new GraphQLEnumType({
-        name: 'BlockTransactionDetails',
-        values: {
-            accounts: {
-                value: 'accounts',
+let memoisedBlockTransactionDetailsInputType: GraphQLEnumType | undefined;
+export const blockTransactionDetailsInputType = () => {
+    if (!memoisedBlockTransactionDetailsInputType)
+        memoisedBlockTransactionDetailsInputType = new GraphQLEnumType({
+            name: 'BlockTransactionDetails',
+            values: {
+                accounts: {
+                    value: 'accounts',
+                },
+                full: {
+                    value: 'full',
+                },
+                none: {
+                    value: 'none',
+                },
+                signatures: {
+                    value: 'signatures',
+                },
             },
-            full: {
-                value: 'full',
-            },
-            none: {
-                value: 'none',
-            },
-            signatures: {
-                value: 'signatures',
-            },
-        },
-    });
+        });
+    return memoisedBlockTransactionDetailsInputType;
+};
 
-export const commitmentInputType = () =>
-    new GraphQLEnumType({
-        name: 'Commitment',
-        values: {
-            confirmed: {
-                value: 'confirmed',
+let memoisedCommitmentInputType: GraphQLEnumType | undefined;
+export const commitmentInputType = () => {
+    if (!memoisedCommitmentInputType)
+        memoisedCommitmentInputType = new GraphQLEnumType({
+            name: 'Commitment',
+            values: {
+                confirmed: {
+                    value: 'confirmed',
+                },
+                finalized: {
+                    value: 'finalized',
+                },
+                processed: {
+                    value: 'processed',
+                },
             },
-            finalized: {
-                value: 'finalized',
-            },
-            processed: {
-                value: 'processed',
-            },
-        },
-    });
+        });
+    return memoisedCommitmentInputType;
+};
 
-export const dataSliceInputType = () =>
-    new GraphQLInputObjectType({
-        fields: {
-            length: number(),
-            offset: number(),
-        },
-        name: 'DataSliceConfig',
-    });
+let memoisedDataSliceInputType: GraphQLInputObjectType | undefined;
+export const dataSliceInputType = () => {
+    if (!memoisedDataSliceInputType)
+        memoisedDataSliceInputType = new GraphQLInputObjectType({
+            fields: {
+                length: number(),
+                offset: number(),
+            },
+            name: 'DataSliceConfig',
+        });
+    return memoisedDataSliceInputType;
+};
 
-export const maxSupportedTransactionVersionInputType = () =>
-    new GraphQLEnumType({
-        name: 'MaxSupportedTransactionVersion',
-        values: {
-            legacy: {
-                value: 'legacy',
+let memoisedMaxSupportedTransactionVersionInputType: GraphQLEnumType | undefined;
+export const maxSupportedTransactionVersionInputType = () => {
+    if (!memoisedMaxSupportedTransactionVersionInputType)
+        memoisedMaxSupportedTransactionVersionInputType = new GraphQLEnumType({
+            name: 'MaxSupportedTransactionVersion',
+            values: {
+                legacy: {
+                    value: 'legacy',
+                },
+                zero: {
+                    value: '0',
+                },
             },
-            zero: {
-                value: '0',
-            },
-        },
-    });
+        });
+    return memoisedMaxSupportedTransactionVersionInputType;
+};
 
-export const programAccountFilterInputType = () =>
-    new GraphQLInputObjectType({
-        fields: {
-            bytes: bigint(),
-            dataSize: bigint(),
-            encoding: string(),
-            offset: bigint(),
-        },
-        name: 'ProgramAccountFilter',
-    });
+let memoisedProgramAccountFilterInputType: GraphQLInputObjectType | undefined;
+export const programAccountFilterInputType = () => {
+    if (!memoisedProgramAccountFilterInputType)
+        memoisedProgramAccountFilterInputType = new GraphQLInputObjectType({
+            fields: {
+                bytes: bigint(),
+                dataSize: bigint(),
+                encoding: string(),
+                offset: bigint(),
+            },
+            name: 'ProgramAccountFilter',
+        });
+    return memoisedProgramAccountFilterInputType;
+};
 
-export const transactionEncodingInputType = () =>
-    new GraphQLEnumType({
-        name: 'TransactionEncoding',
-        values: {
-            base58: {
-                value: 'base58',
+let memoisedTransactionEncodingInputType: GraphQLEnumType | undefined;
+export const transactionEncodingInputType = () => {
+    if (!memoisedTransactionEncodingInputType)
+        memoisedTransactionEncodingInputType = new GraphQLEnumType({
+            name: 'TransactionEncoding',
+            values: {
+                base58: {
+                    value: 'base58',
+                },
+                base64: {
+                    value: 'base64',
+                },
+                json: {
+                    value: 'json',
+                },
+                jsonParsed: {
+                    value: 'jsonParsed',
+                },
             },
-            base64: {
-                value: 'base64',
-            },
-            json: {
-                value: 'json',
-            },
-            jsonParsed: {
-                value: 'jsonParsed',
-            },
-        },
-    });
+        });
+    return memoisedTransactionEncodingInputType;
+};

--- a/packages/rpc-graphql/src/schema/picks.ts
+++ b/packages/rpc-graphql/src/schema/picks.ts
@@ -23,11 +23,21 @@ type GraphQLType =
     | GraphQLScalarType
     | GraphQLUnionType;
 
-export const boolean = () => ({ type: GraphQLBoolean });
-export const bigint = () => ({ type: BigIntScalar });
-export const float = () => ({ type: GraphQLFloat });
-export const number = () => ({ type: GraphQLInt });
-export const string = () => ({ type: GraphQLString });
+export function boolean() {
+    return { type: GraphQLBoolean };
+}
+export function bigint() {
+    return { type: BigIntScalar() };
+}
+export function float() {
+    return { type: GraphQLFloat };
+}
+export function number() {
+    return { type: GraphQLInt };
+}
+export function string() {
+    return { type: GraphQLString };
+}
 
 export function type<TFieldType extends GraphQLType>(
     fieldType: TFieldType

--- a/packages/rpc-graphql/src/schema/picks.ts
+++ b/packages/rpc-graphql/src/schema/picks.ts
@@ -26,15 +26,20 @@ type GraphQLType =
 export function boolean() {
     return { type: GraphQLBoolean };
 }
+
+let memoisedBigint: { type: GraphQLScalarType } | undefined;
 export function bigint() {
-    return { type: BigIntScalar() };
+    if (!memoisedBigint) memoisedBigint = { type: BigIntScalar() };
+    return memoisedBigint;
 }
+
 export function float() {
     return { type: GraphQLFloat };
 }
 export function number() {
     return { type: GraphQLInt };
 }
+
 export function string() {
     return { type: GraphQLString };
 }

--- a/packages/rpc-graphql/src/schema/program-accounts/query.ts
+++ b/packages/rpc-graphql/src/schema/program-accounts/query.ts
@@ -31,19 +31,19 @@ export type ProgramAccountsQueryArgs = {
 /**
  * Program accounts root query for GraphQL
  */
-export const programAccountsQuery = {
+export const programAccountsQuery = () => ({
     programAccounts: {
         args: {
-            commitment: type(commitmentInputType),
-            dataSlice: type(dataSliceInputType),
-            encoding: type(accountEncodingInputType),
-            filters: list(type(programAccountFilterInputType)),
+            commitment: type(commitmentInputType()),
+            dataSlice: type(dataSliceInputType()),
+            encoding: type(accountEncodingInputType()),
+            filters: list(type(programAccountFilterInputType())),
             minContextSlot: bigint(),
             programAddress: nonNull(string()),
             withContext: string(),
         },
         resolve: (_parent: unknown, args: ProgramAccountsQueryArgs, context: RpcGraphQLContext) =>
             context.resolveProgramAccounts(args),
-        type: new GraphQLList(programAccount),
+        type: new GraphQLList(programAccount()),
     },
-};
+});

--- a/packages/rpc-graphql/src/schema/program-accounts/types.ts
+++ b/packages/rpc-graphql/src/schema/program-accounts/types.ts
@@ -3,10 +3,11 @@ import { GraphQLObjectType } from 'graphql';
 import { accountInterface } from '../account';
 import { string, type } from '../picks';
 
-export const programAccount = new GraphQLObjectType({
-    fields: {
-        account: type(accountInterface),
-        pubkey: string(),
-    },
-    name: 'ProgramAccount',
-});
+export const programAccount = () =>
+    new GraphQLObjectType({
+        fields: {
+            account: type(accountInterface()),
+            pubkey: string(),
+        },
+        name: 'ProgramAccount',
+    });

--- a/packages/rpc-graphql/src/schema/scalars.ts
+++ b/packages/rpc-graphql/src/schema/scalars.ts
@@ -1,20 +1,21 @@
 import { GraphQLScalarType, Kind } from 'graphql';
 
-export const BigIntScalar = new GraphQLScalarType({
-    name: 'BigInt',
+export const BigIntScalar = () =>
+    new GraphQLScalarType({
+        name: 'BigInt',
 
-    parseLiteral(ast): bigint | null {
-        if (ast.kind === Kind.STRING) {
-            return BigInt(ast.value);
-        }
-        return null;
-    },
+        parseLiteral(ast): bigint | null {
+            if (ast.kind === Kind.STRING) {
+                return BigInt(ast.value);
+            }
+            return null;
+        },
 
-    parseValue(value): bigint {
-        return BigInt(value as string);
-    },
+        parseValue(value): bigint {
+            return BigInt(value as string);
+        },
 
-    serialize(value): bigint {
-        return BigInt(value as string);
-    },
-});
+        serialize(value): bigint {
+            return BigInt(value as string);
+        },
+    });

--- a/packages/rpc-graphql/src/schema/transaction/query.ts
+++ b/packages/rpc-graphql/src/schema/transaction/query.ts
@@ -16,16 +16,16 @@ export type TransactionQueryArgs = {
 /**
  * Transaction root query for GraphQL
  */
-export const transactionQuery = {
+export const transactionQuery = () => ({
     transaction: {
         args: {
-            commitment: type(commitmentInputType),
-            encoding: type(transactionEncodingInputType),
-            maxSupportedTransactionVersion: type(maxSupportedTransactionVersionInputType),
+            commitment: type(commitmentInputType()),
+            encoding: type(transactionEncodingInputType()),
+            maxSupportedTransactionVersion: type(maxSupportedTransactionVersionInputType()),
             signature: nonNull(string()),
         },
         resolve: (_parent: unknown, args: TransactionQueryArgs, context: RpcGraphQLContext) =>
             context.resolveTransaction(args),
-        type: transactionInterface,
+        type: transactionInterface(),
     },
-};
+});

--- a/packages/rpc-graphql/src/schema/transaction/types.ts
+++ b/packages/rpc-graphql/src/schema/transaction/types.ts
@@ -2,369 +2,377 @@ import { GraphQLInterfaceType, GraphQLList, GraphQLObjectType, GraphQLScalarType
 
 import { bigint, boolean, list, number, object, string, type } from '../picks';
 
-export const tokenBalance = new GraphQLObjectType({
-    fields: {
-        accountIndex: number(),
-        mint: string(),
-        owner: string(),
-        programId: string(),
-        uiAmountString: string(),
-    },
-    name: 'TokenBalance',
-});
+export const tokenBalance = () =>
+    new GraphQLObjectType({
+        fields: {
+            accountIndex: number(),
+            mint: string(),
+            owner: string(),
+            programId: string(),
+            uiAmountString: string(),
+        },
+        name: 'TokenBalance',
+    });
 
-export const transactionStatus = new GraphQLUnionType({
-    name: 'TransactionStatus',
-    types: [
-        new GraphQLObjectType({
-            fields: {
-                Err: string(),
-            },
-            name: 'TransactionStatusError',
-        }),
-        new GraphQLObjectType({
-            fields: {
-                Ok: string(),
-            },
-            name: 'TransactionStatusOk',
-        }),
-    ],
-});
+export const transactionStatus = () =>
+    new GraphQLUnionType({
+        name: 'TransactionStatus',
+        types: [
+            new GraphQLObjectType({
+                fields: {
+                    Err: string(),
+                },
+                name: 'TransactionStatusError',
+            }),
+            new GraphQLObjectType({
+                fields: {
+                    Ok: string(),
+                },
+                name: 'TransactionStatusOk',
+            }),
+        ],
+    });
 
-export const reward = new GraphQLObjectType({
-    fields: {
-        commission: number(),
-        lamports: bigint(),
-        postBalance: bigint(),
-        pubkey: string(),
-        rewardType: string(),
-    },
-    name: 'Reward',
-});
+export const reward = () =>
+    new GraphQLObjectType({
+        fields: {
+            commission: number(),
+            lamports: bigint(),
+            postBalance: bigint(),
+            pubkey: string(),
+            rewardType: string(),
+        },
+        name: 'Reward',
+    });
 
-const addressTableLookup = new GraphQLObjectType({
-    fields: {
-        accountKey: string(),
-        readableIndexes: list(number()),
-        writableIndexes: list(number()),
-    },
-    name: 'AddressTableLookup',
-});
+const addressTableLookup = () =>
+    new GraphQLObjectType({
+        fields: {
+            accountKey: string(),
+            readableIndexes: list(number()),
+            writableIndexes: list(number()),
+        },
+        name: 'AddressTableLookup',
+    });
 
-export const returnData = new GraphQLObjectType({
-    fields: {
-        data: string(),
-        programId: string(),
-    },
-    name: 'ReturnData',
-});
+export const returnData = () =>
+    new GraphQLObjectType({
+        fields: {
+            data: string(),
+            programId: string(),
+        },
+        name: 'ReturnData',
+    });
 
-const transactionInstruction = new GraphQLObjectType({
-    fields: {
-        accounts: list(number()),
-        data: string(),
-        programIdIndex: number(),
-    },
-    name: 'TransactionInstruction',
-});
+const transactionInstruction = () =>
+    new GraphQLObjectType({
+        fields: {
+            accounts: list(number()),
+            data: string(),
+            programIdIndex: number(),
+        },
+        name: 'TransactionInstruction',
+    });
 
-export const transactionMetaLoadedAddresses = new GraphQLObjectType({
-    fields: {
-        readonly: list(string()), // Base58 encoded addresses
-        writable: list(string()), // Base58 encoded addresses
-    },
-    name: 'TransactionMetaLoadedAddresses',
-});
+export const transactionMetaLoadedAddresses = () =>
+    new GraphQLObjectType({
+        fields: {
+            readonly: list(string()), // Base58 encoded addresses
+            writable: list(string()), // Base58 encoded addresses
+        },
+        name: 'TransactionMetaLoadedAddresses',
+    });
 
 /**
  * Interface for a parsed transaction instruction
  */
-const parsedTransactionInstructionInterface = new GraphQLInterfaceType({
-    fields: {
-        programId: string(),
-    },
-    name: 'ParsedTransactionInstruction',
-    resolveType(instruction) {
-        if (instruction.program === 'address-lookup-table') {
-            if (instruction.info.type === 'createLookupTable') {
-                return 'CreateLookupTableInstruction';
-            }
-            if (instruction.info.type === 'freezeLookupTable') {
-                return 'FreezeLookupTableInstruction';
-            }
-            if (instruction.info.type === 'extendLookupTable') {
-                return 'ExtendLookupTableInstruction';
-            }
-            if (instruction.info.type === 'deactivateLookupTable') {
-                return 'DeactivateLookupTableInstruction';
-            }
-            if (instruction.info.type === 'closeLookupTable') {
-                return 'CloseLookupTableInstruction';
-            }
-        }
-        if (instruction.program === 'bpf-loader') {
-            if (instruction.info.type === 'write') {
-                return 'BpfLoaderWriteInstruction';
-            }
-            if (instruction.info.type === 'finalize') {
-                return 'BpfLoaderFinalizeInstruction';
-            }
-        }
-        if (instruction.program === 'bpf-upgradeable-loader') {
-            if (instruction.info.type === 'initializeBuffer') {
-                return 'BpfUpgradeableLoaderInitializeBufferInstruction';
-            }
-            if (instruction.info.type === 'write') {
-                return 'BpfUpgradeableLoaderWriteInstruction';
-            }
-            if (instruction.info.type === 'deployWithMaxDataLen') {
-                return 'BpfUpgradeableLoaderDeployWithMaxDataLenInstruction';
-            }
-            if (instruction.info.type === 'upgrade') {
-                return 'BpfUpgradeableLoaderUpgradeInstruction';
-            }
-            if (instruction.info.type === 'setAuthority') {
-                return 'BpfUpgradeableLoaderSetAuthorityInstruction';
-            }
-            if (instruction.info.type === 'setAuthorityChecked') {
-                return 'BpfUpgradeableLoaderSetAuthorityCheckedInstruction';
-            }
-            if (instruction.info.type === 'close') {
-                return 'BpfUpgradeableLoaderCloseInstruction';
-            }
-            if (instruction.info.type === 'extendProgram') {
-                return 'BpfUpgradeableLoaderExtendProgramInstruction';
-            }
-        }
-        if (instruction.program === 'spl-associated-token-account') {
-            if (instruction.info.type === 'create') {
-                return 'SplAssociatedTokenCreateInstruction';
-            }
-            if (instruction.info.type === 'createIdempotent') {
-                return 'SplAssociatedTokenCreateIdempotentInstruction';
-            }
-            if (instruction.info.type === 'recoverNested') {
-                return 'SplAssociatedTokenRecoverNestedInstruction';
-            }
-        }
-        if (instruction.program === 'spl-memo') {
-            return 'SplMemoInstruction';
-        }
-        if (instruction.program === 'spl-token') {
-            if (instruction.info.type === 'initializeMint') {
-                return 'SplTokenInitializeMintInstruction';
-            }
-            if (instruction.info.type === 'initializeMint2') {
-                return 'SplTokenInitializeMint2Instruction';
-            }
-            if (instruction.info.type === 'initializeAccount') {
-                return 'SplTokenInitializeAccountInstruction';
-            }
-            if (instruction.info.type === 'initializeAccount2') {
-                return 'SplTokenInitializeAccount2Instruction';
-            }
-            if (instruction.info.type === 'initializeAccount3') {
-                return 'SplTokenInitializeAccount3Instruction';
-            }
-            if (instruction.info.type === 'initializeMultisig') {
-                return 'SplTokenInitializeMultisigInstruction';
-            }
-            if (instruction.info.type === 'initializeMultisig2') {
-                return 'SplTokenInitializeMultisig2Instruction';
-            }
-            if (instruction.info.type === 'transfer') {
-                return 'SplTokenTransferInstruction';
-            }
-            if (instruction.info.type === 'approve') {
-                return 'SplTokenApproveInstruction';
-            }
-            if (instruction.info.type === 'revoke') {
-                return 'SplTokenRevokeInstruction';
-            }
-            if (instruction.info.type === 'setAuthority') {
-                return 'SplTokenSetAuthorityInstruction';
-            }
-            if (instruction.info.type === 'mintTo') {
-                return 'SplTokenMintToInstruction';
-            }
-            if (instruction.info.type === 'burn') {
-                return 'SplTokenBurnInstruction';
-            }
-            if (instruction.info.type === 'closeAccount') {
-                return 'SplTokenCloseAccountInstruction';
-            }
-            if (instruction.info.type === 'freezeAccount') {
-                return 'SplTokenFreezeAccountInstruction';
-            }
-            if (instruction.info.type === 'thawAccount') {
-                return 'SplTokenThawAccountInstruction';
-            }
-            if (instruction.info.type === 'transferChecked') {
-                return 'SplTokenTransferCheckedInstruction';
-            }
-            if (instruction.info.type === 'approveChecked') {
-                return 'SplTokenApproveCheckedInstruction';
-            }
-            if (instruction.info.type === 'mintToChecked') {
-                return 'SplTokenMintToCheckedInstruction';
-            }
-            if (instruction.info.type === 'burnChecked') {
-                return 'SplTokenBurnCheckedInstruction';
-            }
-            if (instruction.info.type === 'syncNative') {
-                return 'SplTokenSyncNativeInstruction';
-            }
-            if (instruction.info.type === 'getAccountDataSize') {
-                return 'SplTokenGetAccountDataSizeInstruction';
-            }
-            if (instruction.info.type === 'initializeImmutableOwner') {
-                return 'SplTokenInitializeImmutableOwnerInstruction';
-            }
-            if (instruction.info.type === 'amountToUiAmount') {
-                return 'SplTokenAmountToUiAmountInstruction';
-            }
-            if (instruction.info.type === 'uiAmountToAmount') {
-                return 'SplTokenUiAmountToAmountInstruction';
-            }
-            if (instruction.info.type === 'initializeMintCloseAuthority') {
-                return 'SplTokenInitializeMintCloseAuthorityInstruction';
-            }
-        }
-        if (instruction.program === 'stake') {
-            if (instruction.info.type === 'initialize') {
-                return 'StakeInitializeInstruction';
-            }
-            if (instruction.info.type === 'authorize') {
-                return 'StakeAuthorizeInstruction';
-            }
-            if (instruction.info.type === 'delegate') {
-                return 'StakeDelegateStakeInstruction';
-            }
-            if (instruction.info.type === 'split') {
-                return 'StakeSplitInstruction';
-            }
-            if (instruction.info.type === 'withdraw') {
-                return 'StakeWithdrawInstruction';
-            }
-            if (instruction.info.type === 'deactivate') {
-                return 'StakeDeactivateInstruction';
-            }
-            if (instruction.info.type === 'setLockup') {
-                return 'StakeSetLockupInstruction';
-            }
-            if (instruction.info.type === 'merge') {
-                return 'StakeMergeInstruction';
-            }
-            if (instruction.info.type === 'authorizeWithSeed') {
-                return 'StakeAuthorizeWithSeedInstruction';
-            }
-            if (instruction.info.type === 'initializeChecked') {
-                return 'StakeInitializeCheckedInstruction';
-            }
-            if (instruction.info.type === 'authorizeChecked') {
-                return 'StakeAuthorizeCheckedInstruction';
-            }
-            if (instruction.info.type === 'authorizeCheckedWithSeed') {
-                return 'StakeAuthorizeCheckedWithSeedInstruction';
-            }
-            if (instruction.info.type === 'setLockupChecked') {
-                return 'StakeSetLockupCheckedInstruction';
-            }
-            if (instruction.info.type === 'deactivateDelinquent') {
-                return 'StakeDeactivateDelinquentInstruction';
-            }
-            if (instruction.info.type === 'redelegate') {
-                return 'StakeRedelegateInstruction';
-            }
-        }
-        if (instruction.program === 'system') {
-            if (instruction.info.type === 'createAccount') {
-                return 'CreateAccountInstruction';
-            }
-            if (instruction.info.type === 'assign') {
-                return 'AssignInstruction';
-            }
-            if (instruction.info.type === 'transfer') {
-                return 'TransferInstruction';
-            }
-            if (instruction.info.type === 'createAccountWithSeed') {
-                return 'CreateAccountWithSeedInstruction';
-            }
-            if (instruction.info.type === 'advanceNonceAccount') {
-                return 'AdvanceNonceAccountInstruction';
-            }
-            if (instruction.info.type === 'withdrawNonceAccount') {
-                return 'WithdrawNonceAccountInstruction';
-            }
-            if (instruction.info.type === 'initializeNonceAccount') {
-                return 'InitializeNonceAccountInstruction';
-            }
-            if (instruction.info.type === 'authorizeNonceAccount') {
-                return 'AuthorizeNonceAccountInstruction';
-            }
-            if (instruction.info.type === 'upgradeNonceAccount') {
-                return 'UpgradeNonceAccountInstruction';
-            }
-            if (instruction.info.type === 'allocate') {
-                return 'AllocateInstruction';
-            }
-            if (instruction.info.type === 'allocateWithSeed') {
-                return 'AllocateWithSeedInstruction';
-            }
-            if (instruction.info.type === 'assignWithSeed') {
-                return 'AssignWithSeedInstruction';
-            }
-            if (instruction.info.type === 'transferWithSeed') {
-                return 'TransferWithSeedInstruction';
-            }
-        }
-        if (instruction.program === 'vote') {
-            if (instruction.info.type === 'initialize') {
-                return 'VoteInitializeAccountInstruction';
-            }
-            if (instruction.info.type === 'authorize') {
-                return 'VoteAuthorizeInstruction';
-            }
-            if (instruction.info.type === 'authorizeWithSeed') {
-                return 'VoteAuthorizeWithSeedInstruction';
-            }
-            if (instruction.info.type === 'authorizeCheckedWithSeed') {
-                return 'VoteAuthorizeCheckedWithSeedInstruction';
-            }
-            if (instruction.info.type === 'vote') {
-                return 'VoteVoteInstruction';
-            }
-            if (instruction.info.type === 'updatevotestate') {
-                return 'VoteUpdateVoteStateInstruction';
-            }
-            if (instruction.info.type === 'updatevotestateswitch') {
-                return 'VoteUpdateVoteStateSwitchInstruction';
-            }
-            if (instruction.info.type === 'compactupdatevotestate') {
-                return 'VoteCompactUpdateVoteStateInstruction';
-            }
-            if (instruction.info.type === 'compactupdatevotestateswitch') {
-                return 'VoteCompactUpdateVoteStateSwitchInstruction';
-            }
-            if (instruction.info.type === 'withdraw') {
-                return 'VoteWithdrawInstruction';
-            }
-            if (instruction.info.type === 'updateValidatorIdentity') {
-                return 'VoteUpdateValidatorIdentityInstruction';
-            }
-            if (instruction.info.type === 'updateCommission') {
-                return 'VoteUpdateCommissionInstruction';
-            }
-            if (instruction.info.type === 'voteSwitch') {
-                return 'VoteVoteSwitchInstruction';
-            }
-            if (instruction.info.type === 'authorizeChecked') {
-                return 'VoteAuthorizeCheckedInstruction';
-            }
-        }
-        return 'PartiallyDecodedInstruction';
-    },
-});
+const parsedTransactionInstructionInterface = () =>
+    new GraphQLInterfaceType({
+        fields: {
+            programId: string(),
+        },
+        name: 'ParsedTransactionInstruction',
+        resolveType(instruction) {
+            if (instruction.program === 'address-lookup-table') {
+                if (instruction.info.type === 'createLookupTable') {
+                    return 'CreateLookupTableInstruction';
+                }
+                if (instruction.info.type === 'freezeLookupTable') {
+                    return 'FreezeLookupTableInstruction';
+                }
+                if (instruction.info.type === 'extendLookupTable') {
+                    return 'ExtendLookupTableInstruction';
+                }
+                if (instruction.info.type === 'deactivateLookupTable') {
+                    return 'DeactivateLookupTableInstruction';
+                }
+                if (instruction.info.type === 'closeLookupTable') {
+                    return 'CloseLookupTableInstruction';
+                }
+            }
+            if (instruction.program === 'bpf-loader') {
+                if (instruction.info.type === 'write') {
+                    return 'BpfLoaderWriteInstruction';
+                }
+                if (instruction.info.type === 'finalize') {
+                    return 'BpfLoaderFinalizeInstruction';
+                }
+            }
+            if (instruction.program === 'bpf-upgradeable-loader') {
+                if (instruction.info.type === 'initializeBuffer') {
+                    return 'BpfUpgradeableLoaderInitializeBufferInstruction';
+                }
+                if (instruction.info.type === 'write') {
+                    return 'BpfUpgradeableLoaderWriteInstruction';
+                }
+                if (instruction.info.type === 'deployWithMaxDataLen') {
+                    return 'BpfUpgradeableLoaderDeployWithMaxDataLenInstruction';
+                }
+                if (instruction.info.type === 'upgrade') {
+                    return 'BpfUpgradeableLoaderUpgradeInstruction';
+                }
+                if (instruction.info.type === 'setAuthority') {
+                    return 'BpfUpgradeableLoaderSetAuthorityInstruction';
+                }
+                if (instruction.info.type === 'setAuthorityChecked') {
+                    return 'BpfUpgradeableLoaderSetAuthorityCheckedInstruction';
+                }
+                if (instruction.info.type === 'close') {
+                    return 'BpfUpgradeableLoaderCloseInstruction';
+                }
+                if (instruction.info.type === 'extendProgram') {
+                    return 'BpfUpgradeableLoaderExtendProgramInstruction';
+                }
+            }
+            if (instruction.program === 'spl-associated-token-account') {
+                if (instruction.info.type === 'create') {
+                    return 'SplAssociatedTokenCreateInstruction';
+                }
+                if (instruction.info.type === 'createIdempotent') {
+                    return 'SplAssociatedTokenCreateIdempotentInstruction';
+                }
+                if (instruction.info.type === 'recoverNested') {
+                    return 'SplAssociatedTokenRecoverNestedInstruction';
+                }
+            }
+            if (instruction.program === 'spl-memo') {
+                return 'SplMemoInstruction';
+            }
+            if (instruction.program === 'spl-token') {
+                if (instruction.info.type === 'initializeMint') {
+                    return 'SplTokenInitializeMintInstruction';
+                }
+                if (instruction.info.type === 'initializeMint2') {
+                    return 'SplTokenInitializeMint2Instruction';
+                }
+                if (instruction.info.type === 'initializeAccount') {
+                    return 'SplTokenInitializeAccountInstruction';
+                }
+                if (instruction.info.type === 'initializeAccount2') {
+                    return 'SplTokenInitializeAccount2Instruction';
+                }
+                if (instruction.info.type === 'initializeAccount3') {
+                    return 'SplTokenInitializeAccount3Instruction';
+                }
+                if (instruction.info.type === 'initializeMultisig') {
+                    return 'SplTokenInitializeMultisigInstruction';
+                }
+                if (instruction.info.type === 'initializeMultisig2') {
+                    return 'SplTokenInitializeMultisig2Instruction';
+                }
+                if (instruction.info.type === 'transfer') {
+                    return 'SplTokenTransferInstruction';
+                }
+                if (instruction.info.type === 'approve') {
+                    return 'SplTokenApproveInstruction';
+                }
+                if (instruction.info.type === 'revoke') {
+                    return 'SplTokenRevokeInstruction';
+                }
+                if (instruction.info.type === 'setAuthority') {
+                    return 'SplTokenSetAuthorityInstruction';
+                }
+                if (instruction.info.type === 'mintTo') {
+                    return 'SplTokenMintToInstruction';
+                }
+                if (instruction.info.type === 'burn') {
+                    return 'SplTokenBurnInstruction';
+                }
+                if (instruction.info.type === 'closeAccount') {
+                    return 'SplTokenCloseAccountInstruction';
+                }
+                if (instruction.info.type === 'freezeAccount') {
+                    return 'SplTokenFreezeAccountInstruction';
+                }
+                if (instruction.info.type === 'thawAccount') {
+                    return 'SplTokenThawAccountInstruction';
+                }
+                if (instruction.info.type === 'transferChecked') {
+                    return 'SplTokenTransferCheckedInstruction';
+                }
+                if (instruction.info.type === 'approveChecked') {
+                    return 'SplTokenApproveCheckedInstruction';
+                }
+                if (instruction.info.type === 'mintToChecked') {
+                    return 'SplTokenMintToCheckedInstruction';
+                }
+                if (instruction.info.type === 'burnChecked') {
+                    return 'SplTokenBurnCheckedInstruction';
+                }
+                if (instruction.info.type === 'syncNative') {
+                    return 'SplTokenSyncNativeInstruction';
+                }
+                if (instruction.info.type === 'getAccountDataSize') {
+                    return 'SplTokenGetAccountDataSizeInstruction';
+                }
+                if (instruction.info.type === 'initializeImmutableOwner') {
+                    return 'SplTokenInitializeImmutableOwnerInstruction';
+                }
+                if (instruction.info.type === 'amountToUiAmount') {
+                    return 'SplTokenAmountToUiAmountInstruction';
+                }
+                if (instruction.info.type === 'uiAmountToAmount') {
+                    return 'SplTokenUiAmountToAmountInstruction';
+                }
+                if (instruction.info.type === 'initializeMintCloseAuthority') {
+                    return 'SplTokenInitializeMintCloseAuthorityInstruction';
+                }
+            }
+            if (instruction.program === 'stake') {
+                if (instruction.info.type === 'initialize') {
+                    return 'StakeInitializeInstruction';
+                }
+                if (instruction.info.type === 'authorize') {
+                    return 'StakeAuthorizeInstruction';
+                }
+                if (instruction.info.type === 'delegate') {
+                    return 'StakeDelegateStakeInstruction';
+                }
+                if (instruction.info.type === 'split') {
+                    return 'StakeSplitInstruction';
+                }
+                if (instruction.info.type === 'withdraw') {
+                    return 'StakeWithdrawInstruction';
+                }
+                if (instruction.info.type === 'deactivate') {
+                    return 'StakeDeactivateInstruction';
+                }
+                if (instruction.info.type === 'setLockup') {
+                    return 'StakeSetLockupInstruction';
+                }
+                if (instruction.info.type === 'merge') {
+                    return 'StakeMergeInstruction';
+                }
+                if (instruction.info.type === 'authorizeWithSeed') {
+                    return 'StakeAuthorizeWithSeedInstruction';
+                }
+                if (instruction.info.type === 'initializeChecked') {
+                    return 'StakeInitializeCheckedInstruction';
+                }
+                if (instruction.info.type === 'authorizeChecked') {
+                    return 'StakeAuthorizeCheckedInstruction';
+                }
+                if (instruction.info.type === 'authorizeCheckedWithSeed') {
+                    return 'StakeAuthorizeCheckedWithSeedInstruction';
+                }
+                if (instruction.info.type === 'setLockupChecked') {
+                    return 'StakeSetLockupCheckedInstruction';
+                }
+                if (instruction.info.type === 'deactivateDelinquent') {
+                    return 'StakeDeactivateDelinquentInstruction';
+                }
+                if (instruction.info.type === 'redelegate') {
+                    return 'StakeRedelegateInstruction';
+                }
+            }
+            if (instruction.program === 'system') {
+                if (instruction.info.type === 'createAccount') {
+                    return 'CreateAccountInstruction';
+                }
+                if (instruction.info.type === 'assign') {
+                    return 'AssignInstruction';
+                }
+                if (instruction.info.type === 'transfer') {
+                    return 'TransferInstruction';
+                }
+                if (instruction.info.type === 'createAccountWithSeed') {
+                    return 'CreateAccountWithSeedInstruction';
+                }
+                if (instruction.info.type === 'advanceNonceAccount') {
+                    return 'AdvanceNonceAccountInstruction';
+                }
+                if (instruction.info.type === 'withdrawNonceAccount') {
+                    return 'WithdrawNonceAccountInstruction';
+                }
+                if (instruction.info.type === 'initializeNonceAccount') {
+                    return 'InitializeNonceAccountInstruction';
+                }
+                if (instruction.info.type === 'authorizeNonceAccount') {
+                    return 'AuthorizeNonceAccountInstruction';
+                }
+                if (instruction.info.type === 'upgradeNonceAccount') {
+                    return 'UpgradeNonceAccountInstruction';
+                }
+                if (instruction.info.type === 'allocate') {
+                    return 'AllocateInstruction';
+                }
+                if (instruction.info.type === 'allocateWithSeed') {
+                    return 'AllocateWithSeedInstruction';
+                }
+                if (instruction.info.type === 'assignWithSeed') {
+                    return 'AssignWithSeedInstruction';
+                }
+                if (instruction.info.type === 'transferWithSeed') {
+                    return 'TransferWithSeedInstruction';
+                }
+            }
+            if (instruction.program === 'vote') {
+                if (instruction.info.type === 'initialize') {
+                    return 'VoteInitializeAccountInstruction';
+                }
+                if (instruction.info.type === 'authorize') {
+                    return 'VoteAuthorizeInstruction';
+                }
+                if (instruction.info.type === 'authorizeWithSeed') {
+                    return 'VoteAuthorizeWithSeedInstruction';
+                }
+                if (instruction.info.type === 'authorizeCheckedWithSeed') {
+                    return 'VoteAuthorizeCheckedWithSeedInstruction';
+                }
+                if (instruction.info.type === 'vote') {
+                    return 'VoteVoteInstruction';
+                }
+                if (instruction.info.type === 'updatevotestate') {
+                    return 'VoteUpdateVoteStateInstruction';
+                }
+                if (instruction.info.type === 'updatevotestateswitch') {
+                    return 'VoteUpdateVoteStateSwitchInstruction';
+                }
+                if (instruction.info.type === 'compactupdatevotestate') {
+                    return 'VoteCompactUpdateVoteStateInstruction';
+                }
+                if (instruction.info.type === 'compactupdatevotestateswitch') {
+                    return 'VoteCompactUpdateVoteStateSwitchInstruction';
+                }
+                if (instruction.info.type === 'withdraw') {
+                    return 'VoteWithdrawInstruction';
+                }
+                if (instruction.info.type === 'updateValidatorIdentity') {
+                    return 'VoteUpdateValidatorIdentityInstruction';
+                }
+                if (instruction.info.type === 'updateCommission') {
+                    return 'VoteUpdateCommissionInstruction';
+                }
+                if (instruction.info.type === 'voteSwitch') {
+                    return 'VoteVoteSwitchInstruction';
+                }
+                if (instruction.info.type === 'authorizeChecked') {
+                    return 'VoteAuthorizeCheckedInstruction';
+                }
+            }
+            return 'PartiallyDecodedInstruction';
+        },
+    });
 
 /**
  * Builds JSON parsed instruction
@@ -386,25 +394,26 @@ const parsedTransactionInstructionType = (name: string, parsedInfoFields: Parame
             program: string(),
             programId: string(),
         },
-        interfaces: [parsedTransactionInstructionInterface],
+        interfaces: [parsedTransactionInstructionInterface()],
         name,
     });
 
-const partiallyDecodedTransactionInstruction = new GraphQLObjectType({
-    fields: {
-        accounts: list(string()),
-        data: string(),
-        programId: string(),
-    },
-    interfaces: [parsedTransactionInstructionInterface],
-    name: 'PartiallyDecodedInstruction',
-});
+const partiallyDecodedTransactionInstruction = () =>
+    new GraphQLObjectType({
+        fields: {
+            accounts: list(string()),
+            data: string(),
+            programId: string(),
+        },
+        interfaces: [parsedTransactionInstructionInterface()],
+        name: 'PartiallyDecodedInstruction',
+    });
 
 /**
  * Address Lookup Table program
  * @see https://github.com/solana-labs/solana/blob/7afb11f1e6daa3e9bd93cfe203211de5b14ba56a/transaction-status/src/parse_address_lookup_table.rs#L13
  */
-const parsedInstructionsAddressLookupTable = [
+const parsedInstructionsAddressLookupTable = () => [
     parsedTransactionInstructionType('CreateLookupTableInstruction', {
         bumpSeed: number(),
         lookupTableAccount: string(),
@@ -439,7 +448,7 @@ const parsedInstructionsAddressLookupTable = [
  * BPF Loader program
  * @see https://github.com/solana-labs/solana/blob/7afb11f1e6daa3e9bd93cfe203211de5b14ba56a/transaction-status/src/parse_bpf_loader.rs#L14
  */
-const parsedInstructionsBpfLoader = [
+const parsedInstructionsBpfLoader = () => [
     parsedTransactionInstructionType('BpfLoaderWriteInstruction', {
         account: string(),
         bytes: string(),
@@ -454,7 +463,7 @@ const parsedInstructionsBpfLoader = [
  * BPF Upgradeable Loader program
  * @see https://github.com/solana-labs/solana/blob/7afb11f1e6daa3e9bd93cfe203211de5b14ba56a/transaction-status/src/parse_bpf_loader.rs#L49
  */
-const parsedInstructionsBpfUpgradeableLoader = [
+const parsedInstructionsBpfUpgradeableLoader = () => [
     parsedTransactionInstructionType('BpfUpgradeableLoaderInitializeBufferInstruction', {
         account: string(),
     }),
@@ -512,7 +521,7 @@ const parsedInstructionsBpfUpgradeableLoader = [
  * SPL Associated Token Account program
  * @see https://github.com/solana-labs/solana/blob/1a2c0943db6519dc9519bfc74c2426332ba26850/transaction-status/src/parse_associated_token.rs#L17
  */
-const parsedInstructionsSplAssociatedToken = [
+const parsedInstructionsSplAssociatedToken = () => [
     parsedTransactionInstructionType('SplAssociatedTokenCreateInstruction', {
         account: string(),
         mint: string(),
@@ -544,21 +553,22 @@ const parsedInstructionsSplAssociatedToken = [
  * SPL Memo program
  * @see https://github.com/solana-labs/solana/blob/1a2c0943db6519dc9519bfc74c2426332ba26850/transaction-status/src/parse_instruction.rs#L146
  */
-const parsedInstructionSplMemo = new GraphQLObjectType({
-    fields: {
-        parsed: string(),
-        program: string(),
-        programId: string(),
-    },
-    interfaces: [parsedTransactionInstructionInterface],
-    name: 'SplMemoInstruction',
-});
+const parsedInstructionSplMemo = () =>
+    new GraphQLObjectType({
+        fields: {
+            parsed: string(),
+            program: string(),
+            programId: string(),
+        },
+        interfaces: [parsedTransactionInstructionInterface()],
+        name: 'SplMemoInstruction',
+    });
 
 /**
  * SPL Token program
  * @see https://github.com/solana-labs/solana/blob/d74de6780e2975472796a6a752b362152cd008a6/transaction-status/src/parse_token.rs#L29
  */
-const parsedInstructionsSplToken = [
+const parsedInstructionsSplToken = () => [
     parsedTransactionInstructionType('SplTokenInitializeMintInstruction', {
         decimals: number(),
         freezeAuthority: string(),
@@ -728,20 +738,21 @@ const parsedInstructionsSplToken = [
     // - MetadataPointerExtension
 ];
 
-const lockup = new GraphQLObjectType({
-    fields: {
-        custodian: string(),
-        epoch: bigint(),
-        unixTimestamp: bigint(),
-    },
-    name: 'Lockup',
-});
+const lockup = () =>
+    new GraphQLObjectType({
+        fields: {
+            custodian: string(),
+            epoch: bigint(),
+            unixTimestamp: bigint(),
+        },
+        name: 'Lockup',
+    });
 
 /**
  * Stake program
  * @see https://github.com/solana-labs/solana/blob/7afb11f1e6daa3e9bd93cfe203211de5b14ba56a/transaction-status/src/parse_stake.rs#L13
  */
-const parsedInstructionsStake = [
+const parsedInstructionsStake = () => [
     parsedTransactionInstructionType('StakeInitializeInstruction', {
         authorized: object('StakeInitializeInstructionAuthorized', {
             staker: string(),
@@ -791,7 +802,7 @@ const parsedInstructionsStake = [
     }),
     parsedTransactionInstructionType('StakeSetLockupInstruction', {
         custodian: string(),
-        lockup: type(lockup),
+        lockup: type(lockup()),
         stakeAccount: string(),
     }),
     parsedTransactionInstructionType('StakeMergeInstruction', {
@@ -837,7 +848,7 @@ const parsedInstructionsStake = [
     }),
     parsedTransactionInstructionType('StakeSetLockupCheckedInstruction', {
         custodian: string(),
-        lockup: type(lockup),
+        lockup: type(lockup()),
         stakeAccount: string(),
     }),
     parsedTransactionInstructionType('StakeDeactivateDelinquentInstruction', {
@@ -858,7 +869,7 @@ const parsedInstructionsStake = [
  * System program
  * @see https://github.com/solana-labs/solana/blob/d74de6780e2975472796a6a752b362152cd008a6/transaction-status/src/parse_system.rs#L13
  */
-const parsedInstructionsSystem = [
+const parsedInstructionsSystem = () => [
     parsedTransactionInstructionType('CreateAccountInstruction', {
         lamports: bigint(),
         newAccount: string(),
@@ -935,35 +946,37 @@ const parsedInstructionsSystem = [
     }),
 ];
 
-const vote = new GraphQLObjectType({
-    fields: {
-        hash: string(),
-        slots: list(bigint()),
-        timestamp: bigint(),
-    },
-    name: 'Vote',
-});
+const vote = () =>
+    new GraphQLObjectType({
+        fields: {
+            hash: string(),
+            slots: list(bigint()),
+            timestamp: bigint(),
+        },
+        name: 'Vote',
+    });
 
-const voteStateUpdate = new GraphQLObjectType({
-    fields: {
-        hash: string(),
-        lockouts: list(
-            object('VoteStateUpdateLockout', {
-                confirmationCount: number(),
-                slot: bigint(),
-            })
-        ),
-        root: bigint(),
-        timestamp: bigint(),
-    },
-    name: 'VoteStateUpdate',
-});
+const voteStateUpdate = () =>
+    new GraphQLObjectType({
+        fields: {
+            hash: string(),
+            lockouts: list(
+                object('VoteStateUpdateLockout', {
+                    confirmationCount: number(),
+                    slot: bigint(),
+                })
+            ),
+            root: bigint(),
+            timestamp: bigint(),
+        },
+        name: 'VoteStateUpdate',
+    });
 
 /**
  * Vote program
  * @see https://github.com/solana-labs/solana/blob/d74de6780e2975472796a6a752b362152cd008a6/transaction-status/src/parse_vote.rs#L12
  */
-const parsedInstructionsVote = [
+const parsedInstructionsVote = () => [
     parsedTransactionInstructionType('VoteInitializeAccountInstruction', {
         authorizedVoter: string(),
         authorizedWithdrawer: string(),
@@ -1001,7 +1014,7 @@ const parsedInstructionsVote = [
     parsedTransactionInstructionType('VoteVoteInstruction', {
         clockSysvar: string(),
         slotHashedSysvar: string(),
-        vote: type(vote),
+        vote: type(vote()),
         voteAccount: string(),
         voteAuthority: string(),
     }),
@@ -1009,25 +1022,25 @@ const parsedInstructionsVote = [
         hash: string(),
         voteAccount: string(),
         voteAuthority: string(),
-        voteStateUpdate: type(voteStateUpdate),
+        voteStateUpdate: type(voteStateUpdate()),
     }),
     parsedTransactionInstructionType('VoteUpdateVoteStateSwitchInstruction', {
         hash: string(),
         voteAccount: string(),
         voteAuthority: string(),
-        voteStateUpdate: type(voteStateUpdate),
+        voteStateUpdate: type(voteStateUpdate()),
     }),
     parsedTransactionInstructionType('VoteCompactUpdateVoteStateInstruction', {
         hash: string(),
         voteAccount: string(),
         voteAuthority: string(),
-        voteStateUpdate: type(voteStateUpdate),
+        voteStateUpdate: type(voteStateUpdate()),
     }),
     parsedTransactionInstructionType('VoteCompactUpdateVoteStateSwitchInstruction', {
         hash: string(),
         voteAccount: string(),
         voteAuthority: string(),
-        voteStateUpdate: type(voteStateUpdate),
+        voteStateUpdate: type(voteStateUpdate()),
     }),
     parsedTransactionInstructionType('VoteWithdrawInstruction', {
         destination: string(),
@@ -1049,7 +1062,7 @@ const parsedInstructionsVote = [
         clockSysvar: string(),
         hash: string(),
         slotHashesSysvar: string(),
-        vote: type(vote),
+        vote: type(vote()),
         voteAccount: string(),
         voteAuthority: string(),
     }),
@@ -1065,37 +1078,38 @@ const parsedInstructionsVote = [
 /**
  * The fields for the transaction meta interface
  */
-const transactionMetaInterfaceFields = {
+const transactionMetaInterfaceFields = () => ({
     computeUnitsConsumed: bigint(),
     err: string(),
     fee: bigint(),
     format: string(),
-    loadedAddresses: type(transactionMetaLoadedAddresses),
+    loadedAddresses: type(transactionMetaLoadedAddresses()),
     logMessages: list(string()),
     postBalances: list(bigint()),
-    postTokenBalances: list(type(tokenBalance)),
+    postTokenBalances: list(type(tokenBalance())),
     preBalances: list(bigint()),
-    preTokenBalances: list(type(tokenBalance)),
-    returnData: type(returnData),
-    rewards: list(type(reward)),
-    status: type(transactionStatus),
-};
+    preTokenBalances: list(type(tokenBalance())),
+    returnData: type(returnData()),
+    rewards: list(type(reward())),
+    status: type(transactionStatus()),
+});
 
 /**
  * Interface for a transaction meta
  */
-const transactionMetaInterface = new GraphQLInterfaceType({
-    fields: {
-        ...transactionMetaInterfaceFields,
-    },
-    name: 'TransactionMeta',
-    resolveType(meta) {
-        if (meta.format === 'parsed') {
-            return 'TransactionMetaParsed';
-        }
-        return 'TransactionMetaUnparsed';
-    },
-});
+const transactionMetaInterface = () =>
+    new GraphQLInterfaceType({
+        fields: {
+            ...transactionMetaInterfaceFields(),
+        },
+        name: 'TransactionMeta',
+        resolveType(meta) {
+            if (meta.format === 'parsed') {
+                return 'TransactionMetaParsed';
+            }
+            return 'TransactionMetaUnparsed';
+        },
+    });
 
 /**
  * Builds a transaction meta type
@@ -1112,45 +1126,47 @@ const transactionMetaType = (
     new GraphQLObjectType({
         description,
         fields: {
-            ...transactionMetaInterfaceFields,
+            ...transactionMetaInterfaceFields(),
             innerInstructions,
         },
-        interfaces: [transactionMetaInterface],
+        interfaces: [transactionMetaInterface()],
         name,
     });
 
-const transactionMetaUnparsed = transactionMetaType(
-    'TransactionMetaUnparsed',
-    'Non-parsed transaction meta',
-    list(
-        object('TransactionMetaInnerInstructionsUnparsed', {
-            index: number(),
-            instructions: list(
-                object('TransactionMetaInnerInstructionsUnparsedInstruction', {
-                    index: number(),
-                    instructions: list(type(transactionInstruction)),
-                })
-            ),
-        })
-    )
-);
+const transactionMetaUnparsed = () =>
+    transactionMetaType(
+        'TransactionMetaUnparsed',
+        'Non-parsed transaction meta',
+        list(
+            object('TransactionMetaInnerInstructionsUnparsed', {
+                index: number(),
+                instructions: list(
+                    object('TransactionMetaInnerInstructionsUnparsedInstruction', {
+                        index: number(),
+                        instructions: list(type(transactionInstruction())),
+                    })
+                ),
+            })
+        )
+    );
 
-const transactionMetaParsed = transactionMetaType(
-    'TransactionMetaParsed',
-    'Parsed transaction meta',
-    list(
-        object('TransactionMetaInnerInstructionsParsed', {
-            index: number(),
-            instructions: list(type(parsedTransactionInstructionInterface)),
-        })
-    )
-);
+const transactionMetaParsed = () =>
+    transactionMetaType(
+        'TransactionMetaParsed',
+        'Parsed transaction meta',
+        list(
+            object('TransactionMetaInnerInstructionsParsed', {
+                index: number(),
+                instructions: list(type(parsedTransactionInstructionInterface())),
+            })
+        )
+    );
 
 /**
  * The fields for the transaction message interface
  */
-const transactionMessageInterfaceFields = {
-    addressTableLookups: list(type(addressTableLookup)),
+const transactionMessageInterfaceFields = () => ({
+    addressTableLookups: list(type(addressTableLookup())),
     format: string(),
     header: object('TransactionJsonTransactionHeader', {
         numReadonlySignedAccounts: number(),
@@ -1158,23 +1174,24 @@ const transactionMessageInterfaceFields = {
         numRequiredSignatures: number(),
     }),
     recentBlockhash: string(),
-};
+});
 
 /**
  * Interface for a transaction message
  */
-const transactionMessageInterface = new GraphQLInterfaceType({
-    fields: {
-        ...transactionMessageInterfaceFields,
-    },
-    name: 'TransactionMessage',
-    resolveType(message) {
-        if (message.format === 'parsed') {
-            return 'TransactionMessageParsed';
-        }
-        return 'TransactionMessageUnparsed';
-    },
-});
+const transactionMessageInterface = () =>
+    new GraphQLInterfaceType({
+        fields: {
+            ...transactionMessageInterfaceFields(),
+        },
+        name: 'TransactionMessage',
+        resolveType(message) {
+            if (message.format === 'parsed') {
+                return 'TransactionMessageParsed';
+            }
+            return 'TransactionMessageUnparsed';
+        },
+    });
 
 /**
  * Builds a transaction message type
@@ -1193,77 +1210,81 @@ const transactionMessageType = (
     new GraphQLObjectType({
         description,
         fields: {
-            ...transactionMessageInterfaceFields,
+            ...transactionMessageInterfaceFields(),
             accountKeys,
             instructions,
         },
-        interfaces: [transactionMessageInterface],
+        interfaces: [transactionMessageInterface()],
         name,
     });
 
-const transactionMessageUnparsed = transactionMessageType(
-    'TransactionMessageUnparsed',
-    'Non-parsed transaction message',
-    list(string()),
-    list(type(transactionInstruction))
-);
+const transactionMessageUnparsed = () =>
+    transactionMessageType(
+        'TransactionMessageUnparsed',
+        'Non-parsed transaction message',
+        list(string()),
+        list(type(transactionInstruction()))
+    );
 
-const transactionMessageParsed = transactionMessageType(
-    'TransactionMessageParsed',
-    'Parsed transaction message',
-    list(
-        object('transactionMessageParsedAccountKey', {
-            pubkey: string(),
-            signer: boolean(),
-            source: string(),
-            writable: boolean(),
-        })
-    ),
-    list(type(parsedTransactionInstructionInterface))
-);
+const transactionMessageParsed = () =>
+    transactionMessageType(
+        'TransactionMessageParsed',
+        'Parsed transaction message',
+        list(
+            object('transactionMessageParsedAccountKey', {
+                pubkey: string(),
+                signer: boolean(),
+                source: string(),
+                writable: boolean(),
+            })
+        ),
+        list(type(parsedTransactionInstructionInterface()))
+    );
 
 /**
  * The standard transaction type, comprised of all the interfaces
  */
-const transactionTransaction = new GraphQLObjectType({
-    fields: {
-        message: type(transactionMessageInterface),
-        signatures: list(string()),
-    },
-    name: 'TransactionTransaction',
-});
+const transactionTransaction = () =>
+    new GraphQLObjectType({
+        fields: {
+            message: type(transactionMessageInterface()),
+            signatures: list(string()),
+        },
+        name: 'TransactionTransaction',
+    });
 
 /**
  * The fields for the transaction interface
  */
-const transactionInterfaceFields = {
+const transactionInterfaceFields = () => ({
     blockTime: bigint(),
     encoding: string(),
-    meta: type(transactionMetaInterface),
+    meta: type(transactionMetaInterface()),
     slot: bigint(),
-};
+});
 
 /**
  * Interface for a transaction
  */
-export const transactionInterface = new GraphQLInterfaceType({
-    fields: {
-        ...transactionInterfaceFields,
-    },
-    name: 'Transaction',
-    resolveType(transaction) {
-        if (transaction.encoding === 'base58') {
-            return 'TransactionBase58';
-        }
-        if (transaction.encoding === 'base64') {
-            return 'TransactionBase64';
-        }
-        if (transaction.encoding === 'json') {
-            return 'TransactionJson';
-        }
-        return 'TransactionJsonParsed';
-    },
-});
+export const transactionInterface = () =>
+    new GraphQLInterfaceType({
+        fields: {
+            ...transactionInterfaceFields(),
+        },
+        name: 'Transaction',
+        resolveType(transaction) {
+            if (transaction.encoding === 'base58') {
+                return 'TransactionBase58';
+            }
+            if (transaction.encoding === 'base64') {
+                return 'TransactionBase64';
+            }
+            if (transaction.encoding === 'json') {
+                return 'TransactionJson';
+            }
+            return 'TransactionJsonParsed';
+        },
+    });
 
 /**
  * Builds a transaction type
@@ -1280,46 +1301,46 @@ const transactionType = (
     new GraphQLObjectType({
         description,
         fields: {
-            ...transactionInterfaceFields,
+            ...transactionInterfaceFields(),
             transaction,
         },
-        interfaces: [transactionInterface],
+        interfaces: [transactionInterface()],
         name,
     });
 
-const transactionBase58 = transactionType('TransactionBase58', 'A Solana transaction as base58 encoded data', string());
+const transactionBase58 = () =>
+    transactionType('TransactionBase58', 'A Solana transaction as base58 encoded data', string());
 
-const transactionBase64 = transactionType('TransactionBase64', 'A Solana transaction as base64 encoded data', string());
+const transactionBase64 = () =>
+    transactionType('TransactionBase64', 'A Solana transaction as base64 encoded data', string());
 
-const transactionJson = transactionType(
-    'TransactionJson',
-    'A Solana transaction as a JSON object',
-    type(transactionTransaction)
-);
+const transactionJson = () =>
+    transactionType('TransactionJson', 'A Solana transaction as a JSON object', type(transactionTransaction()));
 
-const transactionJsonParsed = transactionType(
-    'TransactionJsonParsed',
-    'A Solana transaction as a parsed JSON object',
-    type(transactionTransaction)
-);
+const transactionJsonParsed = () =>
+    transactionType(
+        'TransactionJsonParsed',
+        'A Solana transaction as a parsed JSON object',
+        type(transactionTransaction())
+    );
 
-export const transactionTypes = [
-    partiallyDecodedTransactionInstruction,
-    ...parsedInstructionsAddressLookupTable,
-    ...parsedInstructionsBpfLoader,
-    ...parsedInstructionsBpfUpgradeableLoader,
-    ...parsedInstructionsStake,
-    ...parsedInstructionsSplAssociatedToken,
-    parsedInstructionSplMemo,
-    ...parsedInstructionsSplToken,
-    ...parsedInstructionsSystem,
-    ...parsedInstructionsVote,
-    transactionMetaUnparsed,
-    transactionMetaParsed,
-    transactionMessageUnparsed,
-    transactionMessageParsed,
-    transactionBase58,
-    transactionBase64,
-    transactionJson,
-    transactionJsonParsed,
+export const transactionTypes = () => [
+    partiallyDecodedTransactionInstruction(),
+    ...parsedInstructionsAddressLookupTable(),
+    ...parsedInstructionsBpfLoader(),
+    ...parsedInstructionsBpfUpgradeableLoader(),
+    ...parsedInstructionsStake(),
+    ...parsedInstructionsSplAssociatedToken(),
+    parsedInstructionSplMemo(),
+    ...parsedInstructionsSplToken(),
+    ...parsedInstructionsSystem(),
+    ...parsedInstructionsVote(),
+    transactionMetaUnparsed(),
+    transactionMetaParsed(),
+    transactionMessageUnparsed(),
+    transactionMessageParsed(),
+    transactionBase58(),
+    transactionBase64(),
+    transactionJson(),
+    transactionJsonParsed(),
 ];

--- a/packages/rpc-graphql/src/schema/transaction/types.ts
+++ b/packages/rpc-graphql/src/schema/transaction/types.ts
@@ -2,377 +2,409 @@ import { GraphQLInterfaceType, GraphQLList, GraphQLObjectType, GraphQLScalarType
 
 import { bigint, boolean, list, number, object, string, type } from '../picks';
 
-export const tokenBalance = () =>
-    new GraphQLObjectType({
-        fields: {
-            accountIndex: number(),
-            mint: string(),
-            owner: string(),
-            programId: string(),
-            uiAmountString: string(),
-        },
-        name: 'TokenBalance',
-    });
+let memoisedTokenBalance: GraphQLObjectType | undefined;
+export const tokenBalance = () => {
+    if (!memoisedTokenBalance)
+        memoisedTokenBalance = new GraphQLObjectType({
+            fields: {
+                accountIndex: number(),
+                mint: string(),
+                owner: string(),
+                programId: string(),
+                uiAmountString: string(),
+            },
+            name: 'TokenBalance',
+        });
+    return memoisedTokenBalance;
+};
 
-export const transactionStatus = () =>
-    new GraphQLUnionType({
-        name: 'TransactionStatus',
-        types: [
-            new GraphQLObjectType({
-                fields: {
-                    Err: string(),
-                },
-                name: 'TransactionStatusError',
-            }),
-            new GraphQLObjectType({
-                fields: {
-                    Ok: string(),
-                },
-                name: 'TransactionStatusOk',
-            }),
-        ],
-    });
+let memoisedTransactionStatus: GraphQLUnionType | undefined;
+export const transactionStatus = () => {
+    if (!memoisedTransactionStatus)
+        memoisedTransactionStatus = new GraphQLUnionType({
+            name: 'TransactionStatus',
+            types: [
+                new GraphQLObjectType({
+                    fields: {
+                        Err: string(),
+                    },
+                    name: 'TransactionStatusError',
+                }),
+                new GraphQLObjectType({
+                    fields: {
+                        Ok: string(),
+                    },
+                    name: 'TransactionStatusOk',
+                }),
+            ],
+        });
+    return memoisedTransactionStatus;
+};
 
-export const reward = () =>
-    new GraphQLObjectType({
-        fields: {
-            commission: number(),
-            lamports: bigint(),
-            postBalance: bigint(),
-            pubkey: string(),
-            rewardType: string(),
-        },
-        name: 'Reward',
-    });
+let memoisedReward: GraphQLObjectType | undefined;
+export const reward = () => {
+    if (!memoisedReward)
+        memoisedReward = new GraphQLObjectType({
+            fields: {
+                commission: number(),
+                lamports: bigint(),
+                postBalance: bigint(),
+                pubkey: string(),
+                rewardType: string(),
+            },
+            name: 'Reward',
+        });
+    return memoisedReward;
+};
 
-const addressTableLookup = () =>
-    new GraphQLObjectType({
-        fields: {
-            accountKey: string(),
-            readableIndexes: list(number()),
-            writableIndexes: list(number()),
-        },
-        name: 'AddressTableLookup',
-    });
+let memoisedAddressTableLookup: GraphQLObjectType | undefined;
+const addressTableLookup = () => {
+    if (!memoisedAddressTableLookup)
+        memoisedAddressTableLookup = new GraphQLObjectType({
+            fields: {
+                accountKey: string(),
+                readableIndexes: list(number()),
+                writableIndexes: list(number()),
+            },
+            name: 'AddressTableLookup',
+        });
+    return memoisedAddressTableLookup;
+};
 
-export const returnData = () =>
-    new GraphQLObjectType({
-        fields: {
-            data: string(),
-            programId: string(),
-        },
-        name: 'ReturnData',
-    });
+let memoisedReturnData: GraphQLObjectType | undefined;
+export const returnData = () => {
+    if (!memoisedReturnData)
+        memoisedReturnData = new GraphQLObjectType({
+            fields: {
+                data: string(),
+                programId: string(),
+            },
+            name: 'ReturnData',
+        });
+    return memoisedReturnData;
+};
 
-const transactionInstruction = () =>
-    new GraphQLObjectType({
-        fields: {
-            accounts: list(number()),
-            data: string(),
-            programIdIndex: number(),
-        },
-        name: 'TransactionInstruction',
-    });
+let memoisedTransactionInstruction: GraphQLObjectType | undefined;
+const transactionInstruction = () => {
+    if (!memoisedTransactionInstruction)
+        memoisedTransactionInstruction = new GraphQLObjectType({
+            fields: {
+                accounts: list(number()),
+                data: string(),
+                programIdIndex: number(),
+            },
+            name: 'TransactionInstruction',
+        });
+    return memoisedTransactionInstruction;
+};
 
-export const transactionMetaLoadedAddresses = () =>
-    new GraphQLObjectType({
-        fields: {
-            readonly: list(string()), // Base58 encoded addresses
-            writable: list(string()), // Base58 encoded addresses
-        },
-        name: 'TransactionMetaLoadedAddresses',
-    });
+let memoisedTransactionMetaLoadedAddresses: GraphQLObjectType | undefined;
+export const transactionMetaLoadedAddresses = () => {
+    if (!memoisedTransactionMetaLoadedAddresses)
+        memoisedTransactionMetaLoadedAddresses = new GraphQLObjectType({
+            fields: {
+                readonly: list(string()), // Base58 encoded addresses
+                writable: list(string()), // Base58 encoded addresses
+            },
+            name: 'TransactionMetaLoadedAddresses',
+        });
+    return memoisedTransactionMetaLoadedAddresses;
+};
 
+let memoisedParsedTransactionInstructionInterface: GraphQLInterfaceType | undefined;
 /**
  * Interface for a parsed transaction instruction
  */
-const parsedTransactionInstructionInterface = () =>
-    new GraphQLInterfaceType({
-        fields: {
-            programId: string(),
-        },
-        name: 'ParsedTransactionInstruction',
-        resolveType(instruction) {
-            if (instruction.program === 'address-lookup-table') {
-                if (instruction.info.type === 'createLookupTable') {
-                    return 'CreateLookupTableInstruction';
-                }
-                if (instruction.info.type === 'freezeLookupTable') {
-                    return 'FreezeLookupTableInstruction';
-                }
-                if (instruction.info.type === 'extendLookupTable') {
-                    return 'ExtendLookupTableInstruction';
-                }
-                if (instruction.info.type === 'deactivateLookupTable') {
-                    return 'DeactivateLookupTableInstruction';
-                }
-                if (instruction.info.type === 'closeLookupTable') {
-                    return 'CloseLookupTableInstruction';
-                }
-            }
-            if (instruction.program === 'bpf-loader') {
-                if (instruction.info.type === 'write') {
-                    return 'BpfLoaderWriteInstruction';
-                }
-                if (instruction.info.type === 'finalize') {
-                    return 'BpfLoaderFinalizeInstruction';
-                }
-            }
-            if (instruction.program === 'bpf-upgradeable-loader') {
-                if (instruction.info.type === 'initializeBuffer') {
-                    return 'BpfUpgradeableLoaderInitializeBufferInstruction';
-                }
-                if (instruction.info.type === 'write') {
-                    return 'BpfUpgradeableLoaderWriteInstruction';
-                }
-                if (instruction.info.type === 'deployWithMaxDataLen') {
-                    return 'BpfUpgradeableLoaderDeployWithMaxDataLenInstruction';
-                }
-                if (instruction.info.type === 'upgrade') {
-                    return 'BpfUpgradeableLoaderUpgradeInstruction';
-                }
-                if (instruction.info.type === 'setAuthority') {
-                    return 'BpfUpgradeableLoaderSetAuthorityInstruction';
-                }
-                if (instruction.info.type === 'setAuthorityChecked') {
-                    return 'BpfUpgradeableLoaderSetAuthorityCheckedInstruction';
-                }
-                if (instruction.info.type === 'close') {
-                    return 'BpfUpgradeableLoaderCloseInstruction';
-                }
-                if (instruction.info.type === 'extendProgram') {
-                    return 'BpfUpgradeableLoaderExtendProgramInstruction';
-                }
-            }
-            if (instruction.program === 'spl-associated-token-account') {
-                if (instruction.info.type === 'create') {
-                    return 'SplAssociatedTokenCreateInstruction';
-                }
-                if (instruction.info.type === 'createIdempotent') {
-                    return 'SplAssociatedTokenCreateIdempotentInstruction';
-                }
-                if (instruction.info.type === 'recoverNested') {
-                    return 'SplAssociatedTokenRecoverNestedInstruction';
-                }
-            }
-            if (instruction.program === 'spl-memo') {
-                return 'SplMemoInstruction';
-            }
-            if (instruction.program === 'spl-token') {
-                if (instruction.info.type === 'initializeMint') {
-                    return 'SplTokenInitializeMintInstruction';
-                }
-                if (instruction.info.type === 'initializeMint2') {
-                    return 'SplTokenInitializeMint2Instruction';
-                }
-                if (instruction.info.type === 'initializeAccount') {
-                    return 'SplTokenInitializeAccountInstruction';
-                }
-                if (instruction.info.type === 'initializeAccount2') {
-                    return 'SplTokenInitializeAccount2Instruction';
-                }
-                if (instruction.info.type === 'initializeAccount3') {
-                    return 'SplTokenInitializeAccount3Instruction';
-                }
-                if (instruction.info.type === 'initializeMultisig') {
-                    return 'SplTokenInitializeMultisigInstruction';
-                }
-                if (instruction.info.type === 'initializeMultisig2') {
-                    return 'SplTokenInitializeMultisig2Instruction';
-                }
-                if (instruction.info.type === 'transfer') {
-                    return 'SplTokenTransferInstruction';
-                }
-                if (instruction.info.type === 'approve') {
-                    return 'SplTokenApproveInstruction';
-                }
-                if (instruction.info.type === 'revoke') {
-                    return 'SplTokenRevokeInstruction';
-                }
-                if (instruction.info.type === 'setAuthority') {
-                    return 'SplTokenSetAuthorityInstruction';
-                }
-                if (instruction.info.type === 'mintTo') {
-                    return 'SplTokenMintToInstruction';
-                }
-                if (instruction.info.type === 'burn') {
-                    return 'SplTokenBurnInstruction';
-                }
-                if (instruction.info.type === 'closeAccount') {
-                    return 'SplTokenCloseAccountInstruction';
-                }
-                if (instruction.info.type === 'freezeAccount') {
-                    return 'SplTokenFreezeAccountInstruction';
-                }
-                if (instruction.info.type === 'thawAccount') {
-                    return 'SplTokenThawAccountInstruction';
-                }
-                if (instruction.info.type === 'transferChecked') {
-                    return 'SplTokenTransferCheckedInstruction';
-                }
-                if (instruction.info.type === 'approveChecked') {
-                    return 'SplTokenApproveCheckedInstruction';
-                }
-                if (instruction.info.type === 'mintToChecked') {
-                    return 'SplTokenMintToCheckedInstruction';
-                }
-                if (instruction.info.type === 'burnChecked') {
-                    return 'SplTokenBurnCheckedInstruction';
-                }
-                if (instruction.info.type === 'syncNative') {
-                    return 'SplTokenSyncNativeInstruction';
-                }
-                if (instruction.info.type === 'getAccountDataSize') {
-                    return 'SplTokenGetAccountDataSizeInstruction';
-                }
-                if (instruction.info.type === 'initializeImmutableOwner') {
-                    return 'SplTokenInitializeImmutableOwnerInstruction';
-                }
-                if (instruction.info.type === 'amountToUiAmount') {
-                    return 'SplTokenAmountToUiAmountInstruction';
-                }
-                if (instruction.info.type === 'uiAmountToAmount') {
-                    return 'SplTokenUiAmountToAmountInstruction';
-                }
-                if (instruction.info.type === 'initializeMintCloseAuthority') {
-                    return 'SplTokenInitializeMintCloseAuthorityInstruction';
-                }
-            }
-            if (instruction.program === 'stake') {
-                if (instruction.info.type === 'initialize') {
-                    return 'StakeInitializeInstruction';
-                }
-                if (instruction.info.type === 'authorize') {
-                    return 'StakeAuthorizeInstruction';
-                }
-                if (instruction.info.type === 'delegate') {
-                    return 'StakeDelegateStakeInstruction';
-                }
-                if (instruction.info.type === 'split') {
-                    return 'StakeSplitInstruction';
-                }
-                if (instruction.info.type === 'withdraw') {
-                    return 'StakeWithdrawInstruction';
-                }
-                if (instruction.info.type === 'deactivate') {
-                    return 'StakeDeactivateInstruction';
-                }
-                if (instruction.info.type === 'setLockup') {
-                    return 'StakeSetLockupInstruction';
-                }
-                if (instruction.info.type === 'merge') {
-                    return 'StakeMergeInstruction';
-                }
-                if (instruction.info.type === 'authorizeWithSeed') {
-                    return 'StakeAuthorizeWithSeedInstruction';
-                }
-                if (instruction.info.type === 'initializeChecked') {
-                    return 'StakeInitializeCheckedInstruction';
-                }
-                if (instruction.info.type === 'authorizeChecked') {
-                    return 'StakeAuthorizeCheckedInstruction';
-                }
-                if (instruction.info.type === 'authorizeCheckedWithSeed') {
-                    return 'StakeAuthorizeCheckedWithSeedInstruction';
-                }
-                if (instruction.info.type === 'setLockupChecked') {
-                    return 'StakeSetLockupCheckedInstruction';
-                }
-                if (instruction.info.type === 'deactivateDelinquent') {
-                    return 'StakeDeactivateDelinquentInstruction';
-                }
-                if (instruction.info.type === 'redelegate') {
-                    return 'StakeRedelegateInstruction';
-                }
-            }
-            if (instruction.program === 'system') {
-                if (instruction.info.type === 'createAccount') {
-                    return 'CreateAccountInstruction';
-                }
-                if (instruction.info.type === 'assign') {
-                    return 'AssignInstruction';
-                }
-                if (instruction.info.type === 'transfer') {
-                    return 'TransferInstruction';
-                }
-                if (instruction.info.type === 'createAccountWithSeed') {
-                    return 'CreateAccountWithSeedInstruction';
-                }
-                if (instruction.info.type === 'advanceNonceAccount') {
-                    return 'AdvanceNonceAccountInstruction';
-                }
-                if (instruction.info.type === 'withdrawNonceAccount') {
-                    return 'WithdrawNonceAccountInstruction';
-                }
-                if (instruction.info.type === 'initializeNonceAccount') {
-                    return 'InitializeNonceAccountInstruction';
-                }
-                if (instruction.info.type === 'authorizeNonceAccount') {
-                    return 'AuthorizeNonceAccountInstruction';
-                }
-                if (instruction.info.type === 'upgradeNonceAccount') {
-                    return 'UpgradeNonceAccountInstruction';
-                }
-                if (instruction.info.type === 'allocate') {
-                    return 'AllocateInstruction';
-                }
-                if (instruction.info.type === 'allocateWithSeed') {
-                    return 'AllocateWithSeedInstruction';
-                }
-                if (instruction.info.type === 'assignWithSeed') {
-                    return 'AssignWithSeedInstruction';
-                }
-                if (instruction.info.type === 'transferWithSeed') {
-                    return 'TransferWithSeedInstruction';
-                }
-            }
-            if (instruction.program === 'vote') {
-                if (instruction.info.type === 'initialize') {
-                    return 'VoteInitializeAccountInstruction';
-                }
-                if (instruction.info.type === 'authorize') {
-                    return 'VoteAuthorizeInstruction';
-                }
-                if (instruction.info.type === 'authorizeWithSeed') {
-                    return 'VoteAuthorizeWithSeedInstruction';
-                }
-                if (instruction.info.type === 'authorizeCheckedWithSeed') {
-                    return 'VoteAuthorizeCheckedWithSeedInstruction';
-                }
-                if (instruction.info.type === 'vote') {
-                    return 'VoteVoteInstruction';
-                }
-                if (instruction.info.type === 'updatevotestate') {
-                    return 'VoteUpdateVoteStateInstruction';
-                }
-                if (instruction.info.type === 'updatevotestateswitch') {
-                    return 'VoteUpdateVoteStateSwitchInstruction';
-                }
-                if (instruction.info.type === 'compactupdatevotestate') {
-                    return 'VoteCompactUpdateVoteStateInstruction';
-                }
-                if (instruction.info.type === 'compactupdatevotestateswitch') {
-                    return 'VoteCompactUpdateVoteStateSwitchInstruction';
-                }
-                if (instruction.info.type === 'withdraw') {
-                    return 'VoteWithdrawInstruction';
-                }
-                if (instruction.info.type === 'updateValidatorIdentity') {
-                    return 'VoteUpdateValidatorIdentityInstruction';
-                }
-                if (instruction.info.type === 'updateCommission') {
-                    return 'VoteUpdateCommissionInstruction';
-                }
-                if (instruction.info.type === 'voteSwitch') {
-                    return 'VoteVoteSwitchInstruction';
-                }
-                if (instruction.info.type === 'authorizeChecked') {
-                    return 'VoteAuthorizeCheckedInstruction';
-                }
-            }
-            return 'PartiallyDecodedInstruction';
-        },
-    });
+const parsedTransactionInstructionInterface = () => {
+    if (!memoisedParsedTransactionInstructionInterface)
+        memoisedParsedTransactionInstructionInterface = new GraphQLInterfaceType({
+            fields: {
+                programId: string(),
+            },
+            name: 'ParsedTransactionInstruction',
+            resolveType(instruction) {
+                if (instruction.program === 'address-lookup-table') {
+                    if (instruction.info.type === 'createLookupTable') {
+                        return 'CreateLookupTableInstruction';
+                    }
+                    if (instruction.info.type === 'freezeLookupTable') {
+                        return 'FreezeLookupTableInstruction';
+                    }
+                    if (instruction.info.type === 'extendLookupTable') {
+                        return 'ExtendLookupTableInstruction';
+                    }
+                    if (instruction.info.type === 'deactivateLookupTable') {
+                        return 'DeactivateLookupTableInstruction';
+                    }
+                    if (instruction.info.type === 'closeLookupTable') {
+                        return 'CloseLookupTableInstruction';
+                    }
+                }
+                if (instruction.program === 'bpf-loader') {
+                    if (instruction.info.type === 'write') {
+                        return 'BpfLoaderWriteInstruction';
+                    }
+                    if (instruction.info.type === 'finalize') {
+                        return 'BpfLoaderFinalizeInstruction';
+                    }
+                }
+                if (instruction.program === 'bpf-upgradeable-loader') {
+                    if (instruction.info.type === 'initializeBuffer') {
+                        return 'BpfUpgradeableLoaderInitializeBufferInstruction';
+                    }
+                    if (instruction.info.type === 'write') {
+                        return 'BpfUpgradeableLoaderWriteInstruction';
+                    }
+                    if (instruction.info.type === 'deployWithMaxDataLen') {
+                        return 'BpfUpgradeableLoaderDeployWithMaxDataLenInstruction';
+                    }
+                    if (instruction.info.type === 'upgrade') {
+                        return 'BpfUpgradeableLoaderUpgradeInstruction';
+                    }
+                    if (instruction.info.type === 'setAuthority') {
+                        return 'BpfUpgradeableLoaderSetAuthorityInstruction';
+                    }
+                    if (instruction.info.type === 'setAuthorityChecked') {
+                        return 'BpfUpgradeableLoaderSetAuthorityCheckedInstruction';
+                    }
+                    if (instruction.info.type === 'close') {
+                        return 'BpfUpgradeableLoaderCloseInstruction';
+                    }
+                    if (instruction.info.type === 'extendProgram') {
+                        return 'BpfUpgradeableLoaderExtendProgramInstruction';
+                    }
+                }
+                if (instruction.program === 'spl-associated-token-account') {
+                    if (instruction.info.type === 'create') {
+                        return 'SplAssociatedTokenCreateInstruction';
+                    }
+                    if (instruction.info.type === 'createIdempotent') {
+                        return 'SplAssociatedTokenCreateIdempotentInstruction';
+                    }
+                    if (instruction.info.type === 'recoverNested') {
+                        return 'SplAssociatedTokenRecoverNestedInstruction';
+                    }
+                }
+                if (instruction.program === 'spl-memo') {
+                    return 'SplMemoInstruction';
+                }
+                if (instruction.program === 'spl-token') {
+                    if (instruction.info.type === 'initializeMint') {
+                        return 'SplTokenInitializeMintInstruction';
+                    }
+                    if (instruction.info.type === 'initializeMint2') {
+                        return 'SplTokenInitializeMint2Instruction';
+                    }
+                    if (instruction.info.type === 'initializeAccount') {
+                        return 'SplTokenInitializeAccountInstruction';
+                    }
+                    if (instruction.info.type === 'initializeAccount2') {
+                        return 'SplTokenInitializeAccount2Instruction';
+                    }
+                    if (instruction.info.type === 'initializeAccount3') {
+                        return 'SplTokenInitializeAccount3Instruction';
+                    }
+                    if (instruction.info.type === 'initializeMultisig') {
+                        return 'SplTokenInitializeMultisigInstruction';
+                    }
+                    if (instruction.info.type === 'initializeMultisig2') {
+                        return 'SplTokenInitializeMultisig2Instruction';
+                    }
+                    if (instruction.info.type === 'transfer') {
+                        return 'SplTokenTransferInstruction';
+                    }
+                    if (instruction.info.type === 'approve') {
+                        return 'SplTokenApproveInstruction';
+                    }
+                    if (instruction.info.type === 'revoke') {
+                        return 'SplTokenRevokeInstruction';
+                    }
+                    if (instruction.info.type === 'setAuthority') {
+                        return 'SplTokenSetAuthorityInstruction';
+                    }
+                    if (instruction.info.type === 'mintTo') {
+                        return 'SplTokenMintToInstruction';
+                    }
+                    if (instruction.info.type === 'burn') {
+                        return 'SplTokenBurnInstruction';
+                    }
+                    if (instruction.info.type === 'closeAccount') {
+                        return 'SplTokenCloseAccountInstruction';
+                    }
+                    if (instruction.info.type === 'freezeAccount') {
+                        return 'SplTokenFreezeAccountInstruction';
+                    }
+                    if (instruction.info.type === 'thawAccount') {
+                        return 'SplTokenThawAccountInstruction';
+                    }
+                    if (instruction.info.type === 'transferChecked') {
+                        return 'SplTokenTransferCheckedInstruction';
+                    }
+                    if (instruction.info.type === 'approveChecked') {
+                        return 'SplTokenApproveCheckedInstruction';
+                    }
+                    if (instruction.info.type === 'mintToChecked') {
+                        return 'SplTokenMintToCheckedInstruction';
+                    }
+                    if (instruction.info.type === 'burnChecked') {
+                        return 'SplTokenBurnCheckedInstruction';
+                    }
+                    if (instruction.info.type === 'syncNative') {
+                        return 'SplTokenSyncNativeInstruction';
+                    }
+                    if (instruction.info.type === 'getAccountDataSize') {
+                        return 'SplTokenGetAccountDataSizeInstruction';
+                    }
+                    if (instruction.info.type === 'initializeImmutableOwner') {
+                        return 'SplTokenInitializeImmutableOwnerInstruction';
+                    }
+                    if (instruction.info.type === 'amountToUiAmount') {
+                        return 'SplTokenAmountToUiAmountInstruction';
+                    }
+                    if (instruction.info.type === 'uiAmountToAmount') {
+                        return 'SplTokenUiAmountToAmountInstruction';
+                    }
+                    if (instruction.info.type === 'initializeMintCloseAuthority') {
+                        return 'SplTokenInitializeMintCloseAuthorityInstruction';
+                    }
+                }
+                if (instruction.program === 'stake') {
+                    if (instruction.info.type === 'initialize') {
+                        return 'StakeInitializeInstruction';
+                    }
+                    if (instruction.info.type === 'authorize') {
+                        return 'StakeAuthorizeInstruction';
+                    }
+                    if (instruction.info.type === 'delegate') {
+                        return 'StakeDelegateStakeInstruction';
+                    }
+                    if (instruction.info.type === 'split') {
+                        return 'StakeSplitInstruction';
+                    }
+                    if (instruction.info.type === 'withdraw') {
+                        return 'StakeWithdrawInstruction';
+                    }
+                    if (instruction.info.type === 'deactivate') {
+                        return 'StakeDeactivateInstruction';
+                    }
+                    if (instruction.info.type === 'setLockup') {
+                        return 'StakeSetLockupInstruction';
+                    }
+                    if (instruction.info.type === 'merge') {
+                        return 'StakeMergeInstruction';
+                    }
+                    if (instruction.info.type === 'authorizeWithSeed') {
+                        return 'StakeAuthorizeWithSeedInstruction';
+                    }
+                    if (instruction.info.type === 'initializeChecked') {
+                        return 'StakeInitializeCheckedInstruction';
+                    }
+                    if (instruction.info.type === 'authorizeChecked') {
+                        return 'StakeAuthorizeCheckedInstruction';
+                    }
+                    if (instruction.info.type === 'authorizeCheckedWithSeed') {
+                        return 'StakeAuthorizeCheckedWithSeedInstruction';
+                    }
+                    if (instruction.info.type === 'setLockupChecked') {
+                        return 'StakeSetLockupCheckedInstruction';
+                    }
+                    if (instruction.info.type === 'deactivateDelinquent') {
+                        return 'StakeDeactivateDelinquentInstruction';
+                    }
+                    if (instruction.info.type === 'redelegate') {
+                        return 'StakeRedelegateInstruction';
+                    }
+                }
+                if (instruction.program === 'system') {
+                    if (instruction.info.type === 'createAccount') {
+                        return 'CreateAccountInstruction';
+                    }
+                    if (instruction.info.type === 'assign') {
+                        return 'AssignInstruction';
+                    }
+                    if (instruction.info.type === 'transfer') {
+                        return 'TransferInstruction';
+                    }
+                    if (instruction.info.type === 'createAccountWithSeed') {
+                        return 'CreateAccountWithSeedInstruction';
+                    }
+                    if (instruction.info.type === 'advanceNonceAccount') {
+                        return 'AdvanceNonceAccountInstruction';
+                    }
+                    if (instruction.info.type === 'withdrawNonceAccount') {
+                        return 'WithdrawNonceAccountInstruction';
+                    }
+                    if (instruction.info.type === 'initializeNonceAccount') {
+                        return 'InitializeNonceAccountInstruction';
+                    }
+                    if (instruction.info.type === 'authorizeNonceAccount') {
+                        return 'AuthorizeNonceAccountInstruction';
+                    }
+                    if (instruction.info.type === 'upgradeNonceAccount') {
+                        return 'UpgradeNonceAccountInstruction';
+                    }
+                    if (instruction.info.type === 'allocate') {
+                        return 'AllocateInstruction';
+                    }
+                    if (instruction.info.type === 'allocateWithSeed') {
+                        return 'AllocateWithSeedInstruction';
+                    }
+                    if (instruction.info.type === 'assignWithSeed') {
+                        return 'AssignWithSeedInstruction';
+                    }
+                    if (instruction.info.type === 'transferWithSeed') {
+                        return 'TransferWithSeedInstruction';
+                    }
+                }
+                if (instruction.program === 'vote') {
+                    if (instruction.info.type === 'initialize') {
+                        return 'VoteInitializeAccountInstruction';
+                    }
+                    if (instruction.info.type === 'authorize') {
+                        return 'VoteAuthorizeInstruction';
+                    }
+                    if (instruction.info.type === 'authorizeWithSeed') {
+                        return 'VoteAuthorizeWithSeedInstruction';
+                    }
+                    if (instruction.info.type === 'authorizeCheckedWithSeed') {
+                        return 'VoteAuthorizeCheckedWithSeedInstruction';
+                    }
+                    if (instruction.info.type === 'vote') {
+                        return 'VoteVoteInstruction';
+                    }
+                    if (instruction.info.type === 'updatevotestate') {
+                        return 'VoteUpdateVoteStateInstruction';
+                    }
+                    if (instruction.info.type === 'updatevotestateswitch') {
+                        return 'VoteUpdateVoteStateSwitchInstruction';
+                    }
+                    if (instruction.info.type === 'compactupdatevotestate') {
+                        return 'VoteCompactUpdateVoteStateInstruction';
+                    }
+                    if (instruction.info.type === 'compactupdatevotestateswitch') {
+                        return 'VoteCompactUpdateVoteStateSwitchInstruction';
+                    }
+                    if (instruction.info.type === 'withdraw') {
+                        return 'VoteWithdrawInstruction';
+                    }
+                    if (instruction.info.type === 'updateValidatorIdentity') {
+                        return 'VoteUpdateValidatorIdentityInstruction';
+                    }
+                    if (instruction.info.type === 'updateCommission') {
+                        return 'VoteUpdateCommissionInstruction';
+                    }
+                    if (instruction.info.type === 'voteSwitch') {
+                        return 'VoteVoteSwitchInstruction';
+                    }
+                    if (instruction.info.type === 'authorizeChecked') {
+                        return 'VoteAuthorizeCheckedInstruction';
+                    }
+                }
+                return 'PartiallyDecodedInstruction';
+            },
+        });
+    return memoisedParsedTransactionInstructionInterface;
+};
 
 /**
  * Builds JSON parsed instruction
@@ -398,718 +430,787 @@ const parsedTransactionInstructionType = (name: string, parsedInfoFields: Parame
         name,
     });
 
-const partiallyDecodedTransactionInstruction = () =>
-    new GraphQLObjectType({
-        fields: {
-            accounts: list(string()),
-            data: string(),
-            programId: string(),
-        },
-        interfaces: [parsedTransactionInstructionInterface()],
-        name: 'PartiallyDecodedInstruction',
-    });
+let memoisedPartiallyDecodedTransactionInstruction: GraphQLObjectType | undefined;
+const partiallyDecodedTransactionInstruction = () => {
+    if (!memoisedPartiallyDecodedTransactionInstruction)
+        memoisedPartiallyDecodedTransactionInstruction = new GraphQLObjectType({
+            fields: {
+                accounts: list(string()),
+                data: string(),
+                programId: string(),
+            },
+            interfaces: [parsedTransactionInstructionInterface()],
+            name: 'PartiallyDecodedInstruction',
+        });
+    return memoisedPartiallyDecodedTransactionInstruction;
+};
 
+let memoisedParsedInstructionsAddressLookupTable: GraphQLObjectType[] | undefined;
 /**
  * Address Lookup Table program
  * @see https://github.com/solana-labs/solana/blob/7afb11f1e6daa3e9bd93cfe203211de5b14ba56a/transaction-status/src/parse_address_lookup_table.rs#L13
  */
-const parsedInstructionsAddressLookupTable = () => [
-    parsedTransactionInstructionType('CreateLookupTableInstruction', {
-        bumpSeed: number(),
-        lookupTableAccount: string(),
-        lookupTableAuthority: string(),
-        payerAccount: string(),
-        recentSlot: bigint(),
-        systemProgram: string(),
-    }),
-    parsedTransactionInstructionType('FreezeLookupTableInstruction', {
-        lookupTableAccount: string(),
-        lookupTableAuthority: string(),
-    }),
-    parsedTransactionInstructionType('ExtendLookupTableInstruction', {
-        lookupTableAccount: string(),
-        lookupTableAuthority: string(),
-        newAddresses: list(string()),
-        payerAccount: string(),
-        systemProgram: string(),
-    }),
-    parsedTransactionInstructionType('DeactivateLookupTableInstruction', {
-        lookupTableAccount: string(),
-        lookupTableAuthority: string(),
-    }),
-    parsedTransactionInstructionType('CloseLookupTableInstruction', {
-        lookupTableAccount: string(),
-        lookupTableAuthority: string(),
-        recipient: string(),
-    }),
-];
+const parsedInstructionsAddressLookupTable = () => {
+    if (!memoisedParsedInstructionsAddressLookupTable)
+        memoisedParsedInstructionsAddressLookupTable = [
+            parsedTransactionInstructionType('CreateLookupTableInstruction', {
+                bumpSeed: number(),
+                lookupTableAccount: string(),
+                lookupTableAuthority: string(),
+                payerAccount: string(),
+                recentSlot: bigint(),
+                systemProgram: string(),
+            }),
+            parsedTransactionInstructionType('FreezeLookupTableInstruction', {
+                lookupTableAccount: string(),
+                lookupTableAuthority: string(),
+            }),
+            parsedTransactionInstructionType('ExtendLookupTableInstruction', {
+                lookupTableAccount: string(),
+                lookupTableAuthority: string(),
+                newAddresses: list(string()),
+                payerAccount: string(),
+                systemProgram: string(),
+            }),
+            parsedTransactionInstructionType('DeactivateLookupTableInstruction', {
+                lookupTableAccount: string(),
+                lookupTableAuthority: string(),
+            }),
+            parsedTransactionInstructionType('CloseLookupTableInstruction', {
+                lookupTableAccount: string(),
+                lookupTableAuthority: string(),
+                recipient: string(),
+            }),
+        ];
+    return memoisedParsedInstructionsAddressLookupTable;
+};
 
+let memoisedParsedInstructionsBpfLoader: GraphQLObjectType[] | undefined;
 /**
  * BPF Loader program
  * @see https://github.com/solana-labs/solana/blob/7afb11f1e6daa3e9bd93cfe203211de5b14ba56a/transaction-status/src/parse_bpf_loader.rs#L14
  */
-const parsedInstructionsBpfLoader = () => [
-    parsedTransactionInstructionType('BpfLoaderWriteInstruction', {
-        account: string(),
-        bytes: string(),
-        offset: number(),
-    }),
-    parsedTransactionInstructionType('BpfLoaderFinalizeInstruction', {
-        account: string(),
-    }),
-];
+const parsedInstructionsBpfLoader = () => {
+    if (!memoisedParsedInstructionsBpfLoader)
+        memoisedParsedInstructionsBpfLoader = [
+            parsedTransactionInstructionType('BpfLoaderWriteInstruction', {
+                account: string(),
+                bytes: string(),
+                offset: number(),
+            }),
+            parsedTransactionInstructionType('BpfLoaderFinalizeInstruction', {
+                account: string(),
+            }),
+        ];
+    return memoisedParsedInstructionsBpfLoader;
+};
 
+let memoisedParsedInstructionsBpfUpgradeableLoader: GraphQLObjectType[] | undefined;
 /**
  * BPF Upgradeable Loader program
  * @see https://github.com/solana-labs/solana/blob/7afb11f1e6daa3e9bd93cfe203211de5b14ba56a/transaction-status/src/parse_bpf_loader.rs#L49
  */
-const parsedInstructionsBpfUpgradeableLoader = () => [
-    parsedTransactionInstructionType('BpfUpgradeableLoaderInitializeBufferInstruction', {
-        account: string(),
-    }),
-    parsedTransactionInstructionType('BpfUpgradeableLoaderWriteInstruction', {
-        account: string(),
-        authority: string(),
-        bytes: string(),
-        offset: number(),
-    }),
-    parsedTransactionInstructionType('BpfUpgradeableLoaderDeployWithMaxDataLenInstruction', {
-        authority: string(),
-        bufferAccount: string(),
-        clockSysvar: string(),
-        maxDataLen: bigint(),
-        payerAccount: string(),
-        programAccount: string(),
-        programDataAccount: string(),
-        rentSysvar: string(),
-    }),
-    parsedTransactionInstructionType('BpfUpgradeableLoaderUpgradeInstruction', {
-        authority: string(),
-        bufferAccount: string(),
-        clockSysvar: string(),
-        programAccount: string(),
-        programDataAccount: string(),
-        rentSysvar: string(),
-        spillAccount: string(),
-    }),
-    parsedTransactionInstructionType('BpfUpgradeableLoaderSetAuthorityInstruction', {
-        account: string(),
-        authority: string(),
-        newAuthority: string(),
-    }),
-    parsedTransactionInstructionType('BpfUpgradeableLoaderSetAuthorityCheckedInstruction', {
-        account: string(),
-        authority: string(),
-        newAuthority: string(),
-    }),
-    parsedTransactionInstructionType('BpfUpgradeableLoaderCloseInstruction', {
-        account: string(),
-        authority: string(),
-        programAccount: string(),
-        recipient: string(),
-    }),
-    parsedTransactionInstructionType('BpfUpgradeableLoaderExtendProgramInstruction', {
-        additionalBytes: bigint(),
-        payerAccount: string(),
-        programAccount: string(),
-        programDataAccount: string(),
-        systemProgram: string(),
-    }),
-];
+const parsedInstructionsBpfUpgradeableLoader = () => {
+    if (!memoisedParsedInstructionsBpfUpgradeableLoader)
+        memoisedParsedInstructionsBpfUpgradeableLoader = [
+            parsedTransactionInstructionType('BpfUpgradeableLoaderInitializeBufferInstruction', {
+                account: string(),
+            }),
+            parsedTransactionInstructionType('BpfUpgradeableLoaderWriteInstruction', {
+                account: string(),
+                authority: string(),
+                bytes: string(),
+                offset: number(),
+            }),
+            parsedTransactionInstructionType('BpfUpgradeableLoaderDeployWithMaxDataLenInstruction', {
+                authority: string(),
+                bufferAccount: string(),
+                clockSysvar: string(),
+                maxDataLen: bigint(),
+                payerAccount: string(),
+                programAccount: string(),
+                programDataAccount: string(),
+                rentSysvar: string(),
+            }),
+            parsedTransactionInstructionType('BpfUpgradeableLoaderUpgradeInstruction', {
+                authority: string(),
+                bufferAccount: string(),
+                clockSysvar: string(),
+                programAccount: string(),
+                programDataAccount: string(),
+                rentSysvar: string(),
+                spillAccount: string(),
+            }),
+            parsedTransactionInstructionType('BpfUpgradeableLoaderSetAuthorityInstruction', {
+                account: string(),
+                authority: string(),
+                newAuthority: string(),
+            }),
+            parsedTransactionInstructionType('BpfUpgradeableLoaderSetAuthorityCheckedInstruction', {
+                account: string(),
+                authority: string(),
+                newAuthority: string(),
+            }),
+            parsedTransactionInstructionType('BpfUpgradeableLoaderCloseInstruction', {
+                account: string(),
+                authority: string(),
+                programAccount: string(),
+                recipient: string(),
+            }),
+            parsedTransactionInstructionType('BpfUpgradeableLoaderExtendProgramInstruction', {
+                additionalBytes: bigint(),
+                payerAccount: string(),
+                programAccount: string(),
+                programDataAccount: string(),
+                systemProgram: string(),
+            }),
+        ];
+    return memoisedParsedInstructionsBpfUpgradeableLoader;
+};
 
+let memoisedParsedInstructionsSplAssociatedToken: GraphQLObjectType[] | undefined;
 /**
  * SPL Associated Token Account program
  * @see https://github.com/solana-labs/solana/blob/1a2c0943db6519dc9519bfc74c2426332ba26850/transaction-status/src/parse_associated_token.rs#L17
  */
-const parsedInstructionsSplAssociatedToken = () => [
-    parsedTransactionInstructionType('SplAssociatedTokenCreateInstruction', {
-        account: string(),
-        mint: string(),
-        source: string(),
-        systemProgram: string(),
-        tokenProgram: string(),
-        wallet: string(),
-    }),
-    parsedTransactionInstructionType('SplAssociatedTokenCreateIdempotentInstruction', {
-        account: string(),
-        mint: string(),
-        source: string(),
-        systemProgram: string(),
-        tokenProgram: string(),
-        wallet: string(),
-    }),
-    parsedTransactionInstructionType('SplAssociatedTokenRecoverNestedInstruction', {
-        destination: string(),
-        nestedMint: string(),
-        nestedOwner: string(),
-        nestedSource: string(),
-        ownerMint: string(),
-        tokenProgram: string(),
-        wallet: string(),
-    }),
-];
+const parsedInstructionsSplAssociatedToken = () => {
+    if (!memoisedParsedInstructionsSplAssociatedToken)
+        memoisedParsedInstructionsSplAssociatedToken = [
+            parsedTransactionInstructionType('SplAssociatedTokenCreateInstruction', {
+                account: string(),
+                mint: string(),
+                source: string(),
+                systemProgram: string(),
+                tokenProgram: string(),
+                wallet: string(),
+            }),
+            parsedTransactionInstructionType('SplAssociatedTokenCreateIdempotentInstruction', {
+                account: string(),
+                mint: string(),
+                source: string(),
+                systemProgram: string(),
+                tokenProgram: string(),
+                wallet: string(),
+            }),
+            parsedTransactionInstructionType('SplAssociatedTokenRecoverNestedInstruction', {
+                destination: string(),
+                nestedMint: string(),
+                nestedOwner: string(),
+                nestedSource: string(),
+                ownerMint: string(),
+                tokenProgram: string(),
+                wallet: string(),
+            }),
+        ];
+    return memoisedParsedInstructionsSplAssociatedToken;
+};
 
+let memoisedParsedInstructionSplMemo: GraphQLObjectType | undefined;
 /**
  * SPL Memo program
  * @see https://github.com/solana-labs/solana/blob/1a2c0943db6519dc9519bfc74c2426332ba26850/transaction-status/src/parse_instruction.rs#L146
  */
-const parsedInstructionSplMemo = () =>
-    new GraphQLObjectType({
-        fields: {
-            parsed: string(),
-            program: string(),
-            programId: string(),
-        },
-        interfaces: [parsedTransactionInstructionInterface()],
-        name: 'SplMemoInstruction',
-    });
+const parsedInstructionSplMemo = () => {
+    if (!memoisedParsedInstructionSplMemo)
+        memoisedParsedInstructionSplMemo = new GraphQLObjectType({
+            fields: {
+                parsed: string(),
+                program: string(),
+                programId: string(),
+            },
+            interfaces: [parsedTransactionInstructionInterface()],
+            name: 'SplMemoInstruction',
+        });
+    return memoisedParsedInstructionSplMemo;
+};
 
+let memoisedParsedInstructionsSplToken: GraphQLObjectType[] | undefined;
 /**
  * SPL Token program
  * @see https://github.com/solana-labs/solana/blob/d74de6780e2975472796a6a752b362152cd008a6/transaction-status/src/parse_token.rs#L29
  */
-const parsedInstructionsSplToken = () => [
-    parsedTransactionInstructionType('SplTokenInitializeMintInstruction', {
-        decimals: number(),
-        freezeAuthority: string(),
-        mint: string(),
-        mintAuthority: string(),
-        rentSysvar: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenInitializeMint2Instruction', {
-        decimals: number(),
-        freezeAuthority: string(),
-        mint: string(),
-        mintAuthority: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenInitializeAccountInstruction', {
-        account: string(),
-        mint: string(),
-        owner: string(),
-        rentSysvar: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenInitializeAccount2Instruction', {
-        account: string(),
-        mint: string(),
-        owner: string(),
-        rentSysvar: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenInitializeAccount3Instruction', {
-        account: string(),
-        mint: string(),
-        owner: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenInitializeMultisigInstruction', {
-        m: number(),
-        multisig: string(),
-        rentSysvar: string(),
-        signers: list(string()),
-    }),
-    parsedTransactionInstructionType('SplTokenInitializeMultisig2Instruction', {
-        m: number(),
-        multisig: string(),
-        signers: list(string()),
-    }),
-    parsedTransactionInstructionType('SplTokenTransferInstruction', {
-        amount: string(),
-        authority: string(),
-        destination: string(),
-        multisigAuthority: string(),
-        source: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenApproveInstruction', {
-        amount: string(),
-        delegate: string(),
-        multisigOwner: string(),
-        owner: string(),
-        source: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenRevokeInstruction', {
-        multisigOwner: string(),
-        owner: string(),
-        source: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenSetAuthorityInstruction', {
-        authority: string(),
-        authorityType: string(),
-        multisigAuthority: string(),
-        newAuthority: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenMintToInstruction', {
-        account: string(),
-        amount: string(),
-        authority: string(),
-        mint: string(),
-        mintAuthority: string(),
-        multisigMintAuthority: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenBurnInstruction', {
-        account: string(),
-        amount: string(),
-        authority: string(),
-        mint: string(),
-        multisigAuthority: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenCloseAccountInstruction', {
-        account: string(),
-        destination: string(),
-        multisigOwner: string(),
-        owner: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenFreezeAccountInstruction', {
-        account: string(),
-        freezeAuthority: string(),
-        mint: string(),
-        multisigFreezeAuthority: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenThawAccountInstruction', {
-        account: string(),
-        freezeAuthority: string(),
-        mint: string(),
-        multisigFreezeAuthority: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenTransferCheckedInstruction', {
-        authority: string(),
-        destination: string(),
-        mint: string(),
-        multisigAuthority: string(),
-        source: string(),
-        tokenAmount: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenApproveCheckedInstruction', {
-        delegate: string(),
-        mint: string(),
-        multisigOwner: string(),
-        owner: string(),
-        source: string(),
-        tokenAmount: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenMintToCheckedInstruction', {
-        account: string(),
-        authority: string(),
-        mint: string(),
-        mintAuthority: string(),
-        multisigMintAuthority: string(),
-        tokenAmount: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenBurnCheckedInstruction', {
-        account: string(),
-        authority: string(),
-        mint: string(),
-        multisigAuthority: string(),
-        tokenAmount: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenSyncNativeInstruction', {
-        account: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenGetAccountDataSizeInstruction', {
-        extensionTypes: list(string()),
-        mint: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenInitializeImmutableOwnerInstruction', {
-        account: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenAmountToUiAmountInstruction', {
-        amount: string(),
-        mint: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenUiAmountToAmountInstruction', {
-        mint: string(),
-        uiAmount: string(),
-    }),
-    parsedTransactionInstructionType('SplTokenInitializeMintCloseAuthorityInstruction', {
-        mint: string(),
-        newAuthority: string(),
-    }),
-    // TODO: Extensions!
-    // - TransferFeeExtension
-    // - ConfidentialTransferFeeExtension
-    // - DefaultAccountStateExtension
-    // - Reallocate
-    // - MemoTransferExtension
-    // - CreateNativeMint
-    // - InitializeNonTransferableMint
-    // - InterestBearingMintExtension
-    // - CpiGuardExtension
-    // - InitializePermanentDelegate
-    // - TransferHookExtension
-    // - ConfidentialTransferFeeExtension
-    // - WithdrawExcessLamports
-    // - MetadataPointerExtension
-];
+const parsedInstructionsSplToken = () => {
+    if (!memoisedParsedInstructionsSplToken)
+        memoisedParsedInstructionsSplToken = [
+            parsedTransactionInstructionType('SplTokenInitializeMintInstruction', {
+                decimals: number(),
+                freezeAuthority: string(),
+                mint: string(),
+                mintAuthority: string(),
+                rentSysvar: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenInitializeMint2Instruction', {
+                decimals: number(),
+                freezeAuthority: string(),
+                mint: string(),
+                mintAuthority: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenInitializeAccountInstruction', {
+                account: string(),
+                mint: string(),
+                owner: string(),
+                rentSysvar: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenInitializeAccount2Instruction', {
+                account: string(),
+                mint: string(),
+                owner: string(),
+                rentSysvar: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenInitializeAccount3Instruction', {
+                account: string(),
+                mint: string(),
+                owner: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenInitializeMultisigInstruction', {
+                m: number(),
+                multisig: string(),
+                rentSysvar: string(),
+                signers: list(string()),
+            }),
+            parsedTransactionInstructionType('SplTokenInitializeMultisig2Instruction', {
+                m: number(),
+                multisig: string(),
+                signers: list(string()),
+            }),
+            parsedTransactionInstructionType('SplTokenTransferInstruction', {
+                amount: string(),
+                authority: string(),
+                destination: string(),
+                multisigAuthority: string(),
+                source: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenApproveInstruction', {
+                amount: string(),
+                delegate: string(),
+                multisigOwner: string(),
+                owner: string(),
+                source: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenRevokeInstruction', {
+                multisigOwner: string(),
+                owner: string(),
+                source: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenSetAuthorityInstruction', {
+                authority: string(),
+                authorityType: string(),
+                multisigAuthority: string(),
+                newAuthority: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenMintToInstruction', {
+                account: string(),
+                amount: string(),
+                authority: string(),
+                mint: string(),
+                mintAuthority: string(),
+                multisigMintAuthority: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenBurnInstruction', {
+                account: string(),
+                amount: string(),
+                authority: string(),
+                mint: string(),
+                multisigAuthority: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenCloseAccountInstruction', {
+                account: string(),
+                destination: string(),
+                multisigOwner: string(),
+                owner: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenFreezeAccountInstruction', {
+                account: string(),
+                freezeAuthority: string(),
+                mint: string(),
+                multisigFreezeAuthority: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenThawAccountInstruction', {
+                account: string(),
+                freezeAuthority: string(),
+                mint: string(),
+                multisigFreezeAuthority: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenTransferCheckedInstruction', {
+                authority: string(),
+                destination: string(),
+                mint: string(),
+                multisigAuthority: string(),
+                source: string(),
+                tokenAmount: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenApproveCheckedInstruction', {
+                delegate: string(),
+                mint: string(),
+                multisigOwner: string(),
+                owner: string(),
+                source: string(),
+                tokenAmount: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenMintToCheckedInstruction', {
+                account: string(),
+                authority: string(),
+                mint: string(),
+                mintAuthority: string(),
+                multisigMintAuthority: string(),
+                tokenAmount: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenBurnCheckedInstruction', {
+                account: string(),
+                authority: string(),
+                mint: string(),
+                multisigAuthority: string(),
+                tokenAmount: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenSyncNativeInstruction', {
+                account: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenGetAccountDataSizeInstruction', {
+                extensionTypes: list(string()),
+                mint: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenInitializeImmutableOwnerInstruction', {
+                account: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenAmountToUiAmountInstruction', {
+                amount: string(),
+                mint: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenUiAmountToAmountInstruction', {
+                mint: string(),
+                uiAmount: string(),
+            }),
+            parsedTransactionInstructionType('SplTokenInitializeMintCloseAuthorityInstruction', {
+                mint: string(),
+                newAuthority: string(),
+            }),
+            // TODO: Extensions!
+            // - TransferFeeExtension
+            // - ConfidentialTransferFeeExtension
+            // - DefaultAccountStateExtension
+            // - Reallocate
+            // - MemoTransferExtension
+            // - CreateNativeMint
+            // - InitializeNonTransferableMint
+            // - InterestBearingMintExtension
+            // - CpiGuardExtension
+            // - InitializePermanentDelegate
+            // - TransferHookExtension
+            // - ConfidentialTransferFeeExtension
+            // - WithdrawExcessLamports
+            // - MetadataPointerExtension
+        ];
+    return memoisedParsedInstructionsSplToken;
+};
 
-const lockup = () =>
-    new GraphQLObjectType({
-        fields: {
-            custodian: string(),
-            epoch: bigint(),
-            unixTimestamp: bigint(),
-        },
-        name: 'Lockup',
-    });
+let memoisedLockup: GraphQLObjectType | undefined;
+const lockup = () => {
+    if (!memoisedLockup)
+        memoisedLockup = new GraphQLObjectType({
+            fields: {
+                custodian: string(),
+                epoch: bigint(),
+                unixTimestamp: bigint(),
+            },
+            name: 'Lockup',
+        });
+    return memoisedLockup;
+};
 
+let memoisedParsedInstructionsStake: GraphQLObjectType[] | undefined;
 /**
  * Stake program
  * @see https://github.com/solana-labs/solana/blob/7afb11f1e6daa3e9bd93cfe203211de5b14ba56a/transaction-status/src/parse_stake.rs#L13
  */
-const parsedInstructionsStake = () => [
-    parsedTransactionInstructionType('StakeInitializeInstruction', {
-        authorized: object('StakeInitializeInstructionAuthorized', {
-            staker: string(),
-            withdrawer: string(),
-        }),
-        lockup: object('StakeInitializeInstructionLockup', {
-            custodian: string(),
-            epoch: bigint(),
-            unixTimestamp: bigint(),
-        }),
-        rentSysvar: string(),
-        stakeAccount: string(),
-    }),
-    parsedTransactionInstructionType('StakeAuthorizeInstruction', {
-        authority: string(),
-        authorityType: string(),
-        clockSysvar: string(),
-        custodian: string(),
-        newAuthority: string(),
-        stakeAccount: string(),
-    }),
-    parsedTransactionInstructionType('StakeDelegateStakeInstruction', {
-        clockSysvar: string(),
-        stakeAccount: string(),
-        stakeAuthority: string(),
-        stakeConfigAccount: string(),
-        stakeHistorySysvar: string(),
-        voteAccount: string(),
-    }),
-    parsedTransactionInstructionType('StakeSplitInstruction', {
-        lamports: bigint(),
-        newSplitAccount: string(),
-        stakeAccount: string(),
-        stakeAuthority: string(),
-    }),
-    parsedTransactionInstructionType('StakeWithdrawInstruction', {
-        clockSysvar: string(),
-        destination: string(),
-        lamports: bigint(),
-        stakeAccount: string(),
-        withdrawAuthority: string(),
-    }),
-    parsedTransactionInstructionType('StakeDeactivateInstruction', {
-        clockSysvar: string(),
-        stakeAccount: string(),
-        stakeAuthority: string(),
-    }),
-    parsedTransactionInstructionType('StakeSetLockupInstruction', {
-        custodian: string(),
-        lockup: type(lockup()),
-        stakeAccount: string(),
-    }),
-    parsedTransactionInstructionType('StakeMergeInstruction', {
-        clockSysvar: string(),
-        destination: string(),
-        source: string(),
-        stakeAuthority: string(),
-        stakeHistorySysvar: string(),
-    }),
-    parsedTransactionInstructionType('StakeAuthorizeWithSeedInstruction', {
-        authorityBase: string(),
-        authorityOwner: string(),
-        authoritySeed: string(),
-        authorityType: string(),
-        clockSysvar: string(),
-        custodian: string(),
-        newAuthorized: string(),
-        stakeAccount: string(),
-    }),
-    parsedTransactionInstructionType('StakeInitializeCheckedInstruction', {
-        rentSysvar: string(),
-        stakeAccount: string(),
-        staker: string(),
-        withdrawer: string(),
-    }),
-    parsedTransactionInstructionType('StakeAuthorizeCheckedInstruction', {
-        authority: string(),
-        authorityType: string(),
-        clockSysvar: string(),
-        custodian: string(),
-        newAuthority: string(),
-        stakeAccount: string(),
-    }),
-    parsedTransactionInstructionType('StakeAuthorizeCheckedWithSeedInstruction', {
-        authorityBase: string(),
-        authorityOwner: string(),
-        authoritySeed: string(),
-        authorityType: string(),
-        clockSysvar: string(),
-        custodian: string(),
-        newAuthorized: string(),
-        stakeAccount: string(),
-    }),
-    parsedTransactionInstructionType('StakeSetLockupCheckedInstruction', {
-        custodian: string(),
-        lockup: type(lockup()),
-        stakeAccount: string(),
-    }),
-    parsedTransactionInstructionType('StakeDeactivateDelinquentInstruction', {
-        referenceVoteAccount: string(),
-        stakeAccount: string(),
-        voteAccount: string(),
-    }),
-    parsedTransactionInstructionType('StakeRedelegateInstruction', {
-        newStakeAccount: string(),
-        stakeAccount: string(),
-        stakeAuthority: string(),
-        stakeConfigAccount: string(),
-        voteAccount: string(),
-    }),
-];
+const parsedInstructionsStake = () => {
+    if (!memoisedParsedInstructionsStake)
+        memoisedParsedInstructionsStake = [
+            parsedTransactionInstructionType('StakeInitializeInstruction', {
+                authorized: object('StakeInitializeInstructionAuthorized', {
+                    staker: string(),
+                    withdrawer: string(),
+                }),
+                lockup: object('StakeInitializeInstructionLockup', {
+                    custodian: string(),
+                    epoch: bigint(),
+                    unixTimestamp: bigint(),
+                }),
+                rentSysvar: string(),
+                stakeAccount: string(),
+            }),
+            parsedTransactionInstructionType('StakeAuthorizeInstruction', {
+                authority: string(),
+                authorityType: string(),
+                clockSysvar: string(),
+                custodian: string(),
+                newAuthority: string(),
+                stakeAccount: string(),
+            }),
+            parsedTransactionInstructionType('StakeDelegateStakeInstruction', {
+                clockSysvar: string(),
+                stakeAccount: string(),
+                stakeAuthority: string(),
+                stakeConfigAccount: string(),
+                stakeHistorySysvar: string(),
+                voteAccount: string(),
+            }),
+            parsedTransactionInstructionType('StakeSplitInstruction', {
+                lamports: bigint(),
+                newSplitAccount: string(),
+                stakeAccount: string(),
+                stakeAuthority: string(),
+            }),
+            parsedTransactionInstructionType('StakeWithdrawInstruction', {
+                clockSysvar: string(),
+                destination: string(),
+                lamports: bigint(),
+                stakeAccount: string(),
+                withdrawAuthority: string(),
+            }),
+            parsedTransactionInstructionType('StakeDeactivateInstruction', {
+                clockSysvar: string(),
+                stakeAccount: string(),
+                stakeAuthority: string(),
+            }),
+            parsedTransactionInstructionType('StakeSetLockupInstruction', {
+                custodian: string(),
+                lockup: type(lockup()),
+                stakeAccount: string(),
+            }),
+            parsedTransactionInstructionType('StakeMergeInstruction', {
+                clockSysvar: string(),
+                destination: string(),
+                source: string(),
+                stakeAuthority: string(),
+                stakeHistorySysvar: string(),
+            }),
+            parsedTransactionInstructionType('StakeAuthorizeWithSeedInstruction', {
+                authorityBase: string(),
+                authorityOwner: string(),
+                authoritySeed: string(),
+                authorityType: string(),
+                clockSysvar: string(),
+                custodian: string(),
+                newAuthorized: string(),
+                stakeAccount: string(),
+            }),
+            parsedTransactionInstructionType('StakeInitializeCheckedInstruction', {
+                rentSysvar: string(),
+                stakeAccount: string(),
+                staker: string(),
+                withdrawer: string(),
+            }),
+            parsedTransactionInstructionType('StakeAuthorizeCheckedInstruction', {
+                authority: string(),
+                authorityType: string(),
+                clockSysvar: string(),
+                custodian: string(),
+                newAuthority: string(),
+                stakeAccount: string(),
+            }),
+            parsedTransactionInstructionType('StakeAuthorizeCheckedWithSeedInstruction', {
+                authorityBase: string(),
+                authorityOwner: string(),
+                authoritySeed: string(),
+                authorityType: string(),
+                clockSysvar: string(),
+                custodian: string(),
+                newAuthorized: string(),
+                stakeAccount: string(),
+            }),
+            parsedTransactionInstructionType('StakeSetLockupCheckedInstruction', {
+                custodian: string(),
+                lockup: type(lockup()),
+                stakeAccount: string(),
+            }),
+            parsedTransactionInstructionType('StakeDeactivateDelinquentInstruction', {
+                referenceVoteAccount: string(),
+                stakeAccount: string(),
+                voteAccount: string(),
+            }),
+            parsedTransactionInstructionType('StakeRedelegateInstruction', {
+                newStakeAccount: string(),
+                stakeAccount: string(),
+                stakeAuthority: string(),
+                stakeConfigAccount: string(),
+                voteAccount: string(),
+            }),
+        ];
+    return memoisedParsedInstructionsStake;
+};
 
+let memoisedParsedInstructionsSystem: GraphQLObjectType[] | undefined;
 /**
  * System program
  * @see https://github.com/solana-labs/solana/blob/d74de6780e2975472796a6a752b362152cd008a6/transaction-status/src/parse_system.rs#L13
  */
-const parsedInstructionsSystem = () => [
-    parsedTransactionInstructionType('CreateAccountInstruction', {
-        lamports: bigint(),
-        newAccount: string(),
-        owner: string(),
-        source: string(),
-        space: bigint(),
-    }),
-    parsedTransactionInstructionType('AssignInstruction', {
-        owner: string(),
-    }),
-    parsedTransactionInstructionType('TransferInstruction', {
-        amount: string(),
-        lamports: number(),
-        source: string(),
-    }),
-    parsedTransactionInstructionType('CreateAccountWithSeedInstruction', {
-        base: string(),
-        lamports: bigint(),
-        owner: string(),
-        seed: string(),
-        space: bigint(),
-    }),
-    parsedTransactionInstructionType('AdvanceNonceAccountInstruction', {
-        nonceAccount: string(),
-        nonceAuthority: string(),
-        recentBlockhashesSysvar: string(),
-    }),
-    parsedTransactionInstructionType('WithdrawNonceAccountInstruction', {
-        destination: string(),
-        lamports: bigint(),
-        nonceAccount: string(),
-        nonceAuthority: string(),
-        recentBlockhashesSysvar: string(),
-        rentSysvar: string(),
-    }),
-    parsedTransactionInstructionType('InitializeNonceAccountInstruction', {
-        nonceAccount: string(),
-        nonceAuthority: string(),
-        recentBlockhashesSysvar: string(),
-        rentSysvar: string(),
-    }),
-    parsedTransactionInstructionType('AuthorizeNonceAccountInstruction', {
-        newAuthorized: string(),
-        nonceAccount: string(),
-        nonceAuthority: string(),
-    }),
-    parsedTransactionInstructionType('UpgradeNonceAccountInstruction', {
-        nonceAccount: string(),
-    }),
-    parsedTransactionInstructionType('AllocateInstruction', {
-        account: string(),
-        space: bigint(),
-    }),
-    parsedTransactionInstructionType('AllocateWithSeedInstruction', {
-        account: string(),
-        base: string(),
-        owner: string(),
-        seed: string(),
-        space: bigint(),
-    }),
-    parsedTransactionInstructionType('AssignWithSeedInstruction', {
-        account: string(),
-        base: string(),
-        owner: string(),
-        seed: string(),
-    }),
-    parsedTransactionInstructionType('TransferWithSeedInstruction', {
-        destination: string(),
-        lamports: bigint(),
-        source: string(),
-        sourceBase: string(),
-        sourceOwner: string(),
-        sourceSeed: string(),
-    }),
-];
+const parsedInstructionsSystem = () => {
+    if (!memoisedParsedInstructionsSystem)
+        memoisedParsedInstructionsSystem = [
+            parsedTransactionInstructionType('CreateAccountInstruction', {
+                lamports: bigint(),
+                newAccount: string(),
+                owner: string(),
+                source: string(),
+                space: bigint(),
+            }),
+            parsedTransactionInstructionType('AssignInstruction', {
+                owner: string(),
+            }),
+            parsedTransactionInstructionType('TransferInstruction', {
+                amount: string(),
+                lamports: number(),
+                source: string(),
+            }),
+            parsedTransactionInstructionType('CreateAccountWithSeedInstruction', {
+                base: string(),
+                lamports: bigint(),
+                owner: string(),
+                seed: string(),
+                space: bigint(),
+            }),
+            parsedTransactionInstructionType('AdvanceNonceAccountInstruction', {
+                nonceAccount: string(),
+                nonceAuthority: string(),
+                recentBlockhashesSysvar: string(),
+            }),
+            parsedTransactionInstructionType('WithdrawNonceAccountInstruction', {
+                destination: string(),
+                lamports: bigint(),
+                nonceAccount: string(),
+                nonceAuthority: string(),
+                recentBlockhashesSysvar: string(),
+                rentSysvar: string(),
+            }),
+            parsedTransactionInstructionType('InitializeNonceAccountInstruction', {
+                nonceAccount: string(),
+                nonceAuthority: string(),
+                recentBlockhashesSysvar: string(),
+                rentSysvar: string(),
+            }),
+            parsedTransactionInstructionType('AuthorizeNonceAccountInstruction', {
+                newAuthorized: string(),
+                nonceAccount: string(),
+                nonceAuthority: string(),
+            }),
+            parsedTransactionInstructionType('UpgradeNonceAccountInstruction', {
+                nonceAccount: string(),
+            }),
+            parsedTransactionInstructionType('AllocateInstruction', {
+                account: string(),
+                space: bigint(),
+            }),
+            parsedTransactionInstructionType('AllocateWithSeedInstruction', {
+                account: string(),
+                base: string(),
+                owner: string(),
+                seed: string(),
+                space: bigint(),
+            }),
+            parsedTransactionInstructionType('AssignWithSeedInstruction', {
+                account: string(),
+                base: string(),
+                owner: string(),
+                seed: string(),
+            }),
+            parsedTransactionInstructionType('TransferWithSeedInstruction', {
+                destination: string(),
+                lamports: bigint(),
+                source: string(),
+                sourceBase: string(),
+                sourceOwner: string(),
+                sourceSeed: string(),
+            }),
+        ];
+    return memoisedParsedInstructionsSystem;
+};
 
-const vote = () =>
-    new GraphQLObjectType({
-        fields: {
-            hash: string(),
-            slots: list(bigint()),
-            timestamp: bigint(),
-        },
-        name: 'Vote',
-    });
+let memoisedVote: GraphQLObjectType | undefined;
+const vote = () => {
+    if (!memoisedVote)
+        memoisedVote = new GraphQLObjectType({
+            fields: {
+                hash: string(),
+                slots: list(bigint()),
+                timestamp: bigint(),
+            },
+            name: 'Vote',
+        });
+    return memoisedVote;
+};
 
-const voteStateUpdate = () =>
-    new GraphQLObjectType({
-        fields: {
-            hash: string(),
-            lockouts: list(
-                object('VoteStateUpdateLockout', {
-                    confirmationCount: number(),
-                    slot: bigint(),
-                })
-            ),
-            root: bigint(),
-            timestamp: bigint(),
-        },
-        name: 'VoteStateUpdate',
-    });
+let memoisedVoteStateUpdate: GraphQLObjectType | undefined;
+const voteStateUpdate = () => {
+    if (!memoisedVoteStateUpdate)
+        memoisedVoteStateUpdate = new GraphQLObjectType({
+            fields: {
+                hash: string(),
+                lockouts: list(
+                    object('VoteStateUpdateLockout', {
+                        confirmationCount: number(),
+                        slot: bigint(),
+                    })
+                ),
+                root: bigint(),
+                timestamp: bigint(),
+            },
+            name: 'VoteStateUpdate',
+        });
+    return memoisedVoteStateUpdate;
+};
 
+let memoisedParsedInstructionsVote: GraphQLObjectType[] | undefined;
 /**
  * Vote program
  * @see https://github.com/solana-labs/solana/blob/d74de6780e2975472796a6a752b362152cd008a6/transaction-status/src/parse_vote.rs#L12
  */
-const parsedInstructionsVote = () => [
-    parsedTransactionInstructionType('VoteInitializeAccountInstruction', {
-        authorizedVoter: string(),
-        authorizedWithdrawer: string(),
-        clockSysvar: string(),
-        commission: number(),
-        node: string(),
-        rentSysvar: string(),
-        voteAccount: string(),
-    }),
-    parsedTransactionInstructionType('VoteAuthorizeInstruction', {
-        authority: string(),
-        authorityType: string(),
-        clockSysvar: string(),
-        newAuthority: string(),
-        voteAccount: string(),
-    }),
-    parsedTransactionInstructionType('VoteAuthorizeWithSeedInstruction', {
-        authorityBaseKey: string(),
-        authorityOwner: string(),
-        authoritySeed: string(),
-        authorityType: string(),
-        clockSysvar: string(),
-        newAuthority: string(),
-        voteAccount: string(),
-    }),
-    parsedTransactionInstructionType('VoteAuthorizeCheckedWithSeedInstruction', {
-        authorityBaseKey: string(),
-        authorityOwner: string(),
-        authoritySeed: string(),
-        authorityType: string(),
-        clockSysvar: string(),
-        newAuthority: string(),
-        voteAccount: string(),
-    }),
-    parsedTransactionInstructionType('VoteVoteInstruction', {
-        clockSysvar: string(),
-        slotHashedSysvar: string(),
-        vote: type(vote()),
-        voteAccount: string(),
-        voteAuthority: string(),
-    }),
-    parsedTransactionInstructionType('VoteUpdateVoteStateInstruction', {
-        hash: string(),
-        voteAccount: string(),
-        voteAuthority: string(),
-        voteStateUpdate: type(voteStateUpdate()),
-    }),
-    parsedTransactionInstructionType('VoteUpdateVoteStateSwitchInstruction', {
-        hash: string(),
-        voteAccount: string(),
-        voteAuthority: string(),
-        voteStateUpdate: type(voteStateUpdate()),
-    }),
-    parsedTransactionInstructionType('VoteCompactUpdateVoteStateInstruction', {
-        hash: string(),
-        voteAccount: string(),
-        voteAuthority: string(),
-        voteStateUpdate: type(voteStateUpdate()),
-    }),
-    parsedTransactionInstructionType('VoteCompactUpdateVoteStateSwitchInstruction', {
-        hash: string(),
-        voteAccount: string(),
-        voteAuthority: string(),
-        voteStateUpdate: type(voteStateUpdate()),
-    }),
-    parsedTransactionInstructionType('VoteWithdrawInstruction', {
-        destination: string(),
-        lamports: bigint(),
-        voteAccount: string(),
-        withdrawAuthority: string(),
-    }),
-    parsedTransactionInstructionType('VoteUpdateValidatorIdentityInstruction', {
-        newValidatorIdentity: string(),
-        voteAccount: string(),
-        withdrawAuthority: string(),
-    }),
-    parsedTransactionInstructionType('VoteUpdateCommissionInstruction', {
-        commission: string(),
-        voteAccount: string(),
-        withdrawAuthority: string(),
-    }),
-    parsedTransactionInstructionType('VoteVoteSwitchInstruction', {
-        clockSysvar: string(),
-        hash: string(),
-        slotHashesSysvar: string(),
-        vote: type(vote()),
-        voteAccount: string(),
-        voteAuthority: string(),
-    }),
-    parsedTransactionInstructionType('VoteAuthorizeCheckedInstruction', {
-        authority: string(),
-        authorityType: string(),
-        clockSysvar: string(),
-        newAuthority: string(),
-        voteAccount: string(),
-    }),
-];
+const parsedInstructionsVote = () => {
+    if (!memoisedParsedInstructionsVote)
+        memoisedParsedInstructionsVote = [
+            parsedTransactionInstructionType('VoteInitializeAccountInstruction', {
+                authorizedVoter: string(),
+                authorizedWithdrawer: string(),
+                clockSysvar: string(),
+                commission: number(),
+                node: string(),
+                rentSysvar: string(),
+                voteAccount: string(),
+            }),
+            parsedTransactionInstructionType('VoteAuthorizeInstruction', {
+                authority: string(),
+                authorityType: string(),
+                clockSysvar: string(),
+                newAuthority: string(),
+                voteAccount: string(),
+            }),
+            parsedTransactionInstructionType('VoteAuthorizeWithSeedInstruction', {
+                authorityBaseKey: string(),
+                authorityOwner: string(),
+                authoritySeed: string(),
+                authorityType: string(),
+                clockSysvar: string(),
+                newAuthority: string(),
+                voteAccount: string(),
+            }),
+            parsedTransactionInstructionType('VoteAuthorizeCheckedWithSeedInstruction', {
+                authorityBaseKey: string(),
+                authorityOwner: string(),
+                authoritySeed: string(),
+                authorityType: string(),
+                clockSysvar: string(),
+                newAuthority: string(),
+                voteAccount: string(),
+            }),
+            parsedTransactionInstructionType('VoteVoteInstruction', {
+                clockSysvar: string(),
+                slotHashedSysvar: string(),
+                vote: type(vote()),
+                voteAccount: string(),
+                voteAuthority: string(),
+            }),
+            parsedTransactionInstructionType('VoteUpdateVoteStateInstruction', {
+                hash: string(),
+                voteAccount: string(),
+                voteAuthority: string(),
+                voteStateUpdate: type(voteStateUpdate()),
+            }),
+            parsedTransactionInstructionType('VoteUpdateVoteStateSwitchInstruction', {
+                hash: string(),
+                voteAccount: string(),
+                voteAuthority: string(),
+                voteStateUpdate: type(voteStateUpdate()),
+            }),
+            parsedTransactionInstructionType('VoteCompactUpdateVoteStateInstruction', {
+                hash: string(),
+                voteAccount: string(),
+                voteAuthority: string(),
+                voteStateUpdate: type(voteStateUpdate()),
+            }),
+            parsedTransactionInstructionType('VoteCompactUpdateVoteStateSwitchInstruction', {
+                hash: string(),
+                voteAccount: string(),
+                voteAuthority: string(),
+                voteStateUpdate: type(voteStateUpdate()),
+            }),
+            parsedTransactionInstructionType('VoteWithdrawInstruction', {
+                destination: string(),
+                lamports: bigint(),
+                voteAccount: string(),
+                withdrawAuthority: string(),
+            }),
+            parsedTransactionInstructionType('VoteUpdateValidatorIdentityInstruction', {
+                newValidatorIdentity: string(),
+                voteAccount: string(),
+                withdrawAuthority: string(),
+            }),
+            parsedTransactionInstructionType('VoteUpdateCommissionInstruction', {
+                commission: string(),
+                voteAccount: string(),
+                withdrawAuthority: string(),
+            }),
+            parsedTransactionInstructionType('VoteVoteSwitchInstruction', {
+                clockSysvar: string(),
+                hash: string(),
+                slotHashesSysvar: string(),
+                vote: type(vote()),
+                voteAccount: string(),
+                voteAuthority: string(),
+            }),
+            parsedTransactionInstructionType('VoteAuthorizeCheckedInstruction', {
+                authority: string(),
+                authorityType: string(),
+                clockSysvar: string(),
+                newAuthority: string(),
+                voteAccount: string(),
+            }),
+        ];
+    return memoisedParsedInstructionsVote;
+};
 
+let memoisedTransactionMetaInterfaceFields: object | undefined;
 /**
  * The fields for the transaction meta interface
  */
-const transactionMetaInterfaceFields = () => ({
-    computeUnitsConsumed: bigint(),
-    err: string(),
-    fee: bigint(),
-    format: string(),
-    loadedAddresses: type(transactionMetaLoadedAddresses()),
-    logMessages: list(string()),
-    postBalances: list(bigint()),
-    postTokenBalances: list(type(tokenBalance())),
-    preBalances: list(bigint()),
-    preTokenBalances: list(type(tokenBalance())),
-    returnData: type(returnData()),
-    rewards: list(type(reward())),
-    status: type(transactionStatus()),
-});
+const transactionMetaInterfaceFields = () => {
+    if (!memoisedTransactionMetaInterfaceFields)
+        memoisedTransactionMetaInterfaceFields = {
+            computeUnitsConsumed: bigint(),
+            err: string(),
+            fee: bigint(),
+            format: string(),
+            loadedAddresses: type(transactionMetaLoadedAddresses()),
+            logMessages: list(string()),
+            postBalances: list(bigint()),
+            postTokenBalances: list(type(tokenBalance())),
+            preBalances: list(bigint()),
+            preTokenBalances: list(type(tokenBalance())),
+            returnData: type(returnData()),
+            rewards: list(type(reward())),
+            status: type(transactionStatus()),
+        };
+    return memoisedTransactionMetaInterfaceFields;
+};
 
+let memoisedTransactionMetaInterface: GraphQLInterfaceType | undefined;
 /**
  * Interface for a transaction meta
  */
-const transactionMetaInterface = () =>
-    new GraphQLInterfaceType({
-        fields: {
-            ...transactionMetaInterfaceFields(),
-        },
-        name: 'TransactionMeta',
-        resolveType(meta) {
-            if (meta.format === 'parsed') {
-                return 'TransactionMetaParsed';
-            }
-            return 'TransactionMetaUnparsed';
-        },
-    });
+const transactionMetaInterface = () => {
+    if (!memoisedTransactionMetaInterface)
+        memoisedTransactionMetaInterface = new GraphQLInterfaceType({
+            fields: {
+                ...transactionMetaInterfaceFields(),
+            },
+            name: 'TransactionMeta',
+            resolveType(meta) {
+                if (meta.format === 'parsed') {
+                    return 'TransactionMetaParsed';
+                }
+                return 'TransactionMetaUnparsed';
+            },
+        });
+    return memoisedTransactionMetaInterface;
+};
 
 /**
  * Builds a transaction meta type
@@ -1133,65 +1234,82 @@ const transactionMetaType = (
         name,
     });
 
-const transactionMetaUnparsed = () =>
-    transactionMetaType(
-        'TransactionMetaUnparsed',
-        'Non-parsed transaction meta',
-        list(
-            object('TransactionMetaInnerInstructionsUnparsed', {
-                index: number(),
-                instructions: list(
-                    object('TransactionMetaInnerInstructionsUnparsedInstruction', {
-                        index: number(),
-                        instructions: list(type(transactionInstruction())),
-                    })
-                ),
-            })
-        )
-    );
+let memoisedTransactionMetaUnparsed: GraphQLObjectType | undefined;
+const transactionMetaUnparsed = () => {
+    if (!memoisedTransactionMetaUnparsed)
+        memoisedTransactionMetaUnparsed = transactionMetaType(
+            'TransactionMetaUnparsed',
+            'Non-parsed transaction meta',
+            list(
+                object('TransactionMetaInnerInstructionsUnparsed', {
+                    index: number(),
+                    instructions: list(
+                        object('TransactionMetaInnerInstructionsUnparsedInstruction', {
+                            index: number(),
+                            instructions: list(type(transactionInstruction())),
+                        })
+                    ),
+                })
+            )
+        );
+    return memoisedTransactionMetaUnparsed;
+};
 
-const transactionMetaParsed = () =>
-    transactionMetaType(
-        'TransactionMetaParsed',
-        'Parsed transaction meta',
-        list(
-            object('TransactionMetaInnerInstructionsParsed', {
-                index: number(),
-                instructions: list(type(parsedTransactionInstructionInterface())),
-            })
-        )
-    );
+let memoisedTransactionMetaParsed: GraphQLObjectType | undefined;
+const transactionMetaParsed = () => {
+    if (!memoisedTransactionMetaParsed)
+        memoisedTransactionMetaParsed = transactionMetaType(
+            'TransactionMetaParsed',
+            'Parsed transaction meta',
+            list(
+                object('TransactionMetaInnerInstructionsParsed', {
+                    index: number(),
+                    instructions: list(type(parsedTransactionInstructionInterface())),
+                })
+            )
+        );
+    return memoisedTransactionMetaParsed;
+};
 
+let memoisedTransactionMessageInterfaceFields: object | undefined;
 /**
  * The fields for the transaction message interface
  */
-const transactionMessageInterfaceFields = () => ({
-    addressTableLookups: list(type(addressTableLookup())),
-    format: string(),
-    header: object('TransactionJsonTransactionHeader', {
-        numReadonlySignedAccounts: number(),
-        numReadonlyUnsignedAccounts: number(),
-        numRequiredSignatures: number(),
-    }),
-    recentBlockhash: string(),
-});
+const transactionMessageInterfaceFields = () => {
+    if (!memoisedTransactionMessageInterfaceFields)
+        memoisedTransactionMessageInterfaceFields = {
+            addressTableLookups: list(type(addressTableLookup())),
+            format: string(),
+            header: object('TransactionJsonTransactionHeader', {
+                numReadonlySignedAccounts: number(),
+                numReadonlyUnsignedAccounts: number(),
+                numRequiredSignatures: number(),
+            }),
+            recentBlockhash: string(),
+        };
+    return memoisedTransactionMessageInterfaceFields;
+};
 
+let memoisedTransactionMessageInterface: GraphQLInterfaceType | undefined;
 /**
  * Interface for a transaction message
  */
-const transactionMessageInterface = () =>
-    new GraphQLInterfaceType({
-        fields: {
-            ...transactionMessageInterfaceFields(),
-        },
-        name: 'TransactionMessage',
-        resolveType(message) {
-            if (message.format === 'parsed') {
-                return 'TransactionMessageParsed';
-            }
-            return 'TransactionMessageUnparsed';
-        },
-    });
+const transactionMessageInterface = () => {
+    if (!memoisedTransactionMessageInterface)
+        memoisedTransactionMessageInterface = new GraphQLInterfaceType({
+            fields: {
+                ...transactionMessageInterfaceFields(),
+            },
+            name: 'TransactionMessage',
+            resolveType(message) {
+                if (message.format === 'parsed') {
+                    return 'TransactionMessageParsed';
+                }
+                return 'TransactionMessageUnparsed';
+            },
+        });
+    return memoisedTransactionMessageInterface;
+};
 
 /**
  * Builds a transaction message type
@@ -1218,73 +1336,94 @@ const transactionMessageType = (
         name,
     });
 
-const transactionMessageUnparsed = () =>
-    transactionMessageType(
-        'TransactionMessageUnparsed',
-        'Non-parsed transaction message',
-        list(string()),
-        list(type(transactionInstruction()))
-    );
+let memoisedTransactionMessageUnparsed: GraphQLObjectType | undefined;
+const transactionMessageUnparsed = () => {
+    if (!memoisedTransactionMessageUnparsed)
+        memoisedTransactionMessageUnparsed = transactionMessageType(
+            'TransactionMessageUnparsed',
+            'Non-parsed transaction message',
+            list(string()),
+            list(type(transactionInstruction()))
+        );
+    return memoisedTransactionMessageUnparsed;
+};
 
-const transactionMessageParsed = () =>
-    transactionMessageType(
-        'TransactionMessageParsed',
-        'Parsed transaction message',
-        list(
-            object('transactionMessageParsedAccountKey', {
-                pubkey: string(),
-                signer: boolean(),
-                source: string(),
-                writable: boolean(),
-            })
-        ),
-        list(type(parsedTransactionInstructionInterface()))
-    );
+let memoisedTransactionMessageParsed: GraphQLObjectType | undefined;
+const transactionMessageParsed = () => {
+    if (!memoisedTransactionMessageParsed)
+        memoisedTransactionMessageParsed = transactionMessageType(
+            'TransactionMessageParsed',
+            'Parsed transaction message',
+            list(
+                object('transactionMessageParsedAccountKey', {
+                    pubkey: string(),
+                    signer: boolean(),
+                    source: string(),
+                    writable: boolean(),
+                })
+            ),
+            list(type(parsedTransactionInstructionInterface()))
+        );
+    return memoisedTransactionMessageParsed;
+};
 
+let memoisedTransactionTransaction: GraphQLObjectType | undefined;
 /**
  * The standard transaction type, comprised of all the interfaces
  */
-const transactionTransaction = () =>
-    new GraphQLObjectType({
-        fields: {
-            message: type(transactionMessageInterface()),
-            signatures: list(string()),
-        },
-        name: 'TransactionTransaction',
-    });
+const transactionTransaction = () => {
+    if (!memoisedTransactionTransaction)
+        memoisedTransactionTransaction = new GraphQLObjectType({
+            fields: {
+                message: type(transactionMessageInterface()),
+                signatures: list(string()),
+            },
+            name: 'TransactionTransaction',
+        });
+    return memoisedTransactionTransaction;
+};
 
+let memoisedTransactionInterfaceFields: object | undefined;
 /**
  * The fields for the transaction interface
  */
-const transactionInterfaceFields = () => ({
-    blockTime: bigint(),
-    encoding: string(),
-    meta: type(transactionMetaInterface()),
-    slot: bigint(),
-});
+const transactionInterfaceFields = () => {
+    if (!memoisedTransactionInterfaceFields)
+        memoisedTransactionInterfaceFields = {
+            blockTime: bigint(),
+            encoding: string(),
+            meta: type(transactionMetaInterface()),
+            slot: bigint(),
+        };
+    return memoisedTransactionInterfaceFields;
+};
 
+let memoisedTransactionInterface: GraphQLInterfaceType | undefined;
 /**
  * Interface for a transaction
  */
-export const transactionInterface = () =>
-    new GraphQLInterfaceType({
-        fields: {
-            ...transactionInterfaceFields(),
-        },
-        name: 'Transaction',
-        resolveType(transaction) {
-            if (transaction.encoding === 'base58') {
-                return 'TransactionBase58';
-            }
-            if (transaction.encoding === 'base64') {
-                return 'TransactionBase64';
-            }
-            if (transaction.encoding === 'json') {
-                return 'TransactionJson';
-            }
-            return 'TransactionJsonParsed';
-        },
-    });
+export const transactionInterface = () => {
+    if (!memoisedTransactionInterface)
+        memoisedTransactionInterface = new GraphQLInterfaceType({
+            fields: {
+                ...transactionInterfaceFields(),
+            },
+            name: 'Transaction',
+            resolveType(transaction) {
+                if (transaction.encoding === 'base58') {
+                    return 'TransactionBase58';
+                }
+                if (transaction.encoding === 'base64') {
+                    return 'TransactionBase64';
+                }
+                if (transaction.encoding === 'json') {
+                    return 'TransactionJson';
+                }
+                return 'TransactionJsonParsed';
+            },
+        });
+    return memoisedTransactionInterface;
+};
 
 /**
  * Builds a transaction type
@@ -1308,39 +1447,72 @@ const transactionType = (
         name,
     });
 
-const transactionBase58 = () =>
-    transactionType('TransactionBase58', 'A Solana transaction as base58 encoded data', string());
+let memoisedTransactionBase58: GraphQLObjectType | undefined;
+const transactionBase58 = () => {
+    if (!memoisedTransactionBase58)
+        memoisedTransactionBase58 = transactionType(
+            'TransactionBase58',
+            'A Solana transaction as base58 encoded data',
+            string()
+        );
+    return memoisedTransactionBase58;
+};
 
-const transactionBase64 = () =>
-    transactionType('TransactionBase64', 'A Solana transaction as base64 encoded data', string());
+let memoisedTransactionBase64: GraphQLObjectType | undefined;
+const transactionBase64 = () => {
+    if (!memoisedTransactionBase64)
+        memoisedTransactionBase64 = transactionType(
+            'TransactionBase64',
+            'A Solana transaction as base64 encoded data',
+            string()
+        );
+    return memoisedTransactionBase64;
+};
 
-const transactionJson = () =>
-    transactionType('TransactionJson', 'A Solana transaction as a JSON object', type(transactionTransaction()));
+let memoisedTransactionJson: GraphQLObjectType | undefined;
+const transactionJson = () => {
+    if (!memoisedTransactionJson)
+        memoisedTransactionJson = transactionType(
+            'TransactionJson',
+            'A Solana transaction as a JSON object',
+            type(transactionTransaction())
+        );
+    return memoisedTransactionJson;
+};
 
-const transactionJsonParsed = () =>
-    transactionType(
-        'TransactionJsonParsed',
-        'A Solana transaction as a parsed JSON object',
-        type(transactionTransaction())
-    );
+let memoisedTransactionJsonParsed: GraphQLObjectType | undefined;
+const transactionJsonParsed = () => {
+    if (!memoisedTransactionJsonParsed)
+        memoisedTransactionJsonParsed = transactionType(
+            'TransactionJsonParsed',
+            'A Solana transaction as a parsed JSON object',
+            type(transactionTransaction())
+        );
+    return memoisedTransactionJsonParsed;
+};
 
-export const transactionTypes = () => [
-    partiallyDecodedTransactionInstruction(),
-    ...parsedInstructionsAddressLookupTable(),
-    ...parsedInstructionsBpfLoader(),
-    ...parsedInstructionsBpfUpgradeableLoader(),
-    ...parsedInstructionsStake(),
-    ...parsedInstructionsSplAssociatedToken(),
-    parsedInstructionSplMemo(),
-    ...parsedInstructionsSplToken(),
-    ...parsedInstructionsSystem(),
-    ...parsedInstructionsVote(),
-    transactionMetaUnparsed(),
-    transactionMetaParsed(),
-    transactionMessageUnparsed(),
-    transactionMessageParsed(),
-    transactionBase58(),
-    transactionBase64(),
-    transactionJson(),
-    transactionJsonParsed(),
-];
+let memoisedTransactionTypes: GraphQLObjectType[] | undefined;
+export const transactionTypes = () => {
+    if (!memoisedTransactionTypes)
+        memoisedTransactionTypes = [
+            partiallyDecodedTransactionInstruction(),
+            ...parsedInstructionsAddressLookupTable(),
+            ...parsedInstructionsBpfLoader(),
+            ...parsedInstructionsBpfUpgradeableLoader(),
+            ...parsedInstructionsStake(),
+            ...parsedInstructionsSplAssociatedToken(),
+            parsedInstructionSplMemo(),
+            ...parsedInstructionsSplToken(),
+            ...parsedInstructionsSystem(),
+            ...parsedInstructionsVote(),
+            transactionMetaUnparsed(),
+            transactionMetaParsed(),
+            transactionMessageUnparsed(),
+            transactionMessageParsed(),
+            transactionBase58(),
+            transactionBase64(),
+            transactionJson(),
+            transactionJsonParsed(),
+        ];
+    return memoisedTransactionTypes;
+};


### PR DESCRIPTION
This PR makes `@solana/rpc-graphql` tree-shakable, which is previously was not.

Basically, there appears to be _a lot_ of changes, but I've just converted static constants to arrow functions. Nothing else has been changed.
