### PR TITLE
refactor(experimental): enhance null account info handling for GraphQL

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -60,6 +60,24 @@ describe('account', () => {
                 },
             });
         });
+        it("can query an account's address", async () => {
+            expect.assertions(1);
+            const source = `
+            query testQuery($address: String!, $commitment: Commitment) {
+                account(address: $address, commitment: $commitment) {
+                    address
+                }
+            }
+        `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                    },
+                },
+            });
+        });
         it('can query multiple fields', async () => {
             expect.assertions(1);
             const source = `
@@ -95,6 +113,7 @@ describe('account', () => {
             query testQuery($address: String!, $commitment: Commitment) {
                 account(address: $address, commitment: $commitment) {
                     owner {
+                        address
                         executable
                         lamports
                         rentEpoch
@@ -107,6 +126,7 @@ describe('account', () => {
                 data: {
                     account: {
                         owner: {
+                            address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
                             executable: true,
                             lamports: expect.any(BigInt),
                             rentEpoch: expect.any(BigInt),
@@ -128,7 +148,9 @@ describe('account', () => {
             query testQuery($address: String!, $commitment: Commitment) {
                 account(address: $address, commitment: $commitment) {
                     owner {
+                        address
                         owner {
+                            address
                             executable
                             lamports
                             rentEpoch
@@ -142,10 +164,53 @@ describe('account', () => {
                 data: {
                     account: {
                         owner: {
+                            address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
                             owner: {
+                                address: 'BPFLoader2111111111111111111111111111111111',
                                 executable: true,
                                 lamports: expect.any(BigInt),
                                 rentEpoch: expect.any(BigInt),
+                            },
+                        },
+                    },
+                },
+            });
+        });
+    });
+    describe('triple nested basic queries', () => {
+        // See scripts/fixtures/spl-token-token-account.json
+        const variableValues = {
+            address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+            commitment: 'confirmed',
+        };
+        it("can perform a triple nested query for each account's owner", async () => {
+            expect.assertions(1);
+            const source = `
+            query testQuery($address: String!) {
+                account(address: $address) {
+                    owner {
+                        address
+                        owner {
+                            address
+                            owner {
+                                address
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        owner: {
+                            address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                            owner: {
+                                address: 'BPFLoader2111111111111111111111111111111111',
+                                owner: {
+                                    address: 'NativeLoader1111111111111111111111111111111',
+                                },
                             },
                         },
                     },

--- a/packages/rpc-graphql/src/context.ts
+++ b/packages/rpc-graphql/src/context.ts
@@ -38,7 +38,11 @@ async function resolveAccount(
         });
 
     if (account === null) {
-        return null;
+        // Account does not exist
+        // Return only the address
+        return {
+            address,
+        };
     }
 
     const [data, responseEncoding] = Array.isArray(account.data)
@@ -48,6 +52,7 @@ async function resolveAccount(
         : [account.data, 'jsonParsed'];
     const queryResponse = {
         ...account,
+        address,
         data,
         encoding: responseEncoding,
     };

--- a/packages/rpc-graphql/src/schema/account/types.ts
+++ b/packages/rpc-graphql/src/schema/account/types.ts
@@ -26,6 +26,7 @@ let memoisedAccountInterfaceFields: object | undefined;
 const accountInterfaceFields = () => {
     if (!memoisedAccountInterfaceFields) {
         memoisedAccountInterfaceFields = {
+            address: string(),
             encoding: string(),
             executable: boolean(),
             lamports: bigint(),


### PR DESCRIPTION
This PR enables returning default data - including the account's address - when it's not found by the RPC call `getAccountInfo`. This allows chained/nested queries to be more reliable if the RPC encounters an account that does not exist.
