### PR TITLE
refactor(experimental): make `abortSignal` optional in the confirmation helpers

### DIFF
--- a/packages/library/src/__tests__/transaction-confirmation-strategy-racer-test.ts
+++ b/packages/library/src/__tests__/transaction-confirmation-strategy-racer-test.ts
@@ -1,0 +1,97 @@
+import { TransactionSignature } from '@solana/transactions';
+
+import { raceStrategies } from '../transaction-confirmation-strategy-racer';
+
+const FOREVER_PROMISE = new Promise(() => {
+    /* never resolve */
+});
+
+describe('raceStrategies', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+    it('aborts the `AbortController` passed to `getRecentSignatureConfirmationPromise` when finished', async () => {
+        expect.assertions(2);
+        const getRecentSignatureConfirmationPromise = jest.fn();
+        raceStrategies(
+            'abc' as TransactionSignature,
+            {
+                commitment: 'finalized',
+                getRecentSignatureConfirmationPromise,
+            },
+            function getSpecificStrategiesForRace() {
+                return [];
+            }
+        );
+        expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith(
+            expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: false }) })
+        );
+        await jest.runAllTimersAsync();
+        expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith(
+            expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: true }) })
+        );
+    });
+    it('aborts the `AbortController` passed to `getRecentSignatureConfirmationPromise` when the caller-supplied `AbortSignal` aborts', async () => {
+        expect.assertions(2);
+        const getRecentSignatureConfirmationPromise = jest.fn().mockReturnValue(FOREVER_PROMISE);
+        const abortController = new AbortController();
+        raceStrategies(
+            'abc' as TransactionSignature,
+            {
+                abortSignal: abortController.signal,
+                commitment: 'finalized',
+                getRecentSignatureConfirmationPromise,
+            },
+            function getSpecificStrategiesForRace() {
+                return [];
+            }
+        );
+        expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith(
+            expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: false }) })
+        );
+        abortController.abort();
+        expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith(
+            expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: true }) })
+        );
+    });
+    it('aborts the `AbortController` passed to the specific strategies when finished', async () => {
+        expect.assertions(2);
+        const getSpecificStrategiesForRace = jest.fn().mockReturnValue([]);
+        raceStrategies(
+            'abc' as TransactionSignature,
+            {
+                commitment: 'finalized',
+                getRecentSignatureConfirmationPromise: jest.fn(),
+            },
+            getSpecificStrategiesForRace
+        );
+        expect(getSpecificStrategiesForRace).toHaveBeenCalledWith(
+            expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: false }) })
+        );
+        await jest.runAllTimersAsync();
+        expect(getSpecificStrategiesForRace).toHaveBeenCalledWith(
+            expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: true }) })
+        );
+    });
+    it('aborts the `AbortController` passed to the specific strategies when the caller-supplied `AbortSignal` aborts', async () => {
+        expect.assertions(2);
+        const getSpecificStrategiesForRace = jest.fn().mockReturnValue([]);
+        const abortController = new AbortController();
+        raceStrategies(
+            'abc' as TransactionSignature,
+            {
+                abortSignal: abortController.signal,
+                commitment: 'finalized',
+                getRecentSignatureConfirmationPromise: jest.fn().mockReturnValue(FOREVER_PROMISE),
+            },
+            getSpecificStrategiesForRace
+        );
+        expect(getSpecificStrategiesForRace).toHaveBeenCalledWith(
+            expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: false }) })
+        );
+        abortController.abort();
+        expect(getSpecificStrategiesForRace).toHaveBeenCalledWith(
+            expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: true }) })
+        );
+    });
+});


### PR DESCRIPTION
# Summary

It's conceivable that, despite the fact that the confirmation helpers use subscriptions internally, you might want to be lazy and not manage cancellation. This is so because transaction confirmation is short-lived-ish.

To save you a few keystrokes, and at your own peril, we make `abortSignal` optional in the method signature of `confirmRecentTransaction` and `confirmDurableNonceTransaction`.

# Test Plan

```
cd packages/library/
pnpm test:unit:browser
pnpm test:unit:node
```