### PR TITLE
refactor(experimental): use new partiallySignTransaction in KeyPairSigner implementation

### DIFF
--- a/packages/signers/src/__tests__/keypair-signer-test.ts
+++ b/packages/signers/src/__tests__/keypair-signer-test.ts
@@ -2,7 +2,7 @@ import 'test-matchers/toBeFrozenObject';
 
 import { address, getAddressFromPublicKey } from '@solana/addresses';
 import { generateKeyPair, SignatureBytes, signBytes } from '@solana/keys';
-import { CompilableTransaction, signTransaction } from '@solana/transactions';
+import { CompilableTransaction, partiallySignTransaction } from '@solana/transactions';
 
 import {
     assertIsKeyPairSigner,
@@ -27,7 +27,7 @@ jest.mock('@solana/keys', () => ({
 }));
 jest.mock('@solana/transactions', () => ({
     ...jest.requireActual('@solana/transactions'),
-    signTransaction: jest.fn(),
+    partiallySignTransaction: jest.fn(),
 }));
 
 describe('isKeyPairSigner', () => {
@@ -143,13 +143,13 @@ describe('createSignerFromKeyPair', () => {
         // And given we have a couple of mock transactions to sign.
         const mockTransactions = [{} as CompilableTransaction, {} as CompilableTransaction];
 
-        // And given we mock the next two calls of the signTransactions function.
+        // And given we mock the next two calls of the partiallySignTransaction function.
         const mockSignatures = [new Uint8Array([101, 101, 101]), new Uint8Array([201, 201, 201])] as SignatureBytes[];
-        jest.mocked(signTransaction).mockResolvedValueOnce({
+        jest.mocked(partiallySignTransaction).mockResolvedValueOnce({
             ...mockTransactions[0],
             signatures: { [myAddress]: mockSignatures[0] },
         });
-        jest.mocked(signTransaction).mockResolvedValueOnce({
+        jest.mocked(partiallySignTransaction).mockResolvedValueOnce({
             ...mockTransactions[1],
             signatures: { [myAddress]: mockSignatures[1] },
         });
@@ -165,10 +165,10 @@ describe('createSignerFromKeyPair', () => {
         expect(signatureDictionaries[0]).toBeFrozenObject();
         expect(signatureDictionaries[1]).toBeFrozenObject();
 
-        // And signTransactions was called twice with the expected parameters.
-        expect(jest.mocked(signTransaction)).toHaveBeenCalledTimes(2);
-        expect(jest.mocked(signTransaction)).toHaveBeenNthCalledWith(1, [myKeyPair], mockTransactions[0]);
-        expect(jest.mocked(signTransaction)).toHaveBeenNthCalledWith(2, [myKeyPair], mockTransactions[1]);
+        // And partiallySignTransaction was called twice with the expected parameters.
+        expect(jest.mocked(partiallySignTransaction)).toHaveBeenCalledTimes(2);
+        expect(jest.mocked(partiallySignTransaction)).toHaveBeenNthCalledWith(1, [myKeyPair], mockTransactions[0]);
+        expect(jest.mocked(partiallySignTransaction)).toHaveBeenNthCalledWith(2, [myKeyPair], mockTransactions[1]);
     });
 });
 

--- a/packages/signers/src/keypair-signer.ts
+++ b/packages/signers/src/keypair-signer.ts
@@ -1,6 +1,6 @@
 import { Address, getAddressFromPublicKey } from '@solana/addresses';
 import { generateKeyPair, signBytes } from '@solana/keys';
-import { signTransaction } from '@solana/transactions';
+import { partiallySignTransaction } from '@solana/transactions';
 
 import { isMessagePartialSigner, MessagePartialSigner } from './message-partial-signer';
 import { isTransactionPartialSigner, TransactionPartialSigner } from './transaction-partial-signer';
@@ -48,7 +48,7 @@ export async function createSignerFromKeyPair(keyPair: CryptoKeyPair): Promise<K
         signTransactions: transactions =>
             Promise.all(
                 transactions.map(async transaction => {
-                    const signedTransaction = await signTransaction([keyPair], transaction);
+                    const signedTransaction = await partiallySignTransaction([keyPair], transaction);
                     return Object.freeze({ [address]: signedTransaction.signatures[address] });
                 })
             ),


### PR DESCRIPTION
Fix the typecheck error of `@solana/signers` in CI/CD.

### Problem

The implementation of the `KeyPairSigner` uses the `signTransaction` function from `@solana/transactions` under the hood which was recently updated to also assert the transaction is fully signed. Therefore, the mocked return value was giving a type error because it did not provide a `IFullySignedTransaction` as expected.

### Solution

Use the new `partiallySignTransaction` function from `@solana/transactions` instead of `signTransaction` which does not assert the transaction is full signed (and is equivalent to the old behavior of the `signTransaction` function).
