### PR TITLE
refactor(experimental): add transaction decoder + codec

### DIFF
--- a/packages/transactions/src/serializers/__tests__/transaction-test.ts
+++ b/packages/transactions/src/serializers/__tests__/transaction-test.ts
@@ -1,23 +1,27 @@
 import { Base58EncodedAddress } from '@solana/addresses';
+import { AccountRole } from '@solana/instructions';
 
+import { decompileTransaction } from '../../decompile-transaction';
 import { CompiledMessage, compileMessage } from '../../message';
-import { getCompiledMessageEncoder } from '../message';
-import { getTransactionEncoder } from '../transaction';
+import { getCompiledMessageDecoder, getCompiledMessageEncoder } from '../message';
+import { getTransactionCodec, getTransactionDecoder, getTransactionEncoder } from '../transaction';
 
 jest.mock('../../message');
 jest.mock('../message');
+jest.mock('../../decompile-transaction');
 
 let _nextMockAddress = 0;
 function getMockAddress() {
     return `${_nextMockAddress++}` as Base58EncodedAddress;
 }
 
-describe('Transaction serializer', () => {
+describe.each([getTransactionEncoder, getTransactionCodec])('Transaction serializer %p', serializerFactory => {
+    let transaction: ReturnType<typeof getTransactionEncoder>;
+
     let addressA: Base58EncodedAddress;
     let addressB: Base58EncodedAddress;
     let mockCompiledMessage: CompiledMessage;
     let mockCompiledWireMessage: Uint8Array;
-    let transaction: ReturnType<typeof getTransactionEncoder>;
     beforeEach(() => {
         addressA = getMockAddress();
         addressB = getMockAddress();
@@ -33,8 +37,11 @@ describe('Transaction serializer', () => {
         (getCompiledMessageEncoder as jest.Mock).mockReturnValue({
             encode: jest.fn().mockReturnValue(mockCompiledWireMessage),
         });
+        (getCompiledMessageDecoder as jest.Mock).mockReturnValue({
+            decode: jest.fn().mockReturnValue([mockCompiledMessage, 0]),
+        });
         (compileMessage as jest.Mock).mockReturnValue(mockCompiledMessage);
-        transaction = getTransactionEncoder();
+        transaction = serializerFactory();
     });
     it('serializes a transaction with no signatures', () => {
         expect(transaction.encode({} as Parameters<typeof transaction.encode>[0])).toStrictEqual(
@@ -84,6 +91,149 @@ describe('Transaction serializer', () => {
                 /** COMPILED MESSAGE */
                 ...mockCompiledWireMessage,
             ])
+        );
+    });
+});
+
+describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deserializer %p', deserializerFactory => {
+    let transaction: ReturnType<typeof getTransactionDecoder>;
+
+    let addressA: Base58EncodedAddress;
+    let addressB: Base58EncodedAddress;
+    let mockCompiledMessage: CompiledMessage;
+    let mockCompiledWireMessage: Uint8Array;
+    let mockDecompiledTransaction: ReturnType<typeof decompileTransaction>;
+
+    beforeEach(() => {
+        addressA = getMockAddress();
+        addressB = getMockAddress();
+        mockCompiledMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 0,
+                numReadonlySignerAccounts: 1,
+                numSignerAccounts: 2,
+            },
+            staticAccounts: [addressB, addressA],
+        } as CompiledMessage;
+        mockCompiledWireMessage = new Uint8Array([1, 2, 3]);
+        mockDecompiledTransaction = {
+            instructions: [
+                {
+                    accounts: [
+                        {
+                            address: addressA,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                        {
+                            address: addressB,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                    ],
+                },
+            ],
+        } as unknown as ReturnType<typeof decompileTransaction>;
+
+        (getCompiledMessageEncoder as jest.Mock).mockReturnValue({
+            encode: jest.fn().mockReturnValue(mockCompiledWireMessage),
+        });
+        (getCompiledMessageDecoder as jest.Mock).mockReturnValue({
+            decode: jest.fn().mockReturnValue([mockCompiledMessage, 0]),
+        });
+        (decompileTransaction as jest.Mock).mockReturnValue(mockDecompiledTransaction);
+
+        transaction = deserializerFactory();
+    });
+    it('deserializes a transaction with no signatures', () => {
+        const noSignature = new Uint8Array(Array(64).fill(0));
+        const bytes = new Uint8Array([
+            /** SIGNATURES */
+            2, // Length of signatures array
+            ...noSignature, // null signature for `addressB`
+            ...noSignature, // null signature for `addressA`
+
+            /** COMPILED MESSAGE */
+            ...mockCompiledWireMessage,
+        ]);
+
+        const [decodedTransaction] = transaction.decode(bytes);
+        expect(decodedTransaction).toStrictEqual(mockDecompiledTransaction);
+        expect(decompileTransaction).toHaveBeenCalledWith(
+            {
+                compiledMessage: mockCompiledMessage,
+                signatures: [noSignature, noSignature],
+            },
+            undefined
+        );
+    });
+    it('deserializes a partially signed transaction', () => {
+        const noSignature = new Uint8Array(Array(64).fill(0));
+        const mockSignatureA = new Uint8Array(Array(64).fill(1));
+
+        const bytes = new Uint8Array([
+            /** SIGNATURES */
+            2, // Length of signatures array
+            ...noSignature, // null signature for `addressB`
+            ...mockSignatureA,
+
+            /** COMPILED MESSAGE */
+            ...mockCompiledWireMessage,
+        ]);
+
+        const [decodedTransaction] = transaction.decode(bytes);
+        expect(decodedTransaction).toStrictEqual(mockDecompiledTransaction);
+        expect(decompileTransaction).toHaveBeenCalledWith(
+            {
+                compiledMessage: mockCompiledMessage,
+                signatures: [noSignature, mockSignatureA],
+            },
+            undefined
+        );
+    });
+    it('deserializes a fully signed transaction', () => {
+        const mockSignatureA = new Uint8Array(Array(64).fill(1));
+        const mockSignatureB = new Uint8Array(Array(64).fill(2));
+
+        const bytes = new Uint8Array([
+            /** SIGNATURES */
+            2, // Length of signatures array
+            ...mockSignatureB,
+            ...mockSignatureA,
+
+            /** COMPILED MESSAGE */
+            ...mockCompiledWireMessage,
+        ]);
+
+        const [decodedTransaction] = transaction.decode(bytes);
+        expect(decodedTransaction).toStrictEqual(mockDecompiledTransaction);
+        expect(decompileTransaction).toHaveBeenCalledWith(
+            {
+                compiledMessage: mockCompiledMessage,
+                signatures: [mockSignatureB, mockSignatureA],
+            },
+            undefined
+        );
+    });
+    it('passes lastValidBlockHeight to decompileTransaction', () => {
+        const noSignature = new Uint8Array(Array(64).fill(0));
+        const bytes = new Uint8Array([
+            /** SIGNATURES */
+            2, // Length of signatures array
+            ...noSignature, // null signature for `addressB`
+            ...noSignature, // null signature for `addressA`
+
+            /** COMPILED MESSAGE */
+            ...mockCompiledWireMessage,
+        ]);
+
+        const transaction = deserializerFactory(100n);
+        const [decodedTransaction] = transaction.decode(bytes);
+        expect(decodedTransaction).toStrictEqual(mockDecompiledTransaction);
+        expect(decompileTransaction).toHaveBeenCalledWith(
+            {
+                compiledMessage: mockCompiledMessage,
+                signatures: [noSignature, noSignature],
+            },
+            100n
         );
     });
 });

--- a/packages/transactions/src/serializers/transaction.ts
+++ b/packages/transactions/src/serializers/transaction.ts
@@ -1,18 +1,26 @@
-import { Encoder, mapEncoder } from '@solana/codecs-core';
-import { getArrayEncoder, getBytesEncoder, getStructEncoder } from '@solana/codecs-data-structures';
-import { getShortU16Encoder } from '@solana/codecs-numbers';
+import { Codec, combineCodec, Decoder, Encoder, mapDecoder, mapEncoder } from '@solana/codecs-core';
+import {
+    getArrayDecoder,
+    getArrayEncoder,
+    getBytesDecoder,
+    getBytesEncoder,
+    getStructDecoder,
+    getStructEncoder,
+} from '@solana/codecs-data-structures';
+import { getShortU16Decoder, getShortU16Encoder } from '@solana/codecs-numbers';
+import { Ed25519Signature } from '@solana/keys';
 
-import { ITransactionWithSignatures } from '..';
 import { getCompiledTransaction } from '../compile-transaction';
+import { decompileTransaction } from '../decompile-transaction';
 import { compileMessage } from '../message';
-import { getCompiledMessageEncoder } from './message';
-
-const transactionDescription = __DEV__ ? 'The wire format of a Solana transaction' : 'transaction';
+import { ITransactionWithSignatures } from '../signatures';
+import { getCompiledMessageDecoder, getCompiledMessageEncoder } from './message';
 
 type CompilableTransaction = Parameters<typeof compileMessage>[0];
 type CompiledTransaction = ReturnType<typeof getCompiledTransaction>;
 
 const signaturesDescription = __DEV__ ? 'A compact array of 64-byte, base-64 encoded Ed25519 signatures' : 'signatures';
+const transactionDescription = __DEV__ ? 'The wire format of a Solana transaction' : 'transaction';
 
 function getCompiledTransactionEncoder(): Encoder<CompiledTransaction> {
     return getStructEncoder(
@@ -32,8 +40,44 @@ function getCompiledTransactionEncoder(): Encoder<CompiledTransaction> {
     );
 }
 
+function getSignatureDecoder(): Decoder<Ed25519Signature> {
+    return mapDecoder(getBytesDecoder({ size: 64 }), bytes => bytes as Ed25519Signature);
+}
+
+function getCompiledTransactionDecoder(): Decoder<CompiledTransaction> {
+    return getStructDecoder(
+        [
+            [
+                'signatures',
+                getArrayDecoder(getSignatureDecoder(), {
+                    description: signaturesDescription,
+                    size: getShortU16Decoder(),
+                }),
+            ],
+            ['compiledMessage', getCompiledMessageDecoder()],
+        ],
+        {
+            description: transactionDescription,
+        }
+    );
+}
+
 export function getTransactionEncoder(): Encoder<
     CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)
 > {
     return mapEncoder(getCompiledTransactionEncoder(), getCompiledTransaction);
+}
+
+export function getTransactionDecoder(
+    lastValidBlockHeight?: bigint
+): Decoder<CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)> {
+    return mapDecoder(getCompiledTransactionDecoder(), compiledTransaction =>
+        decompileTransaction(compiledTransaction, lastValidBlockHeight)
+    );
+}
+
+export function getTransactionCodec(
+    lastValidBlockHeight?: bigint
+): Codec<CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)> {
+    return combineCodec(getTransactionEncoder(), getTransactionDecoder(lastValidBlockHeight));
 }


### PR DESCRIPTION
This PR adds `getTransactionDecoder`, which deserializes a compiled transaction and then decompiles it

It also adds `getTransactionCodec`, combining the existing encoder and this new decoder

This gives us the ability to deserialize from transaction bytes to a new transaction
