### PR TITLE
refactor(experimental-graphql): replace block cache with `DataLoader`

### DIFF
--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -247,6 +247,7 @@ describe('block', () => {
         it.todo('can query a block with transactions as JSON parsed with specific instructions');
     });
     describe('cache tests', () => {
+        // Not required yet since blocks are not supported as nested queries.
         it.todo('coalesces multiple requests for the same block into one');
     });
 });

--- a/packages/rpc-graphql/src/context.ts
+++ b/packages/rpc-graphql/src/context.ts
@@ -2,7 +2,7 @@ import { GraphQLResolveInfo } from 'graphql';
 
 import { createGraphQLCache, GraphQLCache } from './cache';
 import { createAccountLoader } from './loaders/account';
-import { loadBlock } from './loaders/block';
+import { createBlockLoader } from './loaders/block';
 import { loadProgramAccounts } from './loaders/program-accounts';
 import { loadTransaction } from './loaders/transaction';
 import { createRpcGraphQL } from './rpc';
@@ -19,7 +19,7 @@ type Loader<TArgs> = {
 export interface RpcGraphQLContext {
     cache: GraphQLCache;
     accountLoader: Loader<AccountQueryArgs>;
-    loadBlock(args: BlockQueryArgs, info?: GraphQLResolveInfo): ReturnType<typeof loadBlock>;
+    blockLoader: Loader<BlockQueryArgs>;
     loadProgramAccounts(
         args: ProgramAccountsQueryArgs,
         info?: GraphQLResolveInfo
@@ -32,10 +32,8 @@ export function createSolanaGraphQLContext(rpc: Rpc): RpcGraphQLContext {
     const cache = createGraphQLCache();
     return {
         accountLoader: createAccountLoader(rpc),
+        blockLoader: createBlockLoader(rpc),
         cache,
-        loadBlock(args, info?) {
-            return loadBlock(args, this.cache, this.rpc, info);
-        },
         loadProgramAccounts(args, info?) {
             return loadProgramAccounts(args, this.cache, this.rpc, info);
         },

--- a/packages/rpc-graphql/src/resolvers/block.ts
+++ b/packages/rpc-graphql/src/resolvers/block.ts
@@ -10,5 +10,5 @@ export const resolveBlock = (fieldName: string) => {
         args: BlockQueryArgs,
         context: RpcGraphQLContext,
         info: GraphQLResolveInfo | undefined
-    ) => (parent[fieldName] === null ? null : context.loadBlock({ ...args, slot: parent[fieldName] }, info));
+    ) => (parent[fieldName] === null ? null : context.blockLoader.load({ ...args, slot: parent[fieldName] }, info));
 };

--- a/packages/rpc-graphql/src/schema/index.ts
+++ b/packages/rpc-graphql/src/schema/index.ts
@@ -64,7 +64,7 @@ const schemaResolvers = {
             context: RpcGraphQLContext,
             info?: GraphQLResolveInfo
         ) {
-            return context.loadBlock(args, info);
+            return context.blockLoader.load(args, info);
         },
         programAccounts(
             _: unknown,


### PR DESCRIPTION
This PR replaces the block loader's use of the custom cache with a `DataLoader`
setup.
