### PR TITLE
refactor(experimental): remove rpc response from `getSignaturesForAddress`

### DIFF
--- a/packages/rpc-core/src/rpc-methods/getSignaturesForAddress.ts
+++ b/packages/rpc-core/src/rpc-methods/getSignaturesForAddress.ts
@@ -3,9 +3,9 @@ import { Signature } from '@solana/keys';
 import { Commitment, UnixTimestamp } from '@solana/rpc-types';
 
 import { TransactionError } from '../transaction-error';
-import { RpcResponse, Slot } from './common';
+import { Slot } from './common';
 
-type GetSignaturesForAddressTransaction = RpcResponse<{
+type GetSignaturesForAddressTransaction = Readonly<{
     /** transaction signature as base-58 encoded string */
     signature: Signature;
     /** The slot that contains the block with the transaction */


### PR DESCRIPTION
#### Problem
`getSignaturesForAddress` does not return objects wrapped in RPC Response contexts.
https://docs.solana.com/api/http#getsignaturesforaddress

#### Solution
Remove the wrapper!