### PR TITLE
refactor(experimental-graphql): enable GraphQL syntax highlighting

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -25,13 +25,13 @@ describe('account', () => {
         };
         it("can query an account's lamports balance", async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($address: String!) {
-                account(address: $address) {
-                    lamports
+            const source = /* GraphQL */ `
+                query testQuery($address: String!) {
+                    account(address: $address) {
+                        lamports
+                    }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -43,13 +43,13 @@ describe('account', () => {
         });
         it("can query an account's executable value", async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($address: String!, $commitment: Commitment) {
-                account(address: $address, commitment: $commitment) {
-                    executable
+            const source = /* GraphQL */ `
+                query testQuery($address: String!, $commitment: Commitment) {
+                    account(address: $address, commitment: $commitment) {
+                        executable
+                    }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -61,13 +61,13 @@ describe('account', () => {
         });
         it("can query an account's address", async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($address: String!, $commitment: Commitment) {
-                account(address: $address, commitment: $commitment) {
-                    address
+            const source = /* GraphQL */ `
+                query testQuery($address: String!, $commitment: Commitment) {
+                    account(address: $address, commitment: $commitment) {
+                        address
+                    }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -79,15 +79,15 @@ describe('account', () => {
         });
         it('can query multiple fields', async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($address: String!, $commitment: Commitment) {
-                account(address: $address, commitment: $commitment) {
-                    executable
-                    lamports
-                    rentEpoch
+            const source = /* GraphQL */ `
+                query testQuery($address: String!, $commitment: Commitment) {
+                    account(address: $address, commitment: $commitment) {
+                        executable
+                        lamports
+                        rentEpoch
+                    }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -108,18 +108,18 @@ describe('account', () => {
         };
         it("can perform a nested query for the account's owner", async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($address: String!, $commitment: Commitment) {
-                account(address: $address, commitment: $commitment) {
-                    owner {
-                        address
-                        executable
-                        lamports
-                        rentEpoch
+            const source = /* GraphQL */ `
+                query testQuery($address: String!, $commitment: Commitment) {
+                    account(address: $address, commitment: $commitment) {
+                        owner {
+                            address
+                            executable
+                            lamports
+                            rentEpoch
+                        }
                     }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -143,21 +143,21 @@ describe('account', () => {
         };
         it("can perform a double nested query for each account's owner", async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($address: String!, $commitment: Commitment) {
-                account(address: $address, commitment: $commitment) {
-                    owner {
-                        address
+            const source = /* GraphQL */ `
+                query testQuery($address: String!, $commitment: Commitment) {
+                    account(address: $address, commitment: $commitment) {
                         owner {
                             address
-                            executable
-                            lamports
-                            rentEpoch
+                            owner {
+                                address
+                                executable
+                                lamports
+                                rentEpoch
+                            }
                         }
                     }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -184,21 +184,21 @@ describe('account', () => {
         };
         it("can perform a triple nested query for each account's owner", async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($address: String!) {
-                account(address: $address) {
-                    owner {
-                        address
+            const source = /* GraphQL */ `
+                query testQuery($address: String!) {
+                    account(address: $address) {
                         owner {
                             address
                             owner {
                                 address
+                                owner {
+                                    address
+                                }
                             }
                         }
                     }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -225,7 +225,7 @@ describe('account', () => {
                 address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
                 encoding: 'base58',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($address: String!, $encoding: AccountEncoding) {
                     account(address: $address, encoding: $encoding) {
                         ... on AccountBase58 {
@@ -250,15 +250,15 @@ describe('account', () => {
                 address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
                 encoding: 'base64',
             };
-            const source = `
-                    query testQuery($address: String!, $encoding: AccountEncoding) {
-                        account(address: $address, encoding: $encoding) {
-                            ... on AccountBase64 {
-                                data
-                            }
+            const source = /* GraphQL */ `
+                query testQuery($address: String!, $encoding: AccountEncoding) {
+                    account(address: $address, encoding: $encoding) {
+                        ... on AccountBase64 {
+                            data
                         }
                     }
-                `;
+                }
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -275,15 +275,15 @@ describe('account', () => {
                 address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
                 encoding: 'base64Zstd',
             };
-            const source = `
-                    query testQuery($address: String!, $encoding: AccountEncoding) {
-                        account(address: $address, encoding: $encoding) {
-                            ... on AccountBase64Zstd {
-                                data
-                            }
+            const source = /* GraphQL */ `
+                query testQuery($address: String!, $encoding: AccountEncoding) {
+                    account(address: $address, encoding: $encoding) {
+                        ... on AccountBase64Zstd {
+                            data
                         }
                     }
-                `;
+                }
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -301,7 +301,7 @@ describe('account', () => {
             const variableValues = {
                 address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($address: String!) {
                     account(address: $address) {
                         ... on MintAccount {
@@ -351,7 +351,7 @@ describe('account', () => {
             const variableValues = {
                 address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($address: String!) {
                     account(address: $address) {
                         ... on TokenAccount {
@@ -414,7 +414,7 @@ describe('account', () => {
             const variableValues = {
                 address: 'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($address: String!) {
                     account(address: $address) {
                         ... on NonceAccount {
@@ -464,7 +464,7 @@ describe('account', () => {
             const variableValues = {
                 address: 'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($address: String!) {
                     account(address: $address) {
                         ... on StakeAccount {
@@ -558,7 +558,7 @@ describe('account', () => {
             const variableValues = {
                 address: '4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($address: String!) {
                     account(address: $address) {
                         ... on VoteAccount {
@@ -656,7 +656,7 @@ describe('account', () => {
             const variableValues = {
                 address: '2JPQuT3dHtPjrdcbUQyrrT4XYRYaWpWfmAJ54SUapg6n',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($address: String!) {
                     account(address: $address) {
                         ... on LookupTableAccount {

--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -37,7 +37,7 @@ describe('block', () => {
         it("can query a block's block time", async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockFull)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     block(slot: ${defaultSlot}) {
                         blockTime
@@ -56,7 +56,7 @@ describe('block', () => {
         it('can query multiple fields on a block', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockFull)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     block(slot: ${defaultSlot}) {
                         blockhash
@@ -93,7 +93,7 @@ describe('block', () => {
         it('can query a block with signatures transaction details', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockSignatures)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     block(slot: ${defaultSlot}, transactionDetails: signatures) {
                         ... on BlockWithSignatures {
@@ -116,7 +116,7 @@ describe('block', () => {
         it('can query a block with accounts transaction details', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockAccounts)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     block(slot: ${defaultSlot}, transactionDetails: accounts) {
                         ... on BlockWithAccounts {
@@ -151,7 +151,7 @@ describe('block', () => {
         it('can query a block with none transaction details', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockNone)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     block(slot: ${defaultSlot}, transactionDetails: none) {
                         ... on BlockWithNone {
@@ -188,7 +188,7 @@ describe('block', () => {
         it('can query a block with base58 encoded transactions', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockFullBase58)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     block(slot: ${defaultSlot}, encoding: base58) {
                         ... on BlockWithFull {
@@ -217,7 +217,7 @@ describe('block', () => {
         it('can query a block with base64 encoded transactions', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockFullBase64)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     block(slot: ${defaultSlot}, encoding: base64) {
                         ... on BlockWithFull {

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -27,13 +27,13 @@ describe('programAccounts', () => {
         };
         it("can query program accounts' lamports balances", async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($programAddress: String!, $commitment: Commitment) {
-                programAccounts(programAddress: $programAddress, commitment: $commitment) {
-                    lamports
+            const source = /* GraphQL */ `
+                query testQuery($programAddress: String!, $commitment: Commitment) {
+                    programAccounts(programAddress: $programAddress, commitment: $commitment) {
+                        lamports
+                    }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -43,13 +43,13 @@ describe('programAccounts', () => {
         });
         it("can query program accounts' executable value", async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($programAddress: String!, $commitment: Commitment) {
-                programAccounts(programAddress: $programAddress, commitment: $commitment) {
-                    executable
+            const source = /* GraphQL */ `
+                query testQuery($programAddress: String!, $commitment: Commitment) {
+                    programAccounts(programAddress: $programAddress, commitment: $commitment) {
+                        executable
+                    }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -59,15 +59,15 @@ describe('programAccounts', () => {
         });
         it('can query multiple fields', async () => {
             expect.assertions(1);
-            const source = `
-            query testQuery($programAddress: String!, $commitment: Commitment) {
-                programAccounts(programAddress: $programAddress, commitment: $commitment) {
-                    executable
-                    lamports
-                    rentEpoch
+            const source = /* GraphQL */ `
+                query testQuery($programAddress: String!, $commitment: Commitment) {
+                    programAccounts(programAddress: $programAddress, commitment: $commitment) {
+                        executable
+                        lamports
+                        rentEpoch
+                    }
                 }
-            }
-        `;
+            `;
             const result = await rpcGraphQL.query(source, variableValues);
             expect(result).toMatchObject({
                 data: {
@@ -91,7 +91,7 @@ describe('programAccounts', () => {
                 commitment: 'confirmed',
                 encoding: 'base58',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($programAddress: String!, $commitment: Commitment, $encoding: AccountEncoding) {
                     programAccounts(programAddress: $programAddress, commitment: $commitment, encoding: $encoding) {
                         ... on AccountBase58 {
@@ -128,7 +128,7 @@ describe('programAccounts', () => {
                 commitment: 'confirmed',
                 encoding: 'base64',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($programAddress: String!, $commitment: Commitment, $encoding: AccountEncoding) {
                     programAccounts(programAddress: $programAddress, commitment: $commitment, encoding: $encoding) {
                         ... on AccountBase64 {
@@ -165,7 +165,7 @@ describe('programAccounts', () => {
                 commitment: 'confirmed',
                 encoding: 'base64Zstd',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($programAddress: String!, $commitment: Commitment, $encoding: AccountEncoding) {
                     programAccounts(programAddress: $programAddress, commitment: $commitment, encoding: $encoding) {
                         ... on AccountBase64Zstd {
@@ -201,7 +201,7 @@ describe('programAccounts', () => {
             const variableValues = {
                 programAddress: 'AddressLookupTab1e1111111111111111111111111',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($programAddress: String!) {
                     programAccounts(programAddress: $programAddress) {
                         ... on LookupTableAccount {
@@ -242,7 +242,7 @@ describe('programAccounts', () => {
             const variableValues = {
                 programAddress: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($programAddress: String!) {
                     programAccounts(programAddress: $programAddress) {
                         ... on MintAccount {
@@ -318,7 +318,7 @@ describe('programAccounts', () => {
             const variableValues = {
                 programAddress: '11111111111111111111111111111111',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($programAddress: String!) {
                     programAccounts(programAddress: $programAddress) {
                         ... on NonceAccount {
@@ -359,7 +359,7 @@ describe('programAccounts', () => {
             const variableValues = {
                 programAddress: 'Stake11111111111111111111111111111111111111',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($programAddress: String!) {
                     programAccounts(programAddress: $programAddress) {
                         ... on StakeAccount {
@@ -444,7 +444,7 @@ describe('programAccounts', () => {
             const variableValues = {
                 programAddress: 'Vote111111111111111111111111111111111111111',
             };
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery($programAddress: String!) {
                     programAccounts(programAddress: $programAddress) {
                         ... on VoteAccount {
@@ -543,18 +543,18 @@ describe('programAccounts', () => {
                     },
                     encoding: 'base58',
                 };
-                const source = `
+                const source = /* GraphQL */ `
                     query testQuery(
-                        $programAddress: String!,
-                        $commitment: Commitment,
-                        $dataSlice: DataSlice,
-                        $encoding: AccountEncoding,
+                        $programAddress: String!
+                        $commitment: Commitment
+                        $dataSlice: DataSlice
+                        $encoding: AccountEncoding
                     ) {
                         programAccounts(
-                            programAddress: $programAddress,
-                            commitment: $commitment,
-                            dataSlice: $dataSlice,
-                            encoding: $encoding,
+                            programAddress: $programAddress
+                            commitment: $commitment
+                            dataSlice: $dataSlice
+                            encoding: $encoding
                         ) {
                             ... on AccountBase58 {
                                 data
@@ -587,18 +587,18 @@ describe('programAccounts', () => {
                     },
                     encoding: 'base64',
                 };
-                const source = `
+                const source = /* GraphQL */ `
                     query testQuery(
-                        $programAddress: String!,
-                        $commitment: Commitment,
-                        $dataSlice: DataSlice,
-                        $encoding: AccountEncoding,
+                        $programAddress: String!
+                        $commitment: Commitment
+                        $dataSlice: DataSlice
+                        $encoding: AccountEncoding
                     ) {
                         programAccounts(
-                            programAddress: $programAddress,
-                            commitment: $commitment,
-                            dataSlice: $dataSlice,
-                            encoding: $encoding,
+                            programAddress: $programAddress
+                            commitment: $commitment
+                            dataSlice: $dataSlice
+                            encoding: $encoding
                         ) {
                             ... on AccountBase64 {
                                 data

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -39,7 +39,7 @@ describe('transaction', () => {
         it("can query a transaction's slot", async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionVote)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         slot
@@ -58,7 +58,7 @@ describe('transaction', () => {
         it("can query a transaction's computeUnitsConsumed from it's meta", async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionVote)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         meta {
@@ -81,7 +81,7 @@ describe('transaction', () => {
         it("can query several fields from a transaction's meta", async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionVote)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         meta {
@@ -113,7 +113,7 @@ describe('transaction', () => {
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionBase58)));
             // Mock again for jsonParsed encoding
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionVote)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}", encoding: base58) {
                         ... on TransactionBase58 {
@@ -137,7 +137,7 @@ describe('transaction', () => {
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionBase64)));
             // Mock again for jsonParsed encoding
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionVote)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}", encoding: base64) {
                         ... on TransactionBase64 {
@@ -158,7 +158,7 @@ describe('transaction', () => {
         it('can get a transaction as jsonParsed', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionVote)));
-            const source = `
+            const source = /* GraphQL */ `
             query testQuery {
                 transaction(signature: "${defaultTransactionSignature}") {
                     ... on TransactionParsed {
@@ -201,7 +201,7 @@ describe('transaction', () => {
         it('defaults to jsonParsed', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionVote)));
-            const source = `
+            const source = /* GraphQL */ `
             query testQuery {
                 transaction(signature: "${defaultTransactionSignature}") {
                     ... on TransactionParsed {
@@ -246,7 +246,7 @@ describe('transaction', () => {
         it('can get a generic instruction', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionGeneric)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         ... on TransactionParsed {
@@ -287,7 +287,7 @@ describe('transaction', () => {
         it('can get a `ExtendLookupTable` instruction', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionAddressLookup)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         ... on TransactionParsed {
@@ -362,7 +362,7 @@ describe('transaction', () => {
         it('can get a `CreateAccount` instruction', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionSystem)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         ... on TransactionParsed {
@@ -433,7 +433,7 @@ describe('transaction', () => {
         it('can get an `Allocate` instruction', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionSystem)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         ... on TransactionParsed {
@@ -492,7 +492,7 @@ describe('transaction', () => {
         it('can get an `Assign` instruction', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionSystem)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         ... on TransactionParsed {
@@ -555,7 +555,7 @@ describe('transaction', () => {
         it('can get a `Transfer` instruction', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionSystem)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         ... on TransactionParsed {
@@ -620,7 +620,7 @@ describe('transaction', () => {
         it('can get a `InitializeMint` instruction', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionToken)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         ... on TransactionParsed {
@@ -691,7 +691,7 @@ describe('transaction', () => {
         it('can get a `SplTokenTransfer` instruction', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionToken)));
-            const source = `
+            const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
                         ... on TransactionParsed {


### PR DESCRIPTION
This PR enables VS Code's GraphQL syntax highlighting in all of the tests!
Pretty!
