### PR TITLE
refactor(experimental): add function to check if a transaction is fully signed

### DIFF
--- a/packages/transactions/src/__typetests__/transaction-typetests.ts
+++ b/packages/transactions/src/__typetests__/transaction-typetests.ts
@@ -2,8 +2,10 @@ import { Base58EncodedAddress } from '@solana/addresses';
 
 import {
     appendTransactionInstruction,
+    assertTransactionIsFullySigned,
     Blockhash,
     IDurableNonceTransaction,
+    IFullySignedTransaction,
     ITransactionWithBlockhashLifetime,
     ITransactionWithSignatures,
     Nonce,
@@ -460,4 +462,11 @@ async () => {
         instructions: Transaction['instructions'];
     } & ITransactionWithFeePayer<'feePayer'> &
         ITransactionWithSignatures;
+
+    // assertTransactionIsFullySigned
+    const transaction = {} as Parameters<typeof assertTransactionIsFullySigned>[0];
+    // @ts-expect-error Should not be fully signed
+    transaction satisfies IFullySignedTransaction;
+    assertTransactionIsFullySigned(transaction);
+    transaction satisfies IFullySignedTransaction;
 };


### PR DESCRIPTION
- asserts that there is a signature for each expected signer
- only verifies the presence of signatures, does not verify the signatures are valid

Part of #1773, but won't close yet in case we want to add a separate function to validate signatures too
