### PR TITLE
fix(legacy): declare GetTransactionRpcResult's `meta` as nullable

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -2524,7 +2524,7 @@ const GetTransactionRpcResult = jsonRpcResult(
   nullable(
     pick({
       slot: number(),
-      meta: ConfirmedTransactionMetaResult,
+      meta: nullable(ConfirmedTransactionMetaResult),
       blockTime: optional(nullable(number())),
       transaction: ConfirmedTransactionResult,
       version: optional(TransactionVersionStruct),


### PR DESCRIPTION
#### Problem

As reported in https://solana.stackexchange.com/questions/7981/structerror-at-path-meta-expected-an-object-but-received-null-gettransac, when calling `getTransaction` directly, the deserialization of the response fails because there's no `meta` field, and `GetTransactionRpcResult` requires it.

Note that `GetParsedTransactionRpcResult` correctly declares the `meta` field as `nullable`, and the docs say that meta may be null https://docs.solana.com/api/http#gettransaction

#### Solution

Make `GetTransactionRpcResult` consistent with its parsed cousin, and declare the meta as `nullable`