### PR TITLE
refactor(experimental): make RPC methods extend `IRpcApiMethods`

### DIFF
--- a/packages/rpc-core/src/rpc-methods/getAccountInfo.ts
+++ b/packages/rpc-core/src/rpc-methods/getAccountInfo.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import {
@@ -31,7 +32,7 @@ type GetAccountInfoApiSliceableCommonConfig = Readonly<{
     dataSlice?: DataSlice;
 }>;
 
-export interface GetAccountInfoApi {
+export interface GetAccountInfoApi extends IRpcApiMethods {
     /**
      * Returns all information associated with the account of provided public key
      */

--- a/packages/rpc-core/src/rpc-methods/getBalance.ts
+++ b/packages/rpc-core/src/rpc-methods/getBalance.ts
@@ -1,11 +1,12 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import { RpcResponse, Slot } from './common';
 
 type GetBalanceApiResponse = RpcResponse<LamportsUnsafeBeyond2Pow53Minus1>;
 
-export interface GetBalanceApi {
+export interface GetBalanceApi extends IRpcApiMethods {
     /**
      * Returns the balance of the account of provided Pubkey
      */

--- a/packages/rpc-core/src/rpc-methods/getBlock.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlock.ts
@@ -1,3 +1,4 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, UnixTimestamp } from '@solana/rpc-types';
 import { Blockhash, TransactionVersion } from '@solana/transactions';
 
@@ -58,7 +59,7 @@ type GetBlockEncoding = 'base58' | 'base64' | 'json' | 'jsonParsed';
 // - These rules apply to both "accounts" and "full" transaction details.
 type GetBlockMaxSupportedTransactionVersion = Exclude<TransactionVersion, 'legacy'>;
 
-export interface GetBlockApi {
+export interface GetBlockApi extends IRpcApiMethods {
     /**
      * Returns identity and transaction information about a confirmed block in the ledger
      */

--- a/packages/rpc-core/src/rpc-methods/getBlockCommitment.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockCommitment.ts
@@ -1,3 +1,4 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import { Slot } from './common';
@@ -7,7 +8,7 @@ type GetBlockCommitmentApiResponse = Readonly<{
     totalStake: LamportsUnsafeBeyond2Pow53Minus1;
 }>;
 
-export interface GetBlockCommitmentApi {
+export interface GetBlockCommitmentApi extends IRpcApiMethods {
     /**
      * Returns the amount of cluster stake in lamports that has voted on
      * a particular block, as well as the stake attributed to each vote account

--- a/packages/rpc-core/src/rpc-methods/getBlockHeight.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockHeight.ts
@@ -1,10 +1,11 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type GetBlockHeightApiResponse = U64UnsafeBeyond2Pow53Minus1;
 
-export interface GetBlockHeightApi {
+export interface GetBlockHeightApi extends IRpcApiMethods {
     /**
      * Returns the current block height of the node
      */

--- a/packages/rpc-core/src/rpc-methods/getBlockProduction.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockProduction.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
@@ -32,7 +33,7 @@ type GetBlockProductionApiResponseWithSingleIdentity<TIdentity extends string> =
     }>;
 }>;
 
-export interface GetBlockProductionApi {
+export interface GetBlockProductionApi extends IRpcApiMethods {
     /**
      * Returns recent block production information from the current or previous epoch.
      */

--- a/packages/rpc-core/src/rpc-methods/getBlockTime.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockTime.ts
@@ -1,3 +1,4 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { UnixTimestamp } from '@solana/rpc-types';
 
 import { Slot } from './common';
@@ -5,7 +6,7 @@ import { Slot } from './common';
 /** Estimated production time, as Unix timestamp (seconds since the Unix epoch) */
 type GetBlockTimeApiResponse = UnixTimestamp;
 
-export interface GetBlockTimeApi {
+export interface GetBlockTimeApi extends IRpcApiMethods {
     /**
      * Returns the estimated production time of a block.
      */

--- a/packages/rpc-core/src/rpc-methods/getBlocks.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlocks.ts
@@ -1,10 +1,11 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot } from './common';
 
 type GetBlocksApiResponse = Slot[];
 
-export interface GetBlocksApi {
+export interface GetBlocksApi extends IRpcApiMethods {
     /**
      * Returns a list of confirmed blocks between two slots
      */

--- a/packages/rpc-core/src/rpc-methods/getBlocksWithLimit.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlocksWithLimit.ts
@@ -1,10 +1,11 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot } from './common';
 
 type GetBlocksWithLimitApiResponse = Slot[];
 
-export interface GetBlocksWithLimitApi {
+export interface GetBlocksWithLimitApi extends IRpcApiMethods {
     /**
      * Returns a list of confirmed blocks starting at the given slot
      * for up to `limit` blocks

--- a/packages/rpc-core/src/rpc-methods/getClusterNodes.ts
+++ b/packages/rpc-core/src/rpc-methods/getClusterNodes.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 
 type GetClusterNodesNode = Readonly<{
     /** The unique identifier of the node's feature set */
@@ -25,7 +26,7 @@ type GetClusterNodesNode = Readonly<{
 
 type GetClusterNodesApiResponse = readonly GetClusterNodesNode[];
 
-export interface GetClusterNodesApi {
+export interface GetClusterNodesApi extends IRpcApiMethods {
     /**
      * Returns information about all the nodes participating in the cluster
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389

--- a/packages/rpc-core/src/rpc-methods/getEpochInfo.ts
+++ b/packages/rpc-core/src/rpc-methods/getEpochInfo.ts
@@ -1,3 +1,4 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
@@ -17,7 +18,7 @@ type GetEpochInfoApiResponse = Readonly<{
     transactionCount: U64UnsafeBeyond2Pow53Minus1 | null;
 }>;
 
-export interface GetEpochInfoApi {
+export interface GetEpochInfoApi extends IRpcApiMethods {
     /**
      * Returns the balance of the account of provided Pubkey
      */

--- a/packages/rpc-core/src/rpc-methods/getEpochSchedule.ts
+++ b/packages/rpc-core/src/rpc-methods/getEpochSchedule.ts
@@ -1,3 +1,5 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 import { U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type GetEpochScheduleApiResponse = Readonly<{
@@ -13,7 +15,7 @@ type GetEpochScheduleApiResponse = Readonly<{
     firstNormalSlot: U64UnsafeBeyond2Pow53Minus1;
 }>;
 
-export interface GetEpochScheduleApi {
+export interface GetEpochScheduleApi extends IRpcApiMethods {
     /**
      * Returns the epoch schedule information from this cluster's genesis config
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389

--- a/packages/rpc-core/src/rpc-methods/getFeeForMessage.ts
+++ b/packages/rpc-core/src/rpc-methods/getFeeForMessage.ts
@@ -1,3 +1,4 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import { SerializedMessageBytesBase64 } from '@solana/transactions';
 
@@ -6,7 +7,7 @@ import { RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 /** Fee corresponding to the message at the specified blockhash */
 type GetFeeForMessageApiResponse = RpcResponse<U64UnsafeBeyond2Pow53Minus1 | null>;
 
-export interface GetFeeForMessageApi {
+export interface GetFeeForMessageApi extends IRpcApiMethods {
     /**
      * Returns the fee the network will charge for a particular Message
      */

--- a/packages/rpc-core/src/rpc-methods/getFirstAvailableBlock.ts
+++ b/packages/rpc-core/src/rpc-methods/getFirstAvailableBlock.ts
@@ -1,8 +1,10 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 import { Slot } from './common';
 
 type GetFirstAvailableBlockApiResponse = Slot;
 
-export interface GetFirstAvailableBlockApi {
+export interface GetFirstAvailableBlockApi extends IRpcApiMethods {
     /**
      * Returns the slot of the lowest confirmed block that has not been purged from the ledger
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389

--- a/packages/rpc-core/src/rpc-methods/getGenesisHash.ts
+++ b/packages/rpc-core/src/rpc-methods/getGenesisHash.ts
@@ -1,8 +1,9 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Blockhash } from '@solana/transactions';
 
 type GetGenesisHashApiResponse = Blockhash;
 
-export interface GetGenesisHashApi {
+export interface GetGenesisHashApi extends IRpcApiMethods {
     /**
      * Returns the genesis hash
      */

--- a/packages/rpc-core/src/rpc-methods/getHealth.ts
+++ b/packages/rpc-core/src/rpc-methods/getHealth.ts
@@ -1,6 +1,8 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 type GetHealthApiResponse = 'ok';
 
-export interface GetHealthApi {
+export interface GetHealthApi extends IRpcApiMethods {
     /**
      * Returns the health status of the node ("ok" if healthy).
      */

--- a/packages/rpc-core/src/rpc-methods/getHighestSnapshotSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getHighestSnapshotSlot.ts
@@ -1,3 +1,5 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 import { Slot } from './common';
 
 type GetHighestSnapshotSlotApiResponse = Readonly<{
@@ -5,7 +7,7 @@ type GetHighestSnapshotSlotApiResponse = Readonly<{
     incremental: Slot | null;
 }>;
 
-export interface GetHighestSnapshotSlotApi {
+export interface GetHighestSnapshotSlotApi extends IRpcApiMethods {
     /**
      * Returns the highest slot information that the node has snapshots for.
      *

--- a/packages/rpc-core/src/rpc-methods/getIdentity.ts
+++ b/packages/rpc-core/src/rpc-methods/getIdentity.ts
@@ -1,10 +1,11 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 
 type GetIdentityApiResponse = Readonly<{
     identity: Address;
 }>;
 
-export interface GetIdentityApi {
+export interface GetIdentityApi extends IRpcApiMethods {
     /**
      * Returns the identity pubkey for the current node
      */

--- a/packages/rpc-core/src/rpc-methods/getInflationGovernor.ts
+++ b/packages/rpc-core/src/rpc-methods/getInflationGovernor.ts
@@ -1,3 +1,4 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { F64UnsafeSeeDocumentation } from './common';
@@ -19,7 +20,7 @@ type GetInflationGovernorApiResponse = Readonly<{
     terminal: F64UnsafeSeeDocumentation;
 }>;
 
-export interface GetInflationGovernorApi {
+export interface GetInflationGovernorApi extends IRpcApiMethods {
     /**
      * Returns the current inflation governor
      */

--- a/packages/rpc-core/src/rpc-methods/getInflationRate.ts
+++ b/packages/rpc-core/src/rpc-methods/getInflationRate.ts
@@ -1,3 +1,5 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 import { F64UnsafeSeeDocumentation, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type GetInflationRateApiResponse = Readonly<{
@@ -11,7 +13,7 @@ type GetInflationRateApiResponse = Readonly<{
     validator: F64UnsafeSeeDocumentation;
 }>;
 
-export interface GetInflationRateApi {
+export interface GetInflationRateApi extends IRpcApiMethods {
     /**
      * Returns the current block height of the node
      */

--- a/packages/rpc-core/src/rpc-methods/getInflationReward.ts
+++ b/packages/rpc-core/src/rpc-methods/getInflationReward.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
@@ -16,7 +17,7 @@ type GetInflationRewardApiResponse = Readonly<{
     postBalance: LamportsUnsafeBeyond2Pow53Minus1;
 }>;
 
-export interface GetInflationRewardApi {
+export interface GetInflationRewardApi extends IRpcApiMethods {
     /**
      * Returns the current block height of the node
      */

--- a/packages/rpc-core/src/rpc-methods/getLargestAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getLargestAccounts.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import { RpcResponse } from './common';
@@ -12,7 +13,7 @@ type GetLargestAccountsResponseItem = Readonly<{
 
 type GetLargestAccountsApiResponse = RpcResponse<GetLargestAccountsResponseItem[]>;
 
-export interface GetLargestAccountsApi {
+export interface GetLargestAccountsApi extends IRpcApiMethods {
     /**
      * Returns the 20 largest accounts, by lamport balance
      * (results may be cached up to two hours)

--- a/packages/rpc-core/src/rpc-methods/getLatestBlockhash.ts
+++ b/packages/rpc-core/src/rpc-methods/getLatestBlockhash.ts
@@ -1,3 +1,4 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import { Blockhash } from '@solana/transactions';
 
@@ -10,7 +11,7 @@ type GetLatestBlockhashApiResponse = RpcResponse<{
     lastValidBlockHeight: U64UnsafeBeyond2Pow53Minus1;
 }>;
 
-export interface GetLatestBlockhashApi {
+export interface GetLatestBlockhashApi extends IRpcApiMethods {
     /**
      * Returns the latest blockhash
      */

--- a/packages/rpc-core/src/rpc-methods/getLeaderSchedule.ts
+++ b/packages/rpc-core/src/rpc-methods/getLeaderSchedule.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot } from './common';
@@ -23,7 +24,7 @@ type GetLeaderScheduleApiResponseBase = Readonly<{
     [key: Address]: Slot[];
 }>;
 
-export interface GetLeaderScheduleApi {
+export interface GetLeaderScheduleApi extends IRpcApiMethods {
     /**
      * Fetch the leader schedule for the epoch that corresponds to the provided slot.
      * If unspecified, the leader schedule for the current epoch is fetched

--- a/packages/rpc-core/src/rpc-methods/getMaxRetransmitSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getMaxRetransmitSlot.ts
@@ -1,8 +1,10 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 import { Slot } from './common';
 
 type GetMaxRetransmitSlotApiResponse = Slot;
 
-export interface GetMaxRetransmitSlotApi {
+export interface GetMaxRetransmitSlotApi extends IRpcApiMethods {
     /**
      * Get the max slot seen from retransmit stage.
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389

--- a/packages/rpc-core/src/rpc-methods/getMaxShredInsertSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getMaxShredInsertSlot.ts
@@ -1,8 +1,10 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 import { Slot } from './common';
 
 type GetMaxShredInsertSlotApiResponse = Slot;
 
-export interface GetMaxShredInsertSlotApi {
+export interface GetMaxShredInsertSlotApi extends IRpcApiMethods {
     /**
      * Get the max slot seen from after shred insert.
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389

--- a/packages/rpc-core/src/rpc-methods/getMinimumBalanceForRentExemption.ts
+++ b/packages/rpc-core/src/rpc-methods/getMinimumBalanceForRentExemption.ts
@@ -1,10 +1,11 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import { U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type GetMinimumBalanceForRentExemptionApiResponse = LamportsUnsafeBeyond2Pow53Minus1;
 
-export interface GetMinimumBalanceForRentExemptionApi {
+export interface GetMinimumBalanceForRentExemptionApi extends IRpcApiMethods {
     /**
      * Returns the minimum balance to exempt an account of a certain size from rent
      */

--- a/packages/rpc-core/src/rpc-methods/getMultipleAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getMultipleAccounts.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import {
@@ -26,7 +27,7 @@ type GetMultipleAccountsApiSliceableCommonConfig = Readonly<{
     dataSlice?: DataSlice;
 }>;
 
-export interface GetMultipleAccountsApi {
+export interface GetMultipleAccountsApi extends IRpcApiMethods {
     /**
      * Returns the account information for a list of Pubkeys.
      */

--- a/packages/rpc-core/src/rpc-methods/getProgramAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getProgramAccounts.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import {
@@ -29,7 +30,7 @@ type GetProgramAccountsApiSliceableCommonConfig = Readonly<{
     /** Limit the returned account data */
     dataSlice?: DataSlice;
 }>;
-export interface GetProgramAccountsApi {
+export interface GetProgramAccountsApi extends IRpcApiMethods {
     /**
      * Returns the account information for a list of Pubkeys.
      */

--- a/packages/rpc-core/src/rpc-methods/getRecentPerformanceSamples.ts
+++ b/packages/rpc-core/src/rpc-methods/getRecentPerformanceSamples.ts
@@ -1,3 +1,5 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type PerformanceSample = Readonly<{
@@ -15,7 +17,7 @@ type PerformanceSample = Readonly<{
 
 type GetRecentPerformanceSamplesApiResponse = readonly PerformanceSample[];
 
-export interface GetRecentPerformanceSamplesApi {
+export interface GetRecentPerformanceSamplesApi extends IRpcApiMethods {
     /**
      * Returns a list of recent performance samples, in reverse slot order. Performance samples are taken every 60 seconds and include the number of transactions and slots that occur in a given time window.
      */

--- a/packages/rpc-core/src/rpc-methods/getRecentPrioritizationFees.ts
+++ b/packages/rpc-core/src/rpc-methods/getRecentPrioritizationFees.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 
 import { MicroLamportsUnsafeBeyond2Pow53Minus1, Slot } from './common';
 
@@ -13,7 +14,7 @@ type GetRecentPrioritizationFeesApiResponse = Readonly<{
     slot: Slot;
 }>[];
 
-export interface GetRecentPrioritizationFeesApi {
+export interface GetRecentPrioritizationFeesApi extends IRpcApiMethods {
     /**
      * Returns the balance of the account of provided Pubkey
      */

--- a/packages/rpc-core/src/rpc-methods/getSignatureStatuses.ts
+++ b/packages/rpc-core/src/rpc-methods/getSignatureStatuses.ts
@@ -1,4 +1,5 @@
 import { Signature } from '@solana/keys';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { TransactionError } from '../transaction-error';
@@ -39,7 +40,7 @@ type GetSignatureStatusesBase = ReadonlyArray<SignatureStatusResult | null>;
 
 type GetSignatureStatusesApiResponse = RpcResponse<GetSignatureStatusesBase>;
 
-export interface GetSignatureStatusesApi {
+export interface GetSignatureStatusesApi extends IRpcApiMethods {
     /**
      * Returns the statuses of a list of signatures.
      * Each signature must be a txid, the first signature of a transaction.

--- a/packages/rpc-core/src/rpc-methods/getSignaturesForAddress.ts
+++ b/packages/rpc-core/src/rpc-methods/getSignaturesForAddress.ts
@@ -1,5 +1,6 @@
 import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, UnixTimestamp } from '@solana/rpc-types';
 
 import { TransactionError } from '../transaction-error';
@@ -36,7 +37,7 @@ type GetSignaturesForAddressConfig = Readonly<{
     until?: Signature;
 }>;
 
-export interface GetSignaturesForAddressApi {
+export interface GetSignaturesForAddressApi extends IRpcApiMethods {
     /**
      * Returns signatures for confirmed transactions that include the given address in their accountKeys list.
      * Returns signatures backwards in time from the provided signature or most recent confirmed block

--- a/packages/rpc-core/src/rpc-methods/getSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getSlot.ts
@@ -1,10 +1,11 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot } from './common';
 
 type GetSlotApiResponse = Slot;
 
-export interface GetSlotApi {
+export interface GetSlotApi extends IRpcApiMethods {
     /**
      * Returns the slot that has reached the given or default commitment level
      */

--- a/packages/rpc-core/src/rpc-methods/getSlotLeader.ts
+++ b/packages/rpc-core/src/rpc-methods/getSlotLeader.ts
@@ -1,9 +1,10 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot } from './common';
 
-export interface GetSlotLeaderApi {
+export interface GetSlotLeaderApi extends IRpcApiMethods {
     /**
      * Returns the current slot leader
      */

--- a/packages/rpc-core/src/rpc-methods/getSlotLeaders.ts
+++ b/packages/rpc-core/src/rpc-methods/getSlotLeaders.ts
@@ -1,11 +1,12 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 
 import { Slot } from './common';
 
 /** array of Node identity public keys as base-58 encoded strings */
 type GetSlotLeadersApiResponse = Address[];
 
-export interface GetSlotLeadersApi {
+export interface GetSlotLeadersApi extends IRpcApiMethods {
     /**
      * Returns the slot leaders for a given slot range
      */

--- a/packages/rpc-core/src/rpc-methods/getStakeActivation.ts
+++ b/packages/rpc-core/src/rpc-methods/getStakeActivation.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
@@ -12,7 +13,7 @@ type GetStakeActivationApiResponse = Readonly<{
     state: 'active' | 'inactive' | 'activating' | 'deactivating';
 }>;
 
-export interface GetStakeActivationApi {
+export interface GetStakeActivationApi extends IRpcApiMethods {
     /**
      * Returns epoch activation information for a stake account
      */

--- a/packages/rpc-core/src/rpc-methods/getStakeMinimumDelegation.ts
+++ b/packages/rpc-core/src/rpc-methods/getStakeMinimumDelegation.ts
@@ -1,10 +1,11 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import { RpcResponse } from './common';
 
 type GetStakeMinimumDelegationApiResponse = RpcResponse<LamportsUnsafeBeyond2Pow53Minus1>;
 
-export interface GetStakeMinimumDelegationApi {
+export interface GetStakeMinimumDelegationApi extends IRpcApiMethods {
     /**
      * Returns the stake minimum delegation, in lamports.
      */

--- a/packages/rpc-core/src/rpc-methods/getSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getSupply.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import { RpcResponse } from './common';
@@ -32,7 +33,7 @@ type GetSupplyApiResponseWithoutNonCirculatingAccounts = GetSupplyApiResponseBas
         }>;
     }>;
 
-export interface GetSupplyApi {
+export interface GetSupplyApi extends IRpcApiMethods {
     /**
      * Returns information about the current supply.
      */

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountBalance.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountBalance.ts
@@ -1,11 +1,12 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { RpcResponse, TokenAmount } from './common';
 
 type GetTokenAccountBalanceApiResponse = RpcResponse<TokenAmount>;
 
-export interface GetTokenAccountBalanceApi {
+export interface GetTokenAccountBalanceApi extends IRpcApiMethods {
     /**
      * Returns the token balance of an SPL Token account
      */

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountsByDelegate.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountsByDelegate.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import {
@@ -50,7 +51,7 @@ type GetTokenAccountsByDelegateApiSliceableCommonConfig = Readonly<{
     /** Limit the returned account data */
     dataSlice?: DataSlice;
 }>;
-export interface GetTokenAccountsByDelegateApi {
+export interface GetTokenAccountsByDelegateApi extends IRpcApiMethods {
     /**
      * Returns all SPL Token accounts by approved Delegate.
      */

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountsByOwner.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountsByOwner.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import {
@@ -50,7 +51,7 @@ type GetTokenAccountsByOwnerApiSliceableCommonConfig = Readonly<{
     /** Limit the returned account data */
     dataSlice?: DataSlice;
 }>;
-export interface GetTokenAccountsByOwnerApi {
+export interface GetTokenAccountsByOwnerApi extends IRpcApiMethods {
     /**
      * Returns all SPL Token accounts by token owner.
      */

--- a/packages/rpc-core/src/rpc-methods/getTokenLargestAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenLargestAccounts.ts
@@ -1,11 +1,12 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { RpcResponse, TokenAmount } from './common';
 
 type GetTokenLargestAccountsApiResponse = RpcResponse<TokenAmount & { address: Address }[]>;
 
-export interface GetTokenLargestAccountsApi {
+export interface GetTokenLargestAccountsApi extends IRpcApiMethods {
     /**
      * Returns the 20 largest accounts of a particular SPL Token type.
      */

--- a/packages/rpc-core/src/rpc-methods/getTokenSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenSupply.ts
@@ -1,11 +1,12 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { RpcResponse, TokenAmount } from './common';
 
 type GetTokenSupplyApiResponse = RpcResponse<TokenAmount>;
 
-export interface GetTokenSupplyApi {
+export interface GetTokenSupplyApi extends IRpcApiMethods {
     /**
      * Returns the total supply of an SPL Token mint
      */

--- a/packages/rpc-core/src/rpc-methods/getTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/getTransaction.ts
@@ -1,5 +1,6 @@
 import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, UnixTimestamp } from '@solana/rpc-types';
 import { Blockhash, TransactionVersion } from '@solana/transactions';
 
@@ -154,7 +155,7 @@ type TransactionAddressTableLookups = Readonly<{
     }>;
 }>;
 
-export interface GetTransactionApi {
+export interface GetTransactionApi extends IRpcApiMethods {
     /**
      * Returns transaction details for a confirmed transaction
      */

--- a/packages/rpc-core/src/rpc-methods/getTransactionCount.ts
+++ b/packages/rpc-core/src/rpc-methods/getTransactionCount.ts
@@ -1,10 +1,11 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 type GetTransactionCountApiResponse = U64UnsafeBeyond2Pow53Minus1;
 
-export interface GetTransactionCountApi {
+export interface GetTransactionCountApi extends IRpcApiMethods {
     /**
      * Returns the current Transaction count from the ledger
      */

--- a/packages/rpc-core/src/rpc-methods/getVersion.ts
+++ b/packages/rpc-core/src/rpc-methods/getVersion.ts
@@ -1,3 +1,5 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 type GetVersionApiResponse = Readonly<{
     /** Unique identifier of the current software's feature set */
     'feature-set': number; // `u32`
@@ -5,7 +7,7 @@ type GetVersionApiResponse = Readonly<{
     'solana-core': string;
 }>;
 
-export interface GetVersionApi {
+export interface GetVersionApi extends IRpcApiMethods {
     /**
      * Returns the current Solana version running on the node
      */

--- a/packages/rpc-core/src/rpc-methods/getVoteAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getVoteAccounts.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
@@ -43,7 +44,7 @@ type GetVoteAccountsConfig<TVotePubkey extends Address> = Readonly<{
     delinquentSlotDistance?: U64UnsafeBeyond2Pow53Minus1;
 }>;
 
-export interface GetVoteAccountsApi {
+export interface GetVoteAccountsApi extends IRpcApiMethods {
     /** Returns the account info and associated stake for all the voting accounts in the current bank. */
     getVoteAccounts<TVoteAccount extends Address>(
         config?: GetVoteAccountsConfig<TVoteAccount>,

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -126,7 +126,7 @@ export function createSolanaRpcApi(config?: Config): IRpcApi<SolanaRpcMethods> {
             ...args: Parameters<NonNullable<ProxyHandler<IRpcApi<SolanaRpcMethods>>['get']>>
         ) {
             const [_, p] = args;
-            const methodName = p.toString() as keyof SolanaRpcMethods;
+            const methodName = p.toString() as keyof SolanaRpcMethods as string;
             return function (
                 ...rawParams: Parameters<
                     SolanaRpcMethods[TMethodName] extends CallableFunction ? SolanaRpcMethods[TMethodName] : never

--- a/packages/rpc-core/src/rpc-methods/isBlockhashValid.ts
+++ b/packages/rpc-core/src/rpc-methods/isBlockhashValid.ts
@@ -1,3 +1,4 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import { Blockhash } from '@solana/transactions';
 
@@ -5,7 +6,7 @@ import { RpcResponse, Slot } from './common';
 
 type IsBlockhashValidApiResponse = RpcResponse<boolean>;
 
-export interface IsBlockhashValidApi {
+export interface IsBlockhashValidApi extends IRpcApiMethods {
     /**
      * Returns whether a blockhash is still valid or not
      */

--- a/packages/rpc-core/src/rpc-methods/minimumLedgerSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/minimumLedgerSlot.ts
@@ -1,8 +1,10 @@
+import type { IRpcApiMethods } from '@solana/rpc-transport';
+
 import { Slot } from './common';
 
 type MinimumLedgerSlotApiResponse = Slot;
 
-export interface MinimumLedgerSlotApi {
+export interface MinimumLedgerSlotApi extends IRpcApiMethods {
     /**
      * Returns the lowest slot that the node has information about in its ledger.
      * This value may increase over time if the node is configured to purge older ledger data.

--- a/packages/rpc-core/src/rpc-methods/requestAirdrop.ts
+++ b/packages/rpc-core/src/rpc-methods/requestAirdrop.ts
@@ -1,5 +1,6 @@
 import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type RequestAirdropConfig = Readonly<{
@@ -8,7 +9,7 @@ type RequestAirdropConfig = Readonly<{
 
 type RequestAirdropResponse = Signature;
 
-export interface RequestAirdropApi {
+export interface RequestAirdropApi extends IRpcApiMethods {
     /**
      * Requests an airdrop of lamports to a Pubkey
      */

--- a/packages/rpc-core/src/rpc-methods/sendTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/sendTransaction.ts
@@ -1,4 +1,5 @@
 import { Signature } from '@solana/keys';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import { Base64EncodedWireTransaction } from '@solana/transactions';
 
@@ -13,7 +14,7 @@ type SendTransactionConfig = Readonly<{
 
 type SendTransactionResponse = Signature;
 
-export interface SendTransactionApi {
+export interface SendTransactionApi extends IRpcApiMethods {
     /** @deprecated Set `encoding` to `'base64'` when calling this method */
     sendTransaction(
         base64EncodedWireTransaction: Base64EncodedWireTransaction,

--- a/packages/rpc-core/src/rpc-methods/simulateTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/simulateTransaction.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiMethods } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import { Base64EncodedWireTransaction } from '@solana/transactions';
 
@@ -95,7 +96,7 @@ type SimulateTransactionApiResponseWithAccounts<T extends AccountInfoBase> = Rpc
     accounts: (T | null)[];
 }>;
 
-export interface SimulateTransactionApi {
+export interface SimulateTransactionApi extends IRpcApiMethods {
     /** @deprecated Set `encoding` to `'base64'` when calling this method */
     simulateTransaction(
         base58EncodedWireTransaction: Base58EncodedBytes,

--- a/packages/rpc-transport/src/apis/api-types.ts
+++ b/packages/rpc-transport/src/apis/api-types.ts
@@ -1,0 +1,11 @@
+export type RpcApiConfig = Readonly<{
+    parametersTransformer?: <T>(params: T, methodName: string) => unknown[];
+    responseTransformer?: <T>(response: unknown, methodName: string) => T;
+}>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RpcMethod = (...args: any) => any;
+
+export interface IRpcApiMethods {
+    [methodName: string]: RpcMethod;
+}

--- a/packages/rpc-transport/src/index.ts
+++ b/packages/rpc-transport/src/index.ts
@@ -1,3 +1,4 @@
+export * from './apis/api-types';
 export * from './json-rpc';
 export type { SolanaJsonRpcErrorCode } from './json-rpc-errors';
 export * from './json-rpc-subscription';


### PR DESCRIPTION
This PR adds a type for `RpcApiMethods` and ensures all RPC methods defined in
`@solana/rpc-core` extend this type.

This relationship will allow use of these RPC method interfaces in our generic
`createJsonRpcApi(..)` function (next commit).
