### PR TITLE
refactor(experimental): revise accounts schema

### DIFF
--- a/packages/rpc-graphql/README.md
+++ b/packages/rpc-graphql/README.md
@@ -202,14 +202,10 @@ const source = `
         account(address: $address) {
             ... on MintAccount {
                 data {
-                    parsed {
-                        info {
-                            decimals
-                            isInitialized
-                            mintAuthority
-                            supply
-                        }
-                    }
+                    decimals
+                    isInitialized
+                    mintAuthority
+                    supply
                 }
             }
         }
@@ -222,9 +218,7 @@ for (const address of maybeMintAddresses) {
         const {
             data: {
                 account: {
-                    data: {
-                        parsed: { info: mintInfo },
-                    },
+                    data: mintInfo,
                 },
             },
         } = result;
@@ -251,26 +245,22 @@ const source = `
         account(address: $address) {
             ... on MintAccount {
                 data {
-                    parsed {
-                        info {
-                            decimals
-                            isInitialized
-                            supply
-                        }
-                        type
-                    }
+                    decimals
+                    isInitialized
+                    supply
+                }
+                meta {
+                    type
                 }
             }
             ... on TokenAccount {
                 data {
-                    parsed {
-                        info {
-                            isNative
-                            mint
-                            state
-                        }
-                        type
-                    }
+                    isNative
+                    mint
+                    state
+                }
+                meta {
+                    type
                 }
             }
         }
@@ -283,11 +273,9 @@ for (const address of mintOrTokenAccountAddresses) {
         const {
             data: {
                 account: {
-                    data: {
-                        parsed: {
-                            info: accountParsedInfo,
-                            type: accountType,
-                        }
+                    data: accountParsedInfo,
+                    meta: {
+                        type: accountType,
                     }
                 }
             }
@@ -427,13 +415,9 @@ const source = `
             ... on MintAccount {
                 address
                 data {
-                    parsed {
-                        info {
-                            mintAuthority {
-                                address
-                                lamports
-                            }
-                        }
+                    mintAuthority {
+                        address
+                        lamports
                     }
                 }
             }
@@ -453,13 +437,9 @@ data: {
     account: {
         address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
         data: {
-            parsed: {
-                info: {
-                    mintAuthority: {
-                        address: 'DpfJkNonoVB3sor9H9ceajhex4XHVPrDAGAq2ahdG4JZ',
-                        lamports: 10290815n,
-                    }
-                }
+            mintAuthority: {
+                address: 'DpfJkNonoVB3sor9H9ceajhex4XHVPrDAGAq2ahdG4JZ',
+                lamports: 10290815n,
             }
         },
     },
@@ -524,26 +504,24 @@ const source = `
         programAccounts(programAddress: $address) {
             ... on MintAccount {
                 data {
-                    parsed {
-                        info {
-                            decimals
-                            isInitialized
-                            mintAuthority
-                            supply
-                        }
-                    }
+                    decimals
+                    isInitialized
+                    mintAuthority
+                    supply
+                }
+                meta {
+                    type
                 }
             }
             ... on TokenAccount {
                 data {
-                    parsed {
-                        info {
-                            isNative
-                            mint
-                            owner
-                            state
-                        }
-                    }
+                    isNative
+                    mint
+                    owner
+                    state
+                }
+                meta {
+                    type
                 }
             }
         }
@@ -559,11 +537,9 @@ const result = await rpcGraphQL.query(source, variableValues);
 const { mints, tokenAccounts } = result.data.programAccounts.reduce(
   (acc: { mints: any[]; tokenAccounts: any[] }, account) => {
     const {
-        data: {
-            parsed: {
-                info: accountParsedInfo,
-                type: accountType,
-            }
+        data: accountParsedInfo,
+        meta: {
+            type: accountType,
         }
     } = account;
     if (accountType === "mint") {
@@ -639,13 +615,9 @@ const source = `
         programAccounts(programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA") {
             ... on TokenAccount {
                 data {
-                    parsed {
-                        info {
-                            owner {
-                                owner {
-                                    lamports
-                                }
-                            }
+                    owner {
+                        owner {
+                            lamports
                         }
                     }
                 }
@@ -657,7 +629,7 @@ const source = `
 const result = await rpcGraphQL.query(source);
 
 const sumOfAllLamportsOfOwnersOfOwnersOfTokenAccounts = result.data
-    .map(o => o.account.data.parsed.info.owner.owner.lamports)
+    .map(o => o.account.data.owner.owner.lamports)
     .reduce((acc, lamports) => acc + lamports, 0);
 ```
 
@@ -975,26 +947,18 @@ const source = `
                                             destination {
                                                 ... on TokenAccount {
                                                     data {
-                                                        parsed {
-                                                            info {
-                                                                address
-                                                                mint {
-                                                                    ... on MintAccount {
-                                                                        data {
-                                                                            parsed {
-                                                                                info {
-                                                                                    address
-                                                                                    decimals
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                                owner {
+                                                        address
+                                                        mint {
+                                                            ... on MintAccount {
+                                                                data {
                                                                     address
-                                                                    lamports
+                                                                    decimals
                                                                 }
                                                             }
+                                                        }
+                                                        owner {
+                                                            address
+                                                            lamports
                                                         }
                                                     }
                                                 }
@@ -1002,26 +966,18 @@ const source = `
                                             source {
                                                 ... on TokenAccount {
                                                     data {
-                                                        parsed {
-                                                            info {
-                                                                address
-                                                                mint {
-                                                                    ... on MintAccount {
-                                                                        data {
-                                                                            parsed {
-                                                                                info {
-                                                                                    address
-                                                                                    decimals
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                                owner {
+                                                        address
+                                                        mint {
+                                                            ... on MintAccount {
+                                                                data {
                                                                     address
-                                                                    lamports
+                                                                    decimals
                                                                 }
                                                             }
+                                                        }
+                                                        owner {
+                                                            address
+                                                            lamports
                                                         }
                                                     }
                                                 }
@@ -1063,23 +1019,15 @@ data: {
                                 },
                                 destination: {
                                     data: {
-                                        parsed: {
-                                            info: {
-                                                address: '2W8mUY75zxqwAcpirn75r3Cc7TStMirFyHwKqo13fmB1',
-                                                mint: data: {
-                                                    parsed: {
-                                                        info: {
-                                                            address: '8poKMotB2cEYVv5sbjrdyssASZj1vwYCe7GJFeXo2QP7',
-                                                            decimals: 6,
-                                                        }
-                                                    }
-                                                },
-                                                owner: {
-                                                    address: '7tRxJ2znbTFpwW9XaMMiDsXDudoPEUXRcpDpm8qjWgAZ',
-                                                    lamports: 890880n,
-                                                },
-                                            }
-                                        }
+                                        address: '2W8mUY75zxqwAcpirn75r3Cc7TStMirFyHwKqo13fmB1',
+                                        mint: data: {
+                                            address: '8poKMotB2cEYVv5sbjrdyssASZj1vwYCe7GJFeXo2QP7',
+                                            decimals: 6,
+                                        },
+                                        owner: {
+                                            address: '7tRxJ2znbTFpwW9XaMMiDsXDudoPEUXRcpDpm8qjWgAZ',
+                                            lamports: 890880n,
+                                        },
                                     }
                                 },
                                 source: {
@@ -1088,12 +1036,8 @@ data: {
                                             info: {
                                                 address: 'BqFCPqXUm4cq6jaZZx1TDTvUR1wdEuNNwAHBEVR6mJhM',
                                                 mint: data: {
-                                                    parsed: {
-                                                        info: {
-                                                            address: '8poKMotB2cEYVv5sbjrdyssASZj1vwYCe7GJFeXo2QP7',
-                                                            decimals: 6,
-                                                        }
-                                                    }
+                                                    address: '8poKMotB2cEYVv5sbjrdyssASZj1vwYCe7GJFeXo2QP7',
+                                                    decimals: 6,
                                                 },
                                                 owner: {
                                                     address: '3dPmVLMD7PC5faZNyJUH9WFrUxAsbjydJfoozwmR1wDG',

--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -342,20 +342,18 @@ describe('account', () => {
                     account(address: $address) {
                         ... on MintAccount {
                             data {
-                                parsed {
-                                    info {
-                                        decimals
-                                        isInitialized
-                                        mintAuthority {
-                                            address
-                                            lamports
-                                        }
-                                        supply
-                                    }
-                                    type
+                                decimals
+                                isInitialized
+                                mintAuthority {
+                                    address
+                                    lamports
                                 }
+                                supply
+                            }
+                            meta {
                                 program
                                 space
+                                type
                             }
                         }
                     }
@@ -366,20 +364,18 @@ describe('account', () => {
                 data: {
                     account: {
                         data: {
-                            parsed: {
-                                info: {
-                                    decimals: 6,
-                                    isInitialized: true,
-                                    mintAuthority: {
-                                        address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
-                                        lamports: expect.any(BigInt),
-                                    },
-                                    supply: expect.any(String),
-                                },
-                                type: 'mint',
+                            decimals: 6,
+                            isInitialized: true,
+                            mintAuthority: {
+                                address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                                lamports: expect.any(BigInt),
                             },
+                            supply: expect.any(String),
+                        },
+                        meta: {
                             program: 'spl-token',
                             space: 82n,
+                            type: 'mint',
                         },
                     },
                 },
@@ -396,25 +392,23 @@ describe('account', () => {
                     account(address: $address) {
                         ... on TokenAccount {
                             data {
-                                parsed {
-                                    info {
-                                        isNative
-                                        mint
-                                        owner {
-                                            address
-                                        }
-                                        state
-                                        tokenAmount {
-                                            amount
-                                            decimals
-                                            uiAmount
-                                            uiAmountString
-                                        }
-                                    }
-                                    type
+                                isNative
+                                mint
+                                owner {
+                                    address
                                 }
+                                state
+                                tokenAmount {
+                                    amount
+                                    decimals
+                                    uiAmount
+                                    uiAmountString
+                                }
+                            }
+                            meta {
                                 program
                                 space
+                                type
                             }
                         }
                     }
@@ -425,24 +419,22 @@ describe('account', () => {
                 data: {
                     account: {
                         data: {
-                            parsed: {
-                                info: {
-                                    isNative: expect.any(Boolean),
-                                    mint: expect.any(String),
-                                    owner: {
-                                        address: '6UsGbaMgchgj4wiwKKuE1v5URHdcDfEiMSM25QpesKir',
-                                    },
-                                    state: expect.any(String),
-                                    tokenAmount: {
-                                        amount: expect.any(String),
-                                        decimals: expect.any(Number),
-                                        uiAmountString: expect.any(String),
-                                    },
-                                },
-                                type: 'account',
+                            isNative: expect.any(Boolean),
+                            mint: expect.any(String),
+                            owner: {
+                                address: '6UsGbaMgchgj4wiwKKuE1v5URHdcDfEiMSM25QpesKir',
                             },
+                            state: expect.any(String),
+                            tokenAmount: {
+                                amount: expect.any(String),
+                                decimals: expect.any(Number),
+                                uiAmountString: expect.any(String),
+                            },
+                        },
+                        meta: {
                             program: 'spl-token',
                             space: 165n,
+                            type: 'account',
                         },
                     },
                 },
@@ -459,20 +451,18 @@ describe('account', () => {
                     account(address: $address) {
                         ... on NonceAccount {
                             data {
-                                parsed {
-                                    info {
-                                        authority {
-                                            address
-                                        }
-                                        blockhash
-                                        feeCalculator {
-                                            lamportsPerSignature
-                                        }
-                                    }
-                                    type
+                                authority {
+                                    address
                                 }
+                                blockhash
+                                feeCalculator {
+                                    lamportsPerSignature
+                                }
+                            }
+                            meta {
                                 program
                                 space
+                                type
                             }
                         }
                     }
@@ -483,20 +473,18 @@ describe('account', () => {
                 data: {
                     account: {
                         data: {
-                            parsed: {
-                                info: {
-                                    authority: {
-                                        address: '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe',
-                                    },
-                                    blockhash: expect.any(String),
-                                    feeCalculator: {
-                                        lamportsPerSignature: expect.any(String),
-                                    },
-                                },
-                                type: 'initialized',
+                            authority: {
+                                address: '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe',
                             },
+                            blockhash: expect.any(String),
+                            feeCalculator: {
+                                lamportsPerSignature: expect.any(String),
+                            },
+                        },
+                        meta: {
                             program: 'nonce',
                             space: 80n,
+                            type: 'initialized',
                         },
                     },
                 },
@@ -513,42 +501,40 @@ describe('account', () => {
                     account(address: $address) {
                         ... on StakeAccount {
                             data {
-                                parsed {
-                                    info {
-                                        meta {
-                                            authorized {
-                                                staker {
-                                                    address
-                                                }
-                                                withdrawer {
-                                                    address
-                                                }
-                                            }
-                                            lockup {
-                                                custodian {
-                                                    address
-                                                }
-                                                epoch
-                                                unixTimestamp
-                                            }
-                                            rentExemptReserve
+                                meta {
+                                    authorized {
+                                        staker {
+                                            address
                                         }
-                                        stake {
-                                            creditsObserved
-                                            delegation {
-                                                activationEpoch
-                                                deactivationEpoch
-                                                stake
-                                                voter {
-                                                    address
-                                                }
-                                            }
+                                        withdrawer {
+                                            address
                                         }
                                     }
-                                    type
+                                    lockup {
+                                        custodian {
+                                            address
+                                        }
+                                        epoch
+                                        unixTimestamp
+                                    }
+                                    rentExemptReserve
                                 }
+                                stake {
+                                    creditsObserved
+                                    delegation {
+                                        activationEpoch
+                                        deactivationEpoch
+                                        stake
+                                        voter {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                            meta {
                                 program
                                 space
+                                type
                             }
                         }
                     }
@@ -559,42 +545,40 @@ describe('account', () => {
                 data: {
                     account: {
                         data: {
-                            parsed: {
-                                info: {
-                                    meta: {
-                                        authorized: {
-                                            staker: {
-                                                address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
-                                            },
-                                            withdrawer: {
-                                                address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
-                                            },
-                                        },
-                                        lockup: {
-                                            custodian: {
-                                                address: '11111111111111111111111111111111',
-                                            },
-                                            epoch: expect.any(BigInt),
-                                            unixTimestamp: expect.any(BigInt),
-                                        },
-                                        rentExemptReserve: expect.any(String),
+                            meta: {
+                                authorized: {
+                                    staker: {
+                                        address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
                                     },
-                                    stake: {
-                                        creditsObserved: expect.any(BigInt),
-                                        delegation: {
-                                            activationEpoch: expect.any(BigInt),
-                                            deactivationEpoch: expect.any(BigInt),
-                                            stake: expect.any(String),
-                                            voter: {
-                                                address: 'CertusDeBmqN8ZawdkxK5kFGMwBXdudvWHYwtNgNhvLu',
-                                            },
-                                        },
+                                    withdrawer: {
+                                        address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
                                     },
                                 },
-                                type: 'delegated',
+                                lockup: {
+                                    custodian: {
+                                        address: '11111111111111111111111111111111',
+                                    },
+                                    epoch: expect.any(BigInt),
+                                    unixTimestamp: expect.any(BigInt),
+                                },
+                                rentExemptReserve: expect.any(String),
                             },
+                            stake: {
+                                creditsObserved: expect.any(BigInt),
+                                delegation: {
+                                    activationEpoch: expect.any(BigInt),
+                                    deactivationEpoch: expect.any(BigInt),
+                                    stake: expect.any(String),
+                                    voter: {
+                                        address: 'CertusDeBmqN8ZawdkxK5kFGMwBXdudvWHYwtNgNhvLu',
+                                    },
+                                },
+                            },
+                        },
+                        meta: {
                             program: 'stake',
                             space: 200n,
+                            type: 'delegated',
                         },
                     },
                 },
@@ -611,41 +595,39 @@ describe('account', () => {
                     account(address: $address) {
                         ... on VoteAccount {
                             data {
-                                parsed {
-                                    info {
-                                        authorizedVoters {
-                                            authorizedVoter {
-                                                address
-                                            }
-                                            epoch
-                                        }
-                                        authorizedWithdrawer {
-                                            address
-                                        }
-                                        commission
-                                        epochCredits {
-                                            credits
-                                            epoch
-                                            previousCredits
-                                        }
-                                        lastTimestamp {
-                                            slot
-                                            timestamp
-                                        }
-                                        node {
-                                            address
-                                        }
-                                        priorVoters
-                                        rootSlot
-                                        votes {
-                                            confirmationCount
-                                            slot
-                                        }
+                                authorizedVoters {
+                                    authorizedVoter {
+                                        address
                                     }
-                                    type
+                                    epoch
                                 }
+                                authorizedWithdrawer {
+                                    address
+                                }
+                                commission
+                                epochCredits {
+                                    credits
+                                    epoch
+                                    previousCredits
+                                }
+                                lastTimestamp {
+                                    slot
+                                    timestamp
+                                }
+                                node {
+                                    address
+                                }
+                                priorVoters
+                                rootSlot
+                                votes {
+                                    confirmationCount
+                                    slot
+                                }
+                            }
+                            meta {
                                 program
                                 space
+                                type
                             }
                         }
                     }
@@ -656,47 +638,45 @@ describe('account', () => {
                 data: {
                     account: {
                         data: {
-                            parsed: {
-                                info: {
-                                    authorizedVoters: expect.arrayContaining([
-                                        {
-                                            authorizedVoter: {
-                                                address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
-                                            },
-                                            epoch: expect.any(BigInt),
-                                        },
-                                    ]),
-                                    authorizedWithdrawer: {
+                            authorizedVoters: expect.arrayContaining([
+                                {
+                                    authorizedVoter: {
                                         address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
                                     },
-                                    commission: expect.any(Number),
-                                    epochCredits: expect.arrayContaining([
-                                        {
-                                            credits: expect.any(String),
-                                            epoch: expect.any(BigInt),
-                                            previousCredits: expect.any(String),
-                                        },
-                                    ]),
-                                    lastTimestamp: {
-                                        slot: expect.any(BigInt),
-                                        timestamp: expect.any(BigInt),
-                                    },
-                                    node: {
-                                        address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
-                                    },
-                                    priorVoters: expect.any(Array),
-                                    rootSlot: expect.any(BigInt),
-                                    votes: expect.arrayContaining([
-                                        {
-                                            confirmationCount: expect.any(Number),
-                                            slot: expect.any(BigInt),
-                                        },
-                                    ]),
+                                    epoch: expect.any(BigInt),
                                 },
-                                type: 'vote',
+                            ]),
+                            authorizedWithdrawer: {
+                                address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
                             },
+                            commission: expect.any(Number),
+                            epochCredits: expect.arrayContaining([
+                                {
+                                    credits: expect.any(String),
+                                    epoch: expect.any(BigInt),
+                                    previousCredits: expect.any(String),
+                                },
+                            ]),
+                            lastTimestamp: {
+                                slot: expect.any(BigInt),
+                                timestamp: expect.any(BigInt),
+                            },
+                            node: {
+                                address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                            },
+                            priorVoters: expect.any(Array),
+                            rootSlot: expect.any(BigInt),
+                            votes: expect.arrayContaining([
+                                {
+                                    confirmationCount: expect.any(Number),
+                                    slot: expect.any(BigInt),
+                                },
+                            ]),
+                        },
+                        meta: {
                             program: 'vote',
                             space: expect.any(BigInt),
+                            type: 'vote',
                         },
                     },
                 },
@@ -713,20 +693,18 @@ describe('account', () => {
                     account(address: $address) {
                         ... on LookupTableAccount {
                             data {
-                                parsed {
-                                    info {
-                                        addresses
-                                        authority {
-                                            address
-                                        }
-                                        deactivationSlot
-                                        lastExtendedSlot
-                                        lastExtendedSlotStartIndex
-                                    }
-                                    type
+                                addresses
+                                authority {
+                                    address
                                 }
+                                deactivationSlot
+                                lastExtendedSlot
+                                lastExtendedSlotStartIndex
+                            }
+                            meta {
                                 program
                                 space
+                                type
                             }
                         }
                     }
@@ -737,20 +715,18 @@ describe('account', () => {
                 data: {
                     account: {
                         data: {
-                            parsed: {
-                                info: {
-                                    addresses: expect.any(Array),
-                                    authority: {
-                                        address: '4msgK65vdz5ADUAB3eTQGpF388NuQUAoknLxutUQJd5B',
-                                    },
-                                    deactivationSlot: expect.any(String),
-                                    lastExtendedSlot: expect.any(String),
-                                    lastExtendedSlotStartIndex: expect.any(Number),
-                                },
-                                type: 'lookupTable',
+                            addresses: expect.any(Array),
+                            authority: {
+                                address: '4msgK65vdz5ADUAB3eTQGpF388NuQUAoknLxutUQJd5B',
                             },
+                            deactivationSlot: expect.any(String),
+                            lastExtendedSlot: expect.any(String),
+                            lastExtendedSlotStartIndex: expect.any(Number),
+                        },
+                        meta: {
                             program: 'address-lookup-table',
                             space: 1304n,
+                            type: 'lookupTable',
                         },
                     },
                 },

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -206,17 +206,13 @@ describe('programAccounts', () => {
                     programAccounts(programAddress: $programAddress) {
                         ... on LookupTableAccount {
                             data {
-                                parsed {
-                                    info {
-                                        addresses
-                                        authority {
-                                            address
-                                        }
-                                        deactivationSlot
-                                        lastExtendedSlot
-                                        lastExtendedSlotStartIndex
-                                    }
+                                addresses
+                                authority {
+                                    address
                                 }
+                                deactivationSlot
+                                lastExtendedSlot
+                                lastExtendedSlotStartIndex
                             }
                         }
                     }
@@ -228,17 +224,13 @@ describe('programAccounts', () => {
                     programAccounts: expect.arrayContaining([
                         {
                             data: {
-                                parsed: {
-                                    info: {
-                                        addresses: expect.arrayContaining([expect.any(String)]),
-                                        authority: {
-                                            address: expect.any(String),
-                                        },
-                                        deactivationSlot: expect.any(String),
-                                        lastExtendedSlot: expect.any(String),
-                                        lastExtendedSlotStartIndex: expect.any(Number),
-                                    },
+                                addresses: expect.arrayContaining([expect.any(String)]),
+                                authority: {
+                                    address: expect.any(String),
                                 },
+                                deactivationSlot: expect.any(String),
+                                lastExtendedSlot: expect.any(String),
+                                lastExtendedSlotStartIndex: expect.any(Number),
                             },
                         },
                     ]),
@@ -255,35 +247,27 @@ describe('programAccounts', () => {
                     programAccounts(programAddress: $programAddress) {
                         ... on MintAccount {
                             data {
-                                parsed {
-                                    info {
-                                        decimals
-                                        isInitialized
-                                        mintAuthority {
-                                            address
-                                        }
-                                        supply
-                                    }
+                                decimals
+                                isInitialized
+                                mintAuthority {
+                                    address
                                 }
+                                supply
                             }
                         }
                         ... on TokenAccount {
                             data {
-                                parsed {
-                                    info {
-                                        isNative
-                                        mint
-                                        owner {
-                                            address
-                                        }
-                                        state
-                                        tokenAmount {
-                                            amount
-                                            decimals
-                                            uiAmount
-                                            uiAmountString
-                                        }
-                                    }
+                                isNative
+                                mint
+                                owner {
+                                    address
+                                }
+                                state
+                                tokenAmount {
+                                    amount
+                                    decimals
+                                    uiAmount
+                                    uiAmountString
                                 }
                             }
                         }
@@ -297,36 +281,28 @@ describe('programAccounts', () => {
                         // Mint account
                         {
                             data: {
-                                parsed: {
-                                    info: {
-                                        decimals: expect.any(Number),
-                                        isInitialized: expect.any(Boolean),
-                                        mintAuthority: {
-                                            address: expect.any(String),
-                                        },
-                                        supply: expect.any(String),
-                                    },
+                                decimals: expect.any(Number),
+                                isInitialized: expect.any(Boolean),
+                                mintAuthority: {
+                                    address: expect.any(String),
                                 },
+                                supply: expect.any(String),
                             },
                         },
                         // Token account
                         {
                             data: {
-                                parsed: {
-                                    info: {
-                                        isNative: expect.any(Boolean),
-                                        mint: expect.any(String),
-                                        owner: {
-                                            address: expect.any(String),
-                                        },
-                                        state: expect.any(String),
-                                        tokenAmount: expect.objectContaining({
-                                            amount: expect.any(String),
-                                            decimals: expect.any(Number),
-                                            uiAmountString: expect.any(String),
-                                        }),
-                                    },
+                                isNative: expect.any(Boolean),
+                                mint: expect.any(String),
+                                owner: {
+                                    address: expect.any(String),
                                 },
+                                state: expect.any(String),
+                                tokenAmount: expect.objectContaining({
+                                    amount: expect.any(String),
+                                    decimals: expect.any(Number),
+                                    uiAmountString: expect.any(String),
+                                }),
                             },
                         },
                     ]),
@@ -343,16 +319,12 @@ describe('programAccounts', () => {
                     programAccounts(programAddress: $programAddress) {
                         ... on NonceAccount {
                             data {
-                                parsed {
-                                    info {
-                                        authority {
-                                            address
-                                        }
-                                        blockhash
-                                        feeCalculator {
-                                            lamportsPerSignature
-                                        }
-                                    }
+                                authority {
+                                    address
+                                }
+                                blockhash
+                                feeCalculator {
+                                    lamportsPerSignature
                                 }
                             }
                         }
@@ -365,16 +337,12 @@ describe('programAccounts', () => {
                     programAccounts: expect.arrayContaining([
                         {
                             data: {
-                                parsed: {
-                                    info: {
-                                        authority: {
-                                            address: expect.any(String),
-                                        },
-                                        blockhash: expect.any(String),
-                                        feeCalculator: {
-                                            lamportsPerSignature: expect.any(String),
-                                        },
-                                    },
+                                authority: {
+                                    address: expect.any(String),
+                                },
+                                blockhash: expect.any(String),
+                                feeCalculator: {
+                                    lamportsPerSignature: expect.any(String),
                                 },
                             },
                         },
@@ -392,36 +360,32 @@ describe('programAccounts', () => {
                     programAccounts(programAddress: $programAddress) {
                         ... on StakeAccount {
                             data {
-                                parsed {
-                                    info {
-                                        meta {
-                                            authorized {
-                                                staker {
-                                                    address
-                                                }
-                                                withdrawer {
-                                                    address
-                                                }
-                                            }
-                                            lockup {
-                                                custodian {
-                                                    address
-                                                }
-                                                epoch
-                                                unixTimestamp
-                                            }
-                                            rentExemptReserve
+                                meta {
+                                    authorized {
+                                        staker {
+                                            address
                                         }
-                                        stake {
-                                            creditsObserved
-                                            delegation {
-                                                activationEpoch
-                                                deactivationEpoch
-                                                stake
-                                                voter {
-                                                    address
-                                                }
-                                            }
+                                        withdrawer {
+                                            address
+                                        }
+                                    }
+                                    lockup {
+                                        custodian {
+                                            address
+                                        }
+                                        epoch
+                                        unixTimestamp
+                                    }
+                                    rentExemptReserve
+                                }
+                                stake {
+                                    creditsObserved
+                                    delegation {
+                                        activationEpoch
+                                        deactivationEpoch
+                                        stake
+                                        voter {
+                                            address
                                         }
                                     }
                                 }
@@ -436,36 +400,32 @@ describe('programAccounts', () => {
                     programAccounts: expect.arrayContaining([
                         {
                             data: {
-                                parsed: {
-                                    info: {
-                                        meta: {
-                                            authorized: {
-                                                staker: {
-                                                    address: expect.any(String),
-                                                },
-                                                withdrawer: {
-                                                    address: expect.any(String),
-                                                },
-                                            },
-                                            lockup: {
-                                                custodian: {
-                                                    address: expect.any(String),
-                                                },
-                                                epoch: expect.any(BigInt),
-                                                unixTimestamp: expect.any(BigInt),
-                                            },
-                                            rentExemptReserve: expect.any(String),
+                                meta: {
+                                    authorized: {
+                                        staker: {
+                                            address: expect.any(String),
                                         },
-                                        stake: {
-                                            creditsObserved: expect.any(BigInt),
-                                            delegation: {
-                                                activationEpoch: expect.any(BigInt),
-                                                deactivationEpoch: expect.any(BigInt),
-                                                stake: expect.any(String),
-                                                voter: {
-                                                    address: expect.any(String),
-                                                },
-                                            },
+                                        withdrawer: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                    lockup: {
+                                        custodian: {
+                                            address: expect.any(String),
+                                        },
+                                        epoch: expect.any(BigInt),
+                                        unixTimestamp: expect.any(BigInt),
+                                    },
+                                    rentExemptReserve: expect.any(String),
+                                },
+                                stake: {
+                                    creditsObserved: expect.any(BigInt),
+                                    delegation: {
+                                        activationEpoch: expect.any(BigInt),
+                                        deactivationEpoch: expect.any(BigInt),
+                                        stake: expect.any(String),
+                                        voter: {
+                                            address: expect.any(String),
                                         },
                                     },
                                 },
@@ -485,37 +445,33 @@ describe('programAccounts', () => {
                     programAccounts(programAddress: $programAddress) {
                         ... on VoteAccount {
                             data {
-                                parsed {
-                                    info {
-                                        authorizedVoters {
-                                            authorizedVoter {
-                                                address
-                                            }
-                                            epoch
-                                        }
-                                        authorizedWithdrawer {
-                                            address
-                                        }
-                                        commission
-                                        epochCredits {
-                                            credits
-                                            epoch
-                                            previousCredits
-                                        }
-                                        lastTimestamp {
-                                            slot
-                                            timestamp
-                                        }
-                                        node {
-                                            address
-                                        }
-                                        priorVoters
-                                        rootSlot
-                                        votes {
-                                            confirmationCount
-                                            slot
-                                        }
+                                authorizedVoters {
+                                    authorizedVoter {
+                                        address
                                     }
+                                    epoch
+                                }
+                                authorizedWithdrawer {
+                                    address
+                                }
+                                commission
+                                epochCredits {
+                                    credits
+                                    epoch
+                                    previousCredits
+                                }
+                                lastTimestamp {
+                                    slot
+                                    timestamp
+                                }
+                                node {
+                                    address
+                                }
+                                priorVoters
+                                rootSlot
+                                votes {
+                                    confirmationCount
+                                    slot
                                 }
                             }
                         }
@@ -528,44 +484,40 @@ describe('programAccounts', () => {
                     programAccounts: expect.arrayContaining([
                         {
                             data: {
-                                parsed: {
-                                    info: {
-                                        authorizedVoters: expect.arrayContaining([
-                                            {
-                                                authorizedVoter: {
-                                                    address: expect.any(String),
-                                                },
-                                                epoch: expect.any(BigInt),
-                                            },
-                                        ]),
-                                        authorizedWithdrawer: {
+                                authorizedVoters: expect.arrayContaining([
+                                    {
+                                        authorizedVoter: {
                                             address: expect.any(String),
                                         },
-                                        commission: expect.any(Number),
-                                        epochCredits: expect.arrayContaining([
-                                            {
-                                                credits: expect.any(String),
-                                                epoch: expect.any(BigInt),
-                                                previousCredits: expect.any(String),
-                                            },
-                                        ]),
-                                        lastTimestamp: {
-                                            slot: expect.any(BigInt),
-                                            timestamp: expect.any(BigInt),
-                                        },
-                                        node: {
-                                            address: expect.any(String),
-                                        },
-                                        priorVoters: expect.any(Array),
-                                        rootSlot: expect.any(BigInt),
-                                        votes: expect.arrayContaining([
-                                            {
-                                                confirmationCount: expect.any(Number),
-                                                slot: expect.any(BigInt),
-                                            },
-                                        ]),
+                                        epoch: expect.any(BigInt),
                                     },
+                                ]),
+                                authorizedWithdrawer: {
+                                    address: expect.any(String),
                                 },
+                                commission: expect.any(Number),
+                                epochCredits: expect.arrayContaining([
+                                    {
+                                        credits: expect.any(String),
+                                        epoch: expect.any(BigInt),
+                                        previousCredits: expect.any(String),
+                                    },
+                                ]),
+                                lastTimestamp: {
+                                    slot: expect.any(BigInt),
+                                    timestamp: expect.any(BigInt),
+                                },
+                                node: {
+                                    address: expect.any(String),
+                                },
+                                priorVoters: expect.any(Array),
+                                rootSlot: expect.any(BigInt),
+                                votes: expect.arrayContaining([
+                                    {
+                                        confirmationCount: expect.any(Number),
+                                        slot: expect.any(BigInt),
+                                    },
+                                ]),
                             },
                         },
                     ]),

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -1,0 +1,89 @@
+import { SolanaRpcMethods } from '@solana/rpc-core';
+import { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import { GraphQLResolveInfo } from 'graphql';
+
+import { GraphQLCache } from '../cache';
+import { AccountQueryArgs } from '../schema/account';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function refineJsonParsedAccountData(jsonParsedData: any) {
+    const meta = {
+        program: jsonParsedData.program,
+        space: jsonParsedData.space,
+        type: jsonParsedData.parsed.type,
+    };
+    const data = jsonParsedData.parsed.info;
+    return { data, meta };
+}
+
+// Default to jsonParsed encoding if none is provided
+export async function resolveAccount(
+    { address, encoding = 'jsonParsed', ...config }: AccountQueryArgs,
+    cache: GraphQLCache,
+    rpc: Rpc<SolanaRpcMethods>,
+    info?: GraphQLResolveInfo
+) {
+    // If a user only requests the account's address, don't call the RPC
+    if (info && info.fieldNodes[0].selectionSet) {
+        const selectionSet = info.fieldNodes[0].selectionSet;
+        const requestedFields = selectionSet.selections.map(field => {
+            if (field.kind === 'Field') {
+                return field.name.value;
+            }
+            return null;
+        });
+        if (requestedFields && requestedFields.length === 1 && requestedFields[0] === 'address') {
+            return { address };
+        }
+    }
+
+    const requestConfig = { encoding, ...config };
+
+    const cached = cache.get(address, requestConfig);
+    if (cached !== null) {
+        return cached;
+    }
+
+    const account = await rpc
+        .getAccountInfo(address, requestConfig as Parameters<SolanaRpcMethods['getAccountInfo']>[1])
+        .send()
+        .then(res => res.value)
+        .catch(e => {
+            throw e;
+        });
+
+    if (account === null) {
+        // Account does not exist
+        // Return only the address
+        return {
+            address,
+        };
+    }
+
+    const [refinedData, responseEncoding] = Array.isArray(account.data)
+        ? encoding === 'jsonParsed'
+            ? [account.data[0], 'base64']
+            : [account.data[0], encoding]
+        : [refineJsonParsedAccountData(account.data), 'jsonParsed'];
+
+    const responseBase = {
+        ...account,
+        address,
+        encoding: responseEncoding,
+    };
+    const queryResponse =
+        typeof refinedData === 'object' && 'meta' in refinedData
+            ? {
+                  ...responseBase,
+                  data: refinedData.data,
+                  meta: refinedData.meta,
+              }
+            : {
+                  ...responseBase,
+                  data: refinedData,
+              };
+
+    cache.insert(address, requestConfig, queryResponse);
+
+    return queryResponse;
+}

--- a/packages/rpc-graphql/src/resolvers/program-accounts.ts
+++ b/packages/rpc-graphql/src/resolvers/program-accounts.ts
@@ -1,0 +1,60 @@
+import { SolanaRpcMethods } from '@solana/rpc-core';
+import { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+
+import { GraphQLCache } from '../cache';
+import { ProgramAccountsQueryArgs } from '../schema/program-accounts';
+import { refineJsonParsedAccountData } from './account';
+
+export async function resolveProgramAccounts(
+    { programAddress, encoding = 'jsonParsed', ...config }: ProgramAccountsQueryArgs,
+    cache: GraphQLCache,
+    rpc: Rpc<SolanaRpcMethods>
+) {
+    const requestConfig = { encoding, ...config };
+
+    const cached = cache.get(programAddress, requestConfig);
+    if (cached !== null) {
+        return cached;
+    }
+
+    const programAccounts = await rpc
+        .getProgramAccounts(programAddress, requestConfig as Parameters<SolanaRpcMethods['getProgramAccounts']>[1])
+        .send()
+        .then(res => {
+            if ('value' in res) {
+                return res.value as ReturnType<SolanaRpcMethods['getProgramAccounts']>;
+            }
+            return res as ReturnType<SolanaRpcMethods['getProgramAccounts']>;
+        })
+        .catch(e => {
+            throw e;
+        });
+
+    const queryResponse = programAccounts.map(programAccount => {
+        const [refinedData, responseEncoding] = Array.isArray(programAccount.account.data)
+            ? encoding === 'jsonParsed'
+                ? [programAccount.account.data[0], 'base64']
+                : [programAccount.account.data[0], encoding]
+            : [refineJsonParsedAccountData(programAccount.account.data), 'jsonParsed'];
+        const pubkey = programAccount.pubkey;
+        const responseBase = {
+            ...programAccount.account,
+            address: pubkey,
+            encoding: responseEncoding,
+        };
+        return typeof refinedData === 'object' && 'meta' in refinedData
+            ? {
+                  ...responseBase,
+                  data: refinedData.data,
+                  meta: refinedData.meta,
+              }
+            : {
+                  ...responseBase,
+                  data: refinedData,
+              };
+    });
+
+    cache.insert(programAddress, requestConfig, queryResponse);
+
+    return queryResponse;
+}


### PR DESCRIPTION
This PR introduces a revised version of the account schema for `jsonParsed`
account data.

Typically we see JSON-parsed account data like this:

```javascript
{
  data: {
    parsed: {
      info: {
        /* data */
      },
      type: 'mint',
    },
    program: 'Tokenkegxxxxxxxx',
    space: 82n,
  },
}
```

However, when it comes to GraphQL, I've made an opinionated decision to move
away from the JSON-parsed format returned by the RPC, and instead opt for this
"optimized" format:

```javascript
{
  data: {
    /* data */
  },
  meta: {
    program: 'Tokenkegxxxxxxxx',
    space: 82n,
    type: 'mint',
  },
}

```

Since we know we'll always get `program`, `space`, and `type`, we can extract
those to be "parsed metadata" about an account and introduce the `meta` field.
