### PR TITLE
refactor(experimental): a timeout-based transaction confirmation strategy

### DIFF
--- a/packages/library/src/__tests__/transaction-confirmation-strategy-timeout-test.ts
+++ b/packages/library/src/__tests__/transaction-confirmation-strategy-timeout-test.ts
@@ -1,0 +1,33 @@
+import { getTimeoutPromise } from '../transaction-confirmation-strategy-timeout';
+
+describe('getTimeoutPromise', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+    it.each`
+        commitment     | defaultTimeoutMs
+        ${'processed'} | ${30_000}
+        ${'confirmed'} | ${60_000}
+        ${'finalized'} | ${60_000}
+    `('pends for $defaultTimeoutMs when the commitment is `$commitment`', async ({ commitment, defaultTimeoutMs }) => {
+        expect.assertions(2);
+        const timeoutPromise = getTimeoutPromise({
+            abortSignal: new AbortController().signal,
+            commitment,
+        });
+        await jest.advanceTimersByTimeAsync(defaultTimeoutMs - 1);
+        await expect(Promise.race([timeoutPromise, 'pending'])).resolves.toBe('pending');
+        await jest.advanceTimersByTimeAsync(1);
+        await expect(Promise.race([timeoutPromise, 'pending'])).rejects.toThrow();
+    });
+    it('throws an abort error when aborted before the timeout', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        const timeoutPromise = getTimeoutPromise({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+        });
+        abortController.abort();
+        await expect(timeoutPromise).rejects.toThrow(/operation was aborted/);
+    });
+});

--- a/packages/library/src/transaction-confirmation-strategy-timeout.ts
+++ b/packages/library/src/transaction-confirmation-strategy-timeout.ts
@@ -1,0 +1,27 @@
+import { Commitment } from '@solana/rpc-core';
+
+type Config = Readonly<{
+    abortSignal: AbortSignal;
+    commitment: Commitment;
+}>;
+
+export async function getTimeoutPromise({ abortSignal: callerAbortSignal, commitment }: Config) {
+    return await new Promise((_, reject) => {
+        const handleAbort = (e: AbortSignalEventMap['abort']) => {
+            clearTimeout(timeoutId);
+            const abortError = new DOMException((e.target as AbortSignal).reason, 'AbortError');
+            reject(abortError);
+        };
+        callerAbortSignal.addEventListener('abort', handleAbort);
+        const timeoutMs = commitment === 'processed' ? 30_000 : 60_000;
+        const startMs = performance.now();
+        const timeoutId =
+            // We use `setTimeout` instead of `AbortSignal.timeout()` because we want to measure
+            // elapsed time instead of active time.
+            // See https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static
+            setTimeout(() => {
+                const elapsedMs = performance.now() - startMs;
+                reject(new DOMException(`Timeout elapsed after ${elapsedMs} ms`, 'TimeoutError'));
+            }, timeoutMs);
+    });
+}


### PR DESCRIPTION
# Summary

This won't be encouraged or exported, but here's a timeout-based confirmation strategy for transactions come with signatures but not last-valid-block-heights (ahem… `requestAirdrop`)
