### PR TITLE
refactor(experimental-graphql): replace accounts cache with `DataLoader`

### DIFF
--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -63,6 +63,8 @@
     ],
     "dependencies": {
         "@graphql-tools/schema": "^10.0.0",
+        "dataloader": "^2.2.2",
+        "fast-stable-stringify": "^1.0.0",
         "graphql": "^16.8.0"
     },
     "devDependencies": {

--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -246,4 +246,7 @@ describe('block', () => {
         it.todo('can query a block with transactions as JSON parsed');
         it.todo('can query a block with transactions as JSON parsed with specific instructions');
     });
+    describe('cache tests', () => {
+        it.todo('coalesces multiple requests for the same block into one');
+    });
 });

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -619,4 +619,7 @@ describe('programAccounts', () => {
             });
         });
     });
+    describe('cache tests', () => {
+        it.todo('coalesces multiple requests for the same program into one');
+    });
 });

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -754,4 +754,7 @@ describe('transaction', () => {
             });
         });
     });
+    describe('cache tests', () => {
+        it.todo('coalesces multiple requests for the same transaction into one');
+    });
 });

--- a/packages/rpc-graphql/src/loaders/common/resolve-info.ts
+++ b/packages/rpc-graphql/src/loaders/common/resolve-info.ts
@@ -1,0 +1,17 @@
+import { GraphQLResolveInfo } from 'graphql';
+
+export function onlyPresentFieldRequested(fieldName: string, info?: GraphQLResolveInfo): boolean {
+    if (info && info.fieldNodes[0].selectionSet) {
+        const selectionSet = info.fieldNodes[0].selectionSet;
+        const requestedFields = selectionSet.selections.map(field => {
+            if (field.kind === 'Field') {
+                return field.name.value;
+            }
+            return null;
+        });
+        if (requestedFields && requestedFields.length === 1 && requestedFields[0] === fieldName) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -10,5 +10,6 @@ export const resolveAccount = (fieldName: string) => {
         args: AccountQueryArgs,
         context: RpcGraphQLContext,
         info: GraphQLResolveInfo | undefined
-    ) => (parent[fieldName] === null ? null : context.loadAccount({ ...args, address: parent[fieldName] }, info));
+    ) =>
+        parent[fieldName] === null ? null : context.accountLoader.load({ ...args, address: parent[fieldName] }, info);
 };

--- a/packages/rpc-graphql/src/schema/index.ts
+++ b/packages/rpc-graphql/src/schema/index.ts
@@ -56,7 +56,7 @@ const schemaResolvers = {
             context: RpcGraphQLContext,
             info?: GraphQLResolveInfo
         ) {
-            return context.loadAccount(args, info);
+            return context.accountLoader.load(args, info);
         },
         block(
             _: unknown,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1264,6 +1264,12 @@ importers:
       '@graphql-tools/schema':
         specifier: ^10.0.0
         version: 10.0.0(graphql@16.8.1)
+      dataloader:
+        specifier: ^2.2.2
+        version: 2.2.2
+      fast-stable-stringify:
+        specifier: ^1.0.0
+        version: 1.0.0
       graphql:
         specifier: ^16.8.0
         version: 16.8.1
@@ -7049,6 +7055,10 @@ packages:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
+
+  /dataloader@2.2.2:
+    resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
+    dev: false
 
   /dateformat@3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}


### PR DESCRIPTION
This PR takes @steveluscher's lay-up from #1827 and kicks off a stack for
replacing the entire custom GraphQL cache with `DataLoader`.

This particular PR migrates the account loader.
