### PR TITLE
refactor(experimental): fix `getSignatureFromTransaction`

### DIFF
--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -91,17 +91,19 @@ describe('getSignatureFromTransaction', () => {
         const transactionWithoutFeePayerSignature = {
             feePayer: '123' as Base58EncodedAddress,
             signatures: {
-                ['123' as Base58EncodedAddress]: 'abc' as unknown as Ed25519Signature,
+                ['123' as Base58EncodedAddress]: new Uint8Array(new Array(64).fill(9)) as Ed25519Signature,
             } as const,
         };
-        expect(getSignatureFromTransaction(transactionWithoutFeePayerSignature)).toBe('abc');
+        expect(getSignatureFromTransaction(transactionWithoutFeePayerSignature)).toBe(
+            'BUguQsv2ZuHus54HAFzjdJHzZBkygAjKhEeYwSG19tUfUyvvz3worsdQCdAXDNjakJHioSiyxhFiDJrm8XpSXRA'
+        );
     });
     it('throws when supplied a transaction that has not been signed by the fee payer', () => {
         const transactionWithoutFeePayerSignature = {
             feePayer: '123' as Base58EncodedAddress,
             signatures: {
                 // No signature by the fee payer.
-                ['456' as Base58EncodedAddress]: 'abc' as unknown as Ed25519Signature,
+                ['456' as Base58EncodedAddress]: new Uint8Array(new Array(64).fill(9)) as Ed25519Signature,
             } as const,
         };
         expect(() => {

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -71,15 +71,16 @@ async function getCompiledMessageSignature(message: CompiledMessage, secretKey: 
 export function getSignatureFromTransaction(
     transaction: ITransactionWithFeePayer & ITransactionWithSignatures
 ): TransactionSignature {
-    const signature = transaction.signatures[transaction.feePayer];
-    if (!signature) {
+    const signatureBytes = transaction.signatures[transaction.feePayer];
+    if (!signatureBytes) {
         // TODO: Coded error.
         throw new Error(
             "Could not determine this transaction's signature. Make sure that the transaction " +
                 'has been signed by its fee payer.'
         );
     }
-    return signature as unknown as TransactionSignature;
+    const transactionSignature = base58.deserialize(signatureBytes)[0];
+    return transactionSignature as TransactionSignature;
 }
 
 export async function signTransaction<TTransaction extends Parameters<typeof compileMessage>[0]>(


### PR DESCRIPTION
This is what happens when you suppress TypeScript, kids.
