### PR TITLE
refactor(experimental): allow the nonce authority account to be writable

### DIFF
--- a/packages/transactions/src/durable-nonce.ts
+++ b/packages/transactions/src/durable-nonce.ts
@@ -1,5 +1,11 @@
 import { Base58EncodedAddress } from '@solana/addresses';
-import { AccountRole, IInstruction, IInstructionWithAccounts, IInstructionWithData } from '@solana/instructions';
+import {
+    AccountRole,
+    IInstruction,
+    IInstructionWithAccounts,
+    IInstructionWithData,
+    isSignerRole,
+} from '@solana/instructions';
 import { ReadonlyAccount, ReadonlySignerAccount, WritableAccount } from '@solana/instructions/dist/types/accounts';
 
 import { ITransactionWithSignatures } from './signatures';
@@ -101,7 +107,7 @@ export function isAdvanceNonceAccountInstruction(
         instruction.accounts[1].role === AccountRole.READONLY &&
         // Third account is nonce authority account
         instruction.accounts[2].address != null &&
-        instruction.accounts[2].role === AccountRole.READONLY_SIGNER
+        isSignerRole(instruction.accounts[2].role)
     );
 }
 


### PR DESCRIPTION
This PR updates the logic to determine whether a given instruction is a durable nonce transaction. Specifically, the nonce authority address can now be writeable. This is the case if the nonce authority is also the fee payer, for example in a transaction created with the CLI: https://explorer.solana.com/tx/2FZPN5ZJqi5LSMe18auxx59G1VZAP71p8KLCDvyH1WAFgqEXfag6xmC8KnzXQW3KSdbmEyWp8rdd1VnmxMsTrUdG?cluster=devnet 

I don't think any change is required for other accounts

- The nonce address is unlikely to need to be a signer, since it is already initialized 
- I think sysvar addresses are always readonly 