### PR TITLE
refactor(experimental): use codecs for transactions package

### DIFF
--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -62,7 +62,6 @@
         "maintained node versions"
     ],
     "dependencies": {
-        "@metaplex-foundation/umi-serializers": "^0.8.9",
         "@solana/addresses": "workspace:*",
         "@solana/codecs-core": "workspace:*",
         "@solana/codecs-data-structures": "workspace:*",

--- a/packages/transactions/src/__tests__/blockhash-test.ts
+++ b/packages/transactions/src/__tests__/blockhash-test.ts
@@ -1,69 +1,111 @@
 import 'test-matchers/toBeFrozenObject';
 
-import { base58 } from '@metaplex-foundation/umi-serializers';
+import { Encoder } from '@solana/codecs-core';
+import { getBase58Encoder } from '@solana/codecs-strings';
 
-import {
-    assertIsBlockhash,
-    Blockhash,
-    ITransactionWithBlockhashLifetime,
-    setTransactionLifetimeUsingBlockhash,
-} from '../blockhash';
+import { Blockhash, ITransactionWithBlockhashLifetime, setTransactionLifetimeUsingBlockhash } from '../blockhash';
 import { ITransactionWithSignatures } from '../signatures';
 import { BaseTransaction } from '../types';
 
+jest.mock('@solana/codecs-strings', () => ({
+    ...jest.requireActual('@solana/codecs-strings'),
+    getBase58Encoder: jest.fn(),
+}));
+
+// real implementations
+const originalBase58Module = jest.requireActual('@solana/codecs-strings');
+const originalGetBase58Encoder = originalBase58Module.getBase58Encoder();
+
 describe('assertIsBlockhash()', () => {
-    it('throws when supplied a non-base58 string', () => {
-        expect(() => {
-            assertIsBlockhash('not-a-base-58-encoded-string');
-        }).toThrow();
-    });
-    it('throws when the decoded byte array has a length other than 32 bytes', () => {
-        expect(() => {
-            assertIsBlockhash(
-                // 31 bytes [128, ..., 128]
-                '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM'
-            );
-        }).toThrow();
-    });
-    it('does not throw when supplied a base-58 encoded hash', () => {
-        expect(() => {
-            assertIsBlockhash('11111111111111111111111111111111');
-        }).not.toThrow();
-    });
-    it('returns undefined when supplied a base-58 encoded hash', () => {
-        expect(assertIsBlockhash('11111111111111111111111111111111')).toBeUndefined();
-    });
-    [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44].forEach(len => {
-        it(`attempts to decode input strings of exactly ${len} characters`, () => {
-            const decodeMethod = jest.spyOn(base58, 'serialize');
-            try {
-                assertIsBlockhash('1'.repeat(len));
-                // eslint-disable-next-line no-empty
-            } catch {}
-            expect(decodeMethod).toHaveBeenCalled();
+    let assertIsBlockhash: typeof import('../blockhash').assertIsBlockhash;
+    // Reload `assertIsBlockhash` before each test to reset memoized state
+    beforeEach(async () => {
+        await jest.isolateModulesAsync(async () => {
+            const base58ModulePromise =
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                import('../blockhash');
+            assertIsBlockhash = (await base58ModulePromise).assertIsBlockhash;
         });
     });
-    it('does not attempt to decode too-short input strings', () => {
-        const decodeMethod = jest.spyOn(base58, 'serialize');
-        try {
-            assertIsBlockhash(
-                // 31 bytes [0, ..., 0]
-                '1111111111111111111111111111111' // 31 characters
-            );
-            // eslint-disable-next-line no-empty
-        } catch {}
-        expect(decodeMethod).not.toHaveBeenCalled();
+
+    describe('using the real base58 implementation', () => {
+        beforeEach(() => {
+            // use real implementation
+            jest.mocked(getBase58Encoder).mockReturnValue(originalGetBase58Encoder);
+        });
+
+        it('throws when supplied a non-base58 string', () => {
+            expect(() => {
+                assertIsBlockhash('not-a-base-58-encoded-string');
+            }).toThrow();
+        });
+        it('throws when the decoded byte array has a length other than 32 bytes', () => {
+            expect(() => {
+                assertIsBlockhash(
+                    // 31 bytes [128, ..., 128]
+                    '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM'
+                );
+            }).toThrow();
+        });
+        it('does not throw when supplied a base-58 encoded hash', () => {
+            expect(() => {
+                assertIsBlockhash('11111111111111111111111111111111');
+            }).not.toThrow();
+        });
+        it('returns undefined when supplied a base-58 encoded hash', () => {
+            expect(assertIsBlockhash('11111111111111111111111111111111')).toBeUndefined();
+        });
     });
-    it('does not attempt to decode too-long input strings', () => {
-        const decodeMethod = jest.spyOn(base58, 'serialize');
-        try {
-            assertIsBlockhash(
-                // 33 bytes [0, 255, ..., 255]
-                '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG' // 45 characters
-            );
-            // eslint-disable-next-line no-empty
-        } catch {}
-        expect(decodeMethod).not.toHaveBeenCalled();
+
+    describe('using a mock base58 implementation', () => {
+        const mockEncode = jest.fn();
+        beforeEach(() => {
+            // use mock implementation
+            mockEncode.mockClear();
+            jest.mocked(getBase58Encoder).mockReturnValue({ encode: mockEncode } as unknown as Encoder<string>);
+        });
+
+        [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44].forEach(len => {
+            it(`attempts to decode input strings of exactly ${len} characters`, () => {
+                try {
+                    assertIsBlockhash('1'.repeat(len));
+                    // eslint-disable-next-line no-empty
+                } catch {}
+                expect(mockEncode).toHaveBeenCalledTimes(1);
+            });
+        });
+        it('does not attempt to decode too-short input strings', () => {
+            try {
+                assertIsBlockhash(
+                    // 31 bytes [0, ..., 0]
+                    '1111111111111111111111111111111' // 31 characters
+                );
+                // eslint-disable-next-line no-empty
+            } catch {}
+            expect(mockEncode).not.toHaveBeenCalled();
+        });
+        it('does not attempt to decode too-long input strings', () => {
+            try {
+                assertIsBlockhash(
+                    // 33 bytes [0, 255, ..., 255]
+                    '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG' // 45 characters
+                );
+                // eslint-disable-next-line no-empty
+            } catch {}
+            expect(mockEncode).not.toHaveBeenCalled();
+        });
+        it('memoizes getBase58Encoder when called multiple times', () => {
+            try {
+                assertIsBlockhash('1'.repeat(32));
+                // eslint-disable-next-line no-empty
+            } catch {}
+            try {
+                assertIsBlockhash('1'.repeat(32));
+                // eslint-disable-next-line no-empty
+            } catch {}
+            expect(jest.mocked(getBase58Encoder)).toHaveBeenCalledTimes(1);
+        });
     });
 });
 

--- a/packages/transactions/src/blockhash.ts
+++ b/packages/transactions/src/blockhash.ts
@@ -1,4 +1,5 @@
-import { base58 } from '@metaplex-foundation/umi-serializers';
+import { Encoder } from '@solana/codecs-core';
+import { getBase58Encoder } from '@solana/codecs-strings';
 
 import { IDurableNonceTransaction } from './durable-nonce';
 import { ITransactionWithSignatures } from './signatures';
@@ -16,7 +17,10 @@ export interface ITransactionWithBlockhashLifetime {
     readonly lifetimeConstraint: BlockhashLifetimeConstraint;
 }
 
+let base58Encoder: Encoder<string> | undefined;
+
 export function assertIsBlockhash(putativeBlockhash: string): asserts putativeBlockhash is Blockhash {
+    if (!base58Encoder) base58Encoder = getBase58Encoder();
     try {
         // Fast-path; see if the input string is of an acceptable length.
         if (
@@ -28,7 +32,7 @@ export function assertIsBlockhash(putativeBlockhash: string): asserts putativeBl
             throw new Error('Expected input string to decode to a byte array of length 32.');
         }
         // Slow-path; actually attempt to decode the input string.
-        const bytes = base58.serialize(putativeBlockhash);
+        const bytes = base58Encoder.encode(putativeBlockhash);
         const numBytes = bytes.byteLength;
         if (numBytes !== 32) {
             throw new Error(`Expected input string to decode to a byte array of length 32. Actual length: ${numBytes}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1614,9 +1614,6 @@ importers:
 
   packages/transactions:
     dependencies:
-      '@metaplex-foundation/umi-serializers':
-        specifier: ^0.8.9
-        version: 0.8.9
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
@@ -4116,42 +4113,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
-
-  /@metaplex-foundation/umi-options@0.8.9:
-    resolution: {integrity: sha512-jSQ61sZMPSAk/TXn8v8fPqtz3x8d0/blVZXLLbpVbo2/T5XobiI6/MfmlUosAjAUaQl6bHRF8aIIqZEFkJiy4A==}
-    dev: false
-
-  /@metaplex-foundation/umi-public-keys@0.8.9:
-    resolution: {integrity: sha512-CxMzN7dgVGOq9OcNCJe2casKUpJ3RmTVoOvDFyeoTQuK+vkZ1YSSahbqC1iGuHEtKTLSjtWjKvUU6O7zWFTw3Q==}
-    dependencies:
-      '@metaplex-foundation/umi-serializers-encodings': 0.8.9
-    dev: false
-
-  /@metaplex-foundation/umi-serializers-core@0.8.9:
-    resolution: {integrity: sha512-WT82tkiYJ0Qmscp7uTj1Hz6aWQPETwaKLAENAUN5DeWghkuBKtuxyBKVvEOuoXerJSdhiAk0e8DWA4cxcTTQ/w==}
-    dev: false
-
-  /@metaplex-foundation/umi-serializers-encodings@0.8.9:
-    resolution: {integrity: sha512-N3VWLDTJ0bzzMKcJDL08U3FaqRmwlN79FyE4BHj6bbAaJ9LEHjDQ9RJijZyWqTm0jE7I750fU7Ow5EZL38Xi6Q==}
-    dependencies:
-      '@metaplex-foundation/umi-serializers-core': 0.8.9
-    dev: false
-
-  /@metaplex-foundation/umi-serializers-numbers@0.8.9:
-    resolution: {integrity: sha512-NtBf1fnVNQJHFQjLFzRu2i9GGnigb9hOm/Gfrk628d0q0tRJB7BOM3bs5C61VAs7kJs4yd+pDNVAERJkknQ7Lg==}
-    dependencies:
-      '@metaplex-foundation/umi-serializers-core': 0.8.9
-    dev: false
-
-  /@metaplex-foundation/umi-serializers@0.8.9:
-    resolution: {integrity: sha512-Sve8Etm3zqvLSUfza+MYRkjTnCpiaAFT7VWdqeHzA3n58P0AfT3p74RrZwVt/UFkxI+ln8BslwBDJmwzcPkuHw==}
-    dependencies:
-      '@metaplex-foundation/umi-options': 0.8.9
-      '@metaplex-foundation/umi-public-keys': 0.8.9
-      '@metaplex-foundation/umi-serializers-core': 0.8.9
-      '@metaplex-foundation/umi-serializers-encodings': 0.8.9
-      '@metaplex-foundation/umi-serializers-numbers': 0.8.9
-    dev: false
 
   /@noble/curves@1.2.0:
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}


### PR DESCRIPTION
- use memoised base58 encoder for blockhash/signatures assertions

After this, no more Umi dependencies! 🎉 