### PR TITLE
refactor(experimental): export CompilableTransaction and CompiledTransaction types

### DIFF
--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -12,6 +12,7 @@ import { AccountRole } from '@solana/instructions';
 import { Ed25519Signature, signBytes } from '@solana/keys';
 
 import { Blockhash } from '../blockhash';
+import { CompilableTransaction } from '../compilable-transaction';
 import { CompiledMessage, compileMessage } from '../message';
 import {
     assertIsTransactionSignature,
@@ -284,7 +285,7 @@ describe('signTransaction', () => {
 });
 
 describe('assertTransactionIsFullySigned', () => {
-    type SignedTransaction = Parameters<typeof compileMessage>[0] & ITransactionWithSignatures;
+    type SignedTransaction = CompilableTransaction & ITransactionWithSignatures;
 
     const mockProgramAddress = 'program' as Base58EncodedAddress;
     const mockPublicKeyAddressA = 'A' as Base58EncodedAddress;

--- a/packages/transactions/src/compilable-transaction.ts
+++ b/packages/transactions/src/compilable-transaction.ts
@@ -1,0 +1,8 @@
+import { ITransactionWithBlockhashLifetime } from './blockhash';
+import { IDurableNonceTransaction } from './durable-nonce';
+import { ITransactionWithFeePayer } from './fee-payer';
+import { BaseTransaction } from './types';
+
+export type CompilableTransaction = BaseTransaction &
+    ITransactionWithFeePayer &
+    (ITransactionWithBlockhashLifetime | IDurableNonceTransaction);

--- a/packages/transactions/src/compile-transaction.ts
+++ b/packages/transactions/src/compile-transaction.ts
@@ -1,14 +1,13 @@
 import { Ed25519Signature } from '@solana/keys';
 
+import { CompilableTransaction } from './compilable-transaction';
 import { CompiledMessage, compileMessage } from './message';
 import { ITransactionWithSignatures } from './signatures';
 
-type CompiledTransaction = Readonly<{
+export type CompiledTransaction = Readonly<{
     compiledMessage: CompiledMessage;
     signatures: Ed25519Signature[];
 }>;
-
-type CompilableTransaction = Parameters<typeof compileMessage>[0];
 
 export function getCompiledTransaction(
     transaction: CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)

--- a/packages/transactions/src/decompile-transaction.ts
+++ b/packages/transactions/src/decompile-transaction.ts
@@ -4,7 +4,8 @@ import { AccountRole, IAccountMeta, IInstruction } from '@solana/instructions';
 import { Ed25519Signature } from '@solana/keys';
 
 import { Blockhash, setTransactionLifetimeUsingBlockhash } from './blockhash';
-import { getCompiledTransaction } from './compile-transaction';
+import { CompilableTransaction } from './compilable-transaction';
+import { CompiledTransaction } from './compile-transaction';
 import { createTransaction } from './create-transaction';
 import { isAdvanceNonceAccountInstruction, Nonce, setTransactionLifetimeUsingDurableNonce } from './durable-nonce';
 import { setTransactionFeePayer } from './fee-payer';
@@ -12,9 +13,6 @@ import { appendTransactionInstruction } from './instructions';
 import { CompiledMessage } from './message';
 import { ITransactionWithSignatures } from './signatures';
 import { TransactionVersion } from './types';
-
-type CompiledTransaction = ReturnType<typeof getCompiledTransaction>;
-type CompilableTransaction = Parameters<typeof getCompiledTransaction>[0];
 
 function getAccountMetas(message: CompiledMessage): IAccountMeta[] {
     const { header } = message;

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -1,4 +1,5 @@
 export * from './blockhash';
+export * from './compilable-transaction';
 export * from './create-transaction';
 export * from './durable-nonce';
 export * from './fee-payer';

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -1,13 +1,10 @@
 import { getAddressMapFromInstructions, getOrderedAccountsFromAddressMap } from './accounts';
-import { ITransactionWithBlockhashLifetime } from './blockhash';
+import { CompilableTransaction } from './compilable-transaction';
 import { getCompiledAddressTableLookups } from './compile-address-table-lookups';
 import { getCompiledMessageHeader } from './compile-header';
 import { getCompiledInstructions } from './compile-instructions';
 import { getCompiledLifetimeToken } from './compile-lifetime-token';
 import { getCompiledStaticAccounts } from './compile-static-accounts';
-import { IDurableNonceTransaction } from './durable-nonce';
-import { ITransactionWithFeePayer } from './fee-payer';
-import { BaseTransaction } from './types';
 
 type BaseCompiledMessage = Readonly<{
     header: ReturnType<typeof getCompiledMessageHeader>;
@@ -15,10 +12,6 @@ type BaseCompiledMessage = Readonly<{
     lifetimeToken: ReturnType<typeof getCompiledLifetimeToken>;
     staticAccounts: ReturnType<typeof getCompiledStaticAccounts>;
 }>;
-
-type CompilableTransaction = BaseTransaction &
-    ITransactionWithFeePayer &
-    (ITransactionWithBlockhashLifetime | IDurableNonceTransaction);
 
 export type CompiledMessage = LegacyCompiledMessage | VersionedCompiledMessage;
 

--- a/packages/transactions/src/serializers/transaction.ts
+++ b/packages/transactions/src/serializers/transaction.ts
@@ -10,14 +10,11 @@ import {
 import { getShortU16Decoder, getShortU16Encoder } from '@solana/codecs-numbers';
 import { Ed25519Signature } from '@solana/keys';
 
-import { getCompiledTransaction } from '../compile-transaction';
+import { CompilableTransaction } from '../compilable-transaction';
+import { CompiledTransaction, getCompiledTransaction } from '../compile-transaction';
 import { decompileTransaction } from '../decompile-transaction';
-import { compileMessage } from '../message';
 import { ITransactionWithSignatures } from '../signatures';
 import { getCompiledMessageDecoder, getCompiledMessageEncoder } from './message';
-
-type CompilableTransaction = Parameters<typeof compileMessage>[0];
-type CompiledTransaction = ReturnType<typeof getCompiledTransaction>;
 
 const signaturesDescription = __DEV__ ? 'A compact array of 64-byte, base-64 encoded Ed25519 signatures' : 'signatures';
 const transactionDescription = __DEV__ ? 'The wire format of a Solana transaction' : 'transaction';

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -3,6 +3,7 @@ import { Base58EncodedAddress, getAddressFromPublicKey } from '@solana/addresses
 import { isSignerRole } from '@solana/instructions';
 import { Ed25519Signature, signBytes } from '@solana/keys';
 
+import { CompilableTransaction } from './compilable-transaction';
 import { ITransactionWithFeePayer } from './fee-payer';
 import { CompiledMessage, compileMessage } from './message';
 import { getCompiledMessageEncoder } from './serializers/message';
@@ -84,7 +85,7 @@ export function getSignatureFromTransaction(
     return transactionSignature as TransactionSignature;
 }
 
-export async function signTransaction<TTransaction extends Parameters<typeof compileMessage>[0]>(
+export async function signTransaction<TTransaction extends CompilableTransaction>(
     keyPairs: CryptoKeyPair[],
     transaction: TTransaction | (TTransaction & ITransactionWithSignatures)
 ): Promise<TTransaction & ITransactionWithSignatures> {
@@ -115,7 +116,7 @@ export function transactionSignature(putativeTransactionSignature: string): Tran
     return putativeTransactionSignature;
 }
 
-export function assertTransactionIsFullySigned<TTransaction extends Parameters<typeof compileMessage>[0]>(
+export function assertTransactionIsFullySigned<TTransaction extends CompilableTransaction>(
     transaction: TTransaction & ITransactionWithSignatures
 ): asserts transaction is TTransaction & IFullySignedTransaction {
     const signerAddressesFromInstructions = transaction.instructions


### PR DESCRIPTION
This PR exports the `CompilableTransaction` and `CompiledTransaction` types as they define important Transaction states and will be required by the `signers` package.
