### PR TITLE
refactor(experimental): a signature-only confirmation strategy

### DIFF
--- a/packages/library/src/transaction-confirmation-strategy-timeout.ts
+++ b/packages/library/src/transaction-confirmation-strategy-timeout.ts
@@ -1,0 +1,24 @@
+type Config = Readonly<{
+    abortSignal: AbortSignal;
+    timeoutMs: number;
+}>;
+
+export async function getTimeoutPromise({ abortSignal: callerAbortSignal, timeoutMs }: Config) {
+    return await new Promise((_, reject) => {
+        const abortController = new AbortController();
+        function handleAbort() {
+            clearTimeout(timeoutId);
+            abortController.abort();
+        }
+        callerAbortSignal.addEventListener('abort', handleAbort, { signal: abortController.signal });
+        const startMs = performance.now();
+        const timeoutId =
+            // We use `setTimeout` instead of `AbortSignal.timeout()` because we want to measure
+            // elapsed time instead of active time.
+            // See https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static
+            setTimeout(() => {
+                const elapsedMs = performance.now() - startMs;
+                reject(new DOMException(`Timeout elapsed after ${elapsedMs} ms`, 'TimeoutError'));
+            }, timeoutMs);
+    });
+}


### PR DESCRIPTION
# Summary

Sometimes, you need to confirm a transaction that is recent, but you _don't_ have the necessary context to use the blockheight-based expiry strategy. One such case is if you obtained a plain signature from the `requestAirdrop` RPC method that gives you no context at all around the airdrop transaction.

This is a strategy that you can use to wait a fixed time interval before giving up on waiting for a signature confirmation. Developers should generally not use this; favor instead the strategy where you supply the `lastValidBlockHeight` for the blockhash against which your transaction was signed, or the durable nonce strategy for nonce transactions.

# Test Plan

```
cd packages/library
pnpm test:unit:browser
pnpm test:unit:node
```
