### PR TITLE
refactor(experimental): rename codec options to codec config

### DIFF
--- a/packages/codecs-core/src/__tests__/__setup__.ts
+++ b/packages/codecs-core/src/__tests__/__setup__.ts
@@ -17,15 +17,15 @@ export const base16: Codec<string> = {
 };
 
 export const getMockCodec = (
-    options: {
+    config: {
         defaultValue?: string;
         description?: string;
         size?: number | null;
     } = {}
 ) => ({
-    decode: jest.fn().mockReturnValue([options.defaultValue ?? '', 0]),
-    description: options.description ?? 'mock',
+    decode: jest.fn().mockReturnValue([config.defaultValue ?? '', 0]),
+    description: config.description ?? 'mock',
     encode: jest.fn().mockReturnValue(new Uint8Array()),
-    fixedSize: options.size ?? null,
-    maxSize: options.size ?? null,
+    fixedSize: config.size ?? null,
+    maxSize: config.size ?? null,
 });

--- a/packages/codecs-core/src/codec.ts
+++ b/packages/codecs-core/src/codec.ts
@@ -46,9 +46,9 @@ export type Decoder<T> = CodecData & {
 export type Codec<From, To extends From = From> = Encoder<From> & Decoder<To>;
 
 /**
- * Defines common options for codec factories.
+ * Defines common configurations for codec factories.
  */
-export type BaseCodecOptions = {
+export type BaseCodecConfig = {
     /** A custom description for the Codec. */
     description?: string;
 };

--- a/packages/codecs-data-structures/src/array.ts
+++ b/packages/codecs-data-structures/src/array.ts
@@ -1,4 +1,4 @@
-import { BaseCodecOptions, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
+import { BaseCodecConfig, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
 import { getU32Decoder, getU32Encoder, NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
 
 import {
@@ -10,8 +10,8 @@ import {
 } from './array-like-codec-size';
 import { assertValidNumberOfItemsForCodec } from './assertions';
 
-/** Defines the options for array codecs. */
-export type ArrayCodecOptions<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecOptions & {
+/** Defines the configs for array codecs. */
+export type ArrayCodecConfig<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecConfig & {
     /**
      * The size of the array.
      * @defaultValue u32 prefix.
@@ -36,12 +36,12 @@ function arrayCodecHelper(item: CodecData, size: ArrayLikeCodecSize<CodecData>, 
  * Encodes an array of items.
  *
  * @param item - The encoder to use for the array's items.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
-export function getArrayEncoder<T>(item: Encoder<T>, options: ArrayCodecOptions<NumberEncoder> = {}): Encoder<T[]> {
-    const size = options.size ?? getU32Encoder();
+export function getArrayEncoder<T>(item: Encoder<T>, config: ArrayCodecConfig<NumberEncoder> = {}): Encoder<T[]> {
+    const size = config.size ?? getU32Encoder();
     return {
-        ...arrayCodecHelper(item, size, options.description),
+        ...arrayCodecHelper(item, size, config.description),
         encode: (value: T[]) => {
             if (typeof size === 'number') {
                 assertValidNumberOfItemsForCodec('array', size, value.length);
@@ -55,12 +55,12 @@ export function getArrayEncoder<T>(item: Encoder<T>, options: ArrayCodecOptions<
  * Decodes an array of items.
  *
  * @param item - The encoder to use for the array's items.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
-export function getArrayDecoder<T>(item: Decoder<T>, options: ArrayCodecOptions<NumberDecoder> = {}): Decoder<T[]> {
-    const size = options.size ?? getU32Decoder();
+export function getArrayDecoder<T>(item: Decoder<T>, config: ArrayCodecConfig<NumberDecoder> = {}): Decoder<T[]> {
+    const size = config.size ?? getU32Decoder();
     return {
-        ...arrayCodecHelper(item, size, options.description),
+        ...arrayCodecHelper(item, size, config.description),
         decode: (bytes: Uint8Array, offset = 0) => {
             if (typeof size === 'object' && bytes.slice(offset).length === 0) {
                 return [[], offset];
@@ -82,11 +82,11 @@ export function getArrayDecoder<T>(item: Decoder<T>, options: ArrayCodecOptions<
  * Creates a codec for an array of items.
  *
  * @param item - The codec to use for the array's items.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
 export function getArrayCodec<T, U extends T = T>(
     item: Codec<T, U>,
-    options: ArrayCodecOptions<NumberCodec> = {}
+    config: ArrayCodecConfig<NumberCodec> = {}
 ): Codec<T[], U[]> {
-    return combineCodec(getArrayEncoder(item, options), getArrayDecoder(item, options));
+    return combineCodec(getArrayEncoder(item, config), getArrayDecoder(item, config));
 }

--- a/packages/codecs-data-structures/src/bit-array.ts
+++ b/packages/codecs-data-structures/src/bit-array.ts
@@ -1,14 +1,14 @@
 import {
     assertByteArrayHasEnoughBytesForCodec,
-    BaseCodecOptions,
+    BaseCodecConfig,
     Codec,
     combineCodec,
     Decoder,
     Encoder,
 } from '@solana/codecs-core';
 
-/** Defines the options for bitArray codecs. */
-export type BitArrayCodecOptions = BaseCodecOptions & {
+/** Defines the config for bitArray codecs. */
+export type BitArrayCodecConfig = BaseCodecConfig & {
     /**
      * Whether to read the bits in reverse order.
      * @defaultValue `false`
@@ -20,14 +20,14 @@ export type BitArrayCodecOptions = BaseCodecOptions & {
  * Encodes an array of booleans into bits.
  *
  * @param size - The amount of bytes to use for the bit array.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
-export const getBitArrayEncoder = (size: number, options: BitArrayCodecOptions | boolean = {}): Encoder<boolean[]> => {
-    const parsedOptions: BitArrayCodecOptions = typeof options === 'boolean' ? { backward: options } : options;
-    const backward = parsedOptions.backward ?? false;
+export const getBitArrayEncoder = (size: number, config: BitArrayCodecConfig | boolean = {}): Encoder<boolean[]> => {
+    const parsedConfig: BitArrayCodecConfig = typeof config === 'boolean' ? { backward: config } : config;
+    const backward = parsedConfig.backward ?? false;
     const backwardSuffix = backward ? '; backward' : '';
     return {
-        description: parsedOptions.description ?? `bitArray(${size}${backwardSuffix})`,
+        description: parsedConfig.description ?? `bitArray(${size}${backwardSuffix})`,
         encode(value: boolean[]) {
             const bytes: number[] = [];
 
@@ -55,11 +55,11 @@ export const getBitArrayEncoder = (size: number, options: BitArrayCodecOptions |
  * Decodes bits into an array of booleans.
  *
  * @param size - The amount of bytes to use for the bit array.
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
-export const getBitArrayDecoder = (size: number, options: BitArrayCodecOptions | boolean = {}): Decoder<boolean[]> => {
-    const parsedOptions: BitArrayCodecOptions = typeof options === 'boolean' ? { backward: options } : options;
-    const backward = parsedOptions.backward ?? false;
+export const getBitArrayDecoder = (size: number, config: BitArrayCodecConfig | boolean = {}): Decoder<boolean[]> => {
+    const parsedConfig: BitArrayCodecConfig = typeof config === 'boolean' ? { backward: config } : config;
+    const backward = parsedConfig.backward ?? false;
     const backwardSuffix = backward ? '; backward' : '';
     return {
         decode(bytes, offset = 0) {
@@ -82,7 +82,7 @@ export const getBitArrayDecoder = (size: number, options: BitArrayCodecOptions |
 
             return [booleans, offset + size];
         },
-        description: parsedOptions.description ?? `bitArray(${size}${backwardSuffix})`,
+        description: parsedConfig.description ?? `bitArray(${size}${backwardSuffix})`,
         fixedSize: size,
         maxSize: size,
     };
@@ -92,7 +92,7 @@ export const getBitArrayDecoder = (size: number, options: BitArrayCodecOptions |
  * An array of boolean codec that converts booleans to bits and vice versa.
  *
  * @param size - The amount of bytes to use for the bit array.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
-export const getBitArrayCodec = (size: number, options: BitArrayCodecOptions | boolean = {}): Codec<boolean[]> =>
-    combineCodec(getBitArrayEncoder(size, options), getBitArrayDecoder(size, options));
+export const getBitArrayCodec = (size: number, config: BitArrayCodecConfig | boolean = {}): Codec<boolean[]> =>
+    combineCodec(getBitArrayEncoder(size, config), getBitArrayDecoder(size, config));

--- a/packages/codecs-data-structures/src/boolean.ts
+++ b/packages/codecs-data-structures/src/boolean.ts
@@ -1,7 +1,7 @@
 import {
     assertByteArrayIsNotEmptyForCodec,
     assertFixedSizeCodec,
-    BaseCodecOptions,
+    BaseCodecConfig,
     Codec,
     combineCodec,
     Decoder,
@@ -9,8 +9,8 @@ import {
 } from '@solana/codecs-core';
 import { getU8Decoder, getU8Encoder, NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
 
-/** Defines the options for boolean codecs. */
-export type BooleanCodecOptions<TSize extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecOptions & {
+/** Defines the config for boolean codecs. */
+export type BooleanCodecConfig<TSize extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecConfig & {
     /**
      * The number codec to delegate to.
      * @defaultValue u8 size.
@@ -21,14 +21,14 @@ export type BooleanCodecOptions<TSize extends NumberCodec | NumberEncoder | Numb
 /**
  * Encodes booleans.
  *
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
-export function getBooleanEncoder(options: BooleanCodecOptions<NumberEncoder> = {}): Encoder<boolean> {
-    const size = options.size ?? getU8Encoder();
+export function getBooleanEncoder(config: BooleanCodecConfig<NumberEncoder> = {}): Encoder<boolean> {
+    const size = config.size ?? getU8Encoder();
     assertFixedSizeCodec(size, 'Codec [bool] requires a fixed size.');
 
     return {
-        description: options.description ?? `bool(${size.description})`,
+        description: config.description ?? `bool(${size.description})`,
         encode: (value: boolean) => size.encode(value ? 1 : 0),
         fixedSize: size.fixedSize,
         maxSize: size.fixedSize,
@@ -38,10 +38,10 @@ export function getBooleanEncoder(options: BooleanCodecOptions<NumberEncoder> = 
 /**
  * Decodes booleans.
  *
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
-export function getBooleanDecoder(options: BooleanCodecOptions<NumberDecoder> = {}): Decoder<boolean> {
-    const size = options.size ?? getU8Decoder();
+export function getBooleanDecoder(config: BooleanCodecConfig<NumberDecoder> = {}): Decoder<boolean> {
+    const size = config.size ?? getU8Decoder();
     assertFixedSizeCodec(size, 'Codec [bool] requires a fixed size.');
 
     return {
@@ -50,7 +50,7 @@ export function getBooleanDecoder(options: BooleanCodecOptions<NumberDecoder> = 
             const [value, vOffset] = size.decode(bytes, offset);
             return [value === 1, vOffset];
         },
-        description: options.description ?? `bool(${size.description})`,
+        description: config.description ?? `bool(${size.description})`,
         fixedSize: size.fixedSize,
         maxSize: size.fixedSize,
     };
@@ -59,8 +59,8 @@ export function getBooleanDecoder(options: BooleanCodecOptions<NumberDecoder> = 
 /**
  * Creates a boolean codec.
  *
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
-export function getBooleanCodec(options: BooleanCodecOptions<NumberCodec> = {}): Codec<boolean> {
-    return combineCodec(getBooleanEncoder(options), getBooleanDecoder(options));
+export function getBooleanCodec(config: BooleanCodecConfig<NumberCodec> = {}): Codec<boolean> {
+    return combineCodec(getBooleanEncoder(config), getBooleanDecoder(config));
 }

--- a/packages/codecs-data-structures/src/bytes.ts
+++ b/packages/codecs-data-structures/src/bytes.ts
@@ -1,7 +1,7 @@
 import {
     assertByteArrayHasEnoughBytesForCodec,
     assertByteArrayIsNotEmptyForCodec,
-    BaseCodecOptions,
+    BaseCodecConfig,
     Codec,
     combineCodec,
     Decoder,
@@ -12,8 +12,8 @@ import {
 } from '@solana/codecs-core';
 import { NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
 
-/** Defines the options for bytes codecs. */
-export type BytesCodecOptions<TSize extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecOptions & {
+/** Defines the config for bytes codecs. */
+export type BytesCodecConfig<TSize extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecConfig & {
     /**
      * The size of the byte array. It can be one of the following:
      * - a {@link NumberSerializer} that prefixes the byte array with its size.
@@ -27,12 +27,12 @@ export type BytesCodecOptions<TSize extends NumberCodec | NumberEncoder | Number
 /**
  * Encodes sized bytes.
  *
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
-export function getBytesEncoder(options: BytesCodecOptions<NumberEncoder> = {}): Encoder<Uint8Array> {
-    const size = options.size ?? 'variable';
+export function getBytesEncoder(config: BytesCodecConfig<NumberEncoder> = {}): Encoder<Uint8Array> {
+    const size = config.size ?? 'variable';
     const sizeDescription = typeof size === 'object' ? size.description : `${size}`;
-    const description = options.description ?? `bytes(${sizeDescription})`;
+    const description = config.description ?? `bytes(${sizeDescription})`;
 
     const byteEncoder: Encoder<Uint8Array> = {
         description,
@@ -62,12 +62,12 @@ export function getBytesEncoder(options: BytesCodecOptions<NumberEncoder> = {}):
 /**
  * Decodes sized bytes.
  *
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
-export function getBytesDecoder(options: BytesCodecOptions<NumberDecoder> = {}): Decoder<Uint8Array> {
-    const size = options.size ?? 'variable';
+export function getBytesDecoder(config: BytesCodecConfig<NumberDecoder> = {}): Decoder<Uint8Array> {
+    const size = config.size ?? 'variable';
     const sizeDescription = typeof size === 'object' ? size.description : `${size}`;
-    const description = options.description ?? `bytes(${sizeDescription})`;
+    const description = config.description ?? `bytes(${sizeDescription})`;
 
     const byteDecoder: Decoder<Uint8Array> = {
         decode: (bytes: Uint8Array, offset = 0) => {
@@ -106,8 +106,8 @@ export function getBytesDecoder(options: BytesCodecOptions<NumberDecoder> = {}):
 /**
  * Creates a sized bytes codec.
  *
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
-export function getBytesCodec(options: BytesCodecOptions<NumberCodec> = {}): Codec<Uint8Array> {
-    return combineCodec(getBytesEncoder(options), getBytesDecoder(options));
+export function getBytesCodec(config: BytesCodecConfig<NumberCodec> = {}): Codec<Uint8Array> {
+    return combineCodec(getBytesEncoder(config), getBytesDecoder(config));
 }

--- a/packages/codecs-data-structures/src/data-enum.ts
+++ b/packages/codecs-data-structures/src/data-enum.ts
@@ -1,6 +1,6 @@
 import {
     assertByteArrayIsNotEmptyForCodec,
-    BaseCodecOptions,
+    BaseCodecConfig,
     Codec,
     CodecData,
     combineCodec,
@@ -91,8 +91,8 @@ export type DataEnumToDecoderTuple<T extends DataEnum> = Array<
           ]
 >;
 
-/** Defines the options for data enum codecs. */
-export type DataEnumCodecOptions<TDiscriminator = NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecOptions & {
+/** Defines the config for data enum codecs. */
+export type DataEnumCodecConfig<TDiscriminator = NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecConfig & {
     /**
      * The codec to use for the enum discriminator prefixing the variant.
      * @defaultValue u8 prefix.
@@ -119,15 +119,15 @@ function dataEnumCodecHelper(variants: Array<[string, CodecData]>, prefix: Codec
  * Creates a data enum encoder.
  *
  * @param variants - The variant encoders of the data enum.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
 export function getDataEnumEncoder<T extends DataEnum>(
     variants: DataEnumToEncoderTuple<T>,
-    options: DataEnumCodecOptions<NumberEncoder> = {}
+    config: DataEnumCodecConfig<NumberEncoder> = {}
 ): Encoder<T> {
-    const prefix = options.size ?? getU8Encoder();
+    const prefix = config.size ?? getU8Encoder();
     return {
-        ...dataEnumCodecHelper(variants, prefix, options.description),
+        ...dataEnumCodecHelper(variants, prefix, config.description),
         encode: (variant: T) => {
             const discriminator = variants.findIndex(([key]) => variant.__kind === key);
             if (discriminator < 0) {
@@ -150,15 +150,15 @@ export function getDataEnumEncoder<T extends DataEnum>(
  * Creates a data enum decoder.
  *
  * @param variants - The variant decoders of the data enum.
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
 export function getDataEnumDecoder<T extends DataEnum>(
     variants: DataEnumToDecoderTuple<T>,
-    options: DataEnumCodecOptions<NumberDecoder> = {}
+    config: DataEnumCodecConfig<NumberDecoder> = {}
 ): Decoder<T> {
-    const prefix = options.size ?? getU8Decoder();
+    const prefix = config.size ?? getU8Decoder();
     return {
-        ...dataEnumCodecHelper(variants, prefix, options.description),
+        ...dataEnumCodecHelper(variants, prefix, config.description),
         decode: (bytes: Uint8Array, offset = 0) => {
             assertByteArrayIsNotEmptyForCodec('dataEnum', bytes, offset);
             const [discriminator, dOffset] = prefix.decode(bytes, offset);
@@ -182,11 +182,11 @@ export function getDataEnumDecoder<T extends DataEnum>(
  * Creates a data enum codec.
  *
  * @param variants - The variant codecs of the data enum.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
 export function getDataEnumCodec<T extends DataEnum, U extends T = T>(
     variants: DataEnumToCodecTuple<T, U>,
-    options: DataEnumCodecOptions<NumberCodec> = {}
+    config: DataEnumCodecConfig<NumberCodec> = {}
 ): Codec<T, U> {
-    return combineCodec(getDataEnumEncoder<T>(variants, options), getDataEnumDecoder<U>(variants, options));
+    return combineCodec(getDataEnumEncoder<T>(variants, config), getDataEnumDecoder<U>(variants, config));
 }

--- a/packages/codecs-data-structures/src/map.ts
+++ b/packages/codecs-data-structures/src/map.ts
@@ -1,4 +1,4 @@
-import { BaseCodecOptions, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
+import { BaseCodecConfig, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
 import { getU32Decoder, getU32Encoder, NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
 
 import {
@@ -10,8 +10,8 @@ import {
 } from './array-like-codec-size';
 import { assertValidNumberOfItemsForCodec } from './assertions';
 
-/** Defines the options for Map codecs. */
-export type MapCodecOptions<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecOptions & {
+/** Defines the config for Map codecs. */
+export type MapCodecConfig<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecConfig & {
     /**
      * The size of the array.
      * @defaultValue u32 prefix.
@@ -43,16 +43,16 @@ function mapCodecHelper(
  *
  * @param key - The encoder to use for the map's keys.
  * @param value - The encoder to use for the map's values.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
 export function getMapEncoder<K, V>(
     key: Encoder<K>,
     value: Encoder<V>,
-    options: MapCodecOptions<NumberEncoder> = {}
+    config: MapCodecConfig<NumberEncoder> = {}
 ): Encoder<Map<K, V>> {
-    const size = options.size ?? getU32Encoder();
+    const size = config.size ?? getU32Encoder();
     return {
-        ...mapCodecHelper(key, value, size, options.description),
+        ...mapCodecHelper(key, value, size, config.description),
         encode: (map: Map<K, V>) => {
             if (typeof size === 'number') {
                 assertValidNumberOfItemsForCodec('map', size, map.size);
@@ -68,16 +68,16 @@ export function getMapEncoder<K, V>(
  *
  * @param key - The decoder to use for the map's keys.
  * @param value - The decoder to use for the map's values.
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
 export function getMapDecoder<K, V>(
     key: Decoder<K>,
     value: Decoder<V>,
-    options: MapCodecOptions<NumberDecoder> = {}
+    config: MapCodecConfig<NumberDecoder> = {}
 ): Decoder<Map<K, V>> {
-    const size = options.size ?? getU32Decoder();
+    const size = config.size ?? getU32Decoder();
     return {
-        ...mapCodecHelper(key, value, size, options.description),
+        ...mapCodecHelper(key, value, size, config.description),
         decode: (bytes: Uint8Array, offset = 0) => {
             const map: Map<K, V> = new Map();
             if (typeof size === 'object' && bytes.slice(offset).length === 0) {
@@ -107,12 +107,12 @@ export function getMapDecoder<K, V>(
  *
  * @param key - The codec to use for the map's keys.
  * @param value - The codec to use for the map's values.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
 export function getMapCodec<TK, TV, UK extends TK = TK, UV extends TV = TV>(
     key: Codec<TK, UK>,
     value: Codec<TV, UV>,
-    options: MapCodecOptions<NumberCodec> = {}
+    config: MapCodecConfig<NumberCodec> = {}
 ): Codec<Map<TK, TV>, Map<UK, UV>> {
-    return combineCodec(getMapEncoder(key, value, options), getMapDecoder(key, value, options));
+    return combineCodec(getMapEncoder(key, value, config), getMapDecoder(key, value, config));
 }

--- a/packages/codecs-data-structures/src/nullable.ts
+++ b/packages/codecs-data-structures/src/nullable.ts
@@ -1,6 +1,6 @@
 import {
     assertFixedSizeCodec,
-    BaseCodecOptions,
+    BaseCodecConfig,
     Codec,
     CodecData,
     combineCodec,
@@ -13,8 +13,8 @@ import { getU8Decoder, getU8Encoder, NumberCodec, NumberDecoder, NumberEncoder }
 
 import { sumCodecSizes } from './utils';
 
-/** Defines the options for nullable codecs. */
-export type NullableCodecOptions<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecOptions & {
+/** Defines the config for nullable codecs. */
+export type NullableCodecConfig<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecConfig & {
     /**
      * The codec to use for the boolean prefix.
      * @defaultValue u8 prefix.
@@ -53,16 +53,16 @@ function nullableCodecHelper(item: CodecData, prefix: CodecData, fixed: boolean,
  * Creates a encoder for an optional value using `null` as the `None` value.
  *
  * @param item - The encoder to use for the value that may be present.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
 export function getNullableEncoder<T>(
     item: Encoder<T>,
-    options: NullableCodecOptions<NumberEncoder> = {}
+    config: NullableCodecConfig<NumberEncoder> = {}
 ): Encoder<T | null> {
-    const prefix = options.prefix ?? getU8Encoder();
-    const fixed = options.fixed ?? false;
+    const prefix = config.prefix ?? getU8Encoder();
+    const fixed = config.fixed ?? false;
     return {
-        ...nullableCodecHelper(item, prefix, fixed, options.description),
+        ...nullableCodecHelper(item, prefix, fixed, config.description),
         encode: (option: T | null) => {
             const prefixByte = prefix.encode(Number(option !== null));
             let itemBytes = option !== null ? item.encode(option) : new Uint8Array();
@@ -76,16 +76,16 @@ export function getNullableEncoder<T>(
  * Creates a decoder for an optional value using `null` as the `None` value.
  *
  * @param item - The decoder to use for the value that may be present.
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
 export function getNullableDecoder<T>(
     item: Decoder<T>,
-    options: NullableCodecOptions<NumberDecoder> = {}
+    config: NullableCodecConfig<NumberDecoder> = {}
 ): Decoder<T | null> {
-    const prefix = options.prefix ?? getU8Decoder();
-    const fixed = options.fixed ?? false;
+    const prefix = config.prefix ?? getU8Decoder();
+    const fixed = config.fixed ?? false;
     return {
-        ...nullableCodecHelper(item, prefix, fixed, options.description),
+        ...nullableCodecHelper(item, prefix, fixed, config.description),
         decode: (bytes: Uint8Array, offset = 0) => {
             if (bytes.length - offset <= 0) {
                 return [null, offset];
@@ -107,11 +107,11 @@ export function getNullableDecoder<T>(
  * Creates a codec for an optional value using `null` as the `None` value.
  *
  * @param item - The codec to use for the value that may be present.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
 export function getNullableCodec<T, U extends T = T>(
     item: Codec<T, U>,
-    options: NullableCodecOptions<NumberCodec> = {}
+    config: NullableCodecConfig<NumberCodec> = {}
 ): Codec<T | null, U | null> {
-    return combineCodec(getNullableEncoder<T>(item, options), getNullableDecoder<U>(item, options));
+    return combineCodec(getNullableEncoder<T>(item, config), getNullableDecoder<U>(item, config));
 }

--- a/packages/codecs-data-structures/src/scalar-enum.ts
+++ b/packages/codecs-data-structures/src/scalar-enum.ts
@@ -1,6 +1,6 @@
 import {
     assertByteArrayIsNotEmptyForCodec,
-    BaseCodecOptions,
+    BaseCodecConfig,
     Codec,
     CodecData,
     combineCodec,
@@ -20,9 +20,9 @@ import { getU8Decoder, getU8Encoder, NumberCodec, NumberDecoder, NumberEncoder }
  */
 export type ScalarEnum<T> = ({ [key: number | string]: string | number | T } | number | T) & NonNullable<unknown>;
 
-/** Defines the options for scalar enum codecs. */
-export type ScalarEnumCodecOptions<TDiscriminator extends NumberCodec | NumberEncoder | NumberDecoder> =
-    BaseCodecOptions & {
+/** Defines the config for scalar enum codecs. */
+export type ScalarEnumCodecConfig<TDiscriminator extends NumberCodec | NumberEncoder | NumberDecoder> =
+    BaseCodecConfig & {
         /**
          * The codec to use for the enum discriminator.
          * @defaultValue u8 discriminator.
@@ -67,15 +67,15 @@ function scalarEnumCoderHelper<T>(
  * Creates a scalar enum encoder.
  *
  * @param constructor - The constructor of the scalar enum.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
 export function getScalarEnumEncoder<T>(
     constructor: ScalarEnum<T>,
-    options: ScalarEnumCodecOptions<NumberEncoder> = {}
+    config: ScalarEnumCodecConfig<NumberEncoder> = {}
 ): Encoder<T> {
-    const prefix = options.size ?? getU8Encoder();
+    const prefix = config.size ?? getU8Encoder();
     const { description, fixedSize, maxSize, minRange, maxRange, stringValues, enumKeys, enumValues } =
-        scalarEnumCoderHelper(constructor, prefix, options.description);
+        scalarEnumCoderHelper(constructor, prefix, config.description);
     return {
         description,
         encode: (value: T) => {
@@ -104,17 +104,17 @@ export function getScalarEnumEncoder<T>(
  * Creates a scalar enum decoder.
  *
  * @param constructor - The constructor of the scalar enum.
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
 export function getScalarEnumDecoder<T>(
     constructor: ScalarEnum<T>,
-    options: ScalarEnumCodecOptions<NumberDecoder> = {}
+    config: ScalarEnumCodecConfig<NumberDecoder> = {}
 ): Decoder<T> {
-    const prefix = options.size ?? getU8Decoder();
+    const prefix = config.size ?? getU8Decoder();
     const { description, fixedSize, maxSize, minRange, maxRange, isNumericEnum, enumValues } = scalarEnumCoderHelper(
         constructor,
         prefix,
-        options.description
+        config.description
     );
     return {
         decode: (bytes: Uint8Array, offset = 0) => {
@@ -141,11 +141,11 @@ export function getScalarEnumDecoder<T>(
  * Creates a scalar enum codec.
  *
  * @param constructor - The constructor of the scalar enum.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
 export function getScalarEnumCodec<T>(
     constructor: ScalarEnum<T>,
-    options: ScalarEnumCodecOptions<NumberCodec> = {}
+    config: ScalarEnumCodecConfig<NumberCodec> = {}
 ): Codec<T> {
-    return combineCodec(getScalarEnumEncoder(constructor, options), getScalarEnumDecoder(constructor, options));
+    return combineCodec(getScalarEnumEncoder(constructor, config), getScalarEnumDecoder(constructor, config));
 }

--- a/packages/codecs-data-structures/src/set.ts
+++ b/packages/codecs-data-structures/src/set.ts
@@ -1,4 +1,4 @@
-import { BaseCodecOptions, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
+import { BaseCodecConfig, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
 import { getU32Decoder, getU32Encoder, NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
 
 import {
@@ -10,8 +10,8 @@ import {
 } from './array-like-codec-size';
 import { assertValidNumberOfItemsForCodec } from './assertions';
 
-/** Defines the options for set codecs. */
-export type SetCodecOptions<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecOptions & {
+/** Defines the config for set codecs. */
+export type SetCodecConfig<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecConfig & {
     /**
      * The size of the set.
      * @defaultValue u32 prefix.
@@ -36,12 +36,12 @@ function setCodecHelper(item: CodecData, size: ArrayLikeCodecSize<CodecData>, de
  * Encodes an set of items.
  *
  * @param item - The encoder to use for the set's items.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
-export function getSetEncoder<T>(item: Encoder<T>, options: SetCodecOptions<NumberEncoder> = {}): Encoder<Set<T>> {
-    const size = options.size ?? getU32Encoder();
+export function getSetEncoder<T>(item: Encoder<T>, config: SetCodecConfig<NumberEncoder> = {}): Encoder<Set<T>> {
+    const size = config.size ?? getU32Encoder();
     return {
-        ...setCodecHelper(item, size, options.description),
+        ...setCodecHelper(item, size, config.description),
         encode: (set: Set<T>) => {
             if (typeof size === 'number' && set.size !== size) {
                 assertValidNumberOfItemsForCodec('set', size, set.size);
@@ -56,12 +56,12 @@ export function getSetEncoder<T>(item: Encoder<T>, options: SetCodecOptions<Numb
  * Decodes an set of items.
  *
  * @param item - The encoder to use for the set's items.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
-export function getSetDecoder<T>(item: Decoder<T>, options: SetCodecOptions<NumberDecoder> = {}): Decoder<Set<T>> {
-    const size = options.size ?? getU32Decoder();
+export function getSetDecoder<T>(item: Decoder<T>, config: SetCodecConfig<NumberDecoder> = {}): Decoder<Set<T>> {
+    const size = config.size ?? getU32Decoder();
     return {
-        ...setCodecHelper(item, size, options.description),
+        ...setCodecHelper(item, size, config.description),
         decode: (bytes: Uint8Array, offset = 0) => {
             const set: Set<T> = new Set();
             if (typeof size === 'object' && bytes.slice(offset).length === 0) {
@@ -83,11 +83,11 @@ export function getSetDecoder<T>(item: Decoder<T>, options: SetCodecOptions<Numb
  * Creates a codec for an set of items.
  *
  * @param item - The codec to use for the set's items.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
 export function getSetCodec<T, U extends T = T>(
     item: Codec<T, U>,
-    options: SetCodecOptions<NumberCodec> = {}
+    config: SetCodecConfig<NumberCodec> = {}
 ): Codec<Set<T>, Set<U>> {
-    return combineCodec(getSetEncoder(item, options), getSetDecoder(item, options));
+    return combineCodec(getSetEncoder(item, config), getSetDecoder(item, config));
 }

--- a/packages/codecs-data-structures/src/struct.ts
+++ b/packages/codecs-data-structures/src/struct.ts
@@ -1,4 +1,4 @@
-import { BaseCodecOptions, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
+import { BaseCodecConfig, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
 
 import { sumCodecSizes } from './utils';
 
@@ -23,8 +23,8 @@ export type StructToCodecTuple<T extends object, U extends T> = Array<
     }[keyof T]
 >;
 
-/** Defines the options for struct codecs. */
-export type StructCodecOptions = BaseCodecOptions;
+/** Defines the config for struct codecs. */
+export type StructCodecConfig = BaseCodecConfig;
 
 function structCodecHelper(fields: Array<[string | number | symbol, CodecData]>, description?: string): CodecData {
     const fieldDescriptions = fields.map(([name, codec]) => `${String(name)}: ${codec.description}`).join(', ');
@@ -40,14 +40,14 @@ function structCodecHelper(fields: Array<[string | number | symbol, CodecData]>,
  * Creates a encoder for a custom object.
  *
  * @param fields - The name and encoder of each field.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
 export function getStructEncoder<T extends object>(
     fields: StructToEncoderTuple<T>,
-    options: StructCodecOptions = {}
+    config: StructCodecConfig = {}
 ): Encoder<T> {
     return {
-        ...structCodecHelper(fields, options.description),
+        ...structCodecHelper(fields, config.description),
         encode: (struct: T) => {
             const fieldBytes = fields.map(([key, codec]) => codec.encode(struct[key]));
             return mergeBytes(fieldBytes);
@@ -59,14 +59,14 @@ export function getStructEncoder<T extends object>(
  * Creates a decoder for a custom object.
  *
  * @param fields - The name and decoder of each field.
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
 export function getStructDecoder<T extends object>(
     fields: StructToDecoderTuple<T>,
-    options: StructCodecOptions = {}
+    config: StructCodecConfig = {}
 ): Decoder<T> {
     return {
-        ...structCodecHelper(fields, options.description),
+        ...structCodecHelper(fields, config.description),
         decode: (bytes: Uint8Array, offset = 0) => {
             const struct: Partial<T> = {};
             fields.forEach(([key, codec]) => {
@@ -83,11 +83,11 @@ export function getStructDecoder<T extends object>(
  * Creates a codec for a custom object.
  *
  * @param fields - The name and codec of each field.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
 export function getStructCodec<T extends object, U extends T = T>(
     fields: StructToCodecTuple<T, U>,
-    options: StructCodecOptions = {}
+    config: StructCodecConfig = {}
 ): Codec<T, U> {
-    return combineCodec(getStructEncoder(fields, options), getStructDecoder(fields, options));
+    return combineCodec(getStructEncoder(fields, config), getStructDecoder(fields, config));
 }

--- a/packages/codecs-data-structures/src/tuple.ts
+++ b/packages/codecs-data-structures/src/tuple.ts
@@ -1,10 +1,10 @@
-import { BaseCodecOptions, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
+import { BaseCodecConfig, Codec, CodecData, combineCodec, Decoder, Encoder, mergeBytes } from '@solana/codecs-core';
 
 import { assertValidNumberOfItemsForCodec } from './assertions';
 import { sumCodecSizes } from './utils';
 
-/** Defines the options for tuple codecs. */
-export type TupleCodecOptions = BaseCodecOptions;
+/** Defines the config for tuple codecs. */
+export type TupleCodecConfig = BaseCodecConfig;
 
 type WrapInEncoder<T> = {
     [P in keyof T]: Encoder<T[P]>;
@@ -33,14 +33,14 @@ function tupleCodecHelper(items: Array<CodecData>, description?: string): CodecD
  * Creates a encoder for a tuple-like array.
  *
  * @param items - The encoders to use for each item in the tuple.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
 export function getTupleEncoder<T extends AnyArray>(
     items: WrapInEncoder<[...T]>,
-    options: TupleCodecOptions = {}
+    config: TupleCodecConfig = {}
 ): Encoder<T> {
     return {
-        ...tupleCodecHelper(items, options.description),
+        ...tupleCodecHelper(items, config.description),
         encode: (value: T) => {
             assertValidNumberOfItemsForCodec('tuple', items.length, value.length);
             return mergeBytes(items.map((item, index) => item.encode(value[index])));
@@ -52,14 +52,14 @@ export function getTupleEncoder<T extends AnyArray>(
  * Creates a decoder for a tuple-like array.
  *
  * @param items - The decoders to use for each item in the tuple.
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
 export function getTupleDecoder<T extends AnyArray>(
     items: WrapInDecoder<[...T]>,
-    options: TupleCodecOptions = {}
+    config: TupleCodecConfig = {}
 ): Decoder<T> {
     return {
-        ...tupleCodecHelper(items, options.description),
+        ...tupleCodecHelper(items, config.description),
         decode: (bytes: Uint8Array, offset = 0) => {
             const values = [] as AnyArray as T;
             items.forEach(codec => {
@@ -76,14 +76,14 @@ export function getTupleDecoder<T extends AnyArray>(
  * Creates a codec for a tuple-like array.
  *
  * @param items - The codecs to use for each item in the tuple.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
 export function getTupleCodec<T extends AnyArray, U extends T = T>(
     items: WrapInCodec<[...T], [...U]>,
-    options: TupleCodecOptions = {}
+    config: TupleCodecConfig = {}
 ): Codec<T, U> {
     return combineCodec(
-        getTupleEncoder(items as WrapInEncoder<[...T]>, options),
-        getTupleDecoder(items as WrapInDecoder<[...U]>, options)
+        getTupleEncoder(items as WrapInEncoder<[...T]>, config),
+        getTupleDecoder(items as WrapInDecoder<[...U]>, config)
     );
 }

--- a/packages/codecs-data-structures/src/unit.ts
+++ b/packages/codecs-data-structures/src/unit.ts
@@ -1,16 +1,16 @@
-import { BaseCodecOptions, Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { BaseCodecConfig, Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-/** Defines the options for unit codecs. */
-export type UnitSerializerOptions = BaseCodecOptions;
+/** Defines the config for unit codecs. */
+export type UnitSerializerconfig = BaseCodecConfig;
 
 /**
  * Creates a void encoder.
  *
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
-export function getUnitEncoder(options: UnitSerializerOptions = {}): Encoder<void> {
+export function getUnitEncoder(config: UnitSerializerconfig = {}): Encoder<void> {
     return {
-        description: options.description ?? 'unit',
+        description: config.description ?? 'unit',
         encode: () => new Uint8Array(),
         fixedSize: 0,
         maxSize: 0,
@@ -20,12 +20,12 @@ export function getUnitEncoder(options: UnitSerializerOptions = {}): Encoder<voi
 /**
  * Creates a void decoder.
  *
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
-export function getUnitDecoder(options: UnitSerializerOptions = {}): Decoder<void> {
+export function getUnitDecoder(config: UnitSerializerconfig = {}): Decoder<void> {
     return {
         decode: (_bytes: Uint8Array, offset = 0) => [undefined, offset],
-        description: options.description ?? 'unit',
+        description: config.description ?? 'unit',
         fixedSize: 0,
         maxSize: 0,
     };
@@ -34,8 +34,8 @@ export function getUnitDecoder(options: UnitSerializerOptions = {}): Decoder<voi
 /**
  * Creates a void codec.
  *
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
-export function getUnitCodec(options: UnitSerializerOptions = {}): Codec<void> {
-    return combineCodec(getUnitEncoder(options), getUnitDecoder(options));
+export function getUnitCodec(config: UnitSerializerconfig = {}): Codec<void> {
+    return combineCodec(getUnitEncoder(config), getUnitDecoder(config));
 }

--- a/packages/codecs-numbers/src/common.ts
+++ b/packages/codecs-numbers/src/common.ts
@@ -1,4 +1,4 @@
-import { BaseCodecOptions, Codec, Decoder, Encoder } from '@solana/codecs-core';
+import { BaseCodecConfig, Codec, Decoder, Encoder } from '@solana/codecs-core';
 
 /** Defines a encoder for numbers and bigints. */
 export type NumberEncoder = Encoder<number> | Encoder<number | bigint>;
@@ -9,11 +9,11 @@ export type NumberDecoder = Decoder<number> | Decoder<bigint>;
 /** Defines a codec for numbers and bigints. */
 export type NumberCodec = Codec<number> | Codec<number | bigint, bigint>;
 
-/** Defines the options for u8 and i8 codecs. */
-export type SingleByteNumberCodecOptions = BaseCodecOptions;
+/** Defines the config for u8 and i8 codecs. */
+export type SingleByteNumberCodecConfig = BaseCodecConfig;
 
-/** Defines the options for number codecs that use more than one byte. */
-export type NumberCodecOptions = BaseCodecOptions & {
+/** Defines the config for number codecs that use more than one byte. */
+export type NumberCodecConfig = BaseCodecConfig & {
     /**
      * Whether the serializer should use little-endian or big-endian encoding.
      * @defaultValue `Endian.LITTLE`

--- a/packages/codecs-numbers/src/f32.ts
+++ b/packages/codecs-numbers/src/f32.ts
@@ -1,23 +1,23 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getF32Encoder = (options: NumberCodecOptions = {}): Encoder<number> =>
+export const getF32Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
     numberEncoderFactory({
+        config,
         name: 'f32',
-        options,
         set: (view, value, le) => view.setFloat32(0, value, le),
         size: 4,
     });
 
-export const getF32Decoder = (options: NumberCodecOptions = {}): Decoder<number> =>
+export const getF32Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => view.getFloat32(0, le),
         name: 'f32',
-        options,
         size: 4,
     });
 
-export const getF32Codec = (options: NumberCodecOptions = {}): Codec<number> =>
-    combineCodec(getF32Encoder(options), getF32Decoder(options));
+export const getF32Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+    combineCodec(getF32Encoder(config), getF32Decoder(config));

--- a/packages/codecs-numbers/src/f64.ts
+++ b/packages/codecs-numbers/src/f64.ts
@@ -1,23 +1,23 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getF64Encoder = (options: NumberCodecOptions = {}): Encoder<number> =>
+export const getF64Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
     numberEncoderFactory({
+        config,
         name: 'f64',
-        options,
         set: (view, value, le) => view.setFloat64(0, value, le),
         size: 8,
     });
 
-export const getF64Decoder = (options: NumberCodecOptions = {}): Decoder<number> =>
+export const getF64Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => view.getFloat64(0, le),
         name: 'f64',
-        options,
         size: 8,
     });
 
-export const getF64Codec = (options: NumberCodecOptions = {}): Codec<number> =>
-    combineCodec(getF64Encoder(options), getF64Decoder(options));
+export const getF64Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+    combineCodec(getF64Encoder(config), getF64Decoder(config));

--- a/packages/codecs-numbers/src/i128.ts
+++ b/packages/codecs-numbers/src/i128.ts
@@ -1,12 +1,12 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI128Encoder = (options: NumberCodecOptions = {}): Encoder<number | bigint> =>
+export const getI128Encoder = (config: NumberCodecConfig = {}): Encoder<number | bigint> =>
     numberEncoderFactory({
+        config,
         name: 'i128',
-        options,
         range: [-BigInt('0x7fffffffffffffffffffffffffffffff') - 1n, BigInt('0x7fffffffffffffffffffffffffffffff')],
         set: (view, value, le) => {
             const leftOffset = le ? 8 : 0;
@@ -18,8 +18,9 @@ export const getI128Encoder = (options: NumberCodecOptions = {}): Encoder<number
         size: 16,
     });
 
-export const getI128Decoder = (options: NumberCodecOptions = {}): Decoder<bigint> =>
+export const getI128Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => {
             const leftOffset = le ? 8 : 0;
             const rightOffset = le ? 0 : 8;
@@ -28,9 +29,8 @@ export const getI128Decoder = (options: NumberCodecOptions = {}): Decoder<bigint
             return (left << 64n) + right;
         },
         name: 'i128',
-        options,
         size: 16,
     });
 
-export const getI128Codec = (options: NumberCodecOptions = {}): Codec<number | bigint, bigint> =>
-    combineCodec(getI128Encoder(options), getI128Decoder(options));
+export const getI128Codec = (config: NumberCodecConfig = {}): Codec<number | bigint, bigint> =>
+    combineCodec(getI128Encoder(config), getI128Decoder(config));

--- a/packages/codecs-numbers/src/i16.ts
+++ b/packages/codecs-numbers/src/i16.ts
@@ -1,24 +1,24 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI16Encoder = (options: NumberCodecOptions = {}): Encoder<number> =>
+export const getI16Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
     numberEncoderFactory({
+        config,
         name: 'i16',
-        options,
         range: [-Number('0x7fff') - 1, Number('0x7fff')],
         set: (view, value, le) => view.setInt16(0, value, le),
         size: 2,
     });
 
-export const getI16Decoder = (options: NumberCodecOptions = {}): Decoder<number> =>
+export const getI16Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => view.getInt16(0, le),
         name: 'i16',
-        options,
         size: 2,
     });
 
-export const getI16Codec = (options: NumberCodecOptions = {}): Codec<number> =>
-    combineCodec(getI16Encoder(options), getI16Decoder(options));
+export const getI16Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+    combineCodec(getI16Encoder(config), getI16Decoder(config));

--- a/packages/codecs-numbers/src/i32.ts
+++ b/packages/codecs-numbers/src/i32.ts
@@ -1,24 +1,24 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI32Encoder = (options: NumberCodecOptions = {}): Encoder<number> =>
+export const getI32Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
     numberEncoderFactory({
+        config,
         name: 'i32',
-        options,
         range: [-Number('0x7fffffff') - 1, Number('0x7fffffff')],
         set: (view, value, le) => view.setInt32(0, value, le),
         size: 4,
     });
 
-export const getI32Decoder = (options: NumberCodecOptions = {}): Decoder<number> =>
+export const getI32Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => view.getInt32(0, le),
         name: 'i32',
-        options,
         size: 4,
     });
 
-export const getI32Codec = (options: NumberCodecOptions = {}): Codec<number> =>
-    combineCodec(getI32Encoder(options), getI32Decoder(options));
+export const getI32Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+    combineCodec(getI32Encoder(config), getI32Decoder(config));

--- a/packages/codecs-numbers/src/i64.ts
+++ b/packages/codecs-numbers/src/i64.ts
@@ -1,24 +1,24 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI64Encoder = (options: NumberCodecOptions = {}): Encoder<number | bigint> =>
+export const getI64Encoder = (config: NumberCodecConfig = {}): Encoder<number | bigint> =>
     numberEncoderFactory({
+        config,
         name: 'i64',
-        options,
         range: [-BigInt('0x7fffffffffffffff') - 1n, BigInt('0x7fffffffffffffff')],
         set: (view, value, le) => view.setBigInt64(0, BigInt(value), le),
         size: 8,
     });
 
-export const getI64Decoder = (options: NumberCodecOptions = {}): Decoder<bigint> =>
+export const getI64Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => view.getBigInt64(0, le),
         name: 'i64',
-        options,
         size: 8,
     });
 
-export const getI64Codec = (options: NumberCodecOptions = {}): Codec<number | bigint, bigint> =>
-    combineCodec(getI64Encoder(options), getI64Decoder(options));
+export const getI64Codec = (config: NumberCodecConfig = {}): Codec<number | bigint, bigint> =>
+    combineCodec(getI64Encoder(config), getI64Decoder(config));

--- a/packages/codecs-numbers/src/i8.ts
+++ b/packages/codecs-numbers/src/i8.ts
@@ -1,24 +1,24 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { SingleByteNumberCodecOptions } from './common';
+import { SingleByteNumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI8Encoder = (options: SingleByteNumberCodecOptions = {}): Encoder<number> =>
+export const getI8Encoder = (config: SingleByteNumberCodecConfig = {}): Encoder<number> =>
     numberEncoderFactory({
+        config,
         name: 'i8',
-        options,
         range: [-Number('0x7f') - 1, Number('0x7f')],
         set: (view, value) => view.setInt8(0, value),
         size: 1,
     });
 
-export const getI8Decoder = (options: SingleByteNumberCodecOptions = {}): Decoder<number> =>
+export const getI8Decoder = (config: SingleByteNumberCodecConfig = {}): Decoder<number> =>
     numberDecoderFactory({
+        config,
         get: view => view.getInt8(0),
         name: 'i8',
-        options,
         size: 1,
     });
 
-export const getI8Codec = (options: SingleByteNumberCodecOptions = {}): Codec<number> =>
-    combineCodec(getI8Encoder(options), getI8Decoder(options));
+export const getI8Codec = (config: SingleByteNumberCodecConfig = {}): Codec<number> =>
+    combineCodec(getI8Encoder(config), getI8Decoder(config));

--- a/packages/codecs-numbers/src/short-u16.ts
+++ b/packages/codecs-numbers/src/short-u16.ts
@@ -1,18 +1,18 @@
-import { BaseCodecOptions, Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { BaseCodecConfig, Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
 import { assertNumberIsBetweenForCodec } from './assertions';
 
 /**
- * Defines the options for the shortU16 serializer.
+ * Defines the config for the shortU16 serializer.
  */
-export type ShortU16CodecOptions = BaseCodecOptions;
+export type ShortU16CodecConfig = BaseCodecConfig;
 
 /**
  * Encodes short u16 numbers.
  * @see {@link getShortU16Codec} for a more detailed description.
  */
-export const getShortU16Encoder = (options: ShortU16CodecOptions = {}): Encoder<number> => ({
-    description: options.description ?? 'shortU16',
+export const getShortU16Encoder = (config: ShortU16CodecConfig = {}): Encoder<number> => ({
+    description: config.description ?? 'shortU16',
     encode: (value: number): Uint8Array => {
         assertNumberIsBetweenForCodec('shortU16', 0, 65535, value);
         const bytes = [0];
@@ -41,7 +41,7 @@ export const getShortU16Encoder = (options: ShortU16CodecOptions = {}): Encoder<
  * Decodes short u16 numbers.
  * @see {@link getShortU16Codec} for a more detailed description.
  */
-export const getShortU16Decoder = (options: ShortU16CodecOptions = {}): Decoder<number> => ({
+export const getShortU16Decoder = (config: ShortU16CodecConfig = {}): Decoder<number> => ({
     decode: (bytes: Uint8Array, offset = 0): [number, number] => {
         let value = 0;
         let byteCount = 0;
@@ -58,7 +58,7 @@ export const getShortU16Decoder = (options: ShortU16CodecOptions = {}): Decoder<
         }
         return [value, offset + byteCount];
     },
-    description: options.description ?? 'shortU16',
+    description: config.description ?? 'shortU16',
     fixedSize: null,
     maxSize: 3,
 });
@@ -72,5 +72,5 @@ export const getShortU16Decoder = (options: ShortU16CodecOptions = {}): Decoder<
  * pattern until the 3rd byte. The 3rd byte, if needed, uses
  * all 8 bits to store the last byte of the original value.
  */
-export const getShortU16Codec = (options: ShortU16CodecOptions = {}): Codec<number> =>
-    combineCodec(getShortU16Encoder(options), getShortU16Decoder(options));
+export const getShortU16Codec = (config: ShortU16CodecConfig = {}): Codec<number> =>
+    combineCodec(getShortU16Encoder(config), getShortU16Decoder(config));

--- a/packages/codecs-numbers/src/u128.ts
+++ b/packages/codecs-numbers/src/u128.ts
@@ -1,12 +1,12 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU128Encoder = (options: NumberCodecOptions = {}): Encoder<number | bigint> =>
+export const getU128Encoder = (config: NumberCodecConfig = {}): Encoder<number | bigint> =>
     numberEncoderFactory({
+        config,
         name: 'u128',
-        options,
         range: [0, BigInt('0xffffffffffffffffffffffffffffffff')],
         set: (view, value, le) => {
             const leftOffset = le ? 8 : 0;
@@ -18,8 +18,9 @@ export const getU128Encoder = (options: NumberCodecOptions = {}): Encoder<number
         size: 16,
     });
 
-export const getU128Decoder = (options: NumberCodecOptions = {}): Decoder<bigint> =>
+export const getU128Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => {
             const leftOffset = le ? 8 : 0;
             const rightOffset = le ? 0 : 8;
@@ -28,9 +29,8 @@ export const getU128Decoder = (options: NumberCodecOptions = {}): Decoder<bigint
             return (left << 64n) + right;
         },
         name: 'u128',
-        options,
         size: 16,
     });
 
-export const getU128Codec = (options: NumberCodecOptions = {}): Codec<number | bigint, bigint> =>
-    combineCodec(getU128Encoder(options), getU128Decoder(options));
+export const getU128Codec = (config: NumberCodecConfig = {}): Codec<number | bigint, bigint> =>
+    combineCodec(getU128Encoder(config), getU128Decoder(config));

--- a/packages/codecs-numbers/src/u16.ts
+++ b/packages/codecs-numbers/src/u16.ts
@@ -1,24 +1,24 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU16Encoder = (options: NumberCodecOptions = {}): Encoder<number> =>
+export const getU16Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
     numberEncoderFactory({
+        config,
         name: 'u16',
-        options,
         range: [0, Number('0xffff')],
         set: (view, value, le) => view.setUint16(0, value, le),
         size: 2,
     });
 
-export const getU16Decoder = (options: NumberCodecOptions = {}): Decoder<number> =>
+export const getU16Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => view.getUint16(0, le),
         name: 'u16',
-        options,
         size: 2,
     });
 
-export const getU16Codec = (options: NumberCodecOptions = {}): Codec<number> =>
-    combineCodec(getU16Encoder(options), getU16Decoder(options));
+export const getU16Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+    combineCodec(getU16Encoder(config), getU16Decoder(config));

--- a/packages/codecs-numbers/src/u32.ts
+++ b/packages/codecs-numbers/src/u32.ts
@@ -1,24 +1,24 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU32Encoder = (options: NumberCodecOptions = {}): Encoder<number> =>
+export const getU32Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
     numberEncoderFactory({
+        config,
         name: 'u32',
-        options,
         range: [0, Number('0xffffffff')],
         set: (view, value, le) => view.setUint32(0, value, le),
         size: 4,
     });
 
-export const getU32Decoder = (options: NumberCodecOptions = {}): Decoder<number> =>
+export const getU32Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => view.getUint32(0, le),
         name: 'u32',
-        options,
         size: 4,
     });
 
-export const getU32Codec = (options: NumberCodecOptions = {}): Codec<number> =>
-    combineCodec(getU32Encoder(options), getU32Decoder(options));
+export const getU32Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+    combineCodec(getU32Encoder(config), getU32Decoder(config));

--- a/packages/codecs-numbers/src/u64.ts
+++ b/packages/codecs-numbers/src/u64.ts
@@ -1,24 +1,24 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { NumberCodecOptions } from './common';
+import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU64Encoder = (options: NumberCodecOptions = {}): Encoder<number | bigint> =>
+export const getU64Encoder = (config: NumberCodecConfig = {}): Encoder<number | bigint> =>
     numberEncoderFactory({
+        config,
         name: 'u64',
-        options,
         range: [0, BigInt('0xffffffffffffffff')],
         set: (view, value, le) => view.setBigUint64(0, BigInt(value), le),
         size: 8,
     });
 
-export const getU64Decoder = (options: NumberCodecOptions = {}): Decoder<bigint> =>
+export const getU64Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =>
     numberDecoderFactory({
+        config,
         get: (view, le) => view.getBigUint64(0, le),
         name: 'u64',
-        options,
         size: 8,
     });
 
-export const getU64Codec = (options: NumberCodecOptions = {}): Codec<number | bigint, bigint> =>
-    combineCodec(getU64Encoder(options), getU64Decoder(options));
+export const getU64Codec = (config: NumberCodecConfig = {}): Codec<number | bigint, bigint> =>
+    combineCodec(getU64Encoder(config), getU64Decoder(config));

--- a/packages/codecs-numbers/src/u8.ts
+++ b/packages/codecs-numbers/src/u8.ts
@@ -1,24 +1,24 @@
 import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
 
-import { SingleByteNumberCodecOptions } from './common';
+import { SingleByteNumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU8Encoder = (options: SingleByteNumberCodecOptions = {}): Encoder<number> =>
+export const getU8Encoder = (config: SingleByteNumberCodecConfig = {}): Encoder<number> =>
     numberEncoderFactory({
+        config,
         name: 'u8',
-        options,
         range: [0, Number('0xff')],
         set: (view, value) => view.setUint8(0, value),
         size: 1,
     });
 
-export const getU8Decoder = (options: SingleByteNumberCodecOptions = {}): Decoder<number> =>
+export const getU8Decoder = (config: SingleByteNumberCodecConfig = {}): Decoder<number> =>
     numberDecoderFactory({
+        config,
         get: view => view.getUint8(0),
         name: 'u8',
-        options,
         size: 1,
     });
 
-export const getU8Codec = (options: SingleByteNumberCodecOptions = {}): Codec<number> =>
-    combineCodec(getU8Encoder(options), getU8Decoder(options));
+export const getU8Codec = (config: SingleByteNumberCodecConfig = {}): Codec<number> =>
+    combineCodec(getU8Encoder(config), getU8Decoder(config));

--- a/packages/codecs-numbers/src/utils.ts
+++ b/packages/codecs-numbers/src/utils.ts
@@ -7,12 +7,12 @@ import {
 } from '@solana/codecs-core';
 
 import { assertNumberIsBetweenForCodec } from './assertions';
-import { Endian, NumberCodecOptions, SingleByteNumberCodecOptions } from './common';
+import { Endian, NumberCodecConfig, SingleByteNumberCodecConfig } from './common';
 
 type NumberFactorySharedInput = {
     name: string;
     size: number;
-    options: SingleByteNumberCodecOptions | NumberCodecOptions;
+    config: SingleByteNumberCodecConfig | NumberCodecConfig;
 };
 
 type NumberFactoryEncoderInput<T> = NumberFactorySharedInput & {
@@ -29,12 +29,12 @@ function sharedNumberFactory(input: NumberFactorySharedInput): CodecData & { lit
     let defaultDescription: string = input.name;
 
     if (input.size > 1) {
-        littleEndian = !('endian' in input.options) || input.options.endian === Endian.LITTLE;
+        littleEndian = !('endian' in input.config) || input.config.endian === Endian.LITTLE;
         defaultDescription += littleEndian ? '(le)' : '(be)';
     }
 
     return {
-        description: input.options.description ?? defaultDescription,
+        description: input.config.description ?? defaultDescription,
         fixedSize: input.size,
         littleEndian,
         maxSize: input.size,

--- a/packages/codecs-strings/src/string.ts
+++ b/packages/codecs-strings/src/string.ts
@@ -1,7 +1,7 @@
 import {
     assertByteArrayHasEnoughBytesForCodec,
     assertByteArrayIsNotEmptyForCodec,
-    BaseCodecOptions,
+    BaseCodecConfig,
     Codec,
     CodecData,
     combineCodec,
@@ -15,11 +15,11 @@ import { getU32Decoder, getU32Encoder, NumberCodec, NumberDecoder, NumberEncoder
 
 import { getUtf8Decoder, getUtf8Encoder } from './utf8';
 
-/** Defines the options for string codecs. */
-export type StringCodecOptions<
+/** Defines the config for string codecs. */
+export type StringCodecConfig<
     TPrefix extends NumberCodec | NumberEncoder | NumberDecoder,
     TEncoding extends Codec<string> | Encoder<string> | Decoder<string>
-> = BaseCodecOptions & {
+> = BaseCodecConfig & {
     /**
      * The size of the string. It can be one of the following:
      * - a {@link NumberCodec} that prefixes the string with its size.
@@ -37,10 +37,10 @@ export type StringCodecOptions<
 };
 
 /** Encodes strings from a given encoding and size strategy. */
-export const getStringEncoder = (options: StringCodecOptions<NumberEncoder, Encoder<string>> = {}): Encoder<string> => {
-    const size = options.size ?? getU32Encoder();
-    const encoding = options.encoding ?? getUtf8Encoder();
-    const description = options.description ?? `string(${encoding.description}; ${getSizeDescription(size)})`;
+export const getStringEncoder = (config: StringCodecConfig<NumberEncoder, Encoder<string>> = {}): Encoder<string> => {
+    const size = config.size ?? getU32Encoder();
+    const encoding = config.encoding ?? getUtf8Encoder();
+    const description = config.description ?? `string(${encoding.description}; ${getSizeDescription(size)})`;
 
     if (size === 'variable') {
         return { ...encoding, description };
@@ -63,10 +63,10 @@ export const getStringEncoder = (options: StringCodecOptions<NumberEncoder, Enco
 };
 
 /** Decodes strings from a given encoding and size strategy. */
-export const getStringDecoder = (options: StringCodecOptions<NumberDecoder, Decoder<string>> = {}): Decoder<string> => {
-    const size = options.size ?? getU32Decoder();
-    const encoding = options.encoding ?? getUtf8Decoder();
-    const description = options.description ?? `string(${encoding.description}; ${getSizeDescription(size)})`;
+export const getStringDecoder = (config: StringCodecConfig<NumberDecoder, Decoder<string>> = {}): Decoder<string> => {
+    const size = config.size ?? getU32Decoder();
+    const encoding = config.encoding ?? getUtf8Decoder();
+    const description = config.description ?? `string(${encoding.description}; ${getSizeDescription(size)})`;
 
     if (size === 'variable') {
         return { ...encoding, description };
@@ -95,8 +95,8 @@ export const getStringDecoder = (options: StringCodecOptions<NumberDecoder, Deco
 };
 
 /** Encodes and decodes strings from a given encoding and size strategy. */
-export const getStringCodec = (options: StringCodecOptions<NumberCodec, Codec<string>> = {}): Codec<string> =>
-    combineCodec(getStringEncoder(options), getStringDecoder(options));
+export const getStringCodec = (config: StringCodecConfig<NumberCodec, Codec<string>> = {}): Codec<string> =>
+    combineCodec(getStringEncoder(config), getStringDecoder(config));
 
 function getSizeDescription(size: CodecData | number | 'variable'): string {
     return typeof size === 'object' ? size.description : `${size}`;

--- a/packages/options/src/__tests__/__setup__.ts
+++ b/packages/options/src/__tests__/__setup__.ts
@@ -17,15 +17,15 @@ export const base16: Codec<string> = {
 };
 
 export const getMockCodec = (
-    options: {
+    config: {
         defaultValue?: string;
         description?: string;
         size?: number | null;
     } = {}
 ) => ({
-    decode: jest.fn().mockReturnValue([options.defaultValue ?? '', 0]),
-    description: options.description ?? 'mock',
+    decode: jest.fn().mockReturnValue([config.defaultValue ?? '', 0]),
+    description: config.description ?? 'mock',
     encode: jest.fn().mockReturnValue(new Uint8Array()),
-    fixedSize: options.size ?? null,
-    maxSize: options.size ?? null,
+    fixedSize: config.size ?? null,
+    maxSize: config.size ?? null,
 });

--- a/packages/options/src/option-codec.ts
+++ b/packages/options/src/option-codec.ts
@@ -1,6 +1,6 @@
 import {
     assertFixedSizeCodec,
-    BaseCodecOptions,
+    BaseCodecConfig,
     Codec,
     CodecData,
     combineCodec,
@@ -14,8 +14,8 @@ import { getU8Decoder, getU8Encoder, NumberCodec, NumberDecoder, NumberEncoder }
 import { isOption, isSome, none, Option, OptionOrNullable, some } from './option';
 import { wrapNullable } from './unwrap-option';
 
-/** Defines the options for option codecs. */
-export type OptionCodecOptions<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecOptions & {
+/** Defines the config for option codecs. */
+export type OptionCodecConfig<TPrefix extends NumberCodec | NumberEncoder | NumberDecoder> = BaseCodecConfig & {
     /**
      * The codec to use for the boolean prefix.
      * @defaultValue u8 prefix.
@@ -58,16 +58,16 @@ function optionCodecHelper(item: CodecData, prefix: CodecData, fixed: boolean, d
  * Creates a encoder for an optional value using `null` as the `None` value.
  *
  * @param item - The encoder to use for the value that may be present.
- * @param options - A set of options for the encoder.
+ * @param config - A set of config for the encoder.
  */
 export function getOptionEncoder<T>(
     item: Encoder<T>,
-    options: OptionCodecOptions<NumberEncoder> = {}
+    config: OptionCodecConfig<NumberEncoder> = {}
 ): Encoder<OptionOrNullable<T>> {
-    const prefix = options.prefix ?? getU8Encoder();
-    const fixed = options.fixed ?? false;
+    const prefix = config.prefix ?? getU8Encoder();
+    const fixed = config.fixed ?? false;
     return {
-        ...optionCodecHelper(item, prefix, fixed, options.description),
+        ...optionCodecHelper(item, prefix, fixed, config.description),
         encode: (optionOrNullable: OptionOrNullable<T>) => {
             const option = isOption<T>(optionOrNullable) ? optionOrNullable : wrapNullable(optionOrNullable);
             const prefixByte = prefix.encode(Number(isSome(option)));
@@ -82,16 +82,16 @@ export function getOptionEncoder<T>(
  * Creates a decoder for an optional value using `null` as the `None` value.
  *
  * @param item - The decoder to use for the value that may be present.
- * @param options - A set of options for the decoder.
+ * @param config - A set of config for the decoder.
  */
 export function getOptionDecoder<T>(
     item: Decoder<T>,
-    options: OptionCodecOptions<NumberDecoder> = {}
+    config: OptionCodecConfig<NumberDecoder> = {}
 ): Decoder<Option<T>> {
-    const prefix = options.prefix ?? getU8Decoder();
-    const fixed = options.fixed ?? false;
+    const prefix = config.prefix ?? getU8Decoder();
+    const fixed = config.fixed ?? false;
     return {
-        ...optionCodecHelper(item, prefix, fixed, options.description),
+        ...optionCodecHelper(item, prefix, fixed, config.description),
         decode: (bytes: Uint8Array, offset = 0) => {
             if (bytes.length - offset <= 0) {
                 return [none(), offset];
@@ -113,11 +113,11 @@ export function getOptionDecoder<T>(
  * Creates a codec for an optional value using `null` as the `None` value.
  *
  * @param item - The codec to use for the value that may be present.
- * @param options - A set of options for the codec.
+ * @param config - A set of config for the codec.
  */
 export function getOptionCodec<T, U extends T = T>(
     item: Codec<T, U>,
-    options: OptionCodecOptions<NumberCodec> = {}
+    config: OptionCodecConfig<NumberCodec> = {}
 ): Codec<OptionOrNullable<T>, Option<U>> {
-    return combineCodec(getOptionEncoder<T>(item, options), getOptionDecoder<U>(item, options));
+    return combineCodec(getOptionEncoder<T>(item, config), getOptionDecoder<U>(item, config));
 }


### PR DESCRIPTION
Rename `options` to `config` in the `@solana/codecs-*` and `@solana/options` libraries to stay consistent with the rest of the library.
