### PR TITLE
refactor(experimental): WIP modify rpc types for performance

### DIFF
--- a/packages/library/src/rpc.ts
+++ b/packages/library/src/rpc.ts
@@ -17,7 +17,7 @@ import { DEFAULT_RPC_CONFIG } from './rpc-default-config';
 import { getRpcSubscriptionsWithSubscriptionCoalescing } from './rpc-subscription-coalescer';
 
 export function createSolanaRpc(config: Omit<Parameters<typeof createJsonRpc>[0], 'api'>): Rpc<SolanaRpcMethods> {
-    return createJsonRpc({
+    return createJsonRpc<SolanaRpcMethods>({
         ...config,
         api: createSolanaRpcApi(DEFAULT_RPC_CONFIG),
     });
@@ -27,7 +27,7 @@ export function createSolanaRpcSubscriptions(
     config: Omit<Parameters<typeof createJsonSubscriptionRpc>[0], 'api'>
 ): RpcSubscriptions<SolanaRpcSubscriptions> {
     return pipe(
-        createJsonSubscriptionRpc({
+        createJsonSubscriptionRpc<SolanaRpcSubscriptions>({
             ...config,
             api: createSolanaRpcSubscriptionsApi(DEFAULT_RPC_CONFIG),
         }),
@@ -42,7 +42,7 @@ export function createSolanaRpcSubscriptions(
 export function createSolanaRpcSubscriptions_UNSTABLE(
     config: Omit<Parameters<typeof createJsonSubscriptionRpc>[0], 'api'>
 ): RpcSubscriptions<SolanaRpcSubscriptions & SolanaRpcSubscriptionsUnstable> {
-    return createJsonSubscriptionRpc({
+    return createJsonSubscriptionRpc<SolanaRpcSubscriptions & SolanaRpcSubscriptionsUnstable>({
         ...config,
         api: createSolanaRpcSubscriptionsApi_UNSTABLE(DEFAULT_RPC_CONFIG),
     });

--- a/packages/rpc-core/src/rpc-methods/getClusterNodes.ts
+++ b/packages/rpc-core/src/rpc-methods/getClusterNodes.ts
@@ -28,10 +28,6 @@ type GetClusterNodesApiResponse = readonly GetClusterNodesNode[];
 export interface GetClusterNodesApi {
     /**
      * Returns information about all the nodes participating in the cluster
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getClusterNodes(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetClusterNodesApiResponse;
+    getClusterNodes(): GetClusterNodesApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getEpochSchedule.ts
+++ b/packages/rpc-core/src/rpc-methods/getEpochSchedule.ts
@@ -16,10 +16,6 @@ type GetEpochScheduleApiResponse = Readonly<{
 export interface GetEpochScheduleApi {
     /**
      * Returns the epoch schedule information from this cluster's genesis config
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getEpochSchedule(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetEpochScheduleApiResponse;
+    getEpochSchedule(): GetEpochScheduleApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getFirstAvailableBlock.ts
+++ b/packages/rpc-core/src/rpc-methods/getFirstAvailableBlock.ts
@@ -5,10 +5,6 @@ type GetFirstAvailableBlockApiResponse = Slot;
 export interface GetFirstAvailableBlockApi {
     /**
      * Returns the slot of the lowest confirmed block that has not been purged from the ledger
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getFirstAvailableBlock(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetFirstAvailableBlockApiResponse;
+    getFirstAvailableBlock(): GetFirstAvailableBlockApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getGenesisHash.ts
+++ b/packages/rpc-core/src/rpc-methods/getGenesisHash.ts
@@ -6,8 +6,5 @@ export interface GetGenesisHashApi {
     /**
      * Returns the genesis hash
      */
-    getGenesisHash(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetGenesisHashApiResponse;
+    getGenesisHash(): GetGenesisHashApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getHealth.ts
+++ b/packages/rpc-core/src/rpc-methods/getHealth.ts
@@ -4,8 +4,5 @@ export interface GetHealthApi {
     /**
      * Returns the health status of the node ("ok" if healthy).
      */
-    getHealth(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetHealthApiResponse;
+    getHealth(): GetHealthApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getHighestSnapshotSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getHighestSnapshotSlot.ts
@@ -13,8 +13,5 @@ export interface GetHighestSnapshotSlotApi {
      * incremental snapshot slot based on the full snapshot slot, if there
      * is one.
      */
-    getHighestSnapshotSlot(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetHighestSnapshotSlotApiResponse;
+    getHighestSnapshotSlot(): GetHighestSnapshotSlotApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getIdentity.ts
+++ b/packages/rpc-core/src/rpc-methods/getIdentity.ts
@@ -8,8 +8,5 @@ export interface GetIdentityApi {
     /**
      * Returns the identity pubkey for the current node
      */
-    getIdentity(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetIdentityApiResponse;
+    getIdentity(): GetIdentityApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getInflationRate.ts
+++ b/packages/rpc-core/src/rpc-methods/getInflationRate.ts
@@ -15,8 +15,5 @@ export interface GetInflationRateApi {
     /**
      * Returns the current block height of the node
      */
-    getInflationRate(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetInflationRateApiResponse;
+    getInflationRate(): GetInflationRateApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getMaxRetransmitSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getMaxRetransmitSlot.ts
@@ -5,10 +5,6 @@ type GetMaxRetransmitSlotApiResponse = Slot;
 export interface GetMaxRetransmitSlotApi {
     /**
      * Get the max slot seen from retransmit stage.
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getMaxRetransmitSlot(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetMaxRetransmitSlotApiResponse;
+    getMaxRetransmitSlot(): GetMaxRetransmitSlotApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getMaxShredInsertSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getMaxShredInsertSlot.ts
@@ -5,10 +5,6 @@ type GetMaxShredInsertSlotApiResponse = Slot;
 export interface GetMaxShredInsertSlotApi {
     /**
      * Get the max slot seen from after shred insert.
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getMaxShredInsertSlot(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetMaxShredInsertSlotApiResponse;
+    getMaxShredInsertSlot(): GetMaxShredInsertSlotApiResponse;
 }

--- a/packages/rpc-core/src/rpc-methods/getVersion.ts
+++ b/packages/rpc-core/src/rpc-methods/getVersion.ts
@@ -9,8 +9,5 @@ export interface GetVersionApi {
     /**
      * Returns the current Solana version running on the node
      */
-    getVersion(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): GetVersionApiResponse;
+    getVersion(): GetVersionApiResponse;
 }

--- a/packages/rpc-core/src/rpc-subscriptions/root-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/root-notifications.ts
@@ -6,8 +6,5 @@ export interface RootNotificationsApi {
     /**
      * Subscribe to receive notification anytime a new root is set by the validator
      */
-    rootNotifications(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): RootNotificationsApiNotification;
+    rootNotifications(): RootNotificationsApiNotification;
 }

--- a/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
@@ -10,8 +10,5 @@ export interface SlotNotificationsApi {
     /**
      * Subscribe to receive notification anytime a slot is processed by the validator
      */
-    slotNotifications(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): SlotNotificationsApiNotification;
+    slotNotifications(): SlotNotificationsApiNotification;
 }

--- a/packages/rpc-core/src/rpc-subscriptions/slots-updates-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/slots-updates-notifications.ts
@@ -39,8 +39,5 @@ export interface SlotsUpdatesNotificationsApi {
     /**
      * Subscribe to receive a notification from the validator on a variety of updates on every slot
      */
-    slotsUpdatesNotifications(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): SlotsUpdatesNotificationsApiNotification;
+    slotsUpdatesNotifications(): SlotsUpdatesNotificationsApiNotification;
 }

--- a/packages/rpc-core/src/rpc-subscriptions/vote-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/vote-notifications.ts
@@ -17,8 +17,5 @@ export interface VoteNotificationsApi {
     /**
      * Subscribe to receive a notification from the validator on a variety of updates on every slot
      */
-    voteNotifications(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>
-    ): VoteNotificationsApiNotification;
+    voteNotifications(): VoteNotificationsApiNotification;
 }

--- a/packages/rpc-transport/src/json-rpc-types.ts
+++ b/packages/rpc-transport/src/json-rpc-types.ts
@@ -55,720 +55,78 @@ export type SubscribeOptions = Readonly<{
  * Private RPC-building types.
  */
 type RpcMethods<TRpcMethods> = {
-    [TMethodName in keyof TRpcMethods]: PendingRpcRequestBuilder<ApiMethodImplementations<TRpcMethods, TMethodName>>;
+    [TMethodName in keyof TRpcMethods]: RpcMethodImplementations<TRpcMethods, TMethodName>;
 };
 type RpcSubscriptionMethods<TRpcSubscriptionMethods> = {
-    [TMethodName in keyof TRpcSubscriptionMethods]: PendingRpcSubscriptionBuilder<
-        ApiMethodImplementations<TRpcSubscriptionMethods, TMethodName>
+    [TMethodName in keyof TRpcSubscriptionMethods]: RpcSubscriptionMethodImplementations<
+        TRpcSubscriptionMethods,
+        TMethodName
     >;
 };
-type ApiMethodImplementations<TRpcMethods, TMethod extends keyof TRpcMethods> = Overloads<TRpcMethods[TMethod]>;
-type PendingRpcRequestBuilder<TMethodImplementations> = UnionToIntersection<
-    Flatten<{
-        // Check that this property of the TRpcMethods interface is, in fact, a function.
-        [P in keyof TMethodImplementations]: TMethodImplementations[P] extends Callable
-            ? (
-                  ...args: Parameters<TMethodImplementations[P]>
-              ) => PendingRpcRequest<ReturnType<TMethodImplementations[P]>>
-            : never;
-    }>
+type RpcMethodImplementations<TRpcMethods, TMethod extends keyof TRpcMethods> = UnionToIntersection<
+    RpcOverloads<TRpcMethods[TMethod]>
 >;
-type PendingRpcSubscriptionBuilder<TSubscriptionMethodImplementations> = UnionToIntersection<
-    Flatten<{
-        // Check that this property of the TRpcSubscriptionMethods interface is, in fact, a function.
-        [P in keyof TSubscriptionMethodImplementations]: TSubscriptionMethodImplementations[P] extends Callable
-            ? (
-                  ...args: Parameters<TSubscriptionMethodImplementations[P]>
-              ) => PendingRpcSubscription<ReturnType<TSubscriptionMethodImplementations[P]>>
-            : never;
-    }>
->;
+type RpcSubscriptionMethodImplementations<
+    TRpcSubscriptionMethods,
+    TMethod extends keyof TRpcSubscriptionMethods
+> = UnionToIntersection<RpcSubscriptionOverloads<TRpcSubscriptionMethods[TMethod]>>;
 
 /**
  * Utility types that do terrible, awful things.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Callable = (...args: any[]) => any;
-type Flatten<T> = T extends (infer Item)[] ? Item : never;
-type Overloads<T> =
-    // Have an RPC method with more than 24 overloads? Add another section and update this comment
-    T extends {
-        (...args: infer A1): infer R1;
-        (...args: infer A2): infer R2;
-        (...args: infer A3): infer R3;
-        (...args: infer A4): infer R4;
-        (...args: infer A5): infer R5;
-        (...args: infer A6): infer R6;
-        (...args: infer A7): infer R7;
-        (...args: infer A8): infer R8;
-        (...args: infer A9): infer R9;
-        (...args: infer A10): infer R10;
-        (...args: infer A11): infer R11;
-        (...args: infer A12): infer R12;
-        (...args: infer A13): infer R13;
-        (...args: infer A14): infer R14;
-        (...args: infer A15): infer R15;
-        (...args: infer A16): infer R16;
-        (...args: infer A17): infer R17;
-        (...args: infer A18): infer R18;
-        (...args: infer A19): infer R19;
-        (...args: infer A20): infer R20;
-        (...args: infer A21): infer R21;
-        (...args: infer A22): infer R22;
-        (...args: infer A23): infer R23;
-        (...args: infer A24): infer R24;
-    }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19,
-              (...args: A20) => R20,
-              (...args: A21) => R21,
-              (...args: A22) => R22,
-              (...args: A23) => R23,
-              (...args: A24) => R24
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-              (...args: infer A20): infer R20;
-              (...args: infer A21): infer R21;
-              (...args: infer A22): infer R22;
-              (...args: infer A23): infer R23;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19,
-              (...args: A20) => R20,
-              (...args: A21) => R21,
-              (...args: A22) => R22,
-              (...args: A23) => R23
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-              (...args: infer A20): infer R20;
-              (...args: infer A21): infer R21;
-              (...args: infer A22): infer R22;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19,
-              (...args: A20) => R20,
-              (...args: A21) => R21,
-              (...args: A22) => R22
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-              (...args: infer A20): infer R20;
-              (...args: infer A21): infer R21;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19,
-              (...args: A20) => R20,
-              (...args: A21) => R21
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-              (...args: infer A20): infer R20;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19,
-              (...args: A20) => R20
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-          }
-        ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3, (...args: A4) => R4, (...args: A5) => R5]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-          }
-        ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3, (...args: A4) => R4]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-          }
-        ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-          }
-        ? [(...args: A1) => R1, (...args: A2) => R2]
-        : T extends {
-              (...args: infer A1): infer R1;
-          }
-        ? [(...args: A1) => R1]
-        : unknown;
+type OverloadProps<TOverload> = Pick<TOverload, keyof TOverload>;
+type RpcOverloadUnionRecursive<TOverload, TPartialOverload = unknown> = TOverload extends (
+    ...args: infer TArgs
+) => infer TReturn
+    ? // Prevent infinite recursion by stopping recursion when TPartialOverload
+      // has accumulated all of the TOverload signatures.
+      TPartialOverload extends TOverload
+        ? never
+        :
+              | RpcOverloadUnionRecursive<
+                    TPartialOverload & TOverload,
+                    TPartialOverload & ((...args: TArgs) => TReturn) & OverloadProps<TOverload>
+                >
+              | ((...args: TArgs) => PendingRpcRequest<TReturn>)
+    : never;
+type RpcOverloads<TOverload> = Exclude<
+    RpcOverloadUnionRecursive<
+        // The "() => never" signature must be hoisted to the "front" of the
+        // intersection, for two reasons: a) because recursion stops when it is
+        // encountered, and b) it seems to prevent the collapse of subsequent
+        // "compatible" signatures (eg. "() => void" into "(a?: 1) => void"),
+        // which gives a direct conversion to a union.
+        (() => never) & TOverload
+    >,
+    TOverload extends () => never ? never : () => PendingRpcRequest<never>
+>;
+type RpcSubscriptionOverloadUnionRecursive<TOverload, TPartialOverload = unknown> = TOverload extends (
+    ...args: infer TArgs
+) => infer TReturn
+    ? // Prevent infinite recursion by stopping recursion when TPartialOverload
+      // has accumulated all of the TOverload signatures.
+      TPartialOverload extends TOverload
+        ? never
+        :
+              | RpcSubscriptionOverloadUnionRecursive<
+                    TPartialOverload & TOverload,
+                    TPartialOverload & ((...args: TArgs) => TReturn) & OverloadProps<TOverload>
+                >
+              | ((...args: TArgs) => PendingRpcSubscription<TReturn>)
+    : never;
+type RpcSubscriptionOverloads<TOverload> = Exclude<
+    RpcSubscriptionOverloadUnionRecursive<
+        // The "() => never" signature must be hoisted to the "front" of the
+        // intersection, for two reasons: a) because recursion stops when it is
+        // encountered, and b) it seems to prevent the collapse of subsequent
+        // "compatible" signatures (eg. "() => void" into "(a?: 1) => void"),
+        // which gives a direct conversion to a union.
+        (() => never) & TOverload
+    >,
+    TOverload extends () => never ? never : () => PendingRpcSubscription<never>
+>;
 type UnionToIntersection<T> = (T extends unknown ? (x: T) => unknown : never) extends (x: infer R) => unknown
     ? R
     : never;


### PR DESCRIPTION
This PR aims to improve the typechecking performance of the RPC types. See #1682 for more information.

This ‘get the overloads recursively with some trickery’ approach was borrowed from @Shakeskeyboarde [here](https://github.com/microsoft/TypeScript/issues/32164#issuecomment-1146737709) ([playground](https://www.typescriptlang.org/play?ts=4.7.2#code/C4TwDgpgBA8gbhATgGwPYEMAmAFRqwDOAPACrxJpYB8UAvFNgJYDGA1qeShpgDRSsQQqAGZQyCLtQDcAWABQoSLAmVMAVQB2jVBoBKEZgFdEBRgg4rufEtnSJgjdMk6q6UQxtYbUAdw016cQpuKAgAD2AIDUwCKAAKeSgoADpUuwBzAgAuKEYNYSQxAEFETPkASjoaPILEMX1gYw1EqAB+KAB6DoZECAQNYFz8vMZIqF6jE20NKAAjECgCYHwwPPTxg2NTHSgfAAsosVt7R2dLLBakrqg99Fj0ZiMAW0NkdEjMKCdkKBEoYAOYhcIVM6Q072MEAIyUuRzsDicwKwoQiURiQPOmFh7Q0fSQsKysKSSQAPspglhNNN9JNTOYicTGTZ4ackZ8AGQYim8BmMpLMk6IzFQTlxOKpZIZbLFUoESq0GgkBpNSqctm4fDEIKSTBUXnEvVyPnEsliiVSnIkEqZeWK5WIDTlFo5XESWQKcDQNlUnQWbkoyLRWLitKynLoDQgADaAF1bV9IwEoABRMLMZCGTAQIgtb1aHQ0rZmbOw64kQEAIji8ddSAri0YYIhvSgLyWc2ge1QjCWEE+y3+leEeAG9b+AIgpe6eUiJgMDh0fGEqDqwB8qA2dx00vQlVmBnQhgI0AmRZ2S01uwOM1GuQIU9CGmYqA8s77fAjn1mlVvx4gT1iAcwF6fpBgnKBn2QN5CGgP4CEMWZjwAR0MKJgAfCtnyeMB3kYWZkAgetQXBRpemDCB0mSKAq3jOBu0wesZw3Kt0FaHIAEZaPoityh4B99hYPYoHSYt7igTBGAmQZnw0CRthmAd0HcfMNBhI1iTFGs8UQVUuR1FoqD49TtVccJA3RasqigWs6hxbSoBySyFWs7T5Cod15A6AAqeRy2gYBEBYVhAI3cD0FmVAEA2Wlpi+XoJXkeRdygABJfIkECjR1nAnDEHQJ4IFnBNPl6UiFM9WI-gjX5MT7KBhA8ZgFxmHxGCg9xj3kcC3nbSL-WI5sID4ATmCEnsvjAXK0OQBZqvCMBkBYW8s2IiCuxYCA1Pkb9UoGJBjyatYvgbLKCIbJtSOgVqAUHWDApE8Efhnfb52mPhmGq3oVyzRAusBZ650OnY4jAVACFMfDZpmDxMFQZ40Lq0ws1CYQCia1pyi2uRmEqNLZwO5rYg+mYdBmjsNgAWm+pB32s1BBnBRA8B8Oq4l6TBDGYPteKgABlVA+AneQAYJ2LbhC8nelmQw2sGPJbuogUETObl63SKIkBYQXr3kU8ph2YnyYvSa6v2Q5wIa9qRdenZxY7Q4pZl5BgDUmAJ0QVrj218b11eEqoVeOWZmqmoRjGPX5LUryOkSuRrmTSFWHQABCLrPTEKFgCKdi3DzaYiAAbxaascjoxhMHdJI4nQDjyg4yv4hrqAACY+FmHJm7rlv3QAX3c2P48wdWoAAYTuCAchoqybKIxsSMhVsj0Gfcbm7XtMDUxRoBITOimb3PMR9DRC+Lruy4r4um84+vL47tuO675uG5Lly3XkPuPLj7pkyH6Ax+PHIAARQwC0WDvGgANS69wWyoCeKMD4m9047yWEUAAzAfbkR8T7qRfufZ+V8u7sWfmfeiUhOjdA5qAj6kRb4t3vi3R++Da713IeJEBi1qGTjkB-Ae3QABy9N-K3DAoCamdQ-h9R1LEcaTx0AzjkbiT48twIeDeleQSrYIARnvF-Qc7xcjAAAOSxBAvtPCZ0jxHSUkfEgqA8YvSBuVJQZsWzgUkaoTy3QxGtnePjKifkURczAM1O81EnI0BnsNPYGi7YDhXutdenj-ihUBMOHQgxxz-T2oDZqVEAASvhtJ8FGMYhWTwwaDAIJAZgjBhAsHOvPXoRlrgjSEgVbRq8ewOCygYxYXY-ZG3QAUXIogVEqVCTJCQHw5gPFYMkhMSTraOKxtcNKtRMrrCUqonYfxcr5UKoURoC0oS-DqKVJo-wKqhO8D4KAoNwbmM2mnJQ6o7D7PxqQAMaJgzmjDAmaMcYrIRhAEmY47z9pEDzr6EgVB+4eheZie0GgSCek+WZb58RfmZHDJGWM8ZgVJiRSiyAkLD4qVILCz+W8M5LAAEI53oK8vKBUPlFxwSQ8uTCoDX25Vy1ucwH4d2IS6bSvc4XPO3pnWl+9GWIsKk0Yl2Y2VVw5RfHBrFmG8tofy9uDChWnxFW-bh4rdECLGOBCsM8NhlUuUoYmhjl7QDyOmTMtN9wfSPNAbZGhYjXSEjZJJsM6ZBxdcjUYakgA)). It's _much_ faster, but it doesn't completely work.

We run into this error:

```
error TS2589: Type instantiation is excessively deep and possibly infinite
```

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lE1zD7Jpg6mWNv3djNKZ/fe40f7af-451c-45a5-9e97-d7d7ae3d958f.png)

1. Interfaces with as little as two overloads (eg. [`getBlockProduction`](https://github.com/solana-labs/solana-web3.js/blob/ce145c805ee15ce0c5ef97623d9cfd006cf0b00b/packages/rpc-core/src/rpc-methods/getBlockProduction.ts#L39-L44)) trigger that error, seemingly _just_ because they are generic.
    ```ts
    getBlockProduction<TIdentity extends Base58EncodedAddress>(
        config: GetBlockProductionApiConfigBase &
            Readonly<{
                identity: TIdentity;
            }>
    ): GetBlockProductionApiResponseBase & GetBlockProductionApiResponseWithSingleIdentity<TIdentity>;
    ```
    Eliminate that type parameter and it compiles just fine.
    ```ts
    getBlockProduction(
        config: GetBlockProductionApiConfigBase &
            Readonly<{
                identity: Base58EncodedAddress;
            }>
    ): GetBlockProductionApiResponseBase & GetBlockProductionApiResponseWithSingleIdentity<Base58EncodedAddress>;
    ```
2. Interfaces with many overloads (eg. [`getBlock`](https://github.com/solana-labs/solana-web3.js/blob/ce145c805ee15ce0c5ef97623d9cfd006cf0b00b/packages/rpc-core/src/rpc-methods/getBlock.ts#L63-L374)) also trigger it, but for what reason I don't know (ie. I'm not sure if it's because of the _quantity_ of overloads, or because of some feature of their method signatures).

# How to test this

```
pnpm i
pnpm turbo test:typecheck
```