### PR TITLE
refactor(experimental-graphql): replace transaction cache with `DataLoader`

### DIFF
--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -755,6 +755,7 @@ describe('transaction', () => {
         });
     });
     describe('cache tests', () => {
+        // Not required yet since transactions are not supported as nested queries.
         it.todo('coalesces multiple requests for the same transaction into one');
     });
 });

--- a/packages/rpc-graphql/src/context.ts
+++ b/packages/rpc-graphql/src/context.ts
@@ -4,7 +4,7 @@ import { createGraphQLCache, GraphQLCache } from './cache';
 import { createAccountLoader } from './loaders/account';
 import { createBlockLoader } from './loaders/block';
 import { loadProgramAccounts } from './loaders/program-accounts';
-import { loadTransaction } from './loaders/transaction';
+import { createTransactionLoader } from './loaders/transaction';
 import { createRpcGraphQL } from './rpc';
 import { AccountQueryArgs } from './schema/account';
 import { BlockQueryArgs } from './schema/block';
@@ -12,34 +12,42 @@ import { ProgramAccountsQueryArgs } from './schema/program-accounts';
 import { TransactionQueryArgs } from './schema/transaction';
 
 export type Rpc = Parameters<typeof createRpcGraphQL>[0];
+
 type Loader<TArgs> = {
     load: (args: TArgs, info?: GraphQLResolveInfo | undefined) => Promise<unknown>;
+};
+type Loaders = {
+    account: Loader<AccountQueryArgs>;
+    block: Loader<BlockQueryArgs>;
+    transaction: Loader<TransactionQueryArgs>;
 };
 
 export interface RpcGraphQLContext {
     cache: GraphQLCache;
-    accountLoader: Loader<AccountQueryArgs>;
-    blockLoader: Loader<BlockQueryArgs>;
     loadProgramAccounts(
         args: ProgramAccountsQueryArgs,
         info?: GraphQLResolveInfo
     ): ReturnType<typeof loadProgramAccounts>;
-    loadTransaction(args: TransactionQueryArgs, info?: GraphQLResolveInfo): ReturnType<typeof loadTransaction>;
+    loaders: Loaders;
     rpc: Rpc;
+}
+
+function createRpcGraphQLLoaders(rpc: Rpc): Loaders {
+    return {
+        account: createAccountLoader(rpc),
+        block: createBlockLoader(rpc),
+        transaction: createTransactionLoader(rpc),
+    };
 }
 
 export function createSolanaGraphQLContext(rpc: Rpc): RpcGraphQLContext {
     const cache = createGraphQLCache();
     return {
-        accountLoader: createAccountLoader(rpc),
-        blockLoader: createBlockLoader(rpc),
         cache,
         loadProgramAccounts(args, info?) {
             return loadProgramAccounts(args, this.cache, this.rpc, info);
         },
-        loadTransaction(args, info?) {
-            return loadTransaction(args, this.cache, this.rpc, info);
-        },
+        loaders: createRpcGraphQLLoaders(rpc),
         rpc,
     };
 }

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -11,5 +11,5 @@ export const resolveAccount = (fieldName: string) => {
         context: RpcGraphQLContext,
         info: GraphQLResolveInfo | undefined
     ) =>
-        parent[fieldName] === null ? null : context.accountLoader.load({ ...args, address: parent[fieldName] }, info);
+        parent[fieldName] === null ? null : context.loaders.account.load({ ...args, address: parent[fieldName] }, info);
 };

--- a/packages/rpc-graphql/src/resolvers/block.ts
+++ b/packages/rpc-graphql/src/resolvers/block.ts
@@ -10,5 +10,5 @@ export const resolveBlock = (fieldName: string) => {
         args: BlockQueryArgs,
         context: RpcGraphQLContext,
         info: GraphQLResolveInfo | undefined
-    ) => (parent[fieldName] === null ? null : context.blockLoader.load({ ...args, slot: parent[fieldName] }, info));
+    ) => (parent[fieldName] === null ? null : context.loaders.block.load({ ...args, slot: parent[fieldName] }, info));
 };

--- a/packages/rpc-graphql/src/schema/index.ts
+++ b/packages/rpc-graphql/src/schema/index.ts
@@ -56,7 +56,7 @@ const schemaResolvers = {
             context: RpcGraphQLContext,
             info?: GraphQLResolveInfo
         ) {
-            return context.accountLoader.load(args, info);
+            return context.loaders.account.load(args, info);
         },
         block(
             _: unknown,
@@ -64,7 +64,7 @@ const schemaResolvers = {
             context: RpcGraphQLContext,
             info?: GraphQLResolveInfo
         ) {
-            return context.blockLoader.load(args, info);
+            return context.loaders.block.load(args, info);
         },
         programAccounts(
             _: unknown,
@@ -80,7 +80,7 @@ const schemaResolvers = {
             context: RpcGraphQLContext,
             info?: GraphQLResolveInfo
         ) {
-            return context.loadTransaction(args, info);
+            return context.loaders.transaction.load(args, info);
         },
     },
 };


### PR DESCRIPTION
This PR replaces the transaction loader's use of the custom cache in favor of a
`DataLoader` setup.
