### PR TITLE
refactor(experimental): add AbortSignal support to the Signer API

### DIFF
--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -440,10 +440,13 @@ If a composite signer implements both interfaces, it will be used as a modifying
 const mySignedTransaction = partiallySignTransactionWithSigners(myTransaction);
 ```
 
-It also accepts an additional array of signers that will be merged with the ones extracted from the transaction, if any.
+It also accepts an optional `AbortSignal` and an additional array of signers that will be merged with the ones extracted from the transaction, if any.
 
 ```ts
-const mySignedTransaction = partiallySignTransactionWithSigners(myTransaction, [myOtherSigner]);
+const mySignedTransaction = partiallySignTransactionWithSigners(myTransaction, {
+    abortSignal: myAbortController.signal,
+    signers: [myOtherSigner],
+});
 ```
 
 Finally, note that this function ignores `TransactionSendingSigners` as it does not send the transaction. See the `signAndSendTransactionWithSigners` function below for more details on how to use sending signers.
@@ -455,8 +458,11 @@ This function works the same as the `partiallySignTransactionWithSigners` functi
 ```ts
 const mySignedTransaction = signTransactionWithSigners(myTransaction);
 
-// With additional signers.
-const mySignedTransaction = signTransactionWithSigners(myTransaction, [myOtherSigner]);
+// With additional config.
+const mySignedTransaction = signTransactionWithSigners(myTransaction, {
+    abortSignal: myAbortController.signal,
+    signers: [myOtherSigner],
+});
 
 // We now know the transaction is fully signed.
 mySignedTransaction satisfies IFullySignedTransaction;
@@ -469,8 +475,11 @@ Extracts all signers inside the provided transaction and uses them to sign it be
 ```ts
 const myTransactionSignature = signAndSendTransactionWithSigners(myTransaction);
 
-// With additional signers.
-const myTransactionSignature = signAndSendTransactionWithSigners(myTransaction, [myOtherSigner]);
+// With additional config.
+const myTransactionSignature = signAndSendTransactionWithSigners(myTransaction, {
+    abortSignal: myAbortController.signal,
+    signers: [myOtherSigner],
+});
 ```
 
 Similarly to the `partiallySignTransactionWithSigners` function, it first uses all `TransactionModifyingSigners` sequentially before using all `TransactionPartialSigners` in parallel. It then sends the transaction using the first `TransactionSendingSigner` it finds. Any other sending signer that does not implement another transaction signer interface will be ignored.
@@ -484,7 +493,7 @@ const fallbackSender = async (transaction: CompilableTransaction) => {
     return getBase58Encoder().encode(signature);
 };
 
-const myTransactionSignature = signAndSendTransactionWithSigners(myTransaction, [], fallbackSender);
+const myTransactionSignature = signAndSendTransactionWithSigners(myTransaction, { fallbackSender });
 ```
 
 Here as well, composite transaction signers are treated such that at least one sending signer is used if any. When a `TransactionSigner` implements more than one interface, use it as a:

--- a/packages/signers/src/message-modifying-signer.ts
+++ b/packages/signers/src/message-modifying-signer.ts
@@ -1,11 +1,17 @@
 import { Address, isAddress } from '@solana/addresses';
 
 import { SignableMessage } from './signable-message';
+import { BaseSignerConfig } from './types';
+
+export type MessageModifyingSignerConfig = BaseSignerConfig;
 
 /** Defines a signer capable of signing messages. */
 export type MessageModifyingSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
-    modifyAndSignMessages(messages: readonly SignableMessage[]): Promise<readonly SignableMessage[]>;
+    modifyAndSignMessages(
+        messages: readonly SignableMessage[],
+        config?: MessageModifyingSignerConfig
+    ): Promise<readonly SignableMessage[]>;
 }>;
 
 /** Checks whether the provided value implements the {@link MessageModifyingSigner} interface. */

--- a/packages/signers/src/message-partial-signer.ts
+++ b/packages/signers/src/message-partial-signer.ts
@@ -1,12 +1,17 @@
 import { Address } from '@solana/addresses';
 
 import { SignableMessage } from './signable-message';
-import { SignatureDictionary } from './types';
+import { BaseSignerConfig, SignatureDictionary } from './types';
+
+export type MessagePartialSignerConfig = BaseSignerConfig;
 
 /** Defines a signer capable of signing messages. */
 export type MessagePartialSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
-    signMessages(messages: readonly SignableMessage[]): Promise<readonly SignatureDictionary[]>;
+    signMessages(
+        messages: readonly SignableMessage[],
+        config?: MessagePartialSignerConfig
+    ): Promise<readonly SignatureDictionary[]>;
 }>;
 
 /** Checks whether the provided value implements the {@link MessagePartialSigner} interface. */

--- a/packages/signers/src/transaction-modifying-signer.ts
+++ b/packages/signers/src/transaction-modifying-signer.ts
@@ -1,11 +1,16 @@
 import { Address } from '@solana/addresses';
 import { CompilableTransaction } from '@solana/transactions';
 
+import { BaseSignerConfig } from './types';
+
+export type TransactionModifyingSignerConfig = BaseSignerConfig;
+
 /** Defines a signer capable of signing transactions. */
 export type TransactionModifyingSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
     modifyAndSignTransactions<TTransaction extends CompilableTransaction>(
-        transactions: readonly TTransaction[]
+        transactions: readonly TTransaction[],
+        config?: TransactionModifyingSignerConfig
     ): Promise<readonly TTransaction[]>;
 }>;
 

--- a/packages/signers/src/transaction-partial-signer.ts
+++ b/packages/signers/src/transaction-partial-signer.ts
@@ -1,12 +1,17 @@
 import { Address } from '@solana/addresses';
 import { CompilableTransaction } from '@solana/transactions';
 
-import { SignatureDictionary } from './types';
+import { BaseSignerConfig, SignatureDictionary } from './types';
+
+export type TransactionPartialSignerConfig = BaseSignerConfig;
 
 /** Defines a signer capable of signing transactions. */
 export type TransactionPartialSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
-    signTransactions(transactions: readonly CompilableTransaction[]): Promise<readonly SignatureDictionary[]>;
+    signTransactions(
+        transactions: readonly CompilableTransaction[],
+        config?: TransactionPartialSignerConfig
+    ): Promise<readonly SignatureDictionary[]>;
 }>;
 
 /** Checks whether the provided value implements the {@link TransactionPartialSigner} interface. */

--- a/packages/signers/src/transaction-sending-signer.ts
+++ b/packages/signers/src/transaction-sending-signer.ts
@@ -2,10 +2,17 @@ import { Address } from '@solana/addresses';
 import { SignatureBytes } from '@solana/keys';
 import { CompilableTransaction } from '@solana/transactions';
 
+import { BaseSignerConfig } from './types';
+
+export type TransactionSendingSignerConfig = BaseSignerConfig;
+
 /** Defines a signer capable of signing and sending transactions simultaneously. */
 export type TransactionSendingSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
-    signAndSendTransactions(transactions: readonly CompilableTransaction[]): Promise<readonly SignatureBytes[]>;
+    signAndSendTransactions(
+        transactions: readonly CompilableTransaction[],
+        config?: TransactionSendingSignerConfig
+    ): Promise<readonly SignatureBytes[]>;
 }>;
 
 /** Checks whether the provided value implements the {@link TransactionSendingSigner} interface. */

--- a/packages/signers/src/types.ts
+++ b/packages/signers/src/types.ts
@@ -2,3 +2,5 @@ import { Address } from '@solana/addresses';
 import { SignatureBytes } from '@solana/keys';
 
 export type SignatureDictionary = Readonly<Record<Address, SignatureBytes>>;
+
+export type BaseSignerConfig = Readonly<{ abortSignal?: AbortSignal }>;


### PR DESCRIPTION
- Adds the optional config object `{ abortSignal?: AbortSignal }` to all five signer interfaces.
  ```ts
  mySigner.signTransactions([tx], { abortSignal });
  mySigner.signTransactions([tx]); // <- Still works.
  ```
- Refactor the `partiallySignTransactionWithSigners`, `signTransactionWithSigners` and  `signAndSendTransactionWithSigners` functions so everything after the first argument is bundled in an optional config object.
  ```ts
  // Before
  partiallySignTransactionWithSigners(tx, [otherSigner]);
  signTransactionWithSigners(tx, [otherSigner]);
  signAndSendTransactionWithSigners(tx, [otherSigner]);
  signAndSendTransactionWithSigners(tx, [], fallbackSender);
  
  // After
  partiallySignTransactionWithSigners(tx, { signers: [otherSigner] });
  signTransactionWithSigners(tx, { signers: [otherSigner] });
  signAndSendTransactionWithSigners(tx, { signers: [otherSigner] });
  signAndSendTransactionWithSigners(tx, { fallbackSender });
  ```
- Adds an optional `abortSignal` attribute to the new config object of all three signing functions mentioned in the previous point.
  ```ts
  partiallySignTransactionWithSigners(tx, { abortSignal });
  signTransactionWithSigners(tx, { abortSignal });
  signAndSendTransactionWithSigners(tx, { abortSignal });
  ```
- Adds tests ensuring we can cancel all three signing functions via abort signals.
- Updates the README accordingly.