### PR TITLE
refactor(experimental): modify account resolver to not send a request for only an address

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -711,4 +711,57 @@ describe('account', () => {
             });
         });
     });
+    describe('when querying only an address', () => {
+        describe('in the first level', () => {
+            it('will not call the RPC for only an address', async () => {
+                expect.assertions(1);
+                const source = `
+                query testQuery {
+                    account(address: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        address
+                    }
+                }
+            `;
+                await rpcGraphQL.query(source);
+                expect(fetchMock).not.toHaveBeenCalled();
+            });
+        });
+        describe('in the second level', () => {
+            it('will not call the RPC for only an address', async () => {
+                expect.assertions(1);
+                const source = `
+                query testQuery {
+                    account(address: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        address
+                        owner {
+                            address
+                        }
+                    }
+                }
+            `;
+                await rpcGraphQL.query(source);
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+            });
+        });
+        describe('in the third level', () => {
+            it('will not call the RPC for only an address', async () => {
+                expect.assertions(1);
+                const source = `
+                query testQuery {
+                    account(address: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        address
+                        owner {
+                            address
+                            owner {
+                                address
+                            }
+                        }
+                    }
+                }
+            `;
+                await rpcGraphQL.query(source);
+                expect(fetchMock).toHaveBeenCalledTimes(2);
+            });
+        });
+    });
 });

--- a/packages/rpc-graphql/src/schema/account/query.ts
+++ b/packages/rpc-graphql/src/schema/account/query.ts
@@ -27,7 +27,9 @@ export const accountQuery = () => ({
             encoding: type(accountEncodingInputType()),
             minContextSlot: bigint(),
         },
-        resolve: (_parent: unknown, args: AccountQueryArgs, context: RpcGraphQLContext) => context.resolveAccount(args),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        resolve: (_parent: unknown, args: AccountQueryArgs, context: RpcGraphQLContext, info: any) =>
+            context.resolveAccount(args, info),
         type: accountInterface(),
     },
 });

--- a/packages/rpc-graphql/src/schema/account/types.ts
+++ b/packages/rpc-graphql/src/schema/account/types.ts
@@ -111,7 +111,8 @@ const accountType = (
                     encoding: type(accountEncodingInputType()),
                     minContextSlot: bigint(),
                 },
-                resolve: (parent, args, context) => context.resolveAccount({ ...args, address: parent.owner }),
+                resolve: (parent, args, context, info) =>
+                    context.resolveAccount({ ...args, address: parent.owner }, info),
                 type: accountInterface(),
             },
         },


### PR DESCRIPTION
This PR adds an interceptor on the actual query passed into the resolver. The interceptor is designed to read which fields have been requested for an account, and determine the necessary action.

If _only_ the address has been requested, it's already in the query - either inside a provided query variable or in a previously obtained return payload. So, there's no need to make an RPC call to `getAccountInfo` if the user only needs the address.

If any other fields are requested, with or without `address`, the resolver will go to the RPC.
