### PR TITLE
refactor(experimental): use getBase64Decoder in getBase64EncodedWireTransaction

### DIFF
--- a/packages/transactions/src/wire-transaction.ts
+++ b/packages/transactions/src/wire-transaction.ts
@@ -1,3 +1,5 @@
+import { getBase64Decoder } from '@solana/codecs-strings';
+
 import { getTransactionEncoder } from './serializers/transaction';
 
 export type Base64EncodedWireTransaction = string & {
@@ -8,9 +10,5 @@ export function getBase64EncodedWireTransaction(
     transaction: Parameters<ReturnType<typeof getTransactionEncoder>['encode']>[0]
 ): Base64EncodedWireTransaction {
     const wireTransactionBytes = getTransactionEncoder().encode(transaction);
-    if (__NODEJS__) {
-        return Buffer.from(wireTransactionBytes).toString('base64') as Base64EncodedWireTransaction;
-    } else {
-        return (btoa as Window['btoa'])(String.fromCharCode(...wireTransactionBytes)) as Base64EncodedWireTransaction;
-    }
+    return getBase64Decoder().decode(wireTransactionBytes)[0] as Base64EncodedWireTransaction;
 }


### PR DESCRIPTION
Refactor the implementation of `getBase64EncodedWireTransaction` such that it uses the `getBase64Decoder` instead of re-implementing its logic.
