### PR TITLE
fix: temporarily lock to Node 18.x for CI/CD workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
This should fix the CI/CD workflow

version-from-git is broken on Node20

fix we're waiting on: https://github.com/compulim/version-from-git/pull/17

Issue to get this moved back to Node 20: #1786 