### PR TITLE
refactor(experimental): export address and keypair compats

### DIFF
--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -1,1 +1,3 @@
+export * from './address';
+export * from './keypair';
 export * from './transaction';


### PR DESCRIPTION
This PR adds proper exports to `@solana/compat` to expose the address and keypair compatibility functions (whoopsie!).
