### PR TITLE
refactor(experimental): add Ed25519 importKey polyfill

### DIFF
--- a/packages/webcrypto-ed25519-polyfill/src/__tests__/index-test.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/__tests__/index-test.ts
@@ -1,10 +1,10 @@
 import {
     exportKeyPolyfill,
     generateKeyPolyfill,
+    importKeyPolyfill,
     isPolyfilledKey,
     signPolyfill,
     verifyPolyfill,
-    importKeyPolyfill,
 } from '../secrets';
 
 jest.mock('../secrets');
@@ -129,13 +129,13 @@ describe('generateKey() polyfill', () => {
             ...['RSASSA-PKCS1-v1_5', 'RSA-PSS'].flatMap(rsaAlgoName =>
                 ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'].map(
                     hashName =>
-                    ({
-                        __variant: hashName,
-                        hash: { name: hashName },
-                        modulusLength: 2048,
-                        name: rsaAlgoName,
-                        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                    } as RsaHashedKeyGenParams)
+                        ({
+                            __variant: hashName,
+                            hash: { name: hashName },
+                            modulusLength: 2048,
+                            name: rsaAlgoName,
+                            publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                        } as RsaHashedKeyGenParams)
                 )
             ),
         ])('fatals when the algorithm is $name/$__variant', async algorithm => {
@@ -214,13 +214,13 @@ describe('generateKey() polyfill', () => {
             ...['RSASSA-PKCS1-v1_5', 'RSA-PSS'].flatMap(rsaAlgoName =>
                 ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'].map(
                     hashName =>
-                    ({
-                        __variant: hashName,
-                        hash: { name: hashName },
-                        modulusLength: 2048,
-                        name: rsaAlgoName,
-                        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                    } as RsaHashedKeyGenParams)
+                        ({
+                            __variant: hashName,
+                            hash: { name: hashName },
+                            modulusLength: 2048,
+                            name: rsaAlgoName,
+                            publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                        } as RsaHashedKeyGenParams)
                 )
             ),
         ])('calls the original `generateKey` when the algorithm is $name/$__variant', async algorithm => {
@@ -473,27 +473,10 @@ describe('verify() polyfill', () => {
 
 describe('importKey() polyfill', () => {
     let originalImportKey: SubtleCrypto['importKey'];
-    beforeEach(() => {
-        jest.spyOn(globalThis.crypto?.subtle, 'importKey');
-        originalImportKey = globalThis.crypto?.subtle?.importKey;
-    });
-    afterEach(() => {
-        globalThis.crypto.subtle.importKey = originalImportKey;
-    });
-    describe('when imported', () => {
-        // TODO
-        it('is a test', () => {
-            expect(typeof importKeyPolyfill).toBe('function');
-        });
-    });
-});
-
-describe('importKey() polyfill', () => {
-    let originalImportKey: SubtleCrypto['importKey'];
 
     const MOCK_PUBLIC_KEY_BYTES = new Uint8Array([
-        0x1d, 0x0e, 0x93, 0x86, 0x4d, 0xcc, 0x81, 0x5f, 0xc3, 0xf2, 0x86, 0x18, 0x09, 0x11, 0xd0, 0x0a, 0x3f, 0xd2, 0x06,
-        0xde, 0x31, 0xa1, 0xc9, 0x42, 0x87, 0xcb, 0x43, 0xf0, 0x5f, 0xc9, 0xf2, 0xb5,
+        0x1d, 0x0e, 0x93, 0x86, 0x4d, 0xcc, 0x81, 0x5f, 0xc3, 0xf2, 0x86, 0x18, 0x09, 0x11, 0xd0, 0x0a, 0x3f, 0xd2,
+        0x06, 0xde, 0x31, 0xa1, 0xc9, 0x42, 0x87, 0xcb, 0x43, 0xf0, 0x5f, 0xc9, 0xf2, 0xb5,
     ]);
 
     beforeEach(() => {
@@ -524,26 +507,34 @@ describe('importKey() polyfill', () => {
             ...['RSASSA-PKCS1-v1_5', 'RSA-PSS'].flatMap(rsaAlgoName =>
                 ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'].map(
                     hashName =>
-                    ({
-                        __variant: hashName,
-                        hash: { name: hashName },
-                        modulusLength: 2048,
-                        name: rsaAlgoName,
-                        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                    } as RsaHashedKeyGenParams)
+                        ({
+                            __variant: hashName,
+                            hash: { name: hashName },
+                            modulusLength: 2048,
+                            name: rsaAlgoName,
+                            publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                        } as RsaHashedKeyGenParams)
                 )
             ),
         ])('fatals when the algorithm is $name/$__variant', async algorithm => {
             expect.assertions(1);
             await expect(() =>
-                globalThis.crypto.subtle.importKey("raw", MOCK_PUBLIC_KEY_BYTES, algorithm, /* extractable */ false, ['verify'])
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, algorithm, /* extractable */ false, [
+                    'verify',
+                ])
             ).rejects.toThrow();
         });
         it('delegates Ed25519 `importKey` calls to the polyfill', async () => {
             expect.assertions(1);
             const mockKey = {};
             (importKeyPolyfill as jest.Mock).mockReturnValue(mockKey);
-            const keyPair = await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify',]);
+            const keyPair = await globalThis.crypto.subtle.importKey(
+                'raw',
+                MOCK_PUBLIC_KEY_BYTES,
+                'Ed25519',
+                /* extractable */ false,
+                ['verify']
+            );
             expect(keyPair).toBe(mockKey);
         });
     });
@@ -566,22 +557,40 @@ describe('importKey() polyfill', () => {
         it('calls the original `importKey` once as a test when the algorithm is "Ed25519" but never again (parallel version)', async () => {
             expect.assertions(1);
             await Promise.all([
-                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
-                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                    'verify',
+                ]),
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                    'verify',
+                ]),
             ]);
             expect(originalImportKey).toHaveBeenCalledTimes(1);
         });
         it('calls the original `importKey` once as a test when the algorithm is "Ed25519" but never again (serial version)', async () => {
             expect.assertions(1);
-            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
-                await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
+            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                'verify',
+            ]),
+                await globalThis.crypto.subtle.importKey(
+                    'raw',
+                    MOCK_PUBLIC_KEY_BYTES,
+                    'Ed25519',
+                    /* extractable */ false,
+                    ['verify']
+                ),
                 expect(originalImportKey).toHaveBeenCalledTimes(1);
         });
         it('delegates Ed25519 `generateKey` calls to the polyfill', async () => {
             expect.assertions(1);
             const mockKey = {};
             (importKeyPolyfill as jest.Mock).mockReturnValue(mockKey);
-            const key = await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']);
+            const key = await globalThis.crypto.subtle.importKey(
+                'raw',
+                MOCK_PUBLIC_KEY_BYTES,
+                'Ed25519',
+                /* extractable */ false,
+                ['verify']
+            );
             expect(key).toBe(mockKey);
         });
     });
@@ -603,19 +612,25 @@ describe('importKey() polyfill', () => {
             ...['RSASSA-PKCS1-v1_5', 'RSA-PSS'].flatMap(rsaAlgoName =>
                 ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'].map(
                     hashName =>
-                    ({
-                        __variant: hashName,
-                        hash: { name: hashName },
-                        modulusLength: 2048,
-                        name: rsaAlgoName,
-                        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                    } as RsaHashedKeyGenParams)
+                        ({
+                            __variant: hashName,
+                            hash: { name: hashName },
+                            modulusLength: 2048,
+                            name: rsaAlgoName,
+                            publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                        } as RsaHashedKeyGenParams)
                 )
             ),
         ])('calls the original `importKey` when the algorithm is $name/$__variant', async algorithm => {
             expect.assertions(1);
             try {
-                await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, algorithm, /* extractable */ false, ['verify']);
+                await globalThis.crypto.subtle.importKey(
+                    'raw',
+                    MOCK_PUBLIC_KEY_BYTES,
+                    algorithm,
+                    /* extractable */ false,
+                    ['verify']
+                );
             } catch {
                 // some of these won't work with our mock key data, we just want to make sure they're called
             }
@@ -626,26 +641,38 @@ describe('importKey() polyfill', () => {
             const mockKey = {};
             (originalImportKey as jest.Mock).mockResolvedValue(mockKey);
             await expect(
-                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify'])
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                    'verify',
+                ])
             ).resolves.toBe(mockKey);
         });
         it('calls the original `importKey` once per call to `importKey` when the algorithm is "Ed25519" (parallel version)', async () => {
             expect.assertions(1);
             await Promise.all([
-                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
-                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify'])
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                    'verify',
+                ]),
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                    'verify',
+                ]),
             ]);
             expect(originalImportKey).toHaveBeenCalledTimes(2);
         });
         it('calls the original `importKey` once per call to `importKey` when the algorithm is "Ed25519" (serial version)', async () => {
             expect.assertions(1);
-            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']);
-            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']);
+            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                'verify',
+            ]);
+            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                'verify',
+            ]);
             expect(originalImportKey).toHaveBeenCalledTimes(2);
         });
         it('does not delegate `importKey` calls to the polyfill', async () => {
             expect.assertions(1);
-            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']);
+            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                'verify',
+            ]);
             expect(importKeyPolyfill).not.toHaveBeenCalled();
         });
     });

--- a/packages/webcrypto-ed25519-polyfill/src/__tests__/index-test.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/__tests__/index-test.ts
@@ -148,11 +148,9 @@ describe('generateKey() polyfill', () => {
             expect.assertions(1);
             const mockKeyPair = {};
             (generateKeyPolyfill as jest.Mock).mockReturnValue(mockKeyPair);
-            const keyPair = await globalThis.crypto.subtle.generateKey('Ed25519', /* extractable */ false, [
-                'sign',
-                'verify',
-            ]);
-            expect(keyPair).toBe(mockKeyPair);
+            await expect(
+                globalThis.crypto.subtle.generateKey('Ed25519', /* extractable */ false, ['sign', 'verify'])
+            ).resolves.toBe(mockKeyPair);
         });
     });
     describe('when imported in an environment that does not support Ed25519', () => {
@@ -189,11 +187,9 @@ describe('generateKey() polyfill', () => {
             expect.assertions(1);
             const mockKeyPair = {};
             (generateKeyPolyfill as jest.Mock).mockReturnValue(mockKeyPair);
-            const keyPair = await globalThis.crypto.subtle.generateKey('Ed25519', /* extractable */ false, [
-                'sign',
-                'verify',
-            ]);
-            expect(keyPair).toBe(mockKeyPair);
+            await expect(
+                globalThis.crypto.subtle.generateKey('Ed25519', /* extractable */ false, ['sign', 'verify'])
+            ).resolves.toBe(mockKeyPair);
         });
     });
     describe('when imported in an environment that supports Ed25519', () => {
@@ -528,14 +524,11 @@ describe('importKey() polyfill', () => {
             expect.assertions(1);
             const mockKey = {};
             (importKeyPolyfill as jest.Mock).mockReturnValue(mockKey);
-            const keyPair = await globalThis.crypto.subtle.importKey(
-                'raw',
-                MOCK_PUBLIC_KEY_BYTES,
-                'Ed25519',
-                /* extractable */ false,
-                ['verify']
-            );
-            expect(keyPair).toBe(mockKey);
+            await expect(
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, [
+                    'verify',
+                ])
+            ).resolves.toBe(mockKey);
         });
     });
     describe('when imported in an environment that does not support Ed25519', () => {

--- a/packages/webcrypto-ed25519-polyfill/src/__tests__/index-test.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/__tests__/index-test.ts
@@ -1,4 +1,11 @@
-import { exportKeyPolyfill, generateKeyPolyfill, isPolyfilledKey, signPolyfill, verifyPolyfill } from '../secrets';
+import {
+    exportKeyPolyfill,
+    generateKeyPolyfill,
+    isPolyfilledKey,
+    signPolyfill,
+    verifyPolyfill,
+    importKeyPolyfill,
+} from '../secrets';
 
 jest.mock('../secrets');
 
@@ -461,5 +468,22 @@ describe('verify() polyfill', () => {
                 expect(globalThis.crypto.subtle.verify).not.toBe(originalVerify);
             });
         }
+    });
+});
+
+describe('importKey() polyfill', () => {
+    let originalImportKey: SubtleCrypto['importKey'];
+    beforeEach(() => {
+        jest.spyOn(globalThis.crypto?.subtle, 'importKey');
+        originalImportKey = globalThis.crypto?.subtle?.importKey;
+    });
+    afterEach(() => {
+        globalThis.crypto.subtle.importKey = originalImportKey;
+    });
+    describe('when imported', () => {
+        // TODO
+        it('is a test', () => {
+            expect(typeof importKeyPolyfill).toBe('function');
+        });
     });
 });

--- a/packages/webcrypto-ed25519-polyfill/src/__tests__/index-test.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/__tests__/index-test.ts
@@ -129,13 +129,13 @@ describe('generateKey() polyfill', () => {
             ...['RSASSA-PKCS1-v1_5', 'RSA-PSS'].flatMap(rsaAlgoName =>
                 ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'].map(
                     hashName =>
-                        ({
-                            __variant: hashName,
-                            hash: { name: hashName },
-                            modulusLength: 2048,
-                            name: rsaAlgoName,
-                            publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                        } as RsaHashedKeyGenParams)
+                    ({
+                        __variant: hashName,
+                        hash: { name: hashName },
+                        modulusLength: 2048,
+                        name: rsaAlgoName,
+                        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                    } as RsaHashedKeyGenParams)
                 )
             ),
         ])('fatals when the algorithm is $name/$__variant', async algorithm => {
@@ -214,13 +214,13 @@ describe('generateKey() polyfill', () => {
             ...['RSASSA-PKCS1-v1_5', 'RSA-PSS'].flatMap(rsaAlgoName =>
                 ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'].map(
                     hashName =>
-                        ({
-                            __variant: hashName,
-                            hash: { name: hashName },
-                            modulusLength: 2048,
-                            name: rsaAlgoName,
-                            publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                        } as RsaHashedKeyGenParams)
+                    ({
+                        __variant: hashName,
+                        hash: { name: hashName },
+                        modulusLength: 2048,
+                        name: rsaAlgoName,
+                        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                    } as RsaHashedKeyGenParams)
                 )
             ),
         ])('calls the original `generateKey` when the algorithm is $name/$__variant', async algorithm => {
@@ -485,5 +485,187 @@ describe('importKey() polyfill', () => {
         it('is a test', () => {
             expect(typeof importKeyPolyfill).toBe('function');
         });
+    });
+});
+
+describe('importKey() polyfill', () => {
+    let originalImportKey: SubtleCrypto['importKey'];
+
+    const MOCK_PUBLIC_KEY_BYTES = new Uint8Array([
+        0x1d, 0x0e, 0x93, 0x86, 0x4d, 0xcc, 0x81, 0x5f, 0xc3, 0xf2, 0x86, 0x18, 0x09, 0x11, 0xd0, 0x0a, 0x3f, 0xd2, 0x06,
+        0xde, 0x31, 0xa1, 0xc9, 0x42, 0x87, 0xcb, 0x43, 0xf0, 0x5f, 0xc9, 0xf2, 0xb5,
+    ]);
+
+    beforeEach(() => {
+        jest.spyOn(globalThis.crypto?.subtle, 'importKey');
+        originalImportKey = globalThis.crypto?.subtle?.importKey;
+    });
+    afterEach(() => {
+        globalThis.crypto.subtle.importKey = originalImportKey;
+    });
+    describe('when imported in an environment with no `importKey` function', () => {
+        beforeEach(async () => {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            globalThis.crypto.subtle.importKey = undefined;
+            await jest.isolateModulesAsync(async () => {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                await import('../index');
+            });
+        });
+        afterEach(() => {
+            globalThis.crypto.subtle.importKey = originalImportKey;
+        });
+        it.each([
+            { __variant: 'P256', name: 'ECDSA', namedCurve: 'P-256' },
+            { __variant: 'P384', name: 'ECDSA', namedCurve: 'P-384' } as EcKeyGenParams,
+            { __variant: 'P521', name: 'ECDSA', namedCurve: 'P-521' } as EcKeyGenParams,
+            ...['RSASSA-PKCS1-v1_5', 'RSA-PSS'].flatMap(rsaAlgoName =>
+                ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'].map(
+                    hashName =>
+                    ({
+                        __variant: hashName,
+                        hash: { name: hashName },
+                        modulusLength: 2048,
+                        name: rsaAlgoName,
+                        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                    } as RsaHashedKeyGenParams)
+                )
+            ),
+        ])('fatals when the algorithm is $name/$__variant', async algorithm => {
+            expect.assertions(1);
+            await expect(() =>
+                globalThis.crypto.subtle.importKey("raw", MOCK_PUBLIC_KEY_BYTES, algorithm, /* extractable */ false, ['verify'])
+            ).rejects.toThrow();
+        });
+        it('delegates Ed25519 `importKey` calls to the polyfill', async () => {
+            expect.assertions(1);
+            const mockKey = {};
+            (importKeyPolyfill as jest.Mock).mockReturnValue(mockKey);
+            const keyPair = await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify',]);
+            expect(keyPair).toBe(mockKey);
+        });
+    });
+    describe('when imported in an environment that does not support Ed25519', () => {
+        beforeEach(async () => {
+            const originalImportKeyImpl = originalImportKey;
+            (originalImportKey as jest.Mock).mockImplementation(async (...args) => {
+                const [_format, _keyData, algorithm] = args;
+                if (algorithm === 'Ed25519') {
+                    throw new Error('Ed25519 not supported');
+                }
+                return await originalImportKeyImpl.apply(globalThis.crypto.subtle, args);
+            });
+            await jest.isolateModulesAsync(async () => {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                await import('../index');
+            });
+        });
+        it('calls the original `importKey` once as a test when the algorithm is "Ed25519" but never again (parallel version)', async () => {
+            expect.assertions(1);
+            await Promise.all([
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
+            ]);
+            expect(originalImportKey).toHaveBeenCalledTimes(1);
+        });
+        it('calls the original `importKey` once as a test when the algorithm is "Ed25519" but never again (serial version)', async () => {
+            expect.assertions(1);
+            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
+                await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
+                expect(originalImportKey).toHaveBeenCalledTimes(1);
+        });
+        it('delegates Ed25519 `generateKey` calls to the polyfill', async () => {
+            expect.assertions(1);
+            const mockKey = {};
+            (importKeyPolyfill as jest.Mock).mockReturnValue(mockKey);
+            const key = await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']);
+            expect(key).toBe(mockKey);
+        });
+    });
+    describe('when imported in an environment that supports Ed25519', () => {
+        beforeEach(async () => {
+            await jest.isolateModulesAsync(async () => {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                await import('../index');
+            });
+        });
+        it('overrides `importKey`', () => {
+            expect(globalThis.crypto.subtle.importKey).not.toBe(originalImportKey);
+        });
+        it.each([
+            { __variant: 'P256', name: 'ECDSA', namedCurve: 'P-256' },
+            { __variant: 'P384', name: 'ECDSA', namedCurve: 'P-384' } as EcKeyGenParams,
+            { __variant: 'P521', name: 'ECDSA', namedCurve: 'P-521' } as EcKeyGenParams,
+            ...['RSASSA-PKCS1-v1_5', 'RSA-PSS'].flatMap(rsaAlgoName =>
+                ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'].map(
+                    hashName =>
+                    ({
+                        __variant: hashName,
+                        hash: { name: hashName },
+                        modulusLength: 2048,
+                        name: rsaAlgoName,
+                        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                    } as RsaHashedKeyGenParams)
+                )
+            ),
+        ])('calls the original `importKey` when the algorithm is $name/$__variant', async algorithm => {
+            expect.assertions(1);
+            try {
+                await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, algorithm, /* extractable */ false, ['verify']);
+            } catch {
+                // some of these won't work with our mock key data, we just want to make sure they're called
+            }
+            expect(originalImportKey).toHaveBeenCalled();
+        });
+        it('delegates the call to the original `importKey` when the algorithm is "Ed25519"', async () => {
+            expect.assertions(1);
+            const mockKey = {};
+            (originalImportKey as jest.Mock).mockResolvedValue(mockKey);
+            await expect(
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify'])
+            ).resolves.toBe(mockKey);
+        });
+        it('calls the original `importKey` once per call to `importKey` when the algorithm is "Ed25519" (parallel version)', async () => {
+            expect.assertions(1);
+            await Promise.all([
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']),
+                globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify'])
+            ]);
+            expect(originalImportKey).toHaveBeenCalledTimes(2);
+        });
+        it('calls the original `importKey` once per call to `importKey` when the algorithm is "Ed25519" (serial version)', async () => {
+            expect.assertions(1);
+            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']);
+            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']);
+            expect(originalImportKey).toHaveBeenCalledTimes(2);
+        });
+        it('does not delegate `importKey` calls to the polyfill', async () => {
+            expect.assertions(1);
+            await globalThis.crypto.subtle.importKey('raw', MOCK_PUBLIC_KEY_BYTES, 'Ed25519', /* extractable */ false, ['verify']);
+            expect(importKeyPolyfill).not.toHaveBeenCalled();
+        });
+    });
+    describe('when imported in an insecure context', () => {
+        beforeEach(async () => {
+            globalThis.isSecureContext = false;
+            await jest.isolateModulesAsync(async () => {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                await import('../index');
+            });
+        });
+        if (__BROWSER__) {
+            it('does not override `importKey`', () => {
+                expect(globalThis.crypto.subtle.importKey).toBe(originalImportKey);
+            });
+        } else {
+            it('overrides `importKey`', () => {
+                expect(globalThis.crypto.subtle.importKey).not.toBe(originalImportKey);
+            });
+        }
     });
 });

--- a/packages/webcrypto-ed25519-polyfill/src/__tests__/secrets-test.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/__tests__/secrets-test.ts
@@ -89,18 +89,22 @@ describe('importKeyPolyfill', () => {
         it('allows importing valid public key bytes', () => {
             expect(() => importKeyPolyfill('raw', MOCK_PUBLIC_KEY_BYTES, false, ['verify'])).not.toThrow();
         });
-        it('fatals when keyUsages is empty', () => {
-            expect(() => importKeyPolyfill('raw', MOCK_PUBLIC_KEY_BYTES, false, [])).toThrow(); // TODO: tighten these up - check real impl errors match
+        it('allows importing with empty keyUsages', () => {
+            expect(() => importKeyPolyfill('raw', MOCK_PUBLIC_KEY_BYTES, false, [])).not.toThrow();
         });
         it.each(['sign', 'decrypt', 'deriveBits', 'deriveKey', 'encrypt', 'unwrapKey', 'wrapKey'] as KeyUsage[])(
             'fatals when the usage `%s` is specified',
             usage => {
-                expect(() => importKeyPolyfill('raw', MOCK_PUBLIC_KEY_BYTES, false, [usage])).toThrow();
+                expect(() => importKeyPolyfill('raw', MOCK_PUBLIC_KEY_BYTES, false, [usage])).toThrow(
+                    'Unsupported key usage for a Ed25519 key'
+                );
             }
         );
         it.each([0, 1, 30, 31, 33, 34, 48])('fatals when bytes is length `%d`', bytesLength => {
             const keyData = new Uint8Array(Array(bytesLength).fill(0));
-            expect(() => importKeyPolyfill('raw', keyData, false, ['verify'])).toThrow();
+            expect(() => importKeyPolyfill('raw', keyData, false, ['verify'])).toThrow(
+                'Ed25519 raw keys must be exactly 32-bytes'
+            );
         });
         it('has the string tag "CryptoKey"', () => {
             const key = importKeyPolyfill('raw', MOCK_PUBLIC_KEY_BYTES, false, ['verify']);
@@ -171,22 +175,24 @@ describe('importKeyPolyfill', () => {
         it('allows importing valid private key bytes', () => {
             expect(() => importKeyPolyfill('pkcs8', mockSecretKeyWithHeader, false, ['sign'])).not.toThrow();
         });
-        it('fatals when keyUsages is empty', () => {
-            expect(() => importKeyPolyfill('pkcs8', mockSecretKeyWithHeader, false, [])).toThrow(); // TODO: tighten these up - check real impl errors match
+        it('allows importing with empty keyUsages', () => {
+            expect(() => importKeyPolyfill('pkcs8', mockSecretKeyWithHeader, false, [])).not.toThrow();
         });
         it.each(['verify', 'decrypt', 'deriveBits', 'deriveKey', 'encrypt', 'unwrapKey', 'wrapKey'] as KeyUsage[])(
             'fatals when the usage `%s` is specified',
             usage => {
-                expect(() => importKeyPolyfill('pkcs8', mockSecretKeyWithHeader, false, [usage])).toThrow();
+                expect(() => importKeyPolyfill('pkcs8', mockSecretKeyWithHeader, false, [usage])).toThrow(
+                    'Unsupported key usage for a Ed25519 key'
+                );
             }
         );
         it.each([0, 1, 32, 46, 47, 49, 50])('fatals when bytes is length `%d`', bytesLength => {
             const keyData = new Uint8Array(Array(bytesLength).fill(0));
-            expect(() => importKeyPolyfill('pkcs8', keyData, false, ['sign'])).toThrow();
+            expect(() => importKeyPolyfill('pkcs8', keyData, false, ['sign'])).toThrow('Invalid keyData');
         });
         it('fatals when the first 16 bytes are not the expected header', () => {
             const keyData = new Uint8Array([...Array(16).fill(0), ...MOCK_SECRET_KEY_BYTES]);
-            expect(() => importKeyPolyfill('pkcs8', keyData, false, ['sign'])).toThrow();
+            expect(() => importKeyPolyfill('pkcs8', keyData, false, ['sign'])).toThrow('Invalid keyData');
         });
         it('has the string tag "CryptoKey"', () => {
             const key = importKeyPolyfill('pkcs8', mockSecretKeyWithHeader, false, ['sign']);

--- a/packages/webcrypto-ed25519-polyfill/src/index.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/index.ts
@@ -1,7 +1,7 @@
 import {
-    importKeyPolyfill,
     exportKeyPolyfill,
     generateKeyPolyfill,
+    importKeyPolyfill,
     isPolyfilledKey,
     signPolyfill,
     verifyPolyfill,
@@ -57,10 +57,10 @@ if (!__BROWSER__ || globalThis.isSecureContext) {
                         if (__DEV__) {
                             console.warn(
                                 '`@solana/webcrypto-ed25519-polyfill` was included in an ' +
-                                'environment that supports Ed25519 key manipulation ' +
-                                'natively. Falling back to the native implementation. ' +
-                                'Consider including this polyfill only in environments where ' +
-                                'Ed25519 is not supported.'
+                                    'environment that supports Ed25519 key manipulation ' +
+                                    'natively. Falling back to the native implementation. ' +
+                                    'Consider including this polyfill only in environments where ' +
+                                    'Ed25519 is not supported.'
                             );
                         }
                         if (originalSubtleCrypto.generateKey !== originalGenerateKey) {
@@ -151,10 +151,10 @@ if (!__BROWSER__ || globalThis.isSecureContext) {
                         if (__DEV__) {
                             console.warn(
                                 '`@solana/webcrypto-ed25519-polyfill` was included in an ' +
-                                'environment that supports Ed25519 key manipulation ' +
-                                'natively. Falling back to the native implementation. ' +
-                                'Consider including this polyfill only in environments where ' +
-                                'Ed25519 is not supported.'
+                                    'environment that supports Ed25519 key manipulation ' +
+                                    'natively. Falling back to the native implementation. ' +
+                                    'Consider including this polyfill only in environments where ' +
+                                    'Ed25519 is not supported.'
                             );
                         }
                         if (originalSubtleCrypto.importKey !== originalImportKey) {
@@ -185,6 +185,4 @@ if (!__BROWSER__ || globalThis.isSecureContext) {
             return importKeyPolyfill(format, keyData, extractable, keyUsages);
         }
     }) as SubtleCrypto['importKey'];
-
-
 }

--- a/packages/webcrypto-ed25519-polyfill/src/index.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/index.ts
@@ -125,7 +125,7 @@ if (!__BROWSER__ || globalThis.isSecureContext) {
     }) as SubtleCrypto['verify'];
 
     /**
-     * Override `SubtleCrypto#generateKey`
+     * Override `SubtleCrypto#importKey`
      */
     const originalImportKey = originalSubtleCrypto.importKey as SubtleCrypto['importKey'] | undefined;
     let originalImportKeySupportsEd25519: Promise<boolean> | boolean | undefined;

--- a/packages/webcrypto-ed25519-polyfill/src/index.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/index.ts
@@ -127,7 +127,7 @@ if (!__BROWSER__ || globalThis.isSecureContext) {
       ...args: Parameters<SubtleCrypto["importKey"]>
     ) => {
       const [format, keyData, algorithm, extractable, keyUsages] = args;
-      if (algorithm.name === "Ed25519") {
+      if (algorithm === "Ed25519") {
         return await importKeyPolyfill(
           format,
           keyData,

--- a/packages/webcrypto-ed25519-polyfill/src/index.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/index.ts
@@ -57,10 +57,10 @@ if (!__BROWSER__ || globalThis.isSecureContext) {
                         if (__DEV__) {
                             console.warn(
                                 '`@solana/webcrypto-ed25519-polyfill` was included in an ' +
-                                    'environment that supports Ed25519 key manipulation ' +
-                                    'natively. Falling back to the native implementation. ' +
-                                    'Consider including this polyfill only in environments where ' +
-                                    'Ed25519 is not supported.'
+                                'environment that supports Ed25519 key manipulation ' +
+                                'natively. Falling back to the native implementation. ' +
+                                'Consider including this polyfill only in environments where ' +
+                                'Ed25519 is not supported.'
                             );
                         }
                         if (originalSubtleCrypto.generateKey !== originalGenerateKey) {
@@ -125,47 +125,66 @@ if (!__BROWSER__ || globalThis.isSecureContext) {
     }) as SubtleCrypto['verify'];
 
     /**
-     * Override `SubtleCrypto#importKey`
+     * Override `SubtleCrypto#generateKey`
      */
     const originalImportKey = originalSubtleCrypto.importKey as SubtleCrypto['importKey'] | undefined;
+    let originalImportKeySupportsEd25519: Promise<boolean> | boolean | undefined;
     originalSubtleCrypto.importKey = (async (...args: Parameters<SubtleCrypto['importKey']>) => {
-        const [format, keyData, algorithm, extractable, keyUsages] = args;
-
-        // States to handle:
-        // importkey does not exist
-        // importkey exists and supports Ed25519
-        // importkey exists and doesn't support Ed25519
-
-        if (!originalImportKey) {
-            if (algorithm === 'Ed25519') {
-                return importKeyPolyfill(format, keyData, extractable, keyUsages);
+        const [format, keyData, algorithm] = args;
+        if (algorithm !== 'Ed25519') {
+            if (originalImportKey) {
+                return await originalImportKey.apply(originalSubtleCrypto, args);
             } else {
                 throw new TypeError('No native `importKey` function exists to handle this call');
             }
-        } else if (algorithm === 'Ed25519') {
-            return originalImportKey
-                .apply(originalSubtleCrypto, args)
-                .then(res => {
-                    if (__DEV__) {
-                        console.warn(
-                            '`@solana/webcrypto-ed25519-polyfill` was included in an ' +
+        }
+        let optimisticallyImportedKey;
+        if (originalImportKeySupportsEd25519 === undefined) {
+            originalImportKeySupportsEd25519 = new Promise(resolve => {
+                if (!originalImportKey) {
+                    resolve((originalImportKeySupportsEd25519 = false));
+                    return;
+                }
+                originalImportKey
+                    .apply(originalSubtleCrypto, args)
+                    .then(key => {
+                        if (__DEV__) {
+                            console.warn(
+                                '`@solana/webcrypto-ed25519-polyfill` was included in an ' +
                                 'environment that supports Ed25519 key manipulation ' +
                                 'natively. Falling back to the native implementation. ' +
                                 'Consider including this polyfill only in environments where ' +
                                 'Ed25519 is not supported.'
-                        );
-                    }
-                    return res;
-                })
-                .catch(err => {
-                    if (err.name === 'NotSupportedError') {
-                        return importKeyPolyfill(format, keyData, extractable, keyUsages);
-                    } else {
-                        throw err;
-                    }
-                });
+                            );
+                        }
+                        if (originalSubtleCrypto.importKey !== originalImportKey) {
+                            originalSubtleCrypto.importKey = originalImportKey;
+                        }
+                        optimisticallyImportedKey = key;
+                        resolve((originalImportKeySupportsEd25519 = true));
+                    })
+                    .catch(() => {
+                        resolve((originalImportKeySupportsEd25519 = false));
+                    });
+            });
+        }
+        if (
+            typeof originalImportKey === 'boolean'
+                ? originalImportKeySupportsEd25519
+                : await originalImportKeySupportsEd25519
+        ) {
+            if (optimisticallyImportedKey) {
+                return optimisticallyImportedKey;
+            } else if (originalImportKey) {
+                return await originalImportKey.apply(originalSubtleCrypto, args);
+            } else {
+                throw new TypeError('No native `importKey` function exists to handle this call');
+            }
         } else {
-            return originalImportKey.apply(originalSubtleCrypto, args);
+            const [_format, _keyData, _algorithm, extractable, keyUsages] = args;
+            return importKeyPolyfill(format, keyData, extractable, keyUsages);
         }
     }) as SubtleCrypto['importKey'];
+
+
 }

--- a/packages/webcrypto-ed25519-polyfill/src/index.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/index.ts
@@ -120,26 +120,16 @@ if (!__BROWSER__ || globalThis.isSecureContext) {
     /**
      * Override `SubtleCrypto#importKey`
      */
-    const originalImportKey = originalSubtleCrypto.importKey as
-      | SubtleCrypto["importKey"]
-      | undefined;
-    originalSubtleCrypto.importKey = (async (
-      ...args: Parameters<SubtleCrypto["importKey"]>
-    ) => {
-      const [format, keyData, algorithm, extractable, keyUsages] = args;
-      if (algorithm === "Ed25519") {
-        return await importKeyPolyfill(
-          format,
-          keyData,
-          extractable,
-          keyUsages as any
-        );
-      } else if (originalImportKey) {
-        return await originalImportKey.apply(originalSubtleCrypto, args);
-      } else {
-        throw new TypeError(
-          "No native `importKey` function exists to handle this call"
-        );
-      }
-    }) as SubtleCrypto["importKey"];
+    const originalImportKey = originalSubtleCrypto.importKey as SubtleCrypto['importKey'] | undefined;
+    originalSubtleCrypto.importKey = (async (...args: Parameters<SubtleCrypto['importKey']>) => {
+        const [format, keyData, algorithm, extractable, keyUsages] = args;
+
+        if (algorithm === 'Ed25519') {
+            return await importKeyPolyfill(format, keyData, extractable, keyUsages);
+        } else if (originalImportKey) {
+            return await originalImportKey.apply(originalSubtleCrypto, args);
+        } else {
+            throw new TypeError('No native `importKey` function exists to handle this call');
+        }
+    }) as SubtleCrypto['importKey'];
 }

--- a/packages/webcrypto-ed25519-polyfill/src/secrets.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/secrets.ts
@@ -144,19 +144,10 @@ export function importKeyPolyfill(
   keyData: BufferSource,
   extractable: boolean,
   keyUsages: readonly KeyUsage[]
-): CryptoKeyPair {
+): CryptoKey {
   const bytes = bufferSourceToUint8Array(keyData);
 
-  if (format !== "raw") {
-    throw new DOMException(
-      `Importing Ed25519 keys in the "${format}" format is unimplemented`,
-      "NotSupportedError"
-    );
-  }
+  const kp = createKeyPairFromBytes(bytes, extractable, keyUsages);
 
-  if (!keyUsages.includes("sign") || !keyUsages.includes("verify")) {
-    throw new DOMException("Invalid keyUsages for Ed25519", "SyntaxError");
-  }
-
-  return createKeyPairFromBytes(bytes, extractable, keyUsages);
+  return kp.privateKey;
 }

--- a/packages/webcrypto-ed25519-polyfill/src/secrets.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/secrets.ts
@@ -138,3 +138,25 @@ export function verifyPolyfill(key: CryptoKey, signature: BufferSource, data: Bu
         return false;
     }
 }
+
+export function importKeyPolyfill(
+  format: KeyFormat,
+  keyData: BufferSource,
+  extractable: boolean,
+  keyUsages: readonly KeyUsage[]
+): CryptoKeyPair {
+  const bytes = bufferSourceToUint8Array(keyData);
+
+  if (format !== "raw") {
+    throw new DOMException(
+      `Importing Ed25519 keys in the "${format}" format is unimplemented`,
+      "NotSupportedError"
+    );
+  }
+
+  if (!keyUsages.includes("sign") || !keyUsages.includes("verify")) {
+    throw new DOMException("Invalid keyUsages for Ed25519", "SyntaxError");
+  }
+
+  return createKeyPairFromBytes(bytes, extractable, keyUsages);
+}

--- a/packages/webcrypto-ed25519-polyfill/src/secrets.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/secrets.ts
@@ -134,11 +134,6 @@ function getPublicKeyBytes(key: CryptoKey): Uint8Array {
     return publicKeyBytes;
 }
 
-function storePublicKeyBytes(key: CryptoKey, publicKeyBytes: Uint8Array) {
-    const cache = (publicKeyBytesStore ||= new WeakMap());
-    cache.set(key, publicKeyBytes);
-}
-
 export function exportKeyPolyfill(format: 'jwk', key: CryptoKey): JsonWebKey;
 export function exportKeyPolyfill(format: KeyFormat, key: CryptoKey): ArrayBuffer;
 export function exportKeyPolyfill(format: KeyFormat, key: CryptoKey): ArrayBuffer | JsonWebKey {
@@ -150,11 +145,7 @@ export function exportKeyPolyfill(format: KeyFormat, key: CryptoKey): ArrayBuffe
             if (key.type !== 'public') {
                 throw new DOMException(`Unable to export a raw Ed25519 ${key.type} key`, 'InvalidAccessError');
             }
-            const publicKeyBytesFromPublicKeyStore = publicKeyBytesStore?.get(key);
-            if (publicKeyBytesFromPublicKeyStore) return publicKeyBytesFromPublicKeyStore;
-
-            const publicKeyBytes = ed25519.getPublicKey(getSecretKeyBytes_INTERNAL_ONLY_DO_NOT_EXPORT(key));
-            storePublicKeyBytes(key, publicKeyBytes);
+            const publicKeyBytes = getPublicKeyBytes(key);
             return publicKeyBytes;
         }
         default:


### PR DESCRIPTION
This PR adds the `importKey` function to the webcrypto polyfill

It supersedes #1681, thanks to @ronanyeah for the contribution!

- when we import public key bytes we store them as-is. Since our existing secrets store stores secrets (from which we can derive a public key), we use a new store for these public key bytes which don't need to be converted to be used as a public key

- when we import private key bytes, we validate the PKCS8 header (we just compare to the known precise expected header), and strip it. The remaining private key bytes are stored in the secrets store
