### PR TITLE
refactor(experimental): add support for nested accounts in all account types

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -346,7 +346,10 @@ describe('account', () => {
                                     info {
                                         decimals
                                         isInitialized
-                                        mintAuthority
+                                        mintAuthority {
+                                            address
+                                            lamports
+                                        }
                                         supply
                                     }
                                     type
@@ -365,9 +368,12 @@ describe('account', () => {
                         data: {
                             parsed: {
                                 info: {
-                                    decimals: expect.any(Number),
-                                    isInitialized: expect.any(Boolean),
-                                    mintAuthority: expect.any(String),
+                                    decimals: 6,
+                                    isInitialized: true,
+                                    mintAuthority: {
+                                        address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                                        lamports: expect.any(BigInt),
+                                    },
                                     supply: expect.any(String),
                                 },
                                 type: 'mint',
@@ -394,7 +400,9 @@ describe('account', () => {
                                     info {
                                         isNative
                                         mint
-                                        owner
+                                        owner {
+                                            address
+                                        }
                                         state
                                         tokenAmount {
                                             amount
@@ -421,7 +429,9 @@ describe('account', () => {
                                 info: {
                                     isNative: expect.any(Boolean),
                                     mint: expect.any(String),
-                                    owner: expect.any(String),
+                                    owner: {
+                                        address: '6UsGbaMgchgj4wiwKKuE1v5URHdcDfEiMSM25QpesKir',
+                                    },
                                     state: expect.any(String),
                                     tokenAmount: {
                                         amount: expect.any(String),
@@ -451,7 +461,9 @@ describe('account', () => {
                             data {
                                 parsed {
                                     info {
-                                        authority
+                                        authority {
+                                            address
+                                        }
                                         blockhash
                                         feeCalculator {
                                             lamportsPerSignature
@@ -473,7 +485,9 @@ describe('account', () => {
                         data: {
                             parsed: {
                                 info: {
-                                    authority: expect.any(String),
+                                    authority: {
+                                        address: '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe',
+                                    },
                                     blockhash: expect.any(String),
                                     feeCalculator: {
                                         lamportsPerSignature: expect.any(String),
@@ -503,11 +517,17 @@ describe('account', () => {
                                     info {
                                         meta {
                                             authorized {
-                                                staker
-                                                withdrawer
+                                                staker {
+                                                    address
+                                                }
+                                                withdrawer {
+                                                    address
+                                                }
                                             }
                                             lockup {
-                                                custodian
+                                                custodian {
+                                                    address
+                                                }
                                                 epoch
                                                 unixTimestamp
                                             }
@@ -519,7 +539,9 @@ describe('account', () => {
                                                 activationEpoch
                                                 deactivationEpoch
                                                 stake
-                                                voter
+                                                voter {
+                                                    address
+                                                }
                                             }
                                         }
                                     }
@@ -541,11 +563,17 @@ describe('account', () => {
                                 info: {
                                     meta: {
                                         authorized: {
-                                            staker: expect.any(String),
-                                            withdrawer: expect.any(String),
+                                            staker: {
+                                                address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+                                            },
+                                            withdrawer: {
+                                                address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+                                            },
                                         },
                                         lockup: {
-                                            custodian: expect.any(String),
+                                            custodian: {
+                                                address: '11111111111111111111111111111111',
+                                            },
                                             epoch: expect.any(BigInt),
                                             unixTimestamp: expect.any(BigInt),
                                         },
@@ -557,7 +585,9 @@ describe('account', () => {
                                             activationEpoch: expect.any(BigInt),
                                             deactivationEpoch: expect.any(BigInt),
                                             stake: expect.any(String),
-                                            voter: expect.any(String),
+                                            voter: {
+                                                address: 'CertusDeBmqN8ZawdkxK5kFGMwBXdudvWHYwtNgNhvLu',
+                                            },
                                         },
                                     },
                                 },
@@ -584,10 +614,14 @@ describe('account', () => {
                                 parsed {
                                     info {
                                         authorizedVoters {
-                                            authorizedVoter
+                                            authorizedVoter {
+                                                address
+                                            }
                                             epoch
                                         }
-                                        authorizedWithdrawer
+                                        authorizedWithdrawer {
+                                            address
+                                        }
                                         commission
                                         epochCredits {
                                             credits
@@ -598,7 +632,9 @@ describe('account', () => {
                                             slot
                                             timestamp
                                         }
-                                        nodePubkey
+                                        node {
+                                            address
+                                        }
                                         priorVoters
                                         rootSlot
                                         votes {
@@ -624,11 +660,15 @@ describe('account', () => {
                                 info: {
                                     authorizedVoters: expect.arrayContaining([
                                         {
-                                            authorizedVoter: expect.any(String),
+                                            authorizedVoter: {
+                                                address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                                            },
                                             epoch: expect.any(BigInt),
                                         },
                                     ]),
-                                    authorizedWithdrawer: expect.any(String),
+                                    authorizedWithdrawer: {
+                                        address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                                    },
                                     commission: expect.any(Number),
                                     epochCredits: expect.arrayContaining([
                                         {
@@ -641,7 +681,9 @@ describe('account', () => {
                                         slot: expect.any(BigInt),
                                         timestamp: expect.any(BigInt),
                                     },
-                                    nodePubkey: expect.any(String),
+                                    node: {
+                                        address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                                    },
                                     priorVoters: expect.any(Array),
                                     rootSlot: expect.any(BigInt),
                                     votes: expect.arrayContaining([
@@ -674,7 +716,9 @@ describe('account', () => {
                                 parsed {
                                     info {
                                         addresses
-                                        authority
+                                        authority {
+                                            address
+                                        }
                                         deactivationSlot
                                         lastExtendedSlot
                                         lastExtendedSlotStartIndex
@@ -696,7 +740,9 @@ describe('account', () => {
                             parsed: {
                                 info: {
                                     addresses: expect.any(Array),
-                                    authority: expect.any(String),
+                                    authority: {
+                                        address: '4msgK65vdz5ADUAB3eTQGpF388NuQUAoknLxutUQJd5B',
+                                    },
                                     deactivationSlot: expect.any(String),
                                     lastExtendedSlot: expect.any(String),
                                     lastExtendedSlotStartIndex: expect.any(Number),

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -236,7 +236,9 @@ describe('programAccounts', () => {
                                     parsed {
                                         info {
                                             addresses
-                                            authority
+                                            authority {
+                                                address
+                                            }
                                             deactivationSlot
                                             lastExtendedSlot
                                             lastExtendedSlotStartIndex
@@ -258,7 +260,9 @@ describe('programAccounts', () => {
                                     parsed: {
                                         info: {
                                             addresses: expect.arrayContaining([expect.any(String)]),
-                                            authority: expect.any(String),
+                                            authority: {
+                                                address: expect.any(String),
+                                            },
                                             deactivationSlot: expect.any(String),
                                             lastExtendedSlot: expect.any(String),
                                             lastExtendedSlotStartIndex: expect.any(Number),
@@ -286,7 +290,9 @@ describe('programAccounts', () => {
                                         info {
                                             decimals
                                             isInitialized
-                                            mintAuthority
+                                            mintAuthority {
+                                                address
+                                            }
                                             supply
                                         }
                                     }
@@ -298,7 +304,9 @@ describe('programAccounts', () => {
                                         info {
                                             isNative
                                             mint
-                                            owner
+                                            owner {
+                                                address
+                                            }
                                             state
                                             tokenAmount {
                                                 amount
@@ -326,7 +334,9 @@ describe('programAccounts', () => {
                                         info: {
                                             decimals: expect.any(Number),
                                             isInitialized: expect.any(Boolean),
-                                            mintAuthority: expect.any(String),
+                                            mintAuthority: {
+                                                address: expect.any(String),
+                                            },
                                             supply: expect.any(String),
                                         },
                                     },
@@ -341,7 +351,9 @@ describe('programAccounts', () => {
                                         info: {
                                             isNative: expect.any(Boolean),
                                             mint: expect.any(String),
-                                            owner: expect.any(String),
+                                            owner: {
+                                                address: expect.any(String),
+                                            },
                                             state: expect.any(String),
                                             tokenAmount: expect.objectContaining({
                                                 amount: expect.any(String),
@@ -370,7 +382,9 @@ describe('programAccounts', () => {
                                 data {
                                     parsed {
                                         info {
-                                            authority
+                                            authority {
+                                                address
+                                            }
                                             blockhash
                                             feeCalculator {
                                                 lamportsPerSignature
@@ -392,7 +406,9 @@ describe('programAccounts', () => {
                                 data: {
                                     parsed: {
                                         info: {
-                                            authority: expect.any(String),
+                                            authority: {
+                                                address: expect.any(String),
+                                            },
                                             blockhash: expect.any(String),
                                             feeCalculator: {
                                                 lamportsPerSignature: expect.any(String),
@@ -421,11 +437,17 @@ describe('programAccounts', () => {
                                         info {
                                             meta {
                                                 authorized {
-                                                    staker
-                                                    withdrawer
+                                                    staker {
+                                                        address
+                                                    }
+                                                    withdrawer {
+                                                        address
+                                                    }
                                                 }
                                                 lockup {
-                                                    custodian
+                                                    custodian {
+                                                        address
+                                                    }
                                                     epoch
                                                     unixTimestamp
                                                 }
@@ -437,7 +459,9 @@ describe('programAccounts', () => {
                                                     activationEpoch
                                                     deactivationEpoch
                                                     stake
-                                                    voter
+                                                    voter {
+                                                        address
+                                                    }
                                                 }
                                             }
                                         }
@@ -459,11 +483,17 @@ describe('programAccounts', () => {
                                         info: {
                                             meta: {
                                                 authorized: {
-                                                    staker: expect.any(String),
-                                                    withdrawer: expect.any(String),
+                                                    staker: {
+                                                        address: expect.any(String),
+                                                    },
+                                                    withdrawer: {
+                                                        address: expect.any(String),
+                                                    },
                                                 },
                                                 lockup: {
-                                                    custodian: expect.any(String),
+                                                    custodian: {
+                                                        address: expect.any(String),
+                                                    },
                                                     epoch: expect.any(BigInt),
                                                     unixTimestamp: expect.any(BigInt),
                                                 },
@@ -475,7 +505,9 @@ describe('programAccounts', () => {
                                                     activationEpoch: expect.any(BigInt),
                                                     deactivationEpoch: expect.any(BigInt),
                                                     stake: expect.any(String),
-                                                    voter: expect.any(String),
+                                                    voter: {
+                                                        address: expect.any(String),
+                                                    },
                                                 },
                                             },
                                         },
@@ -501,10 +533,14 @@ describe('programAccounts', () => {
                                     parsed {
                                         info {
                                             authorizedVoters {
-                                                authorizedVoter
+                                                authorizedVoter {
+                                                    address
+                                                }
                                                 epoch
                                             }
-                                            authorizedWithdrawer
+                                            authorizedWithdrawer {
+                                                address
+                                            }
                                             commission
                                             epochCredits {
                                                 credits
@@ -515,7 +551,9 @@ describe('programAccounts', () => {
                                                 slot
                                                 timestamp
                                             }
-                                            nodePubkey
+                                            node {
+                                                address
+                                            }
                                             priorVoters
                                             rootSlot
                                             votes {
@@ -541,11 +579,15 @@ describe('programAccounts', () => {
                                         info: {
                                             authorizedVoters: expect.arrayContaining([
                                                 {
-                                                    authorizedVoter: expect.any(String),
+                                                    authorizedVoter: {
+                                                        address: expect.any(String),
+                                                    },
                                                     epoch: expect.any(BigInt),
                                                 },
                                             ]),
-                                            authorizedWithdrawer: expect.any(String),
+                                            authorizedWithdrawer: {
+                                                address: expect.any(String),
+                                            },
                                             commission: expect.any(Number),
                                             epochCredits: expect.arrayContaining([
                                                 {
@@ -558,7 +600,9 @@ describe('programAccounts', () => {
                                                 slot: expect.any(BigInt),
                                                 timestamp: expect.any(BigInt),
                                             },
-                                            nodePubkey: expect.any(String),
+                                            node: {
+                                                address: expect.any(String),
+                                            },
                                             priorVoters: expect.any(Array),
                                             rootSlot: expect.any(BigInt),
                                             votes: expect.arrayContaining([

--- a/packages/rpc-graphql/src/schema/account/types.ts
+++ b/packages/rpc-graphql/src/schema/account/types.ts
@@ -104,6 +104,7 @@ const accountType = (
         fields: {
             ...accountInterfaceFields(),
             data,
+            // Nested Account interface
             owner: {
                 args: {
                     commitment: type(commitmentInputType()),
@@ -171,7 +172,19 @@ const accountNonceAccount = () => {
             'NonceAccount',
             'A nonce account',
             accountDataJsonParsed('Nonce', {
-                authority: string(),
+                // Nested Account interface
+                authority: {
+                    args: {
+                        commitment: type(commitmentInputType()),
+                        dataSlice: type(dataSliceInputType()),
+                        encoding: type(accountEncodingInputType()),
+                        minContextSlot: bigint(),
+                    },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    resolve: (parent: any, args, context: any, info) =>
+                        context.resolveAccount({ ...args, address: parent.authority }, info),
+                    type: accountInterface(),
+                },
                 blockhash: string(),
                 feeCalculator: object('NonceFeeCalculator', {
                     lamportsPerSignature: string(),
@@ -189,7 +202,19 @@ const accountLookupTable = () => {
             'An address lookup table account',
             accountDataJsonParsed('LookupTable', {
                 addresses: list(string()),
-                authority: string(),
+                // Nested Account interface
+                authority: {
+                    args: {
+                        commitment: type(commitmentInputType()),
+                        dataSlice: type(dataSliceInputType()),
+                        encoding: type(accountEncodingInputType()),
+                        minContextSlot: bigint(),
+                    },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    resolve: (parent: any, args, context: any, info) =>
+                        context.resolveAccount({ ...args, address: parent.authority }, info),
+                    type: accountInterface(),
+                },
                 deactivationSlot: string(),
                 lastExtendedSlot: string(),
                 lastExtendedSlotStartIndex: number(),
@@ -208,7 +233,19 @@ const accountMint = () => {
                 decimals: number(),
                 freezeAuthority: string(),
                 isInitialized: boolean(),
-                mintAuthority: string(),
+                // Nested Account interface
+                mintAuthority: {
+                    args: {
+                        commitment: type(commitmentInputType()),
+                        dataSlice: type(dataSliceInputType()),
+                        encoding: type(accountEncodingInputType()),
+                        minContextSlot: bigint(),
+                    },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    resolve: (parent: any, args, context: any, info) =>
+                        context.resolveAccount({ ...args, address: parent.mintAuthority }, info),
+                    type: accountInterface(),
+                },
                 supply: string(),
             })
         );
@@ -224,7 +261,19 @@ const accountTokenAccount = () => {
             accountDataJsonParsed('TokenAccount', {
                 isNative: boolean(),
                 mint: string(),
-                owner: string(),
+                // Nested Account interface
+                owner: {
+                    args: {
+                        commitment: type(commitmentInputType()),
+                        dataSlice: type(dataSliceInputType()),
+                        encoding: type(accountEncodingInputType()),
+                        minContextSlot: bigint(),
+                    },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    resolve: (parent: any, args, context: any, info) =>
+                        context.resolveAccount({ ...args, address: parent.owner }, info),
+                    type: accountInterface(),
+                },
                 state: string(),
                 tokenAmount: type(tokenAmountType()),
             })
@@ -241,11 +290,47 @@ const accountStakeAccount = () => {
             accountDataJsonParsed('Stake', {
                 meta: object('StakeMeta', {
                     authorized: object('StakeMetaAuthorized', {
-                        staker: string(),
-                        withdrawer: string(),
+                        // Nested Account interface
+                        staker: {
+                            args: {
+                                commitment: type(commitmentInputType()),
+                                dataSlice: type(dataSliceInputType()),
+                                encoding: type(accountEncodingInputType()),
+                                minContextSlot: bigint(),
+                            },
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            resolve: (parent: any, args, context: any, info) =>
+                                context.resolveAccount({ ...args, address: parent.staker }, info),
+                            type: accountInterface(),
+                        },
+                        // Nested Account interface
+                        withdrawer: {
+                            args: {
+                                commitment: type(commitmentInputType()),
+                                dataSlice: type(dataSliceInputType()),
+                                encoding: type(accountEncodingInputType()),
+                                minContextSlot: bigint(),
+                            },
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            resolve: (parent: any, args, context: any, info) =>
+                                context.resolveAccount({ ...args, address: parent.withdrawer }, info),
+                            type: accountInterface(),
+                        },
                     }),
                     lockup: object('StakeMetaLockup', {
-                        custodian: string(),
+                        // Nested Account interface
+                        custodian: {
+                            args: {
+                                commitment: type(commitmentInputType()),
+                                dataSlice: type(dataSliceInputType()),
+                                encoding: type(accountEncodingInputType()),
+                                minContextSlot: bigint(),
+                            },
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            resolve: (parent: any, args, context: any, info) =>
+                                context.resolveAccount({ ...args, address: parent.custodian }, info),
+                            type: accountInterface(),
+                        },
                         epoch: bigint(),
                         unixTimestamp: bigint(),
                     }),
@@ -257,7 +342,19 @@ const accountStakeAccount = () => {
                         activationEpoch: bigint(),
                         deactivationEpoch: bigint(),
                         stake: string(),
-                        voter: string(),
+                        // Nested Account interface
+                        voter: {
+                            args: {
+                                commitment: type(commitmentInputType()),
+                                dataSlice: type(dataSliceInputType()),
+                                encoding: type(accountEncodingInputType()),
+                                minContextSlot: bigint(),
+                            },
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            resolve: (parent: any, args, context: any, info) =>
+                                context.resolveAccount({ ...args, address: parent.voter }, info),
+                            type: accountInterface(),
+                        },
                         warmupCooldownRate: number(),
                     }),
                 }),
@@ -275,11 +372,35 @@ const accountVoteAccount = () => {
             accountDataJsonParsed('Vote', {
                 authorizedVoters: list(
                     object('VoteAuthorizedVoter', {
-                        authorizedVoter: string(),
+                        // Nested Account interface
+                        authorizedVoter: {
+                            args: {
+                                commitment: type(commitmentInputType()),
+                                dataSlice: type(dataSliceInputType()),
+                                encoding: type(accountEncodingInputType()),
+                                minContextSlot: bigint(),
+                            },
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            resolve: (parent: any, args, context: any, info) =>
+                                context.resolveAccount({ ...args, address: parent.authorizedVoter }, info),
+                            type: accountInterface(),
+                        },
                         epoch: bigint(),
                     })
                 ),
-                authorizedWithdrawer: string(),
+                // Nested Account interface
+                authorizedWithdrawer: {
+                    args: {
+                        commitment: type(commitmentInputType()),
+                        dataSlice: type(dataSliceInputType()),
+                        encoding: type(accountEncodingInputType()),
+                        minContextSlot: bigint(),
+                    },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    resolve: (parent: any, args, context: any, info) =>
+                        context.resolveAccount({ ...args, address: parent.authorizedWithdrawer }, info),
+                    type: accountInterface(),
+                },
                 commission: number(),
                 epochCredits: list(
                     object('VoteEpochCredits', {
@@ -292,7 +413,19 @@ const accountVoteAccount = () => {
                     slot: bigint(),
                     timestamp: bigint(),
                 }),
-                nodePubkey: string(),
+                // Nested Account interface
+                node: {
+                    args: {
+                        commitment: type(commitmentInputType()),
+                        dataSlice: type(dataSliceInputType()),
+                        encoding: type(accountEncodingInputType()),
+                        minContextSlot: bigint(),
+                    },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    resolve: (parent: any, args, context: any, info) =>
+                        context.resolveAccount({ ...args, address: parent.nodePubkey }, info),
+                    type: accountInterface(),
+                },
                 priorVoters: list(string()),
                 rootSlot: bigint(),
                 votes: list(


### PR DESCRIPTION
This PR switches the simple string base58-encoded addresses that are part of the default `jsonParsed` response for account types to the GraphQL `Account` interface type, allowing these fields to be fully queryable with nested queries.

Here's an example:

```typescript
const source = `
    query myQuery($address: String!) {
        account(address: $address) {
            ... on MintAccount {
                address
                data {
                    parsed {
                        info {
                            mintAuthority {
                                address
                                lamports
                            }
                        }
                    }
                }
            }
        }
    }
`;

const variableValues = {
    address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
};

const result = await rpcGraphQL.query(source, variableValues);

expect(result).toMatchObject({
    data: {
        account: {
            address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
            data: {
                parsed: {
                    info: {
                        mintAuthority: {
                            address: expect.any(String),
                            lamports: expect.any(BigInt),
                        }
                    }
                }
            },
        },
    },
});
```