### PR TITLE
refactor(experimental): rename `*Processor` to `*Transformer`

### DIFF
--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -142,7 +142,7 @@ export function createSolanaRpcApi(config?: Config): IRpcApi<SolanaRpcMethods> {
                 return {
                     methodName,
                     params,
-                    responseProcessor: rawResponse => patchResponseForSolanaLabsRpc(rawResponse, methodName),
+                    responseTransformer: rawResponse => patchResponseForSolanaLabsRpc(rawResponse, methodName),
                 };
             };
         },

--- a/packages/rpc-core/src/rpc-subscriptions/index.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/index.ts
@@ -67,7 +67,7 @@ export function createSolanaRpcSubscriptionsApi(
                 );
                 return {
                     params,
-                    responseProcessor: rawResponse =>
+                    responseTransformer: rawResponse =>
                         patchResponseForSolanaLabsRpcSubscriptions(rawResponse, notificationName),
                     subscribeMethodName: notificationName.replace(/Notifications$/, 'Subscribe'),
                     unsubscribeMethodName: notificationName.replace(/Notifications$/, 'Unsubscribe'),

--- a/packages/rpc-transport/README.md
+++ b/packages/rpc-transport/README.md
@@ -55,7 +55,7 @@ const api = {
             // Pre-process the inputs any way you like.
             params: [assertIsInteger(startSlot), assertIsInteger(endSlot)],
             // Provide an optional function to modify the response.
-            responseProcessor: response => ({
+            responseTransformer: response => ({
                 confirmedBlocks: response,
                 queryRange: [startSlot, endSlot],
             }),

--- a/packages/rpc-transport/src/__tests__/json-rpc-subscription-test.ts
+++ b/packages/rpc-transport/src/__tests__/json-rpc-subscription-test.ts
@@ -300,16 +300,16 @@ describe('JSON-RPC 2.0 Subscriptions', () => {
         });
     });
     describe('when calling a method whose concrete implementation returns a response processor', () => {
-        let responseProcessor: jest.Mock;
+        let responseTransformer: jest.Mock;
         let rpc: RpcSubscriptions<TestRpcSubscriptionNotifications>;
         beforeEach(() => {
-            responseProcessor = jest.fn(response => `${response} processed response`);
+            responseTransformer = jest.fn(response => `${response} processed response`);
             rpc = createJsonSubscriptionRpc({
                 api: {
                     thingNotifications(...params: unknown[]): RpcSubscription<unknown> {
                         return {
                             params,
-                            responseProcessor,
+                            responseTransformer,
                             subscribeMethodName: 'thingSubscribe',
                             unsubscribeMethodName: 'thingUnsubscribe',
                         };
@@ -328,7 +328,7 @@ describe('JSON-RPC 2.0 Subscriptions', () => {
                 .thingNotifications()
                 .subscribe({ abortSignal: new AbortController().signal });
             await thingNotifications[Symbol.asyncIterator]().next();
-            expect(responseProcessor).toHaveBeenCalledWith(123);
+            expect(responseTransformer).toHaveBeenCalledWith(123);
         });
         it('returns the processed response', async () => {
             expect.assertions(1);

--- a/packages/rpc-transport/src/__tests__/json-rpc-test.ts
+++ b/packages/rpc-transport/src/__tests__/json-rpc-test.ts
@@ -76,28 +76,28 @@ describe('JSON-RPC 2.0', () => {
         });
     });
     describe('when calling a method whose concrete implementation returns a response processor', () => {
-        let responseProcessor: jest.Mock;
+        let responseTransformer: jest.Mock;
         let rpc: Rpc<TestRpcMethods>;
         beforeEach(() => {
-            responseProcessor = jest.fn(response => `${response} processed response`);
+            responseTransformer = jest.fn(response => `${response} processed response`);
             rpc = createJsonRpc({
                 api: {
                     someMethod(...params: unknown[]): RpcRequest<unknown> {
                         return {
                             methodName: 'someMethod',
                             params,
-                            responseProcessor,
+                            responseTransformer,
                         };
                     },
                 } as IRpcApi<TestRpcMethods>,
                 transport: makeHttpRequest,
             });
         });
-        it('calls the response processor with the response from the JSON-RPC 2.0 endpoint', async () => {
+        it('calls the response transformer with the response from the JSON-RPC 2.0 endpoint', async () => {
             expect.assertions(1);
             (makeHttpRequest as jest.Mock).mockResolvedValueOnce({ result: 123 });
             await rpc.someMethod().send();
-            expect(responseProcessor).toHaveBeenCalledWith(123);
+            expect(responseTransformer).toHaveBeenCalledWith(123);
         });
         it('returns the processed response', async () => {
             expect.assertions(1);

--- a/packages/rpc-transport/src/json-rpc-subscription.ts
+++ b/packages/rpc-transport/src/json-rpc-subscription.ts
@@ -33,7 +33,7 @@ function registerIterableCleanup(iterable: AsyncIterable<unknown>, cleanupFn: Ca
 
 function createPendingRpcSubscription<TRpcSubscriptionMethods, TNotification>(
     rpcConfig: RpcSubscriptionConfig<TRpcSubscriptionMethods>,
-    { params, subscribeMethodName, unsubscribeMethodName, responseProcessor }: RpcSubscription<TNotification>,
+    { params, subscribeMethodName, unsubscribeMethodName, responseTransformer }: RpcSubscription<TNotification>,
 ): PendingRpcSubscription<TNotification> {
     return {
         async subscribe({ abortSignal }: SubscribeOptions): Promise<AsyncIterable<TNotification>> {
@@ -94,7 +94,7 @@ function createPendingRpcSubscription<TRpcSubscriptionMethods, TNotification>(
                             continue;
                         }
                         const notification = message.params.result as TNotification;
-                        yield responseProcessor ? responseProcessor(notification) : notification;
+                        yield responseTransformer ? responseTransformer(notification) : notification;
                     }
                 },
             };

--- a/packages/rpc-transport/src/json-rpc-types.ts
+++ b/packages/rpc-transport/src/json-rpc-types.ts
@@ -26,11 +26,11 @@ export type RpcSubscriptionConfig<TRpcMethods> = Readonly<{
 export type RpcRequest<TResponse> = {
     methodName: string;
     params: unknown[];
-    responseProcessor?: (response: unknown) => TResponse;
+    responseTransformer?: (response: unknown) => TResponse;
 };
 export type RpcSubscription<TResponse> = {
     params: unknown[];
-    responseProcessor?: (response: unknown) => TResponse;
+    responseTransformer?: (response: unknown) => TResponse;
     subscribeMethodName: string;
     unsubscribeMethodName: string;
 };

--- a/packages/rpc-transport/src/json-rpc.ts
+++ b/packages/rpc-transport/src/json-rpc.ts
@@ -14,7 +14,7 @@ function createPendingRpcRequest<TRpcMethods, TResponse>(
 ): PendingRpcRequest<TResponse> {
     return {
         async send(options?: SendOptions): Promise<TResponse> {
-            const { methodName, params, responseProcessor } = pendingRequest;
+            const { methodName, params, responseTransformer } = pendingRequest;
             const payload = createJsonRpcMessage(methodName, params);
             const response = await rpcConfig.transport<JsonRpcResponse<unknown>>({
                 payload,
@@ -23,7 +23,7 @@ function createPendingRpcRequest<TRpcMethods, TResponse>(
             if ('error' in response) {
                 throw new SolanaJsonRpcError(response.error);
             } else {
-                return (responseProcessor ? responseProcessor(response.result) : response.result) as TResponse;
+                return (responseTransformer ? responseTransformer(response.result) : response.result) as TResponse;
             }
         },
     };


### PR DESCRIPTION
This PR renames things like `responseProcessor`, which uses the term
`*Processor`, to instead use the term `*Transformer`.
