### PR TITLE
refactor(experimental): replace umi-serializers with codecs in library package

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -65,14 +65,14 @@
         "maintained node versions"
     ],
     "dependencies": {
-        "@metaplex-foundation/umi-serializers": "^0.8.9",
         "@solana/addresses": "workspace:*",
+        "@solana/codecs-strings": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
         "@solana/rpc-core": "workspace:*",
-        "@solana/rpc-types": "workspace:*",
         "@solana/rpc-transport": "workspace:*",
+        "@solana/rpc-types": "workspace:*",
         "@solana/transactions": "workspace:*",
         "fast-stable-stringify": "^1.0.0"
     },

--- a/packages/library/src/__tests__/transaction-confirmation-strategy-nonce-test.ts
+++ b/packages/library/src/__tests__/transaction-confirmation-strategy-nonce-test.ts
@@ -1,5 +1,5 @@
-import { base64, publicKey } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/addresses';
+import { getBase58Encoder, getBase64Decoder } from '@solana/codecs-strings';
 import { Nonce } from '@solana/transactions';
 
 import { createNonceInvalidationPromiseFactory } from '../transaction-confirmation-strategy-nonce';
@@ -21,8 +21,8 @@ describe('createNonceInvalidationPromiseFactory', () => {
                 32 // nonce value(pubkey)
             // don't care about anything after this
         );
-        bytes.set(publicKey().serialize(nonceValue), NONCE_VALUE_OFFSET);
-        return [base64.deserialize(bytes)[0], 'base64'];
+        bytes.set(getBase58Encoder().encode(nonceValue), NONCE_VALUE_OFFSET);
+        return [getBase64Decoder().decode(bytes)[0], 'base64'];
     }
     let accountNotificationGenerator: jest.Mock;
     let createPendingSubscription: jest.Mock;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,12 +794,12 @@ importers:
 
   packages/library:
     dependencies:
-      '@metaplex-foundation/umi-serializers':
-        specifier: ^0.8.9
-        version: 0.8.9
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/codecs-strings':
+        specifier: workspace:*
+        version: link:../codecs-strings
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional


### PR DESCRIPTION
- straightforward replacement with base58/base64 from codecs-strings
