### PR TITLE
refactor(experimental): create a sham for `Keypair`

### DIFF
--- a/packages/library-legacy-sham/package.json
+++ b/packages/library-legacy-sham/package.json
@@ -65,6 +65,8 @@
         "node": ">=17.4"
     },
     "dependencies": {
+        "@noble/ed25519": "^2.0.0",
+        "@noble/hashes": "^1.3.2",
         "@solana/addresses": "workspace:*"
     },
     "devDependencies": {

--- a/packages/library-legacy-sham/src/__tests__/key-pair-test.ts
+++ b/packages/library-legacy-sham/src/__tests__/key-pair-test.ts
@@ -1,0 +1,81 @@
+import { utils } from '@noble/ed25519';
+
+import { Keypair } from '../key-pair';
+import { PublicKey } from '../public-key';
+
+const MOCK_PRIVATE_KEY_BYTES = [
+    151, 227, 37, 180, 104, 169, 5, 53, 191, 115, 132, 187, 223, 228, 25, 52, 7, 50, 86, 18, 151, 45, 105, 68, 31, 21,
+    128, 21, 32, 16, 222, 239,
+];
+const MOCK_PUBLIC_KEY_BYTES = [
+    117, 62, 75, 185, 26, 65, 209, 23, 95, 56, 97, 216, 197, 215, 208, 14, 138, 142, 59, 114, 43, 60, 190, 86, 21, 58,
+    46, 232, 77, 145, 46, 101,
+];
+
+describe('KeypairSham', () => {
+    it.each(['fromSecretKey', 'fromSeed'] as (keyof typeof Keypair)[])('throws when calling `%s`', method => {
+        expect(() =>
+            // This is basically just complaining that `prototype` is not callable.
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            Keypair[method]()
+        ).toThrow(`Keypair#${method.toString()} is unimplemented`);
+    });
+    describe('generate()', () => {
+        it('returns a `Keypair` instance', () => {
+            expect(Keypair.generate()).toBeInstanceOf(Keypair);
+        });
+    });
+    describe.each([
+        [
+            'generated keypair',
+            () => {
+                jest.spyOn(utils, 'randomPrivateKey').mockReturnValue(new Uint8Array(MOCK_PRIVATE_KEY_BYTES));
+                return new Keypair();
+            },
+        ],
+        [
+            'user-supplied keypair',
+            () =>
+                new Keypair({
+                    publicKey: new Uint8Array(MOCK_PUBLIC_KEY_BYTES),
+                    secretKey: new Uint8Array([...MOCK_PRIVATE_KEY_BYTES, ...MOCK_PUBLIC_KEY_BYTES]),
+                }),
+        ],
+        [
+            'user-supplied keypair whose `publicKey` does not correspond to the supplied private key',
+            () =>
+                new Keypair({
+                    publicKey: new Uint8Array(Array(32).fill(9)),
+                    secretKey: new Uint8Array([...MOCK_PRIVATE_KEY_BYTES, ...MOCK_PUBLIC_KEY_BYTES]),
+                }),
+        ],
+        [
+            "user-supplied keypair whose last 32 bytes of the `secretKey` do not represent the private key's public key",
+            () =>
+                new Keypair({
+                    publicKey: new Uint8Array(MOCK_PUBLIC_KEY_BYTES),
+                    secretKey: new Uint8Array([...MOCK_PRIVATE_KEY_BYTES, ...Array(32).fill(9)]),
+                }),
+        ],
+    ])('given a %s', (_, createKeyPair) => {
+        let keyPair: Keypair;
+        beforeEach(() => {
+            keyPair = createKeyPair();
+        });
+        it('vends the a public key instance at `publicKey`', () => {
+            expect(keyPair.publicKey).toBeInstanceOf(PublicKey);
+        });
+        it('vends the public key associated with the secret key', () => {
+            expect(keyPair.publicKey.toBytes()).toEqual(new Uint8Array(MOCK_PUBLIC_KEY_BYTES));
+        });
+        it('vends a 64 byte array at `secretKey`, the first half of which is the private key and the second half which is the public key', () => {
+            expect(keyPair.secretKey).toEqual(new Uint8Array([...MOCK_PRIVATE_KEY_BYTES, ...MOCK_PUBLIC_KEY_BYTES]));
+        });
+        it('throws when accessing `_keypair`', () => {
+            expect(() => {
+                keyPair._keypair;
+            }).toThrow();
+        });
+    });
+});

--- a/packages/library-legacy-sham/src/__typetests__/key-pair-typetest.ts
+++ b/packages/library-legacy-sham/src/__typetests__/key-pair-typetest.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { Keypair as LegacyKeypairWithPrivateKeypairProperty } from '@solana/web3.js-legacy';
+
+import { Keypair } from '../key-pair';
+
+type LegacyKeypair = Omit<LegacyKeypairWithPrivateKeypairProperty, '_keypair'>;
+
+new Keypair() satisfies LegacyKeypair;
+new Keypair({
+    publicKey: new Uint8Array([]),
+    secretKey: new Uint8Array([]),
+}) satisfies LegacyKeypair;
+
+// I want this to pass, but there's no way to match the `_keypair` properties
+// in each of these classes, because the legacy one has `private` visibilty.
+// @ts-expect-error
+Keypair satisfies typeof LegacyKeypairWithPrivateKeypairProperty;

--- a/packages/library-legacy-sham/src/index.ts
+++ b/packages/library-legacy-sham/src/index.ts
@@ -1,5 +1,5 @@
+export * from './key-pair';
 export * from './public-key';
-
 export const LAMPORTS_PER_SOL = 1_000_000_000;
 export const MAX_SEED_LENGTH = 32;
 export const NONCE_ACCOUNT_LENGTH = 80;

--- a/packages/library-legacy-sham/src/key-pair.ts
+++ b/packages/library-legacy-sham/src/key-pair.ts
@@ -1,0 +1,64 @@
+import { etc, getPublicKey, utils } from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha512';
+import { getAddressDecoder } from '@solana/addresses';
+
+import { PublicKey } from './public-key';
+import { createUnimplementedFunction } from './unimplemented';
+
+export class Keypair {
+    #cachedPublicKey: PublicKey | undefined;
+    #cachedPublicKeyBytes: Uint8Array | undefined;
+    #secretKeyBytes: Uint8Array;
+    constructor(keypair?: {
+        publicKey: Uint8Array;
+        /**
+         * A 64 byte secret key, the first 32 bytes of which is the
+         * private scalar and the last 32 bytes is the public key.
+         * Read more: https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/
+         */
+        secretKey: Uint8Array;
+    }) {
+        if (keypair) {
+            this.#secretKeyBytes = keypair.secretKey.slice(0, 32);
+        } else {
+            this.#secretKeyBytes = this.#generateSecretKeyBytes();
+        }
+    }
+    get #publicKeyBytes() {
+        if (!this.#cachedPublicKeyBytes) {
+            if (!etc.sha512Sync) {
+                etc.sha512Sync = (...m) => sha512(etc.concatBytes(...m));
+            }
+            this.#cachedPublicKeyBytes = getPublicKey(this.#secretKeyBytes);
+        }
+        return this.#cachedPublicKeyBytes;
+    }
+    #generateSecretKeyBytes() {
+        return utils.randomPrivateKey();
+    }
+    get _keypair() {
+        throw new Error(
+            'This error is being thrown from `@solana/web3.js-legacy-sham`. The legacy ' +
+                'implementation of `Keypair` historically exposed the internal property ' +
+                '`_keypair` but the sham does not. Please eliminate this access of `_keypair` ' +
+                'and replace it with an implementation that makes use of the available public ' +
+                'methods.'
+        );
+    }
+    get publicKey(): PublicKey {
+        if (!this.#cachedPublicKey) {
+            const publicKeyBytes = this.#publicKeyBytes;
+            const [address] = getAddressDecoder().decode(publicKeyBytes);
+            this.#cachedPublicKey = new PublicKey(address);
+        }
+        return this.#cachedPublicKey;
+    }
+    get secretKey(): Uint8Array {
+        return new Uint8Array([...this.#secretKeyBytes, ...this.#publicKeyBytes]);
+    }
+    static fromSecretKey = createUnimplementedFunction('Keypair#fromSecretKey');
+    static fromSeed = createUnimplementedFunction('Keypair#fromSeed');
+    static generate() {
+        return new Keypair();
+    }
+}

--- a/packages/test-config/jest-unit.config.common.ts
+++ b/packages/test-config/jest-unit.config.common.ts
@@ -22,6 +22,7 @@ const config: Partial<Config.InitialProjectOptions> = {
             },
         ],
     },
+    transformIgnorePatterns: ['/node_modules/(?!.*\\@noble/ed25519/)', '\\.pnp\\.[^\\/]+$'],
 };
 
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1111,6 +1111,12 @@ importers:
 
   packages/library-legacy-sham:
     dependencies:
+      '@noble/ed25519':
+        specifier: ^2.0.0
+        version: 2.0.0
+      '@noble/hashes':
+        specifier: ^1.3.2
+        version: 1.3.2
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
@@ -4374,6 +4380,10 @@ packages:
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
     dependencies:
       '@noble/hashes': 1.3.2
+
+  /@noble/ed25519@2.0.0:
+    resolution: {integrity: sha512-/extjhkwFupyopDrt80OMWKdLgP429qLZj+z6sYJz90rF2Iz0gjZh2ArMKPImUl13Kx+0EXI2hN9T/KJV0/Zng==}
+    dev: false
 
   /@noble/hashes@1.3.1:
     resolution: {integrity: sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==}


### PR DESCRIPTION
# Preamble

Imagine that you depend on a module that itself depends on the legacy `@solana/web3.js`. This makes it difficult for you to remove the legacy library from your project.

The chances are, though, that module only needs a _fraction_ of what web3.js provides.

The goal of the sham – of which this PR is the first – is to provide drop-in replacements for just the things that a set list of known dependencies require. You should be able to hot-swap the sham in via npm `overrides` or yarn `resolutions` and thereby drop the legacy web3.js from your bundle.

# Summary

This PR introduces an interface compatible(-ish) `Keypair` that you can use as a drop-in replacement for the one in `@solana/web3.js@1`

# Test Plan

```
cd packages/library-legacy-sham/
pnpm test:unit:browser
pnpm test:unit:node
```

See later diffs for a functional test plan where we actually drop the sham in to an actual application and see the results.

Addresses #1825.