### PR TITLE
refactor(experimental): use Node's instance of `Uint8Array` in browser tests

### DIFF
--- a/packages/test-config/browser-environment.ts
+++ b/packages/test-config/browser-environment.ts
@@ -1,0 +1,13 @@
+import { TestEnvironment } from 'jest-environment-jsdom';
+
+export default class BrowserEnvironment extends TestEnvironment {
+    async setup() {
+        await super.setup();
+        /**
+         * Here we inject Node's `Uint8Array` as a global so that `instanceof` checks inside
+         * `SubtleCrypto.digest()` work with `Uint8Array#buffer`. Read more here:
+         * https://github.com/jestjs/jest/issues/7780#issuecomment-615890410
+         */
+        this.global.Uint8Array = globalThis.Uint8Array;
+    }
+}

--- a/packages/test-config/jest-unit.config.browser.ts
+++ b/packages/test-config/jest-unit.config.browser.ts
@@ -26,7 +26,7 @@ const config: Partial<Config.InitialProjectOptions> = {
         path.resolve(__dirname, 'setup-secure-context.ts'),
         path.resolve(__dirname, 'setup-text-encoder.ts'),
     ],
-    testEnvironment: 'jsdom',
+    testEnvironment: path.resolve(__dirname, 'browser-environment.ts'),
     testEnvironmentOptions: {},
 };
 


### PR DESCRIPTION
# Summary

1. When you're running browser tests, we use the JSDOM environment
2. JSDOM doesn't support `SubtleCrypto` yet, so we inject `node:crypto`
3. Now we're in a situation where `Uint8Array` comes from JSDOM but the `instanceof` checks inside `SubtleCrypto#digest` are made against the Node instance of `Uint8Array`. These checks never pass.

To solve this, we override the `Uint8Array` global in JSDOM with the one from Node. Oh well.
