### PR TITLE
createLookupTable should not require authority to be the signer

### DIFF
--- a/packages/library-legacy/src/programs/address-lookup-table/index.ts
+++ b/packages/library-legacy/src/programs/address-lookup-table/index.ts
@@ -290,7 +290,7 @@ export class AddressLookupTableProgram {
       },
       {
         pubkey: params.authority,
-        isSigner: true,
+        isSigner: false,
         isWritable: false,
       },
       {


### PR DESCRIPTION
Authority should not be required as a signer for createLookupTable:
https://github.com/solana-labs/solana/pull/27248

Creation of a LookupTable via a Proposal using SPL Governance should allow for more flexibility as Slots are difficult to predict, ultimately Slots can easily be missed during instruction execution. Creation should be made by the payer which is flexible to set the authority as needed which in this case can be a Governance Treasury Wallet address that is not the same with the payer