### PR TITLE
refactor(experimental): make RPC subscription methods extend `IRpcSubscriptionsApiMethods`

### DIFF
--- a/packages/rpc-core/src/rpc-subscriptions/account-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/account-notifications.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiSubscriptions } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import {
@@ -15,7 +16,7 @@ type AccountNotificationsApiCommonConfig = Readonly<{
     commitment?: Commitment;
 }>;
 
-export interface AccountNotificationsApi {
+export interface AccountNotificationsApi extends IRpcApiSubscriptions {
     /**
      * Subscribe to an account to receive notifications when the lamports or data for
      * a given account public key changes.

--- a/packages/rpc-core/src/rpc-subscriptions/block-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/block-notifications.ts
@@ -1,3 +1,4 @@
+import type { IRpcApiSubscriptions } from '@solana/rpc-transport';
 import { Commitment, UnixTimestamp } from '@solana/rpc-types';
 import { Blockhash, TransactionVersion } from '@solana/transactions';
 
@@ -75,7 +76,7 @@ type BlockNotificationsEncoding = 'base58' | 'base64' | 'json' | 'jsonParsed';
 // - These rules apply to both "accounts" and "full" transaction details.
 type BlockNotificationsMaxSupportedTransactionVersion = Exclude<TransactionVersion, 'legacy'>;
 
-export interface BlockNotificationsApi {
+export interface BlockNotificationsApi extends IRpcApiSubscriptions {
     /**
      * Subscribe to receive notification anytime a new block is Confirmed or Finalized.
      *

--- a/packages/rpc-core/src/rpc-subscriptions/index.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/index.ts
@@ -47,7 +47,8 @@ export function createSolanaRpcSubscriptionsApi(
             >
         ) {
             const [_, p] = args;
-            const notificationName = p.toString() as keyof (SolanaRpcSubscriptions & SolanaRpcSubscriptionsUnstable);
+            const notificationName = p.toString() as keyof (SolanaRpcSubscriptions &
+                SolanaRpcSubscriptionsUnstable) as string;
             return function (
                 ...rawParams: Parameters<
                     (SolanaRpcSubscriptions &

--- a/packages/rpc-core/src/rpc-subscriptions/logs-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/logs-notifications.ts
@@ -1,5 +1,6 @@
 import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
+import type { IRpcApiSubscriptions } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { RpcResponse } from '../rpc-methods/common';
@@ -26,7 +27,7 @@ type LogsNotificationsApiConfig = Readonly<{
     commitment?: Commitment;
 }>;
 
-export interface LogsNotificationsApi {
+export interface LogsNotificationsApi extends IRpcApiSubscriptions {
     /**
      * Subscribe to a transaction logs to receive notification when a given transaction is committed.
      * On `logsNotification` - the subscription is automatically cancelled.

--- a/packages/rpc-core/src/rpc-subscriptions/program-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/program-notifications.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import type { IRpcApiSubscriptions } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import {
@@ -47,7 +48,7 @@ type ProgramNotificationsApiCommonConfig = Readonly<{
     )[];
 }>;
 
-export interface ProgramNotificationsApi {
+export interface ProgramNotificationsApi extends IRpcApiSubscriptions {
     /**
      * Subscribe to a program to receive notifications when the lamports or data for an account
      * owned by the given program changes

--- a/packages/rpc-core/src/rpc-subscriptions/root-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/root-notifications.ts
@@ -1,8 +1,10 @@
+import type { IRpcApiSubscriptions } from '@solana/rpc-transport';
+
 import { Slot } from '../rpc-methods/common';
 
 type RootNotificationsApiNotification = Slot;
 
-export interface RootNotificationsApi {
+export interface RootNotificationsApi extends IRpcApiSubscriptions {
     /**
      * Subscribe to receive notification anytime a new root is set by the validator
      */

--- a/packages/rpc-core/src/rpc-subscriptions/signature-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/signature-notifications.ts
@@ -1,4 +1,5 @@
 import { Signature } from '@solana/keys';
+import type { IRpcApiSubscriptions } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 
 import { RpcResponse } from '../rpc-methods/common';
@@ -17,7 +18,7 @@ type SignatureNotificationsApiConfigBase = Readonly<{
     commitment?: Commitment;
 }>;
 
-export interface SignatureNotificationsApi {
+export interface SignatureNotificationsApi extends IRpcApiSubscriptions {
     /**
      * Subscribe to a transaction signature to receive notification when a given transaction is committed.
      * On `signatureNotification` - the subscription is automatically cancelled.

--- a/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
@@ -1,3 +1,5 @@
+import type { IRpcApiSubscriptions } from '@solana/rpc-transport';
+
 import { Slot } from '../rpc-methods/common';
 
 type SlotNotificationsApiNotification = Readonly<{
@@ -6,7 +8,7 @@ type SlotNotificationsApiNotification = Readonly<{
     slot: Slot;
 }>;
 
-export interface SlotNotificationsApi {
+export interface SlotNotificationsApi extends IRpcApiSubscriptions {
     /**
      * Subscribe to receive notification anytime a slot is processed by the validator
      */

--- a/packages/rpc-transport/src/apis/api-types.ts
+++ b/packages/rpc-transport/src/apis/api-types.ts
@@ -1,3 +1,4 @@
+// RPC Methods
 export type RpcApiConfig = Readonly<{
     parametersTransformer?: <T>(params: T, methodName: string) => unknown[];
     responseTransformer?: <T>(response: unknown, methodName: string) => T;
@@ -8,4 +9,17 @@ type RpcMethod = (...args: any) => any;
 
 export interface IRpcApiMethods {
     [methodName: string]: RpcMethod;
+}
+
+// RPC Subscription Methods
+export type RpcSubscriptionsApiConfig = Readonly<{
+    parametersTransformer?: <T>(params: T, methodName: string) => unknown[];
+    responseTransformer?: <T>(response: unknown, methodName: string) => T;
+}>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RpcSubscription = (...args: any) => any;
+
+export interface IRpcApiSubscriptions {
+    [methodName: string]: RpcSubscription;
 }


### PR DESCRIPTION
This PR introduces a type for `IRpcSubscriptionsApi` and ensures all
subscriptions defined in `@solana/rpc-core` extend this type.

This will allow our subscription interfaces to be used in the generic
`createJsonRpcSubscriptionsApi(..)` (next commit).
