### PR TITLE
refactor(experimental): a send-and-confirm transaction helper

### DIFF
--- a/packages/library/src/__tests__/send-transaction-test.ts
+++ b/packages/library/src/__tests__/send-transaction-test.ts
@@ -1,0 +1,335 @@
+import { Commitment } from '@solana/rpc-core';
+import { Base58EncodedTransactionSignature } from '@solana/rpc-core/dist/types/rpc-methods/common';
+import { SendTransactionApi } from '@solana/rpc-core/dist/types/rpc-methods/sendTransaction';
+import { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import {
+    Base64EncodedWireTransaction,
+    BaseTransaction,
+    getBase64EncodedWireTransaction,
+    IDurableNonceTransaction,
+    IFullySignedTransaction,
+    ITransactionWithBlockhashLifetime,
+    ITransactionWithFeePayer,
+} from '@solana/transactions';
+
+import { sendAndConfirmDurableNonceTransaction, sendAndConfirmTransaction } from '../send-transaction';
+
+jest.mock('@solana/transactions');
+
+const FOREVER_PROMISE = new Promise(() => {
+    /* never resolve */
+});
+
+describe('sendAndConfirmTransaction', () => {
+    const MOCK_TRANSACTION = {} as unknown as BaseTransaction &
+        ITransactionWithFeePayer &
+        IFullySignedTransaction &
+        ITransactionWithBlockhashLifetime;
+    let confirmRecentTransaction: jest.Mock;
+    let createPendingRequest: jest.Mock;
+    let rpc: Rpc<SendTransactionApi>;
+    let sendTransaction: jest.Mock;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        confirmRecentTransaction = jest.fn().mockReturnValue(FOREVER_PROMISE);
+        sendTransaction = jest.fn().mockReturnValue(FOREVER_PROMISE);
+        createPendingRequest = jest.fn().mockReturnValue({ send: sendTransaction });
+        rpc = {
+            sendTransaction: createPendingRequest,
+        };
+        jest.mocked(getBase64EncodedWireTransaction).mockReturnValue(
+            'MOCK_WIRE_TRANSACTION' as Base64EncodedWireTransaction
+        );
+    });
+    it('encodes the transaction into wire format before sending', () => {
+        sendAndConfirmTransaction({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            confirmRecentTransaction,
+            rpc,
+            transaction: MOCK_TRANSACTION,
+        });
+        expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_TRANSACTION);
+        expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', expect.anything());
+    });
+    it('calls `sendTransaction` with the expected inputs', () => {
+        const sendTransactionConfig = {
+            maxRetries: 42n,
+            minContextSlot: 123n,
+            preflightCommitment: 'confirmed' as Commitment,
+            skipPreflight: false,
+        } as Parameters<SendTransactionApi['sendTransaction']>[1];
+        sendAndConfirmTransaction({
+            ...sendTransactionConfig,
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized' as Commitment,
+            confirmRecentTransaction,
+            rpc,
+            transaction: MOCK_TRANSACTION,
+        });
+        expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_TRANSACTION);
+        expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', {
+            ...sendTransactionConfig,
+            encoding: 'base64',
+        });
+    });
+    it('calls `confirmRecentTransaction` with the expected inputs', async () => {
+        expect.assertions(1);
+        const sendTransactionConfig = {
+            maxRetries: 42n,
+            minContextSlot: 123n,
+            preflightCommitment: 'confirmed' as Commitment,
+            skipPreflight: false,
+        } as Parameters<SendTransactionApi['sendTransaction']>[1];
+        sendTransaction.mockResolvedValue('abc' as Base58EncodedTransactionSignature);
+        const abortSignal = new AbortController().signal;
+        sendAndConfirmTransaction({
+            ...sendTransactionConfig,
+            abortSignal,
+            commitment: 'finalized' as Commitment,
+            confirmRecentTransaction,
+            rpc,
+            transaction: MOCK_TRANSACTION,
+        });
+        await jest.runAllTimersAsync();
+        expect(confirmRecentTransaction).toHaveBeenCalledWith({
+            abortSignal,
+            commitment: 'finalized',
+            transaction: MOCK_TRANSACTION,
+        });
+    });
+    it.each`
+        commitment     | expectedPreflightCommitment
+        ${'processed'} | ${'processed'}
+        ${'confirmed'} | ${'confirmed'}
+    `(
+        'when missing a `preflightCommitment` and the commitment is $commitment, applies a downgraded `preflightCommitment`',
+        ({ commitment, expectedPreflightCommitment }) => {
+            sendAndConfirmTransaction({
+                abortSignal: new AbortController().signal,
+                commitment,
+                confirmRecentTransaction,
+                rpc,
+                transaction: MOCK_TRANSACTION,
+            });
+            expect(createPendingRequest).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    preflightCommitment: expectedPreflightCommitment,
+                })
+            );
+        }
+    );
+    it.each`
+        commitment     | preflightCommitment | expectedPreflightCommitment
+        ${'processed'} | ${'processed'}      | ${'processed'}
+        ${'processed'} | ${'confirmed'}      | ${'confirmed'}
+        ${'processed'} | ${'finalized'}      | ${'finalized'}
+        ${'confirmed'} | ${'processed'}      | ${'processed'}
+        ${'confirmed'} | ${'confirmed'}      | ${'confirmed'}
+        ${'confirmed'} | ${'finalized'}      | ${'finalized'}
+        ${'finalized'} | ${'processed'}      | ${'processed'}
+        ${'finalized'} | ${'confirmed'}      | ${'confirmed'}
+        ${'finalized'} | ${'finalized'}      | ${'finalized'}
+    `(
+        'honours the explicit `preflightCommitment` no matter that the commitment is $commitment',
+        ({ commitment, preflightCommitment, expectedPreflightCommitment }) => {
+            sendAndConfirmTransaction({
+                abortSignal: new AbortController().signal,
+                commitment,
+                confirmRecentTransaction,
+                preflightCommitment,
+                rpc,
+                transaction: MOCK_TRANSACTION,
+            });
+            expect(createPendingRequest).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    preflightCommitment: expectedPreflightCommitment,
+                })
+            );
+        }
+    );
+    it('when missing a `preflightCommitment` and the commitment is the same as the server default for `preflightCommitment`, does not apply a `preflightCommitment`', () => {
+        expect.assertions(1);
+        sendAndConfirmTransaction({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            confirmRecentTransaction,
+            rpc,
+            transaction: MOCK_TRANSACTION,
+        });
+        expect(createPendingRequest.mock.lastCall![1]).not.toHaveProperty('preflightCommitment');
+    });
+    it('returns the signature of the transaction', async () => {
+        expect.assertions(1);
+        sendTransaction.mockResolvedValue('abc');
+        confirmRecentTransaction.mockResolvedValue(undefined);
+        await expect(
+            sendAndConfirmTransaction({
+                abortSignal: new AbortController().signal,
+                commitment: 'finalized',
+                confirmRecentTransaction,
+                rpc,
+                transaction: MOCK_TRANSACTION,
+            })
+        ).resolves.toBe('abc');
+    });
+});
+
+describe('sendAndConfirmDurableNonceTransaction', () => {
+    const MOCK_DURABLE_NONCE_TRANSACTION = {} as unknown as BaseTransaction &
+        ITransactionWithFeePayer &
+        IFullySignedTransaction &
+        IDurableNonceTransaction;
+    let confirmDurableNonceTransaction: jest.Mock;
+    let createPendingRequest: jest.Mock;
+    let rpc: Rpc<SendTransactionApi>;
+    let sendTransaction: jest.Mock;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        confirmDurableNonceTransaction = jest.fn().mockReturnValue(FOREVER_PROMISE);
+        sendTransaction = jest.fn().mockReturnValue(FOREVER_PROMISE);
+        createPendingRequest = jest.fn().mockReturnValue({ send: sendTransaction });
+        rpc = {
+            sendTransaction: createPendingRequest,
+        };
+        jest.mocked(getBase64EncodedWireTransaction).mockReturnValue(
+            'MOCK_WIRE_TRANSACTION' as Base64EncodedWireTransaction
+        );
+    });
+    it('encodes the transaction into wire format before sending', () => {
+        sendAndConfirmDurableNonceTransaction({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            confirmDurableNonceTransaction,
+            rpc,
+            transaction: MOCK_DURABLE_NONCE_TRANSACTION,
+        });
+        expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_DURABLE_NONCE_TRANSACTION);
+        expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', expect.anything());
+    });
+    it('calls `sendTransaction` with the expected inputs', () => {
+        const sendTransactionConfig = {
+            maxRetries: 42n,
+            minContextSlot: 123n,
+            preflightCommitment: 'confirmed' as Commitment,
+            skipPreflight: false,
+        } as Parameters<SendTransactionApi['sendTransaction']>[1];
+        sendAndConfirmDurableNonceTransaction({
+            ...sendTransactionConfig,
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized' as Commitment,
+            confirmDurableNonceTransaction,
+            rpc,
+            transaction: MOCK_DURABLE_NONCE_TRANSACTION,
+        });
+        expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_DURABLE_NONCE_TRANSACTION);
+        expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', {
+            ...sendTransactionConfig,
+            encoding: 'base64',
+        });
+    });
+    it('calls `confirmDurableNonceTransaction` with the expected inputs', async () => {
+        expect.assertions(1);
+        const sendTransactionConfig = {
+            maxRetries: 42n,
+            minContextSlot: 123n,
+            preflightCommitment: 'confirmed' as Commitment,
+            skipPreflight: false,
+        } as Parameters<SendTransactionApi['sendTransaction']>[1];
+        sendTransaction.mockResolvedValue('abc' as Base58EncodedTransactionSignature);
+        const abortSignal = new AbortController().signal;
+        sendAndConfirmDurableNonceTransaction({
+            ...sendTransactionConfig,
+            abortSignal,
+            commitment: 'finalized' as Commitment,
+            confirmDurableNonceTransaction,
+            rpc,
+            transaction: MOCK_DURABLE_NONCE_TRANSACTION,
+        });
+        await jest.runAllTimersAsync();
+        expect(confirmDurableNonceTransaction).toHaveBeenCalledWith({
+            abortSignal,
+            commitment: 'finalized',
+            transaction: MOCK_DURABLE_NONCE_TRANSACTION,
+        });
+    });
+    it.each`
+        commitment     | expectedPreflightCommitment
+        ${'processed'} | ${'processed'}
+        ${'confirmed'} | ${'confirmed'}
+    `(
+        'when missing a `preflightCommitment` and the commitment is $commitment, applies a downgraded `preflightCommitment`',
+        ({ commitment, expectedPreflightCommitment }) => {
+            sendAndConfirmDurableNonceTransaction({
+                abortSignal: new AbortController().signal,
+                commitment,
+                confirmDurableNonceTransaction,
+                rpc,
+                transaction: MOCK_DURABLE_NONCE_TRANSACTION,
+            });
+            expect(createPendingRequest).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    preflightCommitment: expectedPreflightCommitment,
+                })
+            );
+        }
+    );
+    it.each`
+        commitment     | preflightCommitment | expectedPreflightCommitment
+        ${'processed'} | ${'processed'}      | ${'processed'}
+        ${'processed'} | ${'confirmed'}      | ${'confirmed'}
+        ${'processed'} | ${'finalized'}      | ${'finalized'}
+        ${'confirmed'} | ${'processed'}      | ${'processed'}
+        ${'confirmed'} | ${'confirmed'}      | ${'confirmed'}
+        ${'confirmed'} | ${'finalized'}      | ${'finalized'}
+        ${'finalized'} | ${'processed'}      | ${'processed'}
+        ${'finalized'} | ${'confirmed'}      | ${'confirmed'}
+        ${'finalized'} | ${'finalized'}      | ${'finalized'}
+    `(
+        'honours the explicit `preflightCommitment` no matter that the commitment is $commitment',
+        ({ commitment, preflightCommitment, expectedPreflightCommitment }) => {
+            sendAndConfirmDurableNonceTransaction({
+                abortSignal: new AbortController().signal,
+                commitment,
+                confirmDurableNonceTransaction,
+                preflightCommitment,
+                rpc,
+                transaction: MOCK_DURABLE_NONCE_TRANSACTION,
+            });
+            expect(createPendingRequest).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    preflightCommitment: expectedPreflightCommitment,
+                })
+            );
+        }
+    );
+    it('when missing a `preflightCommitment` and the commitment is the same as the server default for `preflightCommitment`, does not apply a `preflightCommitment`', () => {
+        expect.assertions(1);
+        sendAndConfirmDurableNonceTransaction({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            confirmDurableNonceTransaction,
+            rpc,
+            transaction: MOCK_DURABLE_NONCE_TRANSACTION,
+        });
+        expect(createPendingRequest.mock.lastCall![1]).not.toHaveProperty('preflightCommitment');
+    });
+    it('returns the signature of the transaction', async () => {
+        expect.assertions(1);
+        sendTransaction.mockResolvedValue('abc');
+        confirmDurableNonceTransaction.mockResolvedValue(undefined);
+        await expect(
+            sendAndConfirmDurableNonceTransaction({
+                abortSignal: new AbortController().signal,
+                commitment: 'finalized',
+                confirmDurableNonceTransaction,
+                rpc,
+                transaction: MOCK_DURABLE_NONCE_TRANSACTION,
+            })
+        ).resolves.toBe('abc');
+    });
+});

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -6,6 +6,7 @@ export * from './airdrop';
 export * from './rpc';
 export * from './rpc-transport';
 export * from './rpc-websocket-transport';
+export * from './send-transaction';
 export * from './transaction-confirmation';
 export * from './transaction-confirmation-strategy-blockheight';
 export * from './transaction-confirmation-strategy-nonce';

--- a/packages/library/src/send-transaction.ts
+++ b/packages/library/src/send-transaction.ts
@@ -1,0 +1,203 @@
+import { Commitment, commitmentComparator } from '@solana/rpc-core';
+import { GetAccountInfoApi } from '@solana/rpc-core/dist/types/rpc-methods/getAccountInfo';
+import { GetSignatureStatusesApi } from '@solana/rpc-core/dist/types/rpc-methods/getSignatureStatuses';
+import { SendTransactionApi } from '@solana/rpc-core/dist/types/rpc-methods/sendTransaction';
+import { AccountNotificationsApi } from '@solana/rpc-core/dist/types/rpc-subscriptions/account-notifications';
+import { SignatureNotificationsApi } from '@solana/rpc-core/dist/types/rpc-subscriptions/signature-notifications';
+import { SlotNotificationsApi } from '@solana/rpc-core/dist/types/rpc-subscriptions/slot-notifications';
+import { Rpc, RpcSubscriptions } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import {
+    BaseTransaction,
+    getBase64EncodedWireTransaction,
+    IDurableNonceTransaction,
+    IFullySignedTransaction,
+    ITransactionWithBlockhashLifetime,
+    ITransactionWithFeePayer,
+    TransactionSignature,
+} from '@solana/transactions';
+
+import {
+    createDefaultDurableNonceTransactionConfirmer,
+    createDefaultRecentTransactionConfirmer,
+} from './transaction-confirmation';
+
+type DurableNonceTransactionSenderConfig = Readonly<{
+    rpc: Rpc<GetAccountInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
+    rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi & AccountNotificationsApi>;
+}>;
+
+type RecentTransactionSenderConfig = Readonly<{
+    rpc: Rpc<GetSignatureStatusesApi & SendTransactionApi>;
+    rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>;
+}>;
+
+type SendableTransaction = BaseTransaction & ITransactionWithFeePayer & IFullySignedTransaction;
+type SendTransactionConfig = Parameters<SendTransactionApi['sendTransaction']>[1];
+type SendTransactionConfigWithoutEncoding = Omit<NonNullable<SendTransactionConfig>, 'encoding'>;
+
+function getSendTransactionConfigWithAdjustedPreflightCommitment(
+    commitment: Commitment,
+    config?: SendTransactionConfigWithoutEncoding
+): SendTransactionConfigWithoutEncoding | void {
+    if (
+        // The developer has supplied no value for `preflightCommitment`.
+        !config?.preflightCommitment &&
+        // The value of `commitment` is lower than the server default of `preflightCommitment`.
+        commitmentComparator(commitment, 'finalized' /* default value of `preflightCommitment` */) < 0
+    ) {
+        return {
+            ...config,
+            // In the common case, it is unlikely that you want to simulate a transaction at
+            // `finalized` commitment when your standard of commitment for confirming the
+            // transaction is lower. Cap the simulation commitment level to the level of the
+            // confirmation commitment.
+            preflightCommitment: commitment,
+        };
+    }
+    // The commitment at which the developer wishes to confirm the transaction is at least as
+    // high as the commitment at which they want to simulate it. Honour the config as-is.
+    return config;
+}
+
+async function sendTransaction_INTERNAL({
+    abortSignal,
+    commitment,
+    rpc,
+    transaction,
+    sendTransactionConfig,
+}: {
+    abortSignal: AbortSignal;
+    commitment: Commitment;
+    rpc: Rpc<SendTransactionApi>;
+    transaction: BaseTransaction &
+        ITransactionWithFeePayer &
+        (ITransactionWithBlockhashLifetime | IDurableNonceTransaction);
+    sendTransactionConfig?: SendTransactionConfigWithoutEncoding;
+}): Promise<TransactionSignature> {
+    const base64EncodedWireTransaction = getBase64EncodedWireTransaction(transaction);
+    return (await rpc
+        .sendTransaction(base64EncodedWireTransaction, {
+            ...getSendTransactionConfigWithAdjustedPreflightCommitment(commitment, sendTransactionConfig),
+            encoding: 'base64',
+        })
+        .send({ abortSignal })) as unknown as TransactionSignature; // FIXME(#1709)
+}
+
+export function createDefaultDurableNonceTransactionSender({
+    rpc,
+    rpcSubscriptions,
+}: DurableNonceTransactionSenderConfig) {
+    const confirmDurableNonceTransaction = createDefaultDurableNonceTransactionConfirmer({
+        rpc,
+        rpcSubscriptions,
+    });
+    return async function sendDurableNonceTransaction(
+        transaction: BaseTransaction & ITransactionWithFeePayer & IDurableNonceTransaction & IFullySignedTransaction,
+        config: Omit<
+            SendTransactionConfig &
+                Readonly<{
+                    abortSignal: AbortSignal;
+                    commitment: Commitment;
+                }>,
+            'encoding'
+        >
+    ): Promise<void> {
+        await sendAndConfirmDurableNonceTransaction({
+            ...config,
+            confirmDurableNonceTransaction,
+            rpc,
+            transaction,
+        });
+    };
+}
+
+export function createDefaultTransactionSender({ rpc, rpcSubscriptions }: RecentTransactionSenderConfig) {
+    const confirmRecentTransaction = createDefaultRecentTransactionConfirmer({
+        rpc,
+        rpcSubscriptions,
+    });
+    return async function sendTransaction(
+        transaction: SendableTransaction & ITransactionWithBlockhashLifetime,
+        config: Omit<
+            SendTransactionConfig &
+                Readonly<{
+                    abortSignal: AbortSignal;
+                    commitment: Commitment;
+                }>,
+            'encoding'
+        >
+    ): Promise<void> {
+        await sendAndConfirmTransaction({
+            ...config,
+            confirmRecentTransaction,
+            rpc,
+            transaction,
+        });
+    };
+}
+
+export async function sendAndConfirmDurableNonceTransaction({
+    abortSignal,
+    commitment,
+    confirmDurableNonceTransaction,
+    rpc,
+    transaction,
+    ...sendTransactionConfig
+}: Omit<
+    SendTransactionConfig &
+        Readonly<{
+            abortSignal: AbortSignal;
+            commitment: Commitment;
+            confirmDurableNonceTransaction: ReturnType<typeof createDefaultDurableNonceTransactionConfirmer>;
+            rpc: Rpc<SendTransactionApi>;
+            transaction: SendableTransaction & IDurableNonceTransaction;
+        }>,
+    'encoding'
+>): Promise<TransactionSignature> {
+    const transactionSignature = await sendTransaction_INTERNAL({
+        abortSignal,
+        commitment,
+        rpc,
+        sendTransactionConfig,
+        transaction,
+    });
+    await confirmDurableNonceTransaction({
+        abortSignal,
+        commitment,
+        transaction,
+    });
+    return transactionSignature;
+}
+
+export async function sendAndConfirmTransaction({
+    abortSignal,
+    commitment,
+    confirmRecentTransaction,
+    rpc,
+    transaction,
+    ...sendTransactionConfig
+}: Omit<
+    SendTransactionConfig &
+        Readonly<{
+            abortSignal: AbortSignal;
+            commitment: Commitment;
+            confirmRecentTransaction: ReturnType<typeof createDefaultRecentTransactionConfirmer>;
+            rpc: Rpc<SendTransactionApi>;
+            transaction: SendableTransaction & ITransactionWithBlockhashLifetime;
+        }>,
+    'encoding'
+>): Promise<TransactionSignature> {
+    const transactionSignature = await sendTransaction_INTERNAL({
+        abortSignal,
+        commitment,
+        rpc,
+        sendTransactionConfig,
+        transaction,
+    });
+    await confirmRecentTransaction({
+        abortSignal,
+        commitment,
+        transaction,
+    });
+    return transactionSignature;
+}


### PR DESCRIPTION
# Summary

This is a high level helper for sending and confirming transactions so that you don't have to think about:

- serializing the transaction to wire format
- confirming it
- how to set the simulation commitment so that you don't immediately faceplant

# Test Plan

Start a local validator (eg. I used `./scripts/start-shared-test-validator.sh`), and then make a memo program transaction.

```ts
const {
  appendTransactionInstruction,
  createDefaultRpcSubscriptionsTransport,
  createDefaultRpcTransport,
  createDefaultTransactionSender,
  createSolanaRpc,
  createSolanaRpcSubscriptions,
  createTransaction,
  generateKeyPair,
  getAddressFromPublicKey,
  getSignatureFromTransaction,
  requestAndConfirmAirdrop,
  setTransactionFeePayer,
  setTransactionLifetimeUsingBlockhash,
  signTransaction,
} = require("./dist/index.node.cjs");
const { pipe } = require("@solana/functional");

const rpc = createSolanaRpc({
  transport: createDefaultRpcTransport({ url: "http://127.0.0.1:8899" }),
});
const rpcSubscriptions = createSolanaRpcSubscriptions({
  transport: createDefaultRpcSubscriptionsTransport({
    url: "ws://127.0.0.1:8900",
  }),
});

// Create an identity.
const keyPair = await generateKeyPair();
const publicAddress = await getAddressFromPublicKey(keyPair.publicKey);
console.log("address", publicAddress);

const abortController = new AbortController();
const abortSignal = abortController.signal;

const [{ value: latestBlockhash }, airdropSignature] = await Promise.all([
  // Grab a blockhash with which to sign the transaction.
  rpc.getLatestBlockhash().send(),
  // Ask for some SOL to be airdropped to pay for the transaction.
  requestAndConfirmAirdrop({
    abortSignal,
    commitment: "confirmed",
    lamports: 1000000n,
    recipientAddress: publicAddress,
    rpc,
    rpcSubscriptions,
  }),
]);
console.log("airdropSignature", airdropSignature);

const tx = pipe(
  createTransaction({ version: "legacy" }),
  (tx) => setTransactionFeePayer(publicAddress, tx),
  (tx) => setTransactionLifetimeUsingBlockhash(latestBlockhash, tx),
  (tx) =>
    appendTransactionInstruction(
      {
        data: Buffer.from("Hello world"),
        programAddress: "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
      },
      tx
    )
);
const signedTx = await signTransaction([keyPair], tx);
console.log("transaction", signedTx);

const sendAndConfirmTransaction = createDefaultTransactionSender({
  rpc,
  rpcSubscriptions,
});
await sendAndConfirmTransaction(signedTx, {
  abortSignal,
  commitment: "confirmed",
});

console.log(getSignatureFromTransaction(signedTx));
```
