### PR TITLE
refactor(experimental): add NoopSigners

### DIFF
--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -336,25 +336,37 @@ assertIsKeyPairSigner({ address: address('1234..5678') }); // ❌ Throws an erro
 
 ## Creating Noop signers
 
-### Functions
-
-#### `createNoopSigner()`
-
-_Coming soon..._
-
-Creates a Noop (No-Operation) signer from a given address. It will return an implementation of both the `MessagePartialSigner` and `TransactionPartialSigner` interfaces that do not sign anything. Namely, signing a transaction or a message will return an empty `SignatureDictionary`.
+For a given address, a Noop (No-Operation) signer can be created to offer an implementation of both the `MessagePartialSigner` and `TransactionPartialSigner` interfaces such that they do not sign anything. Namely, signing a transaction or a message with a `NoopSigner` will return an empty `SignatureDictionary`.
 
 This signer may be useful:
 
 -   For testing purposes.
 -   For indicating that a given account is a signer and taking the responsibility to provide the signature for that account ourselves. For instance, if we need to send the transaction to a server that will sign it and send it for us.
 
+### Types
+
+#### `NoopSigner<TAddress>`
+
+Defines a Noop (No-Operation) signer.
+
+```ts
+const myNoopSigner: NoopSigner;
+myNoopSigner satisfies MessagePartialSigner;
+myNoopSigner satisfies TransactionPartialSigner;
+```
+
+### Functions
+
+#### `createNoopSigner()`
+
+Creates a Noop (No-Operation) signer from a given address.
+
 ```ts
 import { createNoopSigner } from '@solana/signers';
 
-const myAddress = address('1234..5678');
-const myNoopSigner = createNoopSigner(myAddress);
-// ^ MessagePartialSigner<'1234..5678'> & TransactionPartialSigner<'1234..5678'>
+const myNoopSigner = createNoopSigner(address('1234..5678'));
+const [myMessageSignatures] = await myNoopSigner.signMessages([myMessage]); // <- Empty signature dictionary.
+const [myTransactionSignatures] = await myNoopSigner.signTransactions([myTransaction]); // <- Empty signature dictionary.
 ```
 
 ## Storing transaction signers inside instruction account metas

--- a/packages/signers/src/__tests__/noop-signer-test.ts
+++ b/packages/signers/src/__tests__/noop-signer-test.ts
@@ -1,0 +1,66 @@
+import 'test-matchers/toBeFrozenObject';
+
+import { address } from '@solana/addresses';
+import { CompilableTransaction } from '@solana/transactions';
+
+import { createNoopSigner, NoopSigner } from '../noop-signer';
+import { createSignableMessage } from '../signable-message';
+
+describe('createNoopSigner', () => {
+    it('creates a NoopSigner from a given address', () => {
+        // Given a base58 encoded address.
+        const myAddress = address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
+
+        // When we create a NoopSigner from that address.
+        const mySigner = createNoopSigner(myAddress);
+        mySigner satisfies NoopSigner;
+
+        // Then the created signer kept track of the address.
+        expect(mySigner.address).toBe(myAddress);
+
+        // And provided functions to sign messages and transactions.
+        expect(typeof mySigner.signMessages).toBe('function');
+        expect(typeof mySigner.signTransactions).toBe('function');
+    });
+
+    it('freezes the created signer', () => {
+        const mySigner = createNoopSigner(address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'));
+        expect(mySigner).toBeFrozenObject();
+    });
+
+    it('returns an empty signature directory when signing messages', async () => {
+        expect.assertions(4);
+
+        // Given a NoopSigner.
+        const mySigner = createNoopSigner(address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'));
+
+        // When we sign two messages using that signer.
+        const messages = [createSignableMessage('hello'), createSignableMessage('world')];
+        const signatureDictionaries = await mySigner.signMessages(messages);
+
+        // Then the signature directories are empty and frozen.
+        expect(signatureDictionaries[0]).toStrictEqual({});
+        expect(signatureDictionaries[1]).toStrictEqual({});
+        expect(signatureDictionaries[0]).toBeFrozenObject();
+        expect(signatureDictionaries[1]).toBeFrozenObject();
+    });
+
+    it('returns an empty signature directory when signing transactions', async () => {
+        expect.assertions(4);
+
+        // Given a NoopSigner.
+        const mySigner = createNoopSigner(address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'));
+
+        // And given we have a couple of mock transactions to sign.
+        const mockTransactions = [{} as CompilableTransaction, {} as CompilableTransaction];
+
+        // When we sign both transactions using that signer.
+        const signatureDictionaries = await mySigner.signTransactions(mockTransactions);
+
+        // Then the signature directories are empty and frozen.
+        expect(signatureDictionaries[0]).toStrictEqual({});
+        expect(signatureDictionaries[1]).toStrictEqual({});
+        expect(signatureDictionaries[0]).toBeFrozenObject();
+        expect(signatureDictionaries[1]).toBeFrozenObject();
+    });
+});

--- a/packages/signers/src/index.ts
+++ b/packages/signers/src/index.ts
@@ -3,6 +3,7 @@ export * from './keypair-signer';
 export * from './message-modifying-signer';
 export * from './message-partial-signer';
 export * from './message-signer';
+export * from './noop-signer';
 export * from './sign-transaction';
 export * from './signable-message';
 export * from './transaction-modifying-signer';

--- a/packages/signers/src/noop-signer.ts
+++ b/packages/signers/src/noop-signer.ts
@@ -1,0 +1,19 @@
+import { Address } from '@solana/addresses';
+
+import { MessagePartialSigner } from './message-partial-signer';
+import { TransactionPartialSigner } from './transaction-partial-signer';
+
+/** Defines a no-operation signer that pretends to partially sign messages and transactions. */
+export type NoopSigner<TAddress extends string = string> = MessagePartialSigner<TAddress> &
+    TransactionPartialSigner<TAddress>;
+
+/** Creates a NoopSigner from the provided Address. */
+export function createNoopSigner(address: Address): NoopSigner {
+    const out: NoopSigner = {
+        address,
+        signMessages: async messages => messages.map(() => Object.freeze({})),
+        signTransactions: async transactions => transactions.map(() => Object.freeze({})),
+    };
+
+    return Object.freeze(out);
+}


### PR DESCRIPTION
This PR provides a `NoopSigner` implementation of the `TransactionPartialSigner` and `MessagePartialSigner` interfaces.

See the following section of the updated documentation for more details.

---

## Creating Noop signers

For a given address, a Noop (No-Operation) signer can be created to offer an implementation of both the `MessagePartialSigner` and `TransactionPartialSigner` interfaces such that they do not sign anything. Namely, signing a transaction or a message with a `NoopSigner` will return an empty `SignatureDictionary`.

This signer may be useful:

- For testing purposes.
- For indicating that a given account is a signer and taking the responsibility to provide the signature for that account ourselves. For instance, if we need to send the transaction to a server that will sign it and send it for us.

### Types

#### `NoopSigner<TAddress>`

Defines a Noop (No-Operation) signer.

```ts
const myNoopSigner: NoopSigner;
myNoopSigner satisfies MessagePartialSigner;
myNoopSigner satisfies TransactionPartialSigner;
```

### Functions

#### `createNoopSigner()`

Creates a Noop (No-Operation) signer from a given address.

```ts
import { createNoopSigner } from "@solana/signers";

const myNoopSigner = createNoopSigner(address("1234..5678"));
const [myMessageSignatures] = await myNoopSigner.signMessages([myMessage]); // <- Empty signature dictionary.
const [myTransactionSignatures] = await myNoopSigner.signTransactions([myTransaction]); // <- Empty signature dictionary.
```
