### PR TITLE
refactor(experimental): alias JSON-RPC types for performance

### DIFF
--- a/packages/rpc-transport/src/json-rpc-types.ts
+++ b/packages/rpc-transport/src/json-rpc-types.ts
@@ -4,14 +4,10 @@ import { IRpcTransport, IRpcWebSocketTransport } from './transports/transport-ty
  * Public RPC API.
  */
 export type IRpcApi<TRpcMethods> = {
-    [MethodName in keyof TRpcMethods]: TRpcMethods[MethodName] extends Callable
-        ? (...rawParams: unknown[]) => RpcRequest<ReturnType<TRpcMethods[MethodName]>>
-        : never;
+    [MethodName in keyof TRpcMethods]: RpcReturnTypeMapper<TRpcMethods[MethodName]>;
 };
-export type IRpcSubscriptionsApi<TRpcMethods> = {
-    [MethodName in keyof TRpcMethods]: TRpcMethods[MethodName] extends Callable
-        ? (...rawParams: unknown[]) => RpcSubscription<ReturnType<TRpcMethods[MethodName]>>
-        : never;
+export type IRpcSubscriptionsApi<TRpcSubscriptionMethods> = {
+    [MethodName in keyof TRpcSubscriptionMethods]: RpcSubscriptionReturnTypeMapper<TRpcSubscriptionMethods[MethodName]>;
 };
 export type Rpc<TRpcMethods> = RpcMethods<TRpcMethods>;
 export type RpcSubscriptions<TRpcSubscriptionMethods> = RpcSubscriptionMethods<TRpcSubscriptionMethods>;
@@ -54,6 +50,12 @@ export type SubscribeOptions = Readonly<{
 /**
  * Private RPC-building types.
  */
+type RpcReturnTypeMapper<TRpcMethod> = TRpcMethod extends Callable
+    ? (...rawParams: unknown[]) => RpcRequest<ReturnType<TRpcMethod>>
+    : never;
+type RpcSubscriptionReturnTypeMapper<TRpcMethod> = TRpcMethod extends Callable
+    ? (...rawParams: unknown[]) => RpcSubscription<ReturnType<TRpcMethod>>
+    : never;
 type RpcMethods<TRpcMethods> = {
     [TMethodName in keyof TRpcMethods]: PendingRpcRequestBuilder<ApiMethodImplementations<TRpcMethods, TMethodName>>;
 };
@@ -63,24 +65,28 @@ type RpcSubscriptionMethods<TRpcSubscriptionMethods> = {
     >;
 };
 type ApiMethodImplementations<TRpcMethods, TMethod extends keyof TRpcMethods> = Overloads<TRpcMethods[TMethod]>;
+type PendingRpcRequestReturnTypeMapper<TMethodImplementation> =
+    // Check that this property of the TRpcMethods interface is, in fact, a function.
+    TMethodImplementation extends Callable
+        ? (...args: Parameters<TMethodImplementation>) => PendingRpcRequest<ReturnType<TMethodImplementation>>
+        : never;
 type PendingRpcRequestBuilder<TMethodImplementations> = UnionToIntersection<
     Flatten<{
-        // Check that this property of the TRpcMethods interface is, in fact, a function.
-        [P in keyof TMethodImplementations]: TMethodImplementations[P] extends Callable
-            ? (
-                  ...args: Parameters<TMethodImplementations[P]>
-              ) => PendingRpcRequest<ReturnType<TMethodImplementations[P]>>
-            : never;
+        [P in keyof TMethodImplementations]: PendingRpcRequestReturnTypeMapper<TMethodImplementations[P]>;
     }>
 >;
+type PendingRpcSubscriptionReturnTypeMapper<TSubscriptionMethodImplementation> =
+    // Check that this property of the TRpcSubscriptionMethods interface is, in fact, a function.
+    TSubscriptionMethodImplementation extends Callable
+        ? (
+              ...args: Parameters<TSubscriptionMethodImplementation>
+          ) => PendingRpcSubscription<ReturnType<TSubscriptionMethodImplementation>>
+        : never;
 type PendingRpcSubscriptionBuilder<TSubscriptionMethodImplementations> = UnionToIntersection<
     Flatten<{
-        // Check that this property of the TRpcSubscriptionMethods interface is, in fact, a function.
-        [P in keyof TSubscriptionMethodImplementations]: TSubscriptionMethodImplementations[P] extends Callable
-            ? (
-                  ...args: Parameters<TSubscriptionMethodImplementations[P]>
-              ) => PendingRpcSubscription<ReturnType<TSubscriptionMethodImplementations[P]>>
-            : never;
+        [P in keyof TSubscriptionMethodImplementations]: PendingRpcSubscriptionReturnTypeMapper<
+            TSubscriptionMethodImplementations[P]
+        >;
     }>
 >;
 
@@ -90,7 +96,8 @@ type PendingRpcSubscriptionBuilder<TSubscriptionMethodImplementations> = UnionTo
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Callable = (...args: any[]) => any;
 type Flatten<T> = T extends (infer Item)[] ? Item : never;
-type Overloads<T> =
+type Overloads<T> = Overloads24<T>;
+type Overloads24<T> =
     // Have an RPC method with more than 24 overloads? Add another section and update this comment
     T extends {
         (...args: infer A1): infer R1;
@@ -144,631 +151,654 @@ type Overloads<T> =
               (...args: A23) => R23,
               (...args: A24) => R24
           ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-              (...args: infer A20): infer R20;
-              (...args: infer A21): infer R21;
-              (...args: infer A22): infer R22;
-              (...args: infer A23): infer R23;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19,
-              (...args: A20) => R20,
-              (...args: A21) => R21,
-              (...args: A22) => R22,
-              (...args: A23) => R23
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-              (...args: infer A20): infer R20;
-              (...args: infer A21): infer R21;
-              (...args: infer A22): infer R22;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19,
-              (...args: A20) => R20,
-              (...args: A21) => R21,
-              (...args: A22) => R22
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-              (...args: infer A20): infer R20;
-              (...args: infer A21): infer R21;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19,
-              (...args: A20) => R20,
-              (...args: A21) => R21
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-              (...args: infer A20): infer R20;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19,
-              (...args: A20) => R20
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-              (...args: infer A19): infer R19;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18,
-              (...args: A19) => R19
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-              (...args: infer A18): infer R18;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17,
-              (...args: A18) => R18
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-              (...args: infer A17): infer R17;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16,
-              (...args: A17) => R17
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-              (...args: infer A16): infer R16;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15,
-              (...args: A16) => R16
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-              (...args: infer A15): infer R15;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14,
-              (...args: A15) => R15
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-              (...args: infer A14): infer R14;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13,
-              (...args: A14) => R14
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-              (...args: infer A13): infer R13;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12,
-              (...args: A13) => R13
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-              (...args: infer A12): infer R12;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11,
-              (...args: A12) => R12
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-              (...args: infer A11): infer R11;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10,
-              (...args: A11) => R11
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-              (...args: infer A10): infer R10;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9,
-              (...args: A10) => R10
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-              (...args: infer A9): infer R9;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8,
-              (...args: A9) => R9
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-              (...args: infer A8): infer R8;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7,
-              (...args: A8) => R8
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-              (...args: infer A7): infer R7;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6,
-              (...args: A7) => R7
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-              (...args: infer A6): infer R6;
-          }
-        ? [
-              (...args: A1) => R1,
-              (...args: A2) => R2,
-              (...args: A3) => R3,
-              (...args: A4) => R4,
-              (...args: A5) => R5,
-              (...args: A6) => R6
-          ]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-              (...args: infer A5): infer R5;
-          }
-        ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3, (...args: A4) => R4, (...args: A5) => R5]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-              (...args: infer A4): infer R4;
-          }
-        ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3, (...args: A4) => R4]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-              (...args: infer A3): infer R3;
-          }
-        ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3]
-        : T extends {
-              (...args: infer A1): infer R1;
-              (...args: infer A2): infer R2;
-          }
-        ? [(...args: A1) => R1, (...args: A2) => R2]
-        : T extends {
-              (...args: infer A1): infer R1;
-          }
-        ? [(...args: A1) => R1]
-        : unknown;
+        : Overloads23<T>;
+type Overloads23<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+    (...args: infer A16): infer R16;
+    (...args: infer A17): infer R17;
+    (...args: infer A18): infer R18;
+    (...args: infer A19): infer R19;
+    (...args: infer A20): infer R20;
+    (...args: infer A21): infer R21;
+    (...args: infer A22): infer R22;
+    (...args: infer A23): infer R23;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15,
+          (...args: A16) => R16,
+          (...args: A17) => R17,
+          (...args: A18) => R18,
+          (...args: A19) => R19,
+          (...args: A20) => R20,
+          (...args: A21) => R21,
+          (...args: A22) => R22,
+          (...args: A23) => R23
+      ]
+    : Overloads22<T>;
+type Overloads22<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+    (...args: infer A16): infer R16;
+    (...args: infer A17): infer R17;
+    (...args: infer A18): infer R18;
+    (...args: infer A19): infer R19;
+    (...args: infer A20): infer R20;
+    (...args: infer A21): infer R21;
+    (...args: infer A22): infer R22;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15,
+          (...args: A16) => R16,
+          (...args: A17) => R17,
+          (...args: A18) => R18,
+          (...args: A19) => R19,
+          (...args: A20) => R20,
+          (...args: A21) => R21,
+          (...args: A22) => R22
+      ]
+    : Overloads21<T>;
+type Overloads21<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+    (...args: infer A16): infer R16;
+    (...args: infer A17): infer R17;
+    (...args: infer A18): infer R18;
+    (...args: infer A19): infer R19;
+    (...args: infer A20): infer R20;
+    (...args: infer A21): infer R21;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15,
+          (...args: A16) => R16,
+          (...args: A17) => R17,
+          (...args: A18) => R18,
+          (...args: A19) => R19,
+          (...args: A20) => R20,
+          (...args: A21) => R21
+      ]
+    : Overloads20<T>;
+type Overloads20<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+    (...args: infer A16): infer R16;
+    (...args: infer A17): infer R17;
+    (...args: infer A18): infer R18;
+    (...args: infer A19): infer R19;
+    (...args: infer A20): infer R20;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15,
+          (...args: A16) => R16,
+          (...args: A17) => R17,
+          (...args: A18) => R18,
+          (...args: A19) => R19,
+          (...args: A20) => R20
+      ]
+    : Overloads19<T>;
+type Overloads19<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+    (...args: infer A16): infer R16;
+    (...args: infer A17): infer R17;
+    (...args: infer A18): infer R18;
+    (...args: infer A19): infer R19;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15,
+          (...args: A16) => R16,
+          (...args: A17) => R17,
+          (...args: A18) => R18,
+          (...args: A19) => R19
+      ]
+    : Overloads18<T>;
+type Overloads18<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+    (...args: infer A16): infer R16;
+    (...args: infer A17): infer R17;
+    (...args: infer A18): infer R18;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15,
+          (...args: A16) => R16,
+          (...args: A17) => R17,
+          (...args: A18) => R18
+      ]
+    : Overloads17<T>;
+type Overloads17<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+    (...args: infer A16): infer R16;
+    (...args: infer A17): infer R17;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15,
+          (...args: A16) => R16,
+          (...args: A17) => R17
+      ]
+    : Overloads16<T>;
+type Overloads16<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+    (...args: infer A16): infer R16;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15,
+          (...args: A16) => R16
+      ]
+    : Overloads15<T>;
+type Overloads15<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15
+      ]
+    : Overloads14<T>;
+type Overloads14<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14
+      ]
+    : Overloads13<T>;
+type Overloads13<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13
+      ]
+    : Overloads12<T>;
+type Overloads12<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12
+      ]
+    : Overloads11<T>;
+type Overloads11<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11
+      ]
+    : Overloads10<T>;
+type Overloads10<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10
+      ]
+    : Overloads9<T>;
+type Overloads9<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9
+      ]
+    : Overloads8<T>;
+type Overloads8<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8
+      ]
+    : Overloads7<T>;
+type Overloads7<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7
+      ]
+    : Overloads6<T>;
+type Overloads6<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6
+      ]
+    : Overloads5<T>;
+type Overloads5<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+}
+    ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3, (...args: A4) => R4, (...args: A5) => R5]
+    : Overloads4<T>;
+type Overloads4<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+}
+    ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3, (...args: A4) => R4]
+    : Overloads3<T>;
+type Overloads3<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+}
+    ? [(...args: A1) => R1, (...args: A2) => R2, (...args: A3) => R3]
+    : Overloads2<T>;
+type Overloads2<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+}
+    ? [(...args: A1) => R1, (...args: A2) => R2]
+    : Overloads1<T>;
+type Overloads1<T> = T extends {
+    (...args: infer A1): infer R1;
+}
+    ? [(...args: A1) => R1]
+    : unknown;
 type UnionToIntersection<T> = (T extends unknown ? (x: T) => unknown : never) extends (x: infer R) => unknown
     ? R
     : never;


### PR DESCRIPTION
# Summary

_tl;dr, @Dimava is a saint ([link](https://github.com/sindresorhus/type-fest/issues/585#issuecomment-1528768370))_.

Breaking up the mega-overload helper into separate helpers for each level of overload fixed #1682.

# Test Plan

```
~/src/solana-web3.js-git$ cd pacakges/library/
~/src/solana-web3.js-git/packages/library$ pnpm tsc -p ./tsconfig.json --noEmit --generateTrace tracing_output_folder
# open resulting trace in chrome://tracing
```

## Before (11300ms check time)

<img width="2560" alt="image" src="https://github.com/solana-labs/solana-web3.js/assets/13243/2a417733-eaa9-4c5e-8c1c-2af59b20d905">

## After (170ms check time)

<img width="2560" alt="image" src="https://github.com/solana-labs/solana-web3.js/assets/13243/2b2aa740-aadf-4ca9-8c85-9dd613d461cc">

Holy shit.

https://github.com/solana-labs/solana-web3.js/assets/13243/022b05b4-341e-4c35-960d-069d7084f0e5