### PR TITLE
refactor(experimental): use new codecs to de/serialize Instructions

### DIFF
--- a/packages/transactions/src/serializers/__tests__/instruction-test.ts
+++ b/packages/transactions/src/serializers/__tests__/instruction-test.ts
@@ -1,74 +1,60 @@
-import { getInstructionCodec } from '../instruction';
+import { getInstructionCodec, getInstructionDecoder, getInstructionEncoder } from '../instruction';
 
 describe('Instruction codec', () => {
-    let instruction: ReturnType<typeof getInstructionCodec>;
-    beforeEach(() => {
-        instruction = getInstructionCodec();
-    });
-    it('serializes an instruction according to spec', () => {
-        expect(
-            instruction.serialize({
-                accountIndices: [1, 2],
-                data: new Uint8Array([4, 5, 6]),
-                programAddressIndex: 7,
-            })
-        ).toEqual(
-            new Uint8Array([
-                // Program id index
-                7,
-                // Compact array of account indices
-                2, // Compact-u16 length
-                1,
-                2,
-                // Compact array of instruction data
-                3, // Compact-u16 length
-                4,
-                5,
-                6,
-            ])
-        );
-    });
-    it('serializes a zero-length compact array when `accountIndices` is `undefined`', () => {
-        expect(
-            instruction.serialize({
-                data: new Uint8Array([3, 4]),
-                programAddressIndex: 1,
-            })
-        ).toEqual(
-            new Uint8Array([
-                // Program id index
-                1,
-                // Compact array of account indices
-                0, // Compact-u16 length
-                // Compact array of instruction data
-                2, // Compact-u16 length
-                3,
-                4,
-            ])
-        );
-    });
-    it('serializes a zero-length compact array when `data` is `undefined`', () => {
-        expect(
-            instruction.serialize({
-                accountIndices: [3, 4],
-                programAddressIndex: 1,
-            })
-        ).toEqual(
-            new Uint8Array([
-                // Program id index
-                1,
-                // Compact array of account indices
-                2, // Compact-u16 length
-                3,
-                4,
-                // Compact array of instruction data
-                0, // Compact-u16 length
-            ])
-        );
-    });
-    it('deserializes an instruction according to spec', () => {
-        expect(
-            instruction.deserialize(
+    describe.each([getInstructionEncoder, getInstructionCodec])('instruction encoder %p', encoderFactory => {
+        let instruction: ReturnType<typeof getInstructionEncoder>;
+        beforeEach(() => {
+            instruction = encoderFactory();
+        });
+        it('serializes an instruction according to spec', () => {
+            expect(
+                instruction.encode({
+                    accountIndices: [1, 2],
+                    data: new Uint8Array([4, 5, 6]),
+                    programAddressIndex: 7,
+                })
+            ).toEqual(
+                new Uint8Array([
+                    // Program id index
+                    7,
+                    // Compact array of account indices
+                    2, // Compact-u16 length
+                    1,
+                    2,
+                    // Compact array of instruction data
+                    3, // Compact-u16 length
+                    4,
+                    5,
+                    6,
+                ])
+            );
+        });
+        it('serializes a zero-length compact array when `accountIndices` is `undefined`', () => {
+            expect(
+                instruction.encode({
+                    data: new Uint8Array([3, 4]),
+                    programAddressIndex: 1,
+                })
+            ).toEqual(
+                new Uint8Array([
+                    // Program id index
+                    1,
+                    // Compact array of account indices
+                    0, // Compact-u16 length
+                    // Compact array of instruction data
+                    2, // Compact-u16 length
+                    3,
+                    4,
+                ])
+            );
+        });
+        it('serializes a zero-length compact array when `data` is `undefined`', () => {
+            expect(
+                instruction.encode({
+                    accountIndices: [3, 4],
+                    programAddressIndex: 1,
+                })
+            ).toEqual(
                 new Uint8Array([
                     // Program id index
                     1,
@@ -77,50 +63,73 @@ describe('Instruction codec', () => {
                     3,
                     4,
                     // Compact array of instruction data
-                    5, // Compact-u16 length
-                    6,
-                    7,
-                    8,
-                    9,
-                    10,
+                    0, // Compact-u16 length
                 ])
-            )[0]
-        ).toEqual({
-            accountIndices: [3, 4],
-            data: new Uint8Array([6, 7, 8, 9, 10]),
-            programAddressIndex: 1,
+            );
         });
     });
-    it('omits the `accountIndices` property when the indices data is zero-length', () => {
-        expect(
-            instruction.deserialize(
-                new Uint8Array([
-                    // Program id index
-                    1,
-                    // Compact array of account indices
-                    0, // Compact-u16 length
-                    // Compact array of instruction data
-                    2, // Compact-u16 length
-                    3,
-                    4,
-                ])
-            )[0]
-        ).not.toHaveProperty('accountIndices');
-    });
-    it('omits the `data` property when the instruction data is zero-length', () => {
-        expect(
-            instruction.deserialize(
-                new Uint8Array([
-                    // Program id index
-                    1,
-                    // Compact array of account indices
-                    2, // Compact-u16 length
-                    3,
-                    4,
-                    // Compact array of instruction data
-                    0, // Compact-u16 length
-                ])
-            )[0]
-        ).not.toHaveProperty('data');
+
+    describe.each([getInstructionDecoder, getInstructionCodec])('instruction decoder %p', decoderFactory => {
+        let instruction: ReturnType<typeof getInstructionDecoder>;
+        beforeEach(() => {
+            instruction = decoderFactory();
+        });
+        it('deserializes an instruction according to spec', () => {
+            expect(
+                instruction.decode(
+                    new Uint8Array([
+                        // Program id index
+                        1,
+                        // Compact array of account indices
+                        2, // Compact-u16 length
+                        3,
+                        4,
+                        // Compact array of instruction data
+                        5, // Compact-u16 length
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                    ])
+                )[0]
+            ).toEqual({
+                accountIndices: [3, 4],
+                data: new Uint8Array([6, 7, 8, 9, 10]),
+                programAddressIndex: 1,
+            });
+        });
+        it('omits the `accountIndices` property when the indices data is zero-length', () => {
+            expect(
+                instruction.decode(
+                    new Uint8Array([
+                        // Program id index
+                        1,
+                        // Compact array of account indices
+                        0, // Compact-u16 length
+                        // Compact array of instruction data
+                        2, // Compact-u16 length
+                        3,
+                        4,
+                    ])
+                )[0]
+            ).not.toHaveProperty('accountIndices');
+        });
+        it('omits the `data` property when the instruction data is zero-length', () => {
+            expect(
+                instruction.decode(
+                    new Uint8Array([
+                        // Program id index
+                        1,
+                        // Compact array of account indices
+                        2, // Compact-u16 length
+                        3,
+                        4,
+                        // Compact array of instruction data
+                        0, // Compact-u16 length
+                    ])
+                )[0]
+            ).not.toHaveProperty('data');
+        });
     });
 });

--- a/packages/transactions/src/serializers/instruction.ts
+++ b/packages/transactions/src/serializers/instruction.ts
@@ -1,71 +1,98 @@
-import { array, bytes, mapSerializer, Serializer, shortU16, struct, u8 } from '@metaplex-foundation/umi-serializers';
+import { Codec, combineCodec, Decoder, Encoder, mapDecoder, mapEncoder } from '@solana/codecs-core';
+import {
+    getArrayDecoder,
+    getArrayEncoder,
+    getBytesDecoder,
+    getBytesEncoder,
+    getStructDecoder,
+    getStructEncoder,
+} from '@solana/codecs-data-structures';
+import { getShortU16Decoder, getShortU16Encoder, getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
 
 import { getCompiledInstructions } from '../compile-instructions';
 
 type Instruction = ReturnType<typeof getCompiledInstructions>[number];
 
-export function getInstructionCodec(): Serializer<Instruction> {
-    return mapSerializer<Instruction, Required<Instruction>>(
-        struct([
-            [
-                'programAddressIndex',
-                u8(
-                    __DEV__
-                        ? {
-                              description:
-                                  'The index of the program being called, according to the ' +
-                                  'well-ordered accounts list for this transaction',
-                          }
-                        : undefined
-                ),
-            ],
-            [
-                'accountIndices',
-                array(
-                    u8({
-                        description: __DEV__
-                            ? 'The index of an account, according to the well-ordered accounts ' +
-                              'list for this transaction'
-                            : '',
+const programAddressIndexDescription = __DEV__
+    ? 'The index of the program being called, according to the well-ordered accounts list for this transaction'
+    : 'programAddressIndex';
+
+const accountIndexDescription = __DEV__
+    ? 'The index of an account, according to the well-ordered accounts list for this transaction'
+    : undefined;
+
+const accountIndicesDescription = __DEV__
+    ? 'An optional list of account indices, according to the ' +
+      'well-ordered accounts list for this transaction, in the order in ' +
+      'which the program being called expects them'
+    : 'accountIndices';
+
+const dataDescription = __DEV__ ? 'An optional buffer of data passed to the instruction' : 'data';
+
+let memoizedGetInstructionEncoder: Encoder<Instruction> | undefined;
+export function getInstructionEncoder(): Encoder<Instruction> {
+    if (!memoizedGetInstructionEncoder) {
+        memoizedGetInstructionEncoder = mapEncoder<Required<Instruction>, Instruction>(
+            getStructEncoder([
+                ['programAddressIndex', getU8Encoder({ description: programAddressIndexDescription })],
+                [
+                    'accountIndices',
+                    getArrayEncoder(getU8Encoder({ description: accountIndexDescription }), {
+                        description: accountIndicesDescription,
+                        size: getShortU16Encoder(),
                     }),
-                    {
-                        description: __DEV__
-                            ? 'An optional list of account indices, according to the ' +
-                              'well-ordered accounts list for this transaction, in the order in ' +
-                              'which the program being called expects them'
-                            : '',
-                        size: shortU16(),
-                    }
-                ),
-            ],
-            [
-                'data',
-                bytes({
-                    description: __DEV__ ? 'An optional buffer of data passed to the instruction' : '',
-                    size: shortU16(),
-                }),
-            ],
-        ]),
-        (value: Instruction) => {
-            if (value.accountIndices !== undefined && value.data !== undefined) {
-                return value as Required<Instruction>;
+                ],
+                ['data', getBytesEncoder({ description: dataDescription, size: getShortU16Encoder() })],
+            ]),
+            // Convert an instruction to have all fields defined
+            (instruction: Instruction): Required<Instruction> => {
+                if (instruction.accountIndices !== undefined && instruction.data !== undefined) {
+                    return instruction as Required<Instruction>;
+                }
+                return {
+                    ...instruction,
+                    accountIndices: instruction.accountIndices ?? [],
+                    data: instruction.data ?? new Uint8Array(0),
+                } as Required<Instruction>;
             }
-            return {
-                ...value,
-                accountIndices: value.accountIndices ?? [],
-                data: value.data ?? new Uint8Array(0),
-            } as Required<Instruction>;
-        },
-        (value: Required<Instruction>) => {
-            if (value.accountIndices.length && value.data.byteLength) {
-                return value;
+        );
+    }
+
+    return memoizedGetInstructionEncoder;
+}
+
+let memoizedGetInstructionDecoder: Decoder<Instruction> | undefined;
+export function getInstructionDecoder(): Decoder<Instruction> {
+    if (!memoizedGetInstructionDecoder) {
+        memoizedGetInstructionDecoder = mapDecoder<Required<Instruction>, Instruction>(
+            getStructDecoder([
+                ['programAddressIndex', getU8Decoder({ description: programAddressIndexDescription })],
+                [
+                    'accountIndices',
+                    getArrayDecoder(getU8Decoder({ description: accountIndexDescription }), {
+                        description: accountIndicesDescription,
+                        size: getShortU16Decoder(),
+                    }),
+                ],
+                ['data', getBytesDecoder({ description: dataDescription, size: getShortU16Decoder() })],
+            ]),
+            // Convert an instruction to exclude optional fields if they are empty
+            (instruction: Required<Instruction>): Instruction => {
+                if (instruction.accountIndices.length && instruction.data.byteLength) {
+                    return instruction;
+                }
+                const { accountIndices, data, ...rest } = instruction;
+                return {
+                    ...rest,
+                    ...(accountIndices.length ? { accountIndices } : null),
+                    ...(data.byteLength ? { data } : null),
+                };
             }
-            const { accountIndices, data, ...rest } = value;
-            return {
-                ...rest,
-                ...(accountIndices.length ? { accountIndices } : null),
-                ...(data.byteLength ? { data } : null),
-            };
-        }
-    );
+        );
+    }
+    return memoizedGetInstructionDecoder;
+}
+
+export function getInstructionCodec(): Codec<Instruction> {
+    return combineCodec(getInstructionEncoder(), getInstructionDecoder());
 }

--- a/packages/transactions/src/serializers/message.ts
+++ b/packages/transactions/src/serializers/message.ts
@@ -101,7 +101,7 @@ function getPreludeStructSerializerTuple(): StructToSerializerTuple<CompiledMess
         ],
         [
             'instructions',
-            array(getInstructionCodec(), {
+            array(toSerializer(getInstructionCodec()), {
                 description: __DEV__ ? 'A compact-array of instructions belonging to this transaction' : '',
                 size: shortU16(),
             }),


### PR DESCRIPTION
Note that the implementation here is slightly different to what I've done before, but I think better:

- The Encoder/Decoder are memoized at the top level, instead of memoizing constituent parts (this was dumb)
- I used `combineCodec` instead of manually writing the codec (this was also dumb)
