### PR TITLE
refactor(experimental): add support for decompiling a compiled transaction

### DIFF
--- a/packages/compat/src/transaction.ts
+++ b/packages/compat/src/transaction.ts
@@ -109,7 +109,6 @@ export function fromVersionedTransactionWithBlockhash(
     // TODO: coded error
     if (!feePayer) throw new Error('No fee payer set in VersionedTransaction');
 
-    // TOOD: add support for durable nonce transactions
     const blockhashLifetime = {
         blockhash: transaction.message.recentBlockhash as Blockhash,
         lastValidBlockHeight: lastValidBlockHeight ?? 2n ** 64n - 1n, // U64 MAX

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -68,6 +68,7 @@
         "@solana/codecs-data-structures": "workspace:*",
         "@solana/codecs-numbers": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
+        "@solana/functional": "workspace:*",
         "@solana/keys": "workspace:*"
     },
     "devDependencies": {

--- a/packages/transactions/src/__tests__/decompile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/decompile-transaction-test.ts
@@ -1,0 +1,319 @@
+import { Base58EncodedAddress } from '@solana/addresses';
+import { AccountRole, IInstruction } from '@solana/instructions';
+import { Ed25519Signature } from '@solana/keys';
+
+import { ITransactionWithSignatures } from '..';
+import { decompileTransaction } from '../decompile-transaction';
+import { CompiledMessage } from '../message';
+
+type CompiledTransaction = Readonly<{
+    compiledMessage: CompiledMessage;
+    signatures: Ed25519Signature[];
+}>;
+
+describe('decompileTransaction', () => {
+    const U64_MAX = 2n ** 64n - 1n;
+    const feePayer = '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK' as Base58EncodedAddress;
+
+    describe('for a blockhash lifetime', () => {
+        const blockhash = 'J4yED2jcMAHyQUg61DBmm4njmEydUr2WqrV9cdEcDDgL';
+
+        it('converts a transaction with no instructions', () => {
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 0,
+                        numReadonlySignerAccounts: 0,
+                        numSignerAccounts: 1,
+                    },
+                    instructions: [],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [feePayer],
+                    version: 0,
+                },
+                signatures: [],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction);
+
+            expect(transaction.version).toBe(0);
+            expect(transaction.feePayer).toEqual(feePayer);
+            expect(transaction.lifetimeConstraint).toEqual({
+                blockhash,
+                lastValidBlockHeight: U64_MAX,
+            });
+        });
+
+        it('converts a transaction with version legacy', () => {
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 0,
+                        numReadonlySignerAccounts: 0,
+                        numSignerAccounts: 1,
+                    },
+                    instructions: [],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [feePayer],
+                    version: 'legacy',
+                },
+                signatures: [],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction);
+            expect(transaction.version).toBe('legacy');
+        });
+
+        it('converts a transaction with one instruction with no accounts or data', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Base58EncodedAddress;
+
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 1,
+                        // fee payer
+                        numReadonlySignerAccounts: 0,
+                        numSignerAccounts: 1, // program address
+                    },
+                    instructions: [{ programAddressIndex: 1 }],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [feePayer, programAddress],
+                    version: 0,
+                },
+                signatures: [],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction);
+            const expectedInstruction: IInstruction = {
+                programAddress,
+            };
+            expect(transaction.instructions).toStrictEqual([expectedInstruction]);
+        });
+
+        it('converts a transaction with one instruction with accounts and data', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Base58EncodedAddress;
+
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 2, // 1 passed into instruction + 1 program
+                        numReadonlySignerAccounts: 1,
+                        numSignerAccounts: 3, // fee payer + 2 passed into instruction
+                    },
+                    instructions: [
+                        {
+                            accountIndices: [1, 2, 3, 4],
+                            data: new Uint8Array([0, 1, 2, 3, 4]),
+                            programAddressIndex: 5,
+                        },
+                    ],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [
+                        // writable signers
+                        feePayer,
+                        'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Base58EncodedAddress,
+                        // read-only signers
+                        'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Base58EncodedAddress,
+                        // writable non-signers
+                        '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Base58EncodedAddress,
+                        // read-only non-signers
+                        '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Base58EncodedAddress,
+                        programAddress,
+                    ],
+                    version: 0,
+                },
+                signatures: [],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction);
+
+            const expectedInstruction: IInstruction = {
+                accounts: [
+                    {
+                        address: 'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Base58EncodedAddress,
+                        role: AccountRole.WRITABLE_SIGNER,
+                    },
+                    {
+                        address: 'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Base58EncodedAddress,
+                        role: AccountRole.READONLY_SIGNER,
+                    },
+                    {
+                        address: '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Base58EncodedAddress,
+                        role: AccountRole.WRITABLE,
+                    },
+                    {
+                        address: '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Base58EncodedAddress,
+                        role: AccountRole.READONLY,
+                    },
+                ],
+                data: new Uint8Array([0, 1, 2, 3, 4]),
+                programAddress,
+            };
+
+            expect(transaction.instructions).toStrictEqual([expectedInstruction]);
+        });
+
+        it('converts a transaction with multiple instructions', () => {
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 3, // 3 programs
+                        numReadonlySignerAccounts: 0,
+                        numSignerAccounts: 1, // fee payer
+                    },
+                    instructions: [{ programAddressIndex: 1 }, { programAddressIndex: 2 }, { programAddressIndex: 3 }],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [
+                        feePayer,
+                        '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Base58EncodedAddress,
+                        'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Base58EncodedAddress,
+                        'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Base58EncodedAddress,
+                    ],
+                    version: 0,
+                },
+                signatures: [],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction);
+
+            const expectedInstructions: IInstruction[] = [
+                {
+                    programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Base58EncodedAddress,
+                },
+                {
+                    programAddress: 'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Base58EncodedAddress,
+                },
+                {
+                    programAddress: 'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Base58EncodedAddress,
+                },
+            ];
+
+            expect(transaction.instructions).toStrictEqual(expectedInstructions);
+        });
+
+        it('converts a transaction with a single signer', () => {
+            const feePayerSignature = new Uint8Array(Array(64).fill(1)) as Ed25519Signature;
+
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 0,
+                        numReadonlySignerAccounts: 0,
+                        numSignerAccounts: 1,
+                    },
+                    instructions: [],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [feePayer],
+                    version: 0,
+                },
+                signatures: [feePayerSignature],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            expect(transaction.signatures).toStrictEqual({
+                [feePayer]: feePayerSignature as Ed25519Signature,
+            });
+        });
+
+        it('converts a transaction with multiple signers', () => {
+            const feePayerSignature = new Uint8Array(Array(64).fill(1)) as Ed25519Signature;
+
+            const otherSigner1Address = '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Base58EncodedAddress;
+            const otherSigner1Signature = new Uint8Array(Array(64).fill(2)) as Ed25519Signature;
+
+            const otherSigner2Address = '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Base58EncodedAddress;
+            const otherSigner2Signature = new Uint8Array(Array(64).fill(3)) as Ed25519Signature;
+
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Base58EncodedAddress;
+
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 1,
+                        numReadonlySignerAccounts: 2,
+                        numSignerAccounts: 3,
+                    },
+                    instructions: [
+                        {
+                            accountIndices: [1, 2],
+                            programAddressIndex: 3,
+                        },
+                    ],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [feePayer, otherSigner1Address, otherSigner2Address, programAddress],
+                    version: 0,
+                },
+                signatures: [feePayerSignature, otherSigner1Signature, otherSigner2Signature],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            expect(transaction.signatures).toStrictEqual({
+                [feePayer]: feePayerSignature,
+                [otherSigner1Address]: otherSigner1Signature,
+                [otherSigner2Address]: otherSigner2Signature,
+            });
+        });
+
+        it('converts a partially signed transaction with multiple signers', () => {
+            const feePayerSignature = new Uint8Array(Array(64).fill(1)) as Ed25519Signature;
+
+            const otherSigner1Address = '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Base58EncodedAddress;
+            const otherSigner2Address = '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Base58EncodedAddress;
+            const otherSigner2Signature = new Uint8Array(Array(64).fill(3)) as Ed25519Signature;
+
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Base58EncodedAddress;
+
+            // Used in the signatures array for a missing signature
+            const noSignature = new Uint8Array(Array(64).fill(0)) as Ed25519Signature;
+
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 1,
+                        numReadonlySignerAccounts: 2,
+                        numSignerAccounts: 3,
+                    },
+                    instructions: [
+                        {
+                            accountIndices: [1, 2],
+                            programAddressIndex: 3,
+                        },
+                    ],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [feePayer, otherSigner1Address, otherSigner2Address, programAddress],
+                    version: 0,
+                },
+                signatures: [feePayerSignature, noSignature, otherSigner2Signature],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            expect(transaction.signatures).toStrictEqual({
+                [feePayer]: feePayerSignature,
+                [otherSigner2Address]: otherSigner2Signature,
+            });
+        });
+
+        it('converts a transaction with a given lastValidBlockHeight', () => {
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 0,
+                        numReadonlySignerAccounts: 0,
+                        numSignerAccounts: 1,
+                    },
+                    instructions: [],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [feePayer],
+                    version: 0,
+                },
+                signatures: [],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction, 100n);
+            expect(transaction.lifetimeConstraint).toEqual({
+                blockhash,
+                lastValidBlockHeight: 100n,
+            });
+        });
+    });
+});

--- a/packages/transactions/src/decompile-transaction.ts
+++ b/packages/transactions/src/decompile-transaction.ts
@@ -1,0 +1,181 @@
+import { assertIsAddress, Base58EncodedAddress } from '@solana/addresses';
+import { pipe } from '@solana/functional';
+import { AccountRole, IAccountMeta, IInstruction } from '@solana/instructions';
+import { Ed25519Signature } from '@solana/keys';
+
+import { Blockhash, setTransactionLifetimeUsingBlockhash } from './blockhash';
+import { getCompiledTransaction } from './compile-transaction';
+import { createTransaction } from './create-transaction';
+import { isAdvanceNonceAccountInstruction, Nonce, setTransactionLifetimeUsingDurableNonce } from './durable-nonce';
+import { setTransactionFeePayer } from './fee-payer';
+import { appendTransactionInstruction } from './instructions';
+import { CompiledMessage } from './message';
+import { ITransactionWithSignatures } from './signatures';
+import { TransactionVersion } from './types';
+
+type CompiledTransaction = ReturnType<typeof getCompiledTransaction>;
+type CompilableTransaction = Parameters<typeof getCompiledTransaction>[0];
+
+function getAccountMetas(message: CompiledMessage): IAccountMeta[] {
+    const { header } = message;
+    const numWritableSignerAccounts = header.numSignerAccounts - header.numReadonlySignerAccounts;
+    const numWritableNonSignerAccounts =
+        message.staticAccounts.length - header.numSignerAccounts - header.numReadonlyNonSignerAccounts;
+
+    const accountMetas: IAccountMeta[] = [];
+
+    let accountIndex = 0;
+    for (let i = 0; i < numWritableSignerAccounts; i++) {
+        accountMetas.push({
+            address: message.staticAccounts[accountIndex],
+            role: AccountRole.WRITABLE_SIGNER,
+        });
+        accountIndex++;
+    }
+
+    for (let i = 0; i < header.numReadonlySignerAccounts; i++) {
+        accountMetas.push({
+            address: message.staticAccounts[accountIndex],
+            role: AccountRole.READONLY_SIGNER,
+        });
+        accountIndex++;
+    }
+
+    for (let i = 0; i < numWritableNonSignerAccounts; i++) {
+        accountMetas.push({
+            address: message.staticAccounts[accountIndex],
+            role: AccountRole.WRITABLE,
+        });
+        accountIndex++;
+    }
+
+    for (let i = 0; i < header.numReadonlyNonSignerAccounts; i++) {
+        accountMetas.push({
+            address: message.staticAccounts[accountIndex],
+            role: AccountRole.READONLY,
+        });
+        accountIndex++;
+    }
+
+    return accountMetas;
+}
+
+function convertInstruction(
+    instruction: CompiledMessage['instructions'][0],
+    accountMetas: IAccountMeta[]
+): IInstruction {
+    const programAddress = accountMetas[instruction.programAddressIndex]?.address;
+    if (!programAddress) {
+        // TODO coded error
+        throw new Error(`Could not find program address at index ${instruction.programAddressIndex}`);
+    }
+
+    const accounts = instruction.accountIndices?.map(accountIndex => accountMetas[accountIndex]);
+    const { data } = instruction;
+
+    return {
+        programAddress,
+        ...(accounts && accounts.length ? { accounts } : {}),
+        ...(data && data.length ? { data } : {}),
+    };
+}
+
+type LifetimeConstraint =
+    | {
+          blockhash: Blockhash;
+          lastValidBlockHeight: bigint;
+      }
+    | {
+          nonce: Nonce;
+          nonceAccountAddress: Base58EncodedAddress;
+          nonceAuthorityAddress: Base58EncodedAddress;
+      };
+
+function getLifetimeConstraint(
+    messageLifetimeToken: string,
+    firstInstruction?: IInstruction,
+    lastValidBlockHeight?: bigint
+): LifetimeConstraint {
+    if (!firstInstruction || !isAdvanceNonceAccountInstruction(firstInstruction)) {
+        // first instruction is not advance durable nonce, so use blockhash lifetime constraint
+        return {
+            blockhash: messageLifetimeToken as Blockhash,
+            lastValidBlockHeight: lastValidBlockHeight ?? 2n ** 64n - 1n, // U64 MAX
+        };
+    } else {
+        // We know these accounts are defined because we checked `isAdvanceNonceAccountInstruction`
+        const nonceAccountAddress = firstInstruction.accounts![0].address;
+        assertIsAddress(nonceAccountAddress);
+
+        const nonceAuthorityAddress = firstInstruction.accounts![2].address;
+        assertIsAddress(nonceAuthorityAddress);
+
+        return {
+            nonce: messageLifetimeToken as Nonce,
+            nonceAccountAddress,
+            nonceAuthorityAddress,
+        };
+    }
+}
+
+function convertSignatures(compiledTransaction: CompiledTransaction): ITransactionWithSignatures['signatures'] {
+    const {
+        compiledMessage: { staticAccounts },
+        signatures,
+    } = compiledTransaction;
+    return signatures.reduce((acc, sig, index) => {
+        // compiled transaction includes a fake all 0 signature if it hasn't been signed
+        // we don't store those for the new tx model. So just skip if it's all 0s
+        const allZeros = sig.every(byte => byte === 0);
+        if (allZeros) return acc;
+
+        const address = staticAccounts[index];
+        return { ...acc, [address]: sig as Ed25519Signature };
+    }, {});
+}
+
+export function decompileTransaction(
+    compiledTransaction: CompiledTransaction,
+    lastValidBlockHeight?: bigint
+): CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures) {
+    const { compiledMessage } = compiledTransaction;
+
+    // TODO: add support for address lookup tables
+    if ('addressTableLookups' in compiledMessage && compiledMessage.addressTableLookups!.length > 0) {
+        // TODO: coded error
+        throw new Error('Cannot convert transaction with addressTableLookups');
+    }
+
+    const feePayer = compiledMessage.staticAccounts[0];
+    // TODO: coded error
+    if (!feePayer) throw new Error('No fee payer set in CompiledTransaction');
+
+    const accountMetas = getAccountMetas(compiledMessage);
+
+    const instructions: IInstruction[] = compiledMessage.instructions.map(compiledInstruction =>
+        convertInstruction(compiledInstruction, accountMetas)
+    );
+
+    const firstInstruction = instructions[0];
+    const lifetimeConstraint = getLifetimeConstraint(
+        compiledMessage.lifetimeToken,
+        firstInstruction,
+        lastValidBlockHeight
+    );
+
+    const signatures = convertSignatures(compiledTransaction);
+
+    return pipe(
+        createTransaction({ version: compiledMessage.version as TransactionVersion }),
+        tx => setTransactionFeePayer(feePayer, tx),
+        tx =>
+            instructions.reduce((acc, instruction) => {
+                return appendTransactionInstruction(instruction, acc);
+            }, tx),
+        tx =>
+            'blockhash' in lifetimeConstraint
+                ? setTransactionLifetimeUsingBlockhash(lifetimeConstraint, tx)
+                : setTransactionLifetimeUsingDurableNonce(lifetimeConstraint, tx),
+        tx => (compiledTransaction.signatures.length ? { ...tx, signatures } : tx)
+    );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1630,6 +1630,9 @@ importers:
       '@solana/codecs-strings':
         specifier: workspace:*
         version: link:../codecs-strings
+      '@solana/functional':
+        specifier: workspace:*
+        version: link:../functional
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys


### PR DESCRIPTION
This PR adds a first version of the `decompileTransaction` function.

This takes as input a `CompiledTransaction`, ie the result of calling `getCompiledTransaction`. It returns a `CompilableTransaction` which may have signatures, ie the input to `getCompiledTransaction`.

This is quite similar to the compat function that converts old web3js to new. Note though that I've implemented this as a single function which itself determines whether we're using a blockhash or durable lifetime constraint. This means that we always take an optional `lastValidBlockHeight` parameter, which is ignored if using a durable nonce, and defaulted to U64 max if using a blockhash.

The reason for this difference is that given a compiled instruction you can't know which lifetime constraint is used without inspecting the instructions, and this function has to do that anyway (to convert them). With compat you may already know the nature of the transactions being created in old web3js code. 

Since I needed to get that design working, this first PR should support both constraints. I haven't yet written tests for durable nonce transactions though, which I'll do in a follow up PR.

Similarly to compat, this doesn't yet support transactions with address lookup tables.
