### PR TITLE
refactor(experimental): parameterize account metas for instructions and instructions for transactions

### DIFF
--- a/packages/instructions/src/instruction.ts
+++ b/packages/instructions/src/instruction.ts
@@ -2,8 +2,11 @@ import { Address } from '@solana/addresses';
 
 import { IAccountLookupMeta, IAccountMeta } from './accounts';
 
-export interface IInstruction<TProgramAddress extends string = string> {
-    readonly accounts?: readonly (IAccountMeta | IAccountLookupMeta)[];
+export interface IInstruction<
+    TProgramAddress extends string = string,
+    TAccounts extends readonly (IAccountMeta | IAccountLookupMeta)[] = readonly (IAccountMeta | IAccountLookupMeta)[]
+> {
+    readonly accounts?: TAccounts;
     readonly data?: Uint8Array;
     readonly programAddress: Address<TProgramAddress>;
 }

--- a/packages/transactions/src/compilable-transaction.ts
+++ b/packages/transactions/src/compilable-transaction.ts
@@ -1,8 +1,13 @@
+import { IInstruction } from '@solana/instructions';
+
 import { ITransactionWithBlockhashLifetime } from './blockhash';
 import { IDurableNonceTransaction } from './durable-nonce';
 import { ITransactionWithFeePayer } from './fee-payer';
-import { BaseTransaction } from './types';
+import { BaseTransaction, TransactionVersion } from './types';
 
-export type CompilableTransaction = BaseTransaction &
+export type CompilableTransaction<
+    TVersion extends TransactionVersion = TransactionVersion,
+    TInstruction extends IInstruction = IInstruction
+> = BaseTransaction<TVersion, TInstruction> &
     ITransactionWithFeePayer &
     (ITransactionWithBlockhashLifetime | IDurableNonceTransaction);

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -4,23 +4,20 @@ import { IAccountMeta, IInstruction } from '@solana/instructions';
 export type SerializedMessageBytes = Uint8Array & { readonly __serializedMessageBytes: unique symbol };
 export type SerializedMessageBytesBase64 = string & { readonly __serializedMessageBytesBase64: unique symbol };
 
-export type BaseTransaction = Readonly<{
-    instructions: readonly IInstruction[];
-    version: TransactionVersion;
+export type BaseTransaction<
+    TVersion extends TransactionVersion = TransactionVersion,
+    TInstruction extends IInstruction = IInstruction
+> = Readonly<{
+    instructions: readonly TInstruction[];
+    version: TVersion;
 }>;
 
-type LegacyTransaction = BaseTransaction &
-    Readonly<{
-        instructions: readonly (Omit<IInstruction, 'accounts'> &
-            Readonly<{ readonly accounts?: readonly IAccountMeta[] }>)[];
-        version: 'legacy';
-    }>;
-
-type V0Transaction = BaseTransaction &
-    Readonly<{
-        instructions: readonly IInstruction[];
-        version: 0;
-    }>;
+type ILegacyInstruction<TProgramAddress extends string = string> = IInstruction<
+    TProgramAddress,
+    readonly IAccountMeta[]
+>;
+type LegacyTransaction = BaseTransaction<'legacy', ILegacyInstruction>;
+type V0Transaction = BaseTransaction<0, IInstruction>;
 
 export type Transaction = LegacyTransaction | V0Transaction;
 export type TransactionVersion = 'legacy' | 0;


### PR DESCRIPTION
This PR makes add the following type parameters:
- `TAccounts` on `IInstruction` so we can refine the account metas type without asserting that the accounts are provided (via the existing `IInstructionWithAccounts`). This is then being used to re-define the `LegacyTransaction` such that it excludes `IAccountLookupMeta` types.
- `TInstruction` on transaction types (i.e. `BaseTransaction`, `LegacyTransaction`, `V0Transaction` and `CompilableTransaction`). This enables functions to refine the instruction type that they support within a transaction. That way, we can create a `ILegacyInstruction` type for the `LegacyTransaction`.
- `TVersion` on transaction types to make it easier to define the `LegacyTransaction` and `V0Transaction` types.

On top of the nice refactoring we get, this PR allows the `signers` package to require the following type on its signing functions (notice the `IAccountSignerMeta` on the instruction meta that we now support):

```ts
type CompilableTransactionWithSignerMetas = CompilableTransaction<
    TransactionVersion,
    IInstruction<string, readonly (IAccountMeta | IAccountSignerMeta | IAccountLookupMeta)[]>
>;
```