### PR TITLE
refactor(experimental): an airdrop request helper

### DIFF
--- a/packages/library/src/__tests__/airdrop-confirmer-test.ts
+++ b/packages/library/src/__tests__/airdrop-confirmer-test.ts
@@ -1,0 +1,132 @@
+import { TransactionSignature } from '@solana/transactions';
+
+import { waitForRecentTransactionConfirmationUntilTimeout } from '../airdrop-confirmer';
+
+const FOREVER_PROMISE = new Promise(() => {
+    /* never resolve */
+});
+
+describe('waitForRecentTransactionConfirmationUntilTimeout', () => {
+    const MOCK_SIGNATURE = '4'.repeat(44) as TransactionSignature;
+    let getTimeoutPromise: jest.Mock<Promise<void>>;
+    let getRecentSignatureConfirmationPromise: jest.Mock<Promise<void>>;
+    beforeEach(() => {
+        getTimeoutPromise = jest.fn().mockReturnValue(FOREVER_PROMISE);
+        getRecentSignatureConfirmationPromise = jest.fn().mockReturnValue(FOREVER_PROMISE);
+    });
+    it('throws when the signal is already aborted', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        abortController.abort();
+        const commitmentPromise = waitForRecentTransactionConfirmationUntilTimeout({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            getTimeoutPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        await expect(commitmentPromise).rejects.toThrow('aborted');
+    });
+    it('calls `getTimeoutPromise` with the necessary input', async () => {
+        expect.assertions(1);
+        waitForRecentTransactionConfirmationUntilTimeout({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            getTimeoutPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        expect(getTimeoutPromise).toHaveBeenCalledWith({
+            abortSignal: expect.any(AbortSignal),
+            commitment: 'finalized',
+        });
+    });
+    it('calls `getRecentSignatureConfirmationPromise` with the necessary input', async () => {
+        expect.assertions(1);
+        waitForRecentTransactionConfirmationUntilTimeout({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            getTimeoutPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith({
+            abortSignal: expect.any(AbortSignal),
+            commitment: 'finalized',
+            signature: '4'.repeat(44),
+        });
+    });
+    it('resolves when the signature confirmation promise resolves despite the timeout promise having thrown', async () => {
+        expect.assertions(1);
+        getTimeoutPromise.mockRejectedValue(new Error('o no'));
+        getRecentSignatureConfirmationPromise.mockResolvedValue(undefined);
+        const commitmentPromise = waitForRecentTransactionConfirmationUntilTimeout({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            getTimeoutPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        await expect(commitmentPromise).resolves.toBeUndefined();
+    });
+    it('throws when the timeout promise throws', async () => {
+        expect.assertions(1);
+        getTimeoutPromise.mockRejectedValue(new Error('o no'));
+        const commitmentPromise = waitForRecentTransactionConfirmationUntilTimeout({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            getTimeoutPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        await expect(commitmentPromise).rejects.toThrow('o no');
+    });
+    it('throws when the signature confirmation promise throws', async () => {
+        expect.assertions(1);
+        getRecentSignatureConfirmationPromise.mockRejectedValue(new Error('o no'));
+        const commitmentPromise = waitForRecentTransactionConfirmationUntilTimeout({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            getTimeoutPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        await expect(commitmentPromise).rejects.toThrow('o no');
+    });
+    it('calls the abort signal passed to `getTimeoutPromise` when aborted', async () => {
+        expect.assertions(1);
+        const handleAbortOnTimeoutPromise = jest.fn();
+        getTimeoutPromise.mockImplementation(async ({ abortSignal }) => {
+            abortSignal.addEventListener('abort', handleAbortOnTimeoutPromise);
+            await FOREVER_PROMISE;
+        });
+        const abortController = new AbortController();
+        waitForRecentTransactionConfirmationUntilTimeout({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            getTimeoutPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        abortController.abort();
+        expect(handleAbortOnTimeoutPromise).toHaveBeenCalled();
+    });
+    it('calls the abort signal passed to `getRecentSignatureConfirmationPromise` when aborted', async () => {
+        expect.assertions(1);
+        const handleAbortOnSignatureConfirmationPromise = jest.fn();
+        getRecentSignatureConfirmationPromise.mockImplementation(async ({ abortSignal }) => {
+            abortSignal.addEventListener('abort', handleAbortOnSignatureConfirmationPromise);
+            await FOREVER_PROMISE;
+        });
+        const abortController = new AbortController();
+        waitForRecentTransactionConfirmationUntilTimeout({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            getTimeoutPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        abortController.abort();
+        expect(handleAbortOnSignatureConfirmationPromise).toHaveBeenCalled();
+    });
+});

--- a/packages/library/src/__tests__/airdrop-test.ts
+++ b/packages/library/src/__tests__/airdrop-test.ts
@@ -1,0 +1,131 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { lamports } from '@solana/rpc-core';
+import { GetSignatureStatusesApi } from '@solana/rpc-core/dist/types/rpc-methods/getSignatureStatuses';
+import { RequestAirdropApi } from '@solana/rpc-core/dist/types/rpc-methods/requestAirdrop';
+import { SignatureNotificationsApi } from '@solana/rpc-core/dist/types/rpc-subscriptions/signature-notifications';
+import { Rpc, RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import { TransactionSignature } from '@solana/transactions';
+
+import { requestAndConfirmAirdrop } from '../airdrop';
+import { createDefaultSignatureOnlyRecentTransactionConfirmer } from '../airdrop-confirmer';
+
+jest.mock('../airdrop-confirmer');
+
+const FOREVER_PROMISE = new Promise(() => {
+    /* never resolve */
+});
+
+describe('requestAndConfirmAirdrop', () => {
+    let confirmSignatureOnlyTransaction: jest.Mock;
+    let rpc: Rpc<RequestAirdropApi & GetSignatureStatusesApi>;
+    let rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi>;
+    let requestAirdrop: jest.Mock;
+    let sendAirdropRequest: jest.Mock;
+    let subscribe;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        confirmSignatureOnlyTransaction = jest.fn();
+        jest.mocked(createDefaultSignatureOnlyRecentTransactionConfirmer).mockReturnValue(
+            confirmSignatureOnlyTransaction
+        );
+        subscribe = jest.fn().mockReturnValue(FOREVER_PROMISE);
+        sendAirdropRequest = jest.fn().mockReturnValue(FOREVER_PROMISE);
+        requestAirdrop = jest.fn().mockReturnValue({ send: sendAirdropRequest });
+        rpc = {
+            getSignatureStatuses: jest.fn().mockReturnValue({ send: jest.fn() }),
+            requestAirdrop,
+        };
+        rpcSubscriptions = {
+            signatureNotifications: jest.fn().mockReturnValue({ subscribe }),
+        };
+    });
+    it('aborts the `requestAirdrop` request when aborted', async () => {
+        expect.assertions(2);
+        const abortController = new AbortController();
+        requestAndConfirmAirdrop({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            lamports: lamports(1n),
+            recipientAddress: '123' as Base58EncodedAddress,
+            rpc,
+            rpcSubscriptions,
+        });
+        expect(sendAirdropRequest).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: false }),
+        });
+        abortController.abort();
+        expect(sendAirdropRequest).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: true }),
+        });
+    });
+    it('aborts the `confirmSignatureOnlyTransaction` call when aborted', async () => {
+        expect.assertions(2);
+        const abortController = new AbortController();
+        sendAirdropRequest.mockResolvedValue('abc' as TransactionSignature);
+        requestAndConfirmAirdrop({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            lamports: lamports(1n),
+            recipientAddress: '123' as Base58EncodedAddress,
+            rpc,
+            rpcSubscriptions,
+        });
+        await jest.runAllTimersAsync();
+        expect(confirmSignatureOnlyTransaction).toHaveBeenCalledWith(
+            expect.objectContaining({
+                abortSignal: expect.objectContaining({ aborted: false }),
+            })
+        );
+        abortController.abort();
+        expect(confirmSignatureOnlyTransaction).toHaveBeenCalledWith(
+            expect.objectContaining({
+                abortSignal: expect.objectContaining({ aborted: true }),
+            })
+        );
+    });
+    it('passes the expected input to the airdrop request', async () => {
+        expect.assertions(1);
+        sendAirdropRequest.mockResolvedValue('abc' as TransactionSignature);
+        requestAndConfirmAirdrop({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            lamports: lamports(1n),
+            recipientAddress: '123' as Base58EncodedAddress,
+            rpc,
+            rpcSubscriptions,
+        });
+        expect(requestAirdrop).toHaveBeenCalledWith('123', 1n, { commitment: 'finalized' });
+    });
+    it('passes the expected input to the transaction confirmer', async () => {
+        expect.assertions(1);
+        sendAirdropRequest.mockResolvedValue('abc' as TransactionSignature);
+        requestAndConfirmAirdrop({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            lamports: lamports(1n),
+            recipientAddress: '123' as Base58EncodedAddress,
+            rpc,
+            rpcSubscriptions,
+        });
+        await jest.runAllTimersAsync();
+        expect(confirmSignatureOnlyTransaction).toHaveBeenCalledWith({
+            abortSignal: expect.any(AbortSignal),
+            commitment: 'finalized',
+            signature: 'abc' as TransactionSignature,
+        });
+    });
+    it('returns the airdrop transaction signature on success', async () => {
+        expect.assertions(1);
+        sendAirdropRequest.mockResolvedValue('abc' as TransactionSignature);
+        confirmSignatureOnlyTransaction.mockResolvedValue(undefined);
+        const airdropPromise = requestAndConfirmAirdrop({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            lamports: lamports(1n),
+            recipientAddress: '123' as Base58EncodedAddress,
+            rpc,
+            rpcSubscriptions,
+        });
+        await expect(airdropPromise).resolves.toBe('abc');
+    });
+});

--- a/packages/library/src/airdrop-confirmer.ts
+++ b/packages/library/src/airdrop-confirmer.ts
@@ -1,0 +1,60 @@
+import { GetSignatureStatusesApi } from '@solana/rpc-core/dist/types/rpc-methods/getSignatureStatuses';
+import { SignatureNotificationsApi } from '@solana/rpc-core/dist/types/rpc-subscriptions/signature-notifications';
+import { Rpc, RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import { TransactionSignature } from '@solana/transactions';
+
+import { BaseTransactionConfirmationStrategyConfig, raceStrategies } from './transaction-confirmation-strategy-racer';
+import { createRecentSignatureConfirmationPromiseFactory } from './transaction-confirmation-strategy-recent-signature';
+import { getTimeoutPromise } from './transaction-confirmation-strategy-timeout';
+
+interface DefaultSignatureOnlyRecentTransactionConfirmerConfig {
+    rpc: Rpc<GetSignatureStatusesApi>;
+    rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi>;
+}
+
+interface WaitForRecentTransactionWithTimeBasedLifetimeConfirmationConfig
+    extends BaseTransactionConfirmationStrategyConfig {
+    getTimeoutPromise: typeof getTimeoutPromise;
+    signature: TransactionSignature;
+}
+
+/** @deprecated */
+export function createDefaultSignatureOnlyRecentTransactionConfirmer({
+    rpc,
+    rpcSubscriptions,
+}: DefaultSignatureOnlyRecentTransactionConfirmerConfig) {
+    const getRecentSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory(
+        rpc,
+        rpcSubscriptions
+    );
+    return async function confirmSignatureOnlyRecentTransaction(
+        config: Omit<
+            Parameters<typeof waitForRecentTransactionConfirmationUntilTimeout>[0],
+            'getRecentSignatureConfirmationPromise' | 'getTimeoutPromise'
+        >
+    ) {
+        await waitForRecentTransactionConfirmationUntilTimeout({
+            ...config,
+            getRecentSignatureConfirmationPromise,
+            getTimeoutPromise,
+        });
+    };
+}
+
+/** @deprecated */
+export async function waitForRecentTransactionConfirmationUntilTimeout(
+    config: WaitForRecentTransactionWithTimeBasedLifetimeConfirmationConfig
+): Promise<void> {
+    await raceStrategies(
+        config.signature,
+        config,
+        function getSpecificStrategiesForRace({ abortSignal, commitment, getTimeoutPromise }) {
+            return [
+                getTimeoutPromise({
+                    abortSignal,
+                    commitment,
+                }),
+            ];
+        }
+    );
+}

--- a/packages/library/src/airdrop.ts
+++ b/packages/library/src/airdrop.ts
@@ -1,0 +1,41 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-core';
+import { GetSignatureStatusesApi } from '@solana/rpc-core/dist/types/rpc-methods/getSignatureStatuses';
+import { RequestAirdropApi } from '@solana/rpc-core/dist/types/rpc-methods/requestAirdrop';
+import { SignatureNotificationsApi } from '@solana/rpc-core/dist/types/rpc-subscriptions/signature-notifications';
+import { Rpc, RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import { TransactionSignature } from '@solana/transactions';
+
+import { createDefaultSignatureOnlyRecentTransactionConfirmer } from './airdrop-confirmer';
+
+type Config = Readonly<{
+    abortSignal: AbortSignal;
+    commitment: Commitment;
+    lamports: LamportsUnsafeBeyond2Pow53Minus1;
+    recipientAddress: Base58EncodedAddress;
+    rpc: Rpc<RequestAirdropApi & GetSignatureStatusesApi>;
+    rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi>;
+}>;
+
+export async function requestAndConfirmAirdrop({
+    abortSignal,
+    commitment,
+    lamports,
+    recipientAddress,
+    rpc,
+    rpcSubscriptions,
+}: Config): Promise<TransactionSignature> {
+    const airdropTransactionSignature = (await rpc
+        .requestAirdrop(recipientAddress, lamports, { commitment })
+        .send({ abortSignal })) as unknown as TransactionSignature;
+    const confirmSignatureOnlyTransaction = createDefaultSignatureOnlyRecentTransactionConfirmer({
+        rpc,
+        rpcSubscriptions,
+    });
+    await confirmSignatureOnlyTransaction({
+        abortSignal,
+        commitment,
+        signature: airdropTransactionSignature,
+    });
+    return airdropTransactionSignature;
+}

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -2,6 +2,7 @@ export * from '@solana/addresses';
 export * from '@solana/instructions';
 export * from '@solana/keys';
 export * from '@solana/transactions';
+export * from './airdrop';
 export * from './rpc';
 export * from './rpc-transport';
 export * from './rpc-websocket-transport';


### PR DESCRIPTION
# Summary

Folks often find themselves requesting an airdrop but continuing with the rest of their program before confirming that the drop landed. This leads to a lot of confusing ‘insufficient funds’ type errors.

In this PR we introduce a higher-level helper that does airdropping and confirmation in one.

# Test Plan

```ts
const {
  createDefaultRpcSubscriptionsTransport,
  createDefaultRpcTransport,
  createSolanaRpc,
  createSolanaRpcSubscriptions,
  generateKeyPair,
  getAddressFromPublicKey,
  requestAndConfirmAirdrop,
} = require("./dist/index.node.cjs");
const { lamports } = require("@solana/rpc-core");

const rpc = createSolanaRpc({
  transport: createDefaultRpcTransport({
    url: "https://api.devnet.solana.com",
  }),
});
const rpcSubscriptions = createSolanaRpcSubscriptions({
  transport: createDefaultRpcSubscriptionsTransport({
    url: "wss://api.devnet.solana.com",
  }),
});

const keyPair = await generateKeyPair();
const recipientAccount = await getAddressFromPublicKey(keyPair.publicKey);

console.log("getting lamports for", recipientAccount);
await requestAndConfirmAirdrop({
  abortSignal: new AbortController().signal,
  commitment: "finalized",
  rpc,
  rpcSubscriptions,
  recipientAccount,
  lamports: lamports(1000000n),
});
console.log("got it");
```