### PR TITLE
refactor(experimental): use codecs for rpc-core package

### DIFF
--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -61,11 +61,10 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "dependencies": {
-        "@metaplex-foundation/umi-serializers": "^0.8.9"
-    },
     "devDependencies": {
         "@solana/addresses": "workspace:*",
+        "@solana/codecs-core": "workspace:*",
+        "@solana/codecs-strings": "workspace:*",
         "@solana/eslint-config-solana": "^1.0.2",
         "@solana/rpc-transport": "workspace:*",
         "@solana/rpc-types": "workspace:*",

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-fee-for-message-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-fee-for-message-test.ts
@@ -1,4 +1,5 @@
-import { base58, base64, fixSerializer } from '@metaplex-foundation/umi-serializers';
+import { fixEncoder } from '@solana/codecs-core';
+import { getBase58Encoder, getBase64Decoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
@@ -21,7 +22,7 @@ const MOCK_PUBLIC_KEY_BYTES = // DRtXHDgC312wpNdNCSb8vCoXDcofCJcPHdAw4VkJ8L9i
 
 function getMockTransactionMessage(blockhash: Blockhash) {
     const memoString = 'Hello from the web3.js tests!';
-    const blockhashBytes = fixSerializer(base58, 32).serialize(blockhash);
+    const blockhashBytes = fixEncoder(getBase58Encoder(), 32).encode(blockhash);
     // prettier-ignore
     const message = new Uint8Array([
         /** VERSION HEADER */
@@ -52,7 +53,7 @@ function getMockTransactionMessage(blockhash: Blockhash) {
         /** ADDRESS TABLE LOOKUPS */
         0x00, // Number of address table lookups
     ]);
-    const messageBase64 = base64.deserialize(message)[0];
+    const [messageBase64] = getBase64Decoder().decode(message);
     return messageBase64 as SerializedMessageBytesBase64;
 }
 

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-identity-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-identity-test.ts
@@ -1,7 +1,7 @@
 import { open } from 'node:fs/promises';
 
-import { base58 } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/addresses';
+import { getBase58Decoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
@@ -21,7 +21,7 @@ async function getValidatorAddress() {
         }
         if (secretKey) {
             const publicKey = secretKey.slice(32, 64);
-            const expectedAddress = base58.deserialize(publicKey)[0];
+            const expectedAddress = getBase58Decoder().decode(publicKey)[0];
             return expectedAddress as Base58EncodedAddress;
         }
         throw new Error(`Failed to read keypair file \`${validatorKeypairPath}\``);

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-largest-accounts-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-largest-accounts-test.ts
@@ -1,7 +1,7 @@
 import { open } from 'node:fs/promises';
 
-import { base58 } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/addresses';
+import { getBase58Decoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
 import { Commitment } from '@solana/rpc-types';
@@ -28,7 +28,7 @@ async function getNodeAddress(path: string) {
         }
         if (secretKey) {
             const publicKey = secretKey.slice(32, 64);
-            const expectedAddress = base58.deserialize(publicKey)[0];
+            const expectedAddress = getBase58Decoder().decode(publicKey)[0];
             return expectedAddress as Base58EncodedAddress;
         }
         throw new Error(`Failed to read keypair file \`${path}\``);

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
@@ -1,5 +1,5 @@
-import { base58 } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/addresses';
+import { getBase58Decoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
 import { Commitment } from '@solana/rpc-types';
@@ -22,7 +22,7 @@ async function getValidatorAddress() {
         }
         if (secretKey) {
             const publicKey = secretKey.slice(32, 64);
-            const expectedAddress = base58.deserialize(publicKey)[0];
+            const expectedAddress = getBase58Decoder().decode(publicKey)[0];
             return expectedAddress as Base58EncodedAddress;
         }
         throw new Error(`Failed to read keypair file \`${validatorKeypairPath}\``);

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-program-accounts-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-program-accounts-test.ts
@@ -1,7 +1,7 @@
 import { open } from 'node:fs/promises';
 
-import { base58 } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/addresses';
+import { getBase58Decoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
@@ -28,7 +28,7 @@ async function getNodeAddress(path: string) {
         }
         if (secretKey) {
             const publicKey = secretKey.slice(32, 64);
-            const expectedAddress = base58.deserialize(publicKey)[0];
+            const expectedAddress = getBase58Decoder().decode(publicKey)[0];
             return expectedAddress as Base58EncodedAddress;
         }
         throw new Error(`Failed to read keypair file \`${path}\``);
@@ -428,7 +428,7 @@ describe('getProgramAccounts', () => {
                                         space: 36n,
                                     },
                                     executable: true,
-                                    lamports: 1141440n,
+                                    lamports: expect.any(BigInt),
                                     owner: 'BPFLoaderUpgradeab1e11111111111111111111111',
                                     rentEpoch: expect.any(BigInt),
                                     space: 36n,
@@ -448,7 +448,7 @@ describe('getProgramAccounts', () => {
                                         space: 36n,
                                     },
                                     executable: true,
-                                    lamports: 10290815n,
+                                    lamports: expect.any(BigInt),
                                     owner: 'BPFLoaderUpgradeab1e11111111111111111111111',
                                     rentEpoch: expect.any(BigInt),
                                     space: 36n,
@@ -463,13 +463,13 @@ describe('getProgramAccounts', () => {
                                             type: 'programData',
                                         },
                                         program: 'bpf-upgradeable-loader',
-                                        space: 518437n,
+                                        space: expect.any(BigInt),
                                     },
                                     executable: false,
-                                    lamports: 3609212400n,
+                                    lamports: expect.any(BigInt),
                                     owner: 'BPFLoaderUpgradeab1e11111111111111111111111',
                                     rentEpoch: expect.any(BigInt),
-                                    space: 518437n,
+                                    space: expect.any(BigInt),
                                 },
                                 // Token 2022 data account
                                 pubkey: 'DoU57AYuPFu2QU514RktNPG22QhApEjnKxnBcu4BHDTY',
@@ -1433,13 +1433,13 @@ describe('getProgramAccounts', () => {
                                             type: 'programData',
                                         },
                                         program: 'bpf-upgradeable-loader',
-                                        space: 518437n,
+                                        space: expect.any(BigInt),
                                     },
                                     executable: false,
-                                    lamports: 3609212400n,
+                                    lamports: expect.any(BigInt),
                                     owner: 'BPFLoaderUpgradeab1e11111111111111111111111',
                                     rentEpoch: expect.any(BigInt),
-                                    space: 518437n,
+                                    space: expect.any(BigInt),
                                 },
                                 // Token 2022 data account
                                 pubkey: 'DoU57AYuPFu2QU514RktNPG22QhApEjnKxnBcu4BHDTY',

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leader-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leader-test.ts
@@ -1,7 +1,7 @@
 import { open } from 'node:fs/promises';
 
-import { base58 } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/addresses';
+import { getBase58Decoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
@@ -23,7 +23,7 @@ async function getValidatorAddress() {
         }
         if (secretKey) {
             const publicKey = secretKey.slice(32, 64);
-            const expectedAddress = base58.deserialize(publicKey)[0];
+            const expectedAddress = getBase58Decoder().decode(publicKey)[0];
             return expectedAddress as Base58EncodedAddress;
         }
         throw new Error(`Failed to read keypair file \`${validatorKeypairPath}\``);

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leaders-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leaders-test.ts
@@ -1,7 +1,7 @@
 import { open } from 'node:fs/promises';
 
-import { base58 } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/addresses';
+import { getBase58Decoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
@@ -22,7 +22,7 @@ async function getValidatorAddress() {
         }
         if (secretKey) {
             const publicKey = secretKey.slice(32, 64);
-            const expectedAddress = base58.deserialize(publicKey)[0];
+            const expectedAddress = getBase58Decoder().decode(publicKey)[0];
             return expectedAddress as Base58EncodedAddress;
         }
         throw new Error(`Failed to read keypair file \`${validatorKeypairPath}\``);

--- a/packages/rpc-core/src/rpc-methods/__tests__/request-airdrop-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/request-airdrop-test.ts
@@ -1,5 +1,5 @@
-import { base58 } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/addresses';
+import { getBase58Decoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
@@ -23,7 +23,7 @@ describe('requestAirdrop', () => {
                 expect.assertions(1);
                 const randomBytes = new Uint8Array(32);
                 crypto.getRandomValues(randomBytes);
-                const [publicKeyAddress] = base58.deserialize(randomBytes);
+                const [publicKeyAddress] = getBase58Decoder().decode(randomBytes);
                 const resultPromise = rpc
                     .requestAirdrop(
                         publicKeyAddress as Base58EncodedAddress,

--- a/packages/rpc-core/src/rpc-methods/__tests__/send-transaction-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/send-transaction-test.ts
@@ -1,4 +1,5 @@
-import { base58, fixSerializer } from '@metaplex-foundation/umi-serializers';
+import { fixEncoder } from '@solana/codecs-core';
+import { getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
@@ -19,7 +20,7 @@ function getMockTransactionMessage({
     memoString: string;
     version?: number;
 }) {
-    const blockhashBytes = fixSerializer(base58, 32).serialize(blockhash);
+    const blockhashBytes = fixEncoder(getBase58Encoder(), 32).encode(blockhash);
     // prettier-ignore
     return new Uint8Array([
         /** VERSION HEADER */
@@ -142,7 +143,7 @@ describe('sendTransaction', () => {
                         { encoding: 'base64', preflightCommitment: commitment }
                     )
                     .send();
-                await expect(resultPromise).resolves.toEqual(base58.deserialize(signature)[0]);
+                await expect(resultPromise).resolves.toEqual(getBase58Decoder().decode(signature)[0]);
             });
         });
     });
@@ -269,7 +270,7 @@ describe('sendTransaction', () => {
         expect.assertions(1);
         const secretKey = await getSecretKey();
         const message = getMockTransactionMessage({
-            blockhash: base58.deserialize(new Uint8Array(Array(32).fill(0)))[0],
+            blockhash: getBase58Decoder().decode(new Uint8Array(Array(32).fill(0)))[0],
             feePayerAddressBytes: MOCK_PUBLIC_KEY_BYTES,
             memoString: `Hello from the web3.js tests! [${performance.now()}]`,
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/simulate-transaction-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/simulate-transaction-test.ts
@@ -1,5 +1,6 @@
-import { base58, fixSerializer } from '@metaplex-foundation/umi-serializers';
 import { Base58EncodedAddress } from '@solana/addresses';
+import { fixEncoder } from '@solana/codecs-core';
+import { getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import { SolanaJsonRpcErrorCode } from '@solana/rpc-transport/dist/types/json-rpc-errors';
 import type { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
@@ -25,7 +26,7 @@ function getMockTransactionMessage({
     memoString: string;
     version?: number;
 }) {
-    const blockhashBytes = fixSerializer(base58, 32).serialize(blockhash);
+    const blockhashBytes = fixEncoder(getBase58Encoder(), 32).encode(blockhash);
     // prettier-ignore
     return new Uint8Array([
         /** VERSION HEADER */
@@ -71,7 +72,7 @@ function getMockTransactionMessageWithAdditionalAccount({
     memoString: string;
     version?: number;
 }) {
-    const blockhashBytes = fixSerializer(base58, 32).serialize(blockhash);
+    const blockhashBytes = fixEncoder(getBase58Encoder(), 32).encode(blockhash);
     // prettier-ignore
     return new Uint8Array([
         /** VERSION HEADER */
@@ -322,7 +323,7 @@ describe('simulateTransaction', () => {
         expect.assertions(1);
         const secretKey = await getSecretKey();
         const message = getMockTransactionMessage({
-            blockhash: base58.deserialize(new Uint8Array(Array(32).fill(0)))[0],
+            blockhash: getBase58Decoder().decode(new Uint8Array(Array(32).fill(0)))[0],
             feePayerAddressBytes: MOCK_PUBLIC_KEY_BYTES,
             memoString: `Hello from the web3.js tests! [${performance.now()}]`,
         });
@@ -360,7 +361,7 @@ describe('simulateTransaction', () => {
         expect.assertions(1);
         const secretKey = await getSecretKey();
         const message = getMockTransactionMessage({
-            blockhash: base58.deserialize(new Uint8Array(Array(32).fill(0)))[0],
+            blockhash: getBase58Decoder().decode(new Uint8Array(Array(32).fill(0)))[0],
             feePayerAddressBytes: MOCK_PUBLIC_KEY_BYTES,
             memoString: `Hello from the web3.js tests! [${performance.now()}]`,
         });
@@ -600,7 +601,7 @@ describe('simulateTransaction', () => {
             rpc.getLatestBlockhash().send(),
         ]);
         const message = getMockTransactionMessageWithAdditionalAccount({
-            accountAddressBytes: base58.serialize('4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp'), // see scripts/fixtures/vote-account.json
+            accountAddressBytes: getBase58Encoder().encode('4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp'), // see scripts/fixtures/vote-account.json
             blockhash: latestBlockhash.blockhash,
             feePayerAddressBytes: MOCK_PUBLIC_KEY_BYTES,
             memoString: `Hello from the web3.js tests! [${performance.now()}]`,
@@ -819,7 +820,7 @@ describe('simulateTransaction', () => {
             memoString: `Hello from the web3.js tests! [${performance.now()}]`,
         });
         const signature = new Uint8Array(await crypto.subtle.sign('Ed25519', secretKey, message));
-        const [base58WireTransaction] = base58.deserialize(
+        const [base58WireTransaction] = getBase58Decoder().decode(
             Buffer.from(
                 new Uint8Array([
                     0x01, // Length of signatures

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1177,14 +1177,16 @@ importers:
         version: 1.1.1
 
   packages/rpc-core:
-    dependencies:
-      '@metaplex-foundation/umi-serializers':
-        specifier: ^0.8.9
-        version: 0.8.9
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/codecs-core':
+        specifier: workspace:*
+        version: link:../codecs-core
+      '@solana/codecs-strings':
+        specifier: workspace:*
+        version: link:../codecs-strings
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
         version: 1.0.2(@typescript-eslint/eslint-plugin@6.7.0)(@typescript-eslint/parser@6.3.0)(eslint-plugin-jest@27.4.2)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-simple-import-sort@10.0.0)(eslint-plugin-sort-keys-fix@1.1.2)(eslint@8.45.0)(typescript@5.2.2)


### PR DESCRIPTION
- These were only used in tests, but umi-serializers was a dependency
- I've also loosened some test values that seem to vary by validator
version. This may be the cause of the flaky rpc-core tests in CI