### PR TITLE
fix(experimental): fix scalar enum codec options

### DIFF
--- a/packages/codecs-data-structures/src/scalar-enum.ts
+++ b/packages/codecs-data-structures/src/scalar-enum.ts
@@ -71,7 +71,7 @@ function scalarEnumCoderHelper<T>(
  */
 export function getScalarEnumEncoder<T>(
     constructor: ScalarEnum<T>,
-    options: ScalarEnumCodecOptions<NumberCodec> = {}
+    options: ScalarEnumCodecOptions<NumberEncoder> = {}
 ): Encoder<T> {
     const prefix = options.size ?? getU8Encoder();
     const { description, fixedSize, maxSize, minRange, maxRange, stringValues, enumKeys, enumValues } =
@@ -108,7 +108,7 @@ export function getScalarEnumEncoder<T>(
  */
 export function getScalarEnumDecoder<T>(
     constructor: ScalarEnum<T>,
-    options: ScalarEnumCodecOptions<NumberCodec> = {}
+    options: ScalarEnumCodecOptions<NumberDecoder> = {}
 ): Decoder<T> {
     const prefix = options.size ?? getU8Decoder();
     const { description, fixedSize, maxSize, minRange, maxRange, isNumericEnum, enumValues } = scalarEnumCoderHelper(


### PR DESCRIPTION
This was an error on my side. The encoder function should ask for a `NumberEncoder` and the decoder function for a `NumberDecoder`. They currently both ask for a `NumberCodec` which is too much.
