### PR TITLE
refactor(experimental): use `DataLoader` to coalesce multiple requests for the same block

### DIFF
--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -62,6 +62,8 @@
         "maintained node versions"
     ],
     "dependencies": {
+        "dataloader": "^2.2.2",
+        "fast-stable-stringify": "^1.0.0",
         "graphql": "^16.8.0"
     },
     "devDependencies": {

--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -1,6 +1,7 @@
 describe('block', () => {
     describe('basic queries', () => {
         it.todo("can query a block's block time");
+        it.todo('coalesces multiple requests for the same block into one');
     });
     describe('block with signatures transaction details', () => {
         it.todo('can query a block with signatures');

--- a/packages/rpc-graphql/src/schema/block/query.ts
+++ b/packages/rpc-graphql/src/schema/block/query.ts
@@ -29,7 +29,7 @@ export const blockQuery = () => ({
             slot: nonNull(bigint()),
             transactionDetails: type(blockTransactionDetailsInputType()),
         },
-        resolve: (_parent: unknown, args: BlockQueryArgs, context: RpcGraphQLContext) => context.resolveBlock(args),
+        resolve: (_parent: unknown, args: BlockQueryArgs, context: RpcGraphQLContext) => context.block.load(args),
         type: blockInterface(),
     },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1264,6 +1264,12 @@ importers:
 
   packages/rpc-graphql:
     dependencies:
+      dataloader:
+        specifier: ^2.2.2
+        version: 2.2.2
+      fast-stable-stringify:
+        specifier: ^1.0.0
+        version: 1.0.0
       graphql:
         specifier: ^16.8.0
         version: 16.8.1
@@ -6938,6 +6944,10 @@ packages:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
+
+  /dataloader@2.2.2:
+    resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
+    dev: false
 
   /dateformat@3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}


### PR DESCRIPTION
# Summary

The DataLoader pattern is used to dedupe and cache requests for identical entities across a GraphQL query. Created at the top level, a DataLoader coalesces requests in the same tick, sends them as an array of keys to a batch loader function, and caches the results based on the key generated by `cacheKeyFn`.

With this change, this query will produce exactly one request to `getBlock()`

```graphql
query {
  block(slot: 123) {
    blockTime
  }
  transactionThatHappensToBeInBlock123: transaction(signature: '...') {
    block { # Cached from before
      blockTime
    }
  }
}
```


In this PR we replace the custom cache for resolving blocks with a dataloader. Once all of the resolvers are rewritten as dataloaders, you can delete the `GraphQLCache` completely.

# Test Plan

Didn't.
