### PR TITLE
refactor(experimental): delete `Buffer` in non-Node tests

### DIFF
--- a/packages/test-config/jest-unit.config.browser.ts
+++ b/packages/test-config/jest-unit.config.browser.ts
@@ -25,6 +25,7 @@ const config: Partial<Config.InitialProjectOptions> = {
         ...(commonConfig.setupFilesAfterEnv ?? []),
         path.resolve(__dirname, 'setup-secure-context.ts'),
         path.resolve(__dirname, 'setup-text-encoder.ts'),
+        path.resolve(__dirname, 'setup-web-buffer-global.ts'),
     ],
     testEnvironment: 'jsdom',
     testEnvironmentOptions: {},

--- a/packages/test-config/setup-web-buffer-global.ts
+++ b/packages/test-config/setup-web-buffer-global.ts
@@ -1,0 +1,8 @@
+/**
+ * Browsers don't have a `Buffer` global, so delete it now.
+ */
+beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    delete globalThis.Buffer;
+});


### PR DESCRIPTION
# Summary

This makes the browser environment closer to an actual browser, because browsers have no access to `Buffer`.
