### PR TITLE
refactor(experimental): pre-build the byte array before encoding with codecs

### DIFF
--- a/packages/codecs-core/src/__tests__/__setup__.ts
+++ b/packages/codecs-core/src/__tests__/__setup__.ts
@@ -3,12 +3,12 @@ import { Codec, createCodec } from '../codec';
 export const b = (s: string) => base16.encode(s);
 
 export const base16: Codec<string> = createCodec({
-    description: 'base16',
-    getSize: (value: string) => Math.ceil(value.length / 2),
-    read(bytes, offset = 0) {
+    fixedSize: null,
+    read(bytes, offset) {
         const value = bytes.slice(offset).reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
         return [value, bytes.length];
     },
+    variableSize: (value: string) => Math.ceil(value.length / 2),
     write(value: string, bytes, offset) {
         const matches = value.toLowerCase().match(/.{1,2}/g);
         const hexBytes = matches ? matches.map((byte: string) => parseInt(byte, 16)) : [];
@@ -25,10 +25,13 @@ export const getMockCodec = (
     } = {}
 ) =>
     createCodec({
-        description: config.description ?? 'mock',
-        fixedSize: config.size ?? undefined,
-        getSize: jest.fn().mockReturnValue(config.size ?? 0),
-        maxSize: config.size ?? null,
+        fixedSize: config.size ?? null,
+        maxSize: config.size ?? undefined,
         read: jest.fn().mockReturnValue([config.defaultValue ?? '', 0]),
+        variableSize: jest.fn().mockReturnValue(config.size ?? 0),
         write: jest.fn().mockReturnValue(0),
-    });
+    }) as Codec<unknown> & {
+        readonly read: jest.Mock;
+        readonly variableSize: jest.Mock;
+        readonly write: jest.Mock;
+    };

--- a/packages/codecs-core/src/__tests__/__setup__.ts
+++ b/packages/codecs-core/src/__tests__/__setup__.ts
@@ -1,31 +1,34 @@
-import { Codec } from '../codec';
+import { Codec, createCodec } from '../codec';
 
 export const b = (s: string) => base16.encode(s);
 
-export const base16: Codec<string> = {
-    decode(bytes, offset = 0) {
+export const base16: Codec<string> = createCodec({
+    description: 'base16',
+    getSize: (value: string) => Math.ceil(value.length / 2),
+    read(bytes, offset = 0) {
         const value = bytes.slice(offset).reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
         return [value, bytes.length];
     },
-    description: 'base16',
-    encode(value: string) {
+    write(value: string, bytes, offset) {
         const matches = value.toLowerCase().match(/.{1,2}/g);
-        return Uint8Array.from(matches ? matches.map((byte: string) => parseInt(byte, 16)) : []);
+        const hexBytes = matches ? matches.map((byte: string) => parseInt(byte, 16)) : [];
+        bytes.set(hexBytes, offset);
+        return offset + hexBytes.length;
     },
-    fixedSize: null,
-    maxSize: null,
-};
+});
 
 export const getMockCodec = (
     config: {
         defaultValue?: string;
         description?: string;
         size?: number | null;
-    } = {},
-) => ({
-    decode: jest.fn().mockReturnValue([config.defaultValue ?? '', 0]),
-    description: config.description ?? 'mock',
-    encode: jest.fn().mockReturnValue(new Uint8Array()),
-    fixedSize: config.size ?? null,
-    maxSize: config.size ?? null,
-});
+    } = {}
+) =>
+    createCodec({
+        description: config.description ?? 'mock',
+        fixedSize: config.size ?? undefined,
+        getSize: jest.fn().mockReturnValue(config.size ?? 0),
+        maxSize: config.size ?? null,
+        read: jest.fn().mockReturnValue([config.defaultValue ?? '', 0]),
+        write: jest.fn().mockReturnValue(0),
+    });

--- a/packages/codecs-core/src/__tests__/codec-test.ts
+++ b/packages/codecs-core/src/__tests__/codec-test.ts
@@ -1,75 +1,84 @@
-import { Codec, Decoder, Encoder } from '../codec';
+import { Codec, createCodec, createDecoder, createEncoder, Decoder, Encoder } from '../codec';
 
 describe('Encoder', () => {
     it('can define Encoder instances', () => {
-        const myEncoder: Encoder<string> = {
+        const myEncoder: Encoder<string> = createEncoder({
             description: 'myEncoder',
-            encode: (value: string) => {
-                const bytes = new Uint8Array(32).fill(0);
-                const charCodes = [...value.slice(0, 32)].map(char => Math.min(char.charCodeAt(0), 255));
-                bytes.set(new Uint8Array(charCodes));
-                return bytes;
-            },
             fixedSize: 32,
-            maxSize: 32,
-        };
+            write: (value: string, bytes, offset) => {
+                const charCodes = [...value.slice(0, 32)].map(char => Math.min(char.charCodeAt(0), 255));
+                bytes.set(charCodes, offset);
+                return offset + 32;
+            },
+        });
 
         expect(myEncoder.description).toBe('myEncoder');
         expect(myEncoder.fixedSize).toBe(32);
         expect(myEncoder.maxSize).toBe(32);
+        expect(myEncoder.getSize('hello')).toBe(32);
 
         const expectedBytes = new Uint8Array(32).fill(0);
         expectedBytes.set(new Uint8Array([104, 101, 108, 108, 111]));
         expect(myEncoder.encode('hello')).toStrictEqual(expectedBytes);
+
+        const writtenBytes = new Uint8Array(32).fill(0);
+        expect(myEncoder.write('hello', writtenBytes, 0)).toBe(32);
+        expect(writtenBytes).toStrictEqual(expectedBytes);
     });
 });
 
 describe('Decoder', () => {
     it('can define Decoder instances', () => {
-        const myDecoder: Decoder<string> = {
-            decode: (bytes: Uint8Array, offset = 0) => {
+        const myDecoder: Decoder<string> = createDecoder({
+            description: 'myDecoder',
+            fixedSize: 32,
+            read: (bytes: Uint8Array, offset) => {
                 const slice = bytes.slice(offset, offset + 32);
                 const str = [...slice].map(charCode => String.fromCharCode(charCode)).join('');
                 return [str, offset + 32];
             },
-            description: 'myDecoder',
-            fixedSize: 32,
-            maxSize: 32,
-        };
+        });
 
         expect(myDecoder.description).toBe('myDecoder');
         expect(myDecoder.fixedSize).toBe(32);
         expect(myDecoder.maxSize).toBe(32);
-        expect(myDecoder.decode(new Uint8Array([104, 101, 108, 108, 111]))).toStrictEqual(['hello', 32]);
+
+        expect(myDecoder.decode(new Uint8Array([104, 101, 108, 108, 111]))).toBe('hello');
+        expect(myDecoder.read(new Uint8Array([104, 101, 108, 108, 111]), 0)).toStrictEqual(['hello', 32]);
     });
 });
 
 describe('Codec', () => {
     it('can define Codec instances', () => {
-        const myCodec: Codec<string> = {
-            decode: (bytes: Uint8Array, offset = 0) => {
+        const myCodec: Codec<string> = createCodec({
+            description: 'myCodec',
+            fixedSize: 32,
+            read: (bytes: Uint8Array, offset) => {
                 const slice = bytes.slice(offset, offset + 32);
                 const str = [...slice].map(charCode => String.fromCharCode(charCode)).join('');
                 return [str, offset + 32];
             },
-            description: 'myCodec',
-            encode: (value: string) => {
-                const bytes = new Uint8Array(32).fill(0);
+            write: (value: string, bytes, offset) => {
                 const charCodes = [...value.slice(0, 32)].map(char => Math.min(char.charCodeAt(0), 255));
-                bytes.set(new Uint8Array(charCodes));
-                return bytes;
+                bytes.set(charCodes, offset);
+                return offset + 32;
             },
-            fixedSize: 32,
-            maxSize: 32,
-        };
+        });
 
         expect(myCodec.description).toBe('myCodec');
         expect(myCodec.fixedSize).toBe(32);
         expect(myCodec.maxSize).toBe(32);
+        expect(myCodec.getSize('hello')).toBe(32);
 
         const expectedBytes = new Uint8Array(32).fill(0);
         expectedBytes.set(new Uint8Array([104, 101, 108, 108, 111]));
         expect(myCodec.encode('hello')).toStrictEqual(expectedBytes);
-        expect(myCodec.decode(new Uint8Array([104, 101, 108, 108, 111]))).toStrictEqual(['hello', 32]);
+
+        const writtenBytes = new Uint8Array(32).fill(0);
+        expect(myCodec.write('hello', writtenBytes, 0)).toBe(32);
+        expect(writtenBytes).toStrictEqual(expectedBytes);
+
+        expect(myCodec.decode(new Uint8Array([104, 101, 108, 108, 111]))).toBe('hello');
+        expect(myCodec.read(new Uint8Array([104, 101, 108, 108, 111]), 0)).toStrictEqual(['hello', 32]);
     });
 });

--- a/packages/codecs-core/src/__tests__/codec-test.ts
+++ b/packages/codecs-core/src/__tests__/codec-test.ts
@@ -3,7 +3,6 @@ import { Codec, createCodec, createDecoder, createEncoder, Decoder, Encoder } fr
 describe('Encoder', () => {
     it('can define Encoder instances', () => {
         const myEncoder: Encoder<string> = createEncoder({
-            description: 'myEncoder',
             fixedSize: 32,
             write: (value: string, bytes, offset) => {
                 const charCodes = [...value.slice(0, 32)].map(char => Math.min(char.charCodeAt(0), 255));
@@ -12,10 +11,7 @@ describe('Encoder', () => {
             },
         });
 
-        expect(myEncoder.description).toBe('myEncoder');
         expect(myEncoder.fixedSize).toBe(32);
-        expect(myEncoder.maxSize).toBe(32);
-        expect(myEncoder.getSize('hello')).toBe(32);
 
         const expectedBytes = new Uint8Array(32).fill(0);
         expectedBytes.set(new Uint8Array([104, 101, 108, 108, 111]));
@@ -30,7 +26,6 @@ describe('Encoder', () => {
 describe('Decoder', () => {
     it('can define Decoder instances', () => {
         const myDecoder: Decoder<string> = createDecoder({
-            description: 'myDecoder',
             fixedSize: 32,
             read: (bytes: Uint8Array, offset) => {
                 const slice = bytes.slice(offset, offset + 32);
@@ -39,9 +34,7 @@ describe('Decoder', () => {
             },
         });
 
-        expect(myDecoder.description).toBe('myDecoder');
         expect(myDecoder.fixedSize).toBe(32);
-        expect(myDecoder.maxSize).toBe(32);
 
         expect(myDecoder.decode(new Uint8Array([104, 101, 108, 108, 111]))).toBe('hello');
         expect(myDecoder.read(new Uint8Array([104, 101, 108, 108, 111]), 0)).toStrictEqual(['hello', 32]);
@@ -51,7 +44,6 @@ describe('Decoder', () => {
 describe('Codec', () => {
     it('can define Codec instances', () => {
         const myCodec: Codec<string> = createCodec({
-            description: 'myCodec',
             fixedSize: 32,
             read: (bytes: Uint8Array, offset) => {
                 const slice = bytes.slice(offset, offset + 32);
@@ -65,10 +57,7 @@ describe('Codec', () => {
             },
         });
 
-        expect(myCodec.description).toBe('myCodec');
         expect(myCodec.fixedSize).toBe(32);
-        expect(myCodec.maxSize).toBe(32);
-        expect(myCodec.getSize('hello')).toBe(32);
 
         const expectedBytes = new Uint8Array(32).fill(0);
         expectedBytes.set(new Uint8Array([104, 101, 108, 108, 111]));

--- a/packages/codecs-core/src/__tests__/combine-codec.ts
+++ b/packages/codecs-core/src/__tests__/combine-codec.ts
@@ -2,13 +2,8 @@ import { Codec, createDecoder, createEncoder, Decoder, Encoder } from '../codec'
 import { combineCodec } from '../combine-codec';
 
 describe('combineCodec', () => {
-    const mockGetSize: Encoder<number>['getSize'] = () => 42;
-    const mockWrite: Encoder<number>['write'] = () => 42;
-    const mockRead: Decoder<number>['read'] = (_bytes: Uint8Array, offset = 0) => [42, offset];
-
     it('can join encoders and decoders with the same type', () => {
         const u8Encoder: Encoder<number> = createEncoder({
-            description: 'u8',
             fixedSize: 1,
             write: (value: number, buffer, offset) => {
                 buffer.set([value], offset);
@@ -17,23 +12,19 @@ describe('combineCodec', () => {
         });
 
         const u8Decoder: Decoder<number> = createDecoder({
-            description: 'u8',
             fixedSize: 1,
             read: (bytes: Uint8Array, offset = 0) => [bytes[offset], offset + 1],
         });
 
         const u8Codec: Codec<number> = combineCodec(u8Encoder, u8Decoder);
 
-        expect(u8Codec.description).toBe('u8');
         expect(u8Codec.fixedSize).toBe(1);
-        expect(u8Codec.maxSize).toBe(1);
         expect(u8Codec.encode(42)).toStrictEqual(new Uint8Array([42]));
         expect(u8Codec.decode(new Uint8Array([42]))).toBe(42);
     });
 
     it('can join encoders and decoders with different but matching types', () => {
         const u8Encoder: Encoder<number | bigint> = createEncoder({
-            description: 'u8',
             fixedSize: 1,
             write: (value: number | bigint, buffer, offset) => {
                 buffer.set([Number(value)], offset);
@@ -42,51 +33,31 @@ describe('combineCodec', () => {
         });
 
         const u8Decoder: Decoder<bigint> = createDecoder({
-            description: 'u8',
             fixedSize: 1,
             read: (bytes: Uint8Array, offset = 0) => [BigInt(bytes[offset]), offset + 1],
         });
 
         const u8Codec: Codec<number | bigint, bigint> = combineCodec(u8Encoder, u8Decoder);
 
-        expect(u8Codec.description).toBe('u8');
         expect(u8Codec.fixedSize).toBe(1);
-        expect(u8Codec.maxSize).toBe(1);
         expect(u8Codec.encode(42)).toStrictEqual(new Uint8Array([42]));
         expect(u8Codec.encode(42n)).toStrictEqual(new Uint8Array([42]));
         expect(u8Codec.decode(new Uint8Array([42]))).toBe(42n);
     });
 
-    it('cannot join encoders and decoders with sizes or descriptions', () => {
+    it('cannot join encoders and decoders with different sizes', () => {
         expect(() =>
             combineCodec(
-                createEncoder({ fixedSize: 1, write: mockWrite }),
-                createDecoder({ fixedSize: 2, read: mockRead })
+                createEncoder({ fixedSize: 1, write: jest.fn() }),
+                createDecoder({ fixedSize: 2, read: jest.fn() })
             )
         ).toThrow('Encoder and decoder must have the same fixed size, got [1] and [2]');
 
         expect(() =>
             combineCodec(
-                createEncoder({ getSize: mockGetSize, maxSize: 1, write: mockWrite }),
-                createDecoder({ fixedSize: null, maxSize: null, read: mockRead })
+                createEncoder({ fixedSize: null, maxSize: 1, variableSize: jest.fn(), write: jest.fn() }),
+                createDecoder({ fixedSize: null, read: jest.fn() })
             )
-        ).toThrow('Encoder and decoder must have the same max size, got [1] and [null]');
-
-        expect(() =>
-            combineCodec(
-                createEncoder({ description: 'u8', fixedSize: 1, write: mockWrite }),
-                createDecoder({ description: 'u16', fixedSize: 1, read: mockRead })
-            )
-        ).toThrow('Encoder and decoder must have the same description, got [u8] and [u16]');
-    });
-
-    it('can override the description of the joined codec', () => {
-        const myCodec = combineCodec(
-            createEncoder({ description: 'u8', fixedSize: 1, write: mockWrite }),
-            createDecoder({ description: 'u16', fixedSize: 1, read: mockRead }),
-            'myCustomDescription'
-        );
-
-        expect(myCodec.description).toBe('myCustomDescription');
+        ).toThrow('Encoder and decoder must have the same max size, got [1] and [undefined]');
     });
 });

--- a/packages/codecs-core/src/__tests__/fix-codec-test.ts
+++ b/packages/codecs-core/src/__tests__/fix-codec-test.ts
@@ -1,4 +1,4 @@
-import { Codec } from '../codec';
+import { createCodec } from '../codec';
 import { fixCodec, fixDecoder, fixEncoder } from '../fix-codec';
 import { b, getMockCodec } from './__setup__';
 
@@ -6,92 +6,93 @@ describe('fixCodec', () => {
     it('keeps same-sized byte arrays as-is', () => {
         const mockCodec = getMockCodec();
 
-        mockCodec.encode.mockReturnValueOnce(b('08050c0c0f170f120c04'));
+        mockCodec.variableSize.mockReturnValueOnce(10);
+        mockCodec.write.mockImplementation((_, bytes: Uint8Array, offset: number) => {
+            bytes.set(b('08050c0c0f170f120c04'), offset);
+            return offset + 10;
+        });
         expect(fixCodec(mockCodec, 10).encode('helloworld')).toStrictEqual(b('08050c0c0f170f120c04'));
-        expect(mockCodec.encode).toHaveBeenCalledWith('helloworld');
+        expect(mockCodec.write).toHaveBeenCalledWith('helloworld', expect.any(Uint8Array), 0);
 
         fixCodec(mockCodec, 10).decode(b('08050c0c0f170f120c04'));
-        expect(mockCodec.decode).toHaveBeenCalledWith(b('08050c0c0f170f120c04'), 0);
+        expect(mockCodec.read).toHaveBeenCalledWith(b('08050c0c0f170f120c04'), 0);
 
-        fixCodec(mockCodec, 10).decode(b('ffff08050c0c0f170f120c04'), 2);
-        expect(mockCodec.decode).toHaveBeenCalledWith(b('08050c0c0f170f120c04'), 0);
+        fixCodec(mockCodec, 10).read(b('ffff08050c0c0f170f120c04'), 2);
+        expect(mockCodec.read).toHaveBeenCalledWith(b('08050c0c0f170f120c04'), 0);
     });
 
     it('truncates over-sized byte arrays', () => {
         const mockCodec = getMockCodec();
 
-        mockCodec.encode.mockReturnValueOnce(b('08050c0c0f170f120c04'));
+        mockCodec.variableSize.mockReturnValueOnce(10);
+        mockCodec.write.mockImplementation((_, bytes: Uint8Array, offset: number) => {
+            bytes.set(b('08050c0c0f170f120c04'), offset);
+            return offset + 10;
+        });
         expect(fixCodec(mockCodec, 5).encode('helloworld')).toStrictEqual(b('08050c0c0f'));
-        expect(mockCodec.encode).toHaveBeenCalledWith('helloworld');
+        expect(mockCodec.write).toHaveBeenCalledWith('helloworld', expect.any(Uint8Array), 0);
 
         fixCodec(mockCodec, 5).decode(b('08050c0c0f170f120c04'));
-        expect(mockCodec.decode).toHaveBeenCalledWith(b('08050c0c0f'), 0);
+        expect(mockCodec.read).toHaveBeenCalledWith(b('08050c0c0f'), 0);
 
-        fixCodec(mockCodec, 5).decode(b('ffff08050c0c0f170f120c04'), 2);
-        expect(mockCodec.decode).toHaveBeenCalledWith(b('08050c0c0f'), 0);
+        fixCodec(mockCodec, 5).read(b('ffff08050c0c0f170f120c04'), 2);
+        expect(mockCodec.read).toHaveBeenCalledWith(b('08050c0c0f'), 0);
     });
 
     it('pads under-sized byte arrays', () => {
         const mockCodec = getMockCodec();
 
-        mockCodec.encode.mockReturnValueOnce(b('08050c0c0f'));
+        mockCodec.variableSize.mockReturnValueOnce(5);
+        mockCodec.write.mockImplementation((_, bytes: Uint8Array, offset: number) => {
+            bytes.set(b('08050c0c0f'), offset);
+            return offset + 5;
+        });
         expect(fixCodec(mockCodec, 10).encode('hello')).toStrictEqual(b('08050c0c0f0000000000'));
-        expect(mockCodec.encode).toHaveBeenCalledWith('hello');
+        expect(mockCodec.write).toHaveBeenCalledWith('hello', expect.any(Uint8Array), 0);
 
         fixCodec(mockCodec, 10).decode(b('08050c0c0f0000000000'));
-        expect(mockCodec.decode).toHaveBeenCalledWith(b('08050c0c0f0000000000'), 0);
+        expect(mockCodec.read).toHaveBeenCalledWith(b('08050c0c0f0000000000'), 0);
 
-        fixCodec(mockCodec, 10).decode(b('ffff08050c0c0f0000000000'), 2);
-        expect(mockCodec.decode).toHaveBeenCalledWith(b('08050c0c0f0000000000'), 0);
+        fixCodec(mockCodec, 10).read(b('ffff08050c0c0f0000000000'), 2);
+        expect(mockCodec.read).toHaveBeenCalledWith(b('08050c0c0f0000000000'), 0);
 
         expect(() => fixCodec(mockCodec, 10).decode(b('08050c0c0f'))).toThrow(
             'Codec [fixCodec] expected 10 bytes, got 5.',
         );
     });
 
-    it('has the right description', () => {
-        const mockCodec = getMockCodec({ description: 'mock' });
-
-        // Description matches the fixed definition.
-        expect(fixCodec(mockCodec, 42).description).toBe('fixed(42, mock)');
-
-        // Description can be overridden.
-        expect(fixCodec(mockCodec, 42, 'my fixed').description).toBe('my fixed');
-    });
-
     it('has the right sizes', () => {
         const mockCodec = getMockCodec({ size: null });
         expect(fixCodec(mockCodec, 12).fixedSize).toBe(12);
-        expect(fixCodec(mockCodec, 12).maxSize).toBe(12);
         expect(fixCodec(mockCodec, 42).fixedSize).toBe(42);
-        expect(fixCodec(mockCodec, 42).maxSize).toBe(42);
     });
 
     it('can fix a codec that requires a minimum amount of bytes', () => {
         // Given a mock `u32` codec that ensures the byte array is 4 bytes long.
-        const u32: Codec<number> = {
-            decode(bytes, offset = 0): [number, number] {
+        const u32 = createCodec<number>({
+            fixedSize: 4,
+            read(bytes, offset = 0): [number, number] {
                 // eslint-disable-next-line jest/no-conditional-in-test
                 if (bytes.slice(offset).length < offset + 4) {
                     throw new Error('Not enough bytes to decode a u32.');
                 }
                 return [bytes.slice(offset)[0], offset + 4];
             },
-            description: 'u32',
-            encode: (value: number) => new Uint8Array([value, 0, 0, 0]),
-            fixedSize: 4,
-            maxSize: 4,
-        };
+            write: (value: number, bytes, offset) => {
+                bytes.set([value], offset);
+                return offset + 4;
+            },
+        });
 
         // When we synthesize a `u24` from that `u32` using `fixCodec`.
         const u24 = fixCodec(u32, 3);
 
         // Then we can encode a `u24`.
-        const buf = u24.encode(42);
-        expect(buf).toStrictEqual(new Uint8Array([42, 0, 0]));
+        const bytes = u24.encode(42);
+        expect(bytes).toStrictEqual(new Uint8Array([42, 0, 0]));
 
         // And we can decode it back.
-        const hydrated = u24.decode(buf);
+        const hydrated = u24.read(bytes, 0);
         expect(hydrated).toStrictEqual([42, 3]);
     });
 });
@@ -100,17 +101,29 @@ describe('fixEncoder', () => {
     it('can fix an encoder to a given amount of bytes', () => {
         const mockCodec = getMockCodec();
 
-        mockCodec.encode.mockReturnValueOnce(b('08050c0c0f170f120c04'));
+        mockCodec.variableSize.mockReturnValueOnce(10);
+        mockCodec.write.mockImplementationOnce((_, bytes: Uint8Array, offset: number) => {
+            bytes.set(b('08050c0c0f170f120c04'), offset);
+            return offset + 10;
+        });
         expect(fixEncoder(mockCodec, 10).encode('helloworld')).toStrictEqual(b('08050c0c0f170f120c04'));
-        expect(mockCodec.encode).toHaveBeenCalledWith('helloworld');
+        expect(mockCodec.write).toHaveBeenCalledWith('helloworld', expect.any(Uint8Array), 0);
 
-        mockCodec.encode.mockReturnValueOnce(b('08050c0c0f170f120c04'));
+        mockCodec.variableSize.mockReturnValueOnce(10);
+        mockCodec.write.mockImplementationOnce((_, bytes: Uint8Array, offset: number) => {
+            bytes.set(b('08050c0c0f170f120c04'), offset);
+            return offset + 10;
+        });
         expect(fixEncoder(mockCodec, 5).encode('helloworld')).toStrictEqual(b('08050c0c0f'));
-        expect(mockCodec.encode).toHaveBeenCalledWith('helloworld');
+        expect(mockCodec.write).toHaveBeenCalledWith('helloworld', expect.any(Uint8Array), 0);
 
-        mockCodec.encode.mockReturnValueOnce(b('08050c0c0f'));
+        mockCodec.variableSize.mockReturnValueOnce(5);
+        mockCodec.write.mockImplementationOnce((_, bytes: Uint8Array, offset: number) => {
+            bytes.set(b('08050c0c0f'), offset);
+            return offset + 5;
+        });
         expect(fixEncoder(mockCodec, 10).encode('hello')).toStrictEqual(b('08050c0c0f0000000000'));
-        expect(mockCodec.encode).toHaveBeenCalledWith('hello');
+        expect(mockCodec.write).toHaveBeenCalledWith('hello', expect.any(Uint8Array), 0);
     });
 });
 
@@ -119,13 +132,13 @@ describe('fixDecoder', () => {
         const mockCodec = getMockCodec();
 
         fixDecoder(mockCodec, 10).decode(b('08050c0c0f170f120c04'));
-        expect(mockCodec.decode).toHaveBeenCalledWith(b('08050c0c0f170f120c04'), 0);
+        expect(mockCodec.read).toHaveBeenCalledWith(b('08050c0c0f170f120c04'), 0);
 
         fixDecoder(mockCodec, 5).decode(b('08050c0c0f170f120c04'));
-        expect(mockCodec.decode).toHaveBeenCalledWith(b('08050c0c0f'), 0);
+        expect(mockCodec.read).toHaveBeenCalledWith(b('08050c0c0f'), 0);
 
         fixDecoder(mockCodec, 10).decode(b('08050c0c0f0000000000'));
-        expect(mockCodec.decode).toHaveBeenCalledWith(b('08050c0c0f0000000000'), 0);
+        expect(mockCodec.read).toHaveBeenCalledWith(b('08050c0c0f0000000000'), 0);
 
         expect(() => fixDecoder(mockCodec, 10).decode(b('08050c0c0f'))).toThrow(
             'Codec [fixCodec] expected 10 bytes, got 5.',

--- a/packages/codecs-core/src/assertions.ts
+++ b/packages/codecs-core/src/assertions.ts
@@ -1,5 +1,3 @@
-import { CodecData } from './codec';
-
 /**
  * Asserts that a given byte array is not empty.
  */
@@ -17,7 +15,7 @@ export function assertByteArrayHasEnoughBytesForCodec(
     codecDescription: string,
     expected: number,
     bytes: Uint8Array,
-    offset = 0,
+    offset = 0
 ) {
     const bytesLength = bytes.length - offset;
     if (bytesLength < expected) {
@@ -30,8 +28,8 @@ export function assertByteArrayHasEnoughBytesForCodec(
  * Asserts that a given codec is fixed-size codec.
  */
 export function assertFixedSizeCodec(
-    data: Pick<CodecData, 'fixedSize'>,
-    message?: string,
+    data: { fixedSize: number | null },
+    message?: string
 ): asserts data is { fixedSize: number } {
     if (data.fixedSize === null) {
         // TODO: Coded error.

--- a/packages/codecs-core/src/codec.ts
+++ b/packages/codecs-core/src/codec.ts
@@ -7,8 +7,8 @@ export type Offset = number;
  * The shared attributes between codecs, encoders and decoders.
  */
 export type CodecData = {
-    /** A description for the codec. */
-    description: string;
+    /** An optional description for the codec. */
+    description?: string;
     /** The fixed size of the encoded value in bytes, or `null` if it is variable. */
     fixedSize: number | null;
     /** The maximum size an encoded value can be in bytes, or `null` if it is variable. */
@@ -19,6 +19,15 @@ export type CodecData = {
  * An object that can encode a value to a `Uint8Array`.
  */
 export type Encoder<T> = CodecData & {
+    /** Returns the total size of the encoded value in bytes. */
+    getSize: (value: T) => number;
+
+    /**
+     * Writes the encoded value into the provided byte array at the given offset.
+     * Returns the offset of the next byte after the encoded value.
+     */
+    write: (value: T, bytes: Uint8Array, offset: Offset) => Offset;
+
     /** The function that encodes a value into bytes. */
     encode: (value: T) => Uint8Array;
 };
@@ -28,10 +37,13 @@ export type Encoder<T> = CodecData & {
  */
 export type Decoder<T> = CodecData & {
     /**
-     * The function that decodes a value from bytes.
-     * It returns the decoded value and the number of bytes read.
+     * Reads the encoded value from the provided byte array at the given offset.
+     * Returns the decoded value and the offset of the next byte after the encoded value.
      */
-    decode: (bytes: Uint8Array, offset?: Offset) => [T, Offset];
+    read: (bytes: Uint8Array, offset: Offset) => [T, Offset];
+
+    /** The function that decodes a value from bytes. */
+    decode: (bytes: Uint8Array, offset?: Offset) => T;
 };
 
 /**
@@ -59,3 +71,76 @@ export type BaseCodecConfig = {
 export type WrapInCodec<T, U extends T = T> = {
     [P in keyof T]: Codec<T[P], U[P]>;
 };
+
+type EncoderInput<T> =
+    | {
+          description?: string;
+          fixedSize: number;
+          write: Encoder<T>['write'];
+      }
+    | {
+          description?: string;
+          maxSize?: number | null;
+          getSize: Encoder<T>['getSize'];
+          write: Encoder<T>['write'];
+      };
+
+/**
+ * Fills the `encode` function of an encoder based on the provided `getSize` and `write` functions.
+ */
+export function createEncoder<T>(encoder: EncoderInput<T>): Encoder<T> {
+    return {
+        description: encoder.description,
+        encode: (value: T): Uint8Array => {
+            const size = 'fixedSize' in encoder ? encoder.fixedSize : encoder.getSize(value);
+            const bytes = new Uint8Array(size).fill(0);
+            encoder.write(value, bytes, 0);
+            return bytes;
+        },
+        fixedSize: 'fixedSize' in encoder ? encoder.fixedSize : null,
+        getSize: 'fixedSize' in encoder ? () => encoder.fixedSize : encoder.getSize,
+        maxSize: 'fixedSize' in encoder ? encoder.fixedSize : encoder.maxSize ?? null,
+        write: encoder.write,
+    };
+}
+
+type DecoderInput<T> =
+    | {
+          description?: string;
+          fixedSize: number;
+          read: Decoder<T>['read'];
+      }
+    | {
+          description?: string;
+          fixedSize: null;
+          maxSize?: number | null;
+          read: Decoder<T>['read'];
+      };
+
+/**
+ * Fills the `decode` function of a decoder based on the provided `read` function.
+ */
+export function createDecoder<T>(decoder: DecoderInput<T>): Decoder<T> {
+    return {
+        decode: (bytes: Uint8Array, offset = 0): T => decoder.read(bytes, offset)[0],
+        description: decoder.description,
+        fixedSize: decoder.fixedSize,
+        maxSize: decoder.fixedSize !== null ? decoder.fixedSize : decoder.maxSize ?? null,
+        read: decoder.read,
+    };
+}
+
+type CodecInput<T, U extends T = T> = EncoderInput<T> & {
+    read: Decoder<U>['read'];
+};
+
+/**
+ * Fills the `encode` and `decode` functions of a codec based on the provided `getSize`, `write` and `read` functions.
+ */
+export function createCodec<T, U extends T = T>(codec: CodecInput<T, U>): Codec<T, U> {
+    return {
+        ...createEncoder(codec),
+        decode: (bytes: Uint8Array, offset = 0): U => codec.read(bytes, offset)[0],
+        read: codec.read,
+    };
+}

--- a/packages/codecs-core/src/combine-codec.ts
+++ b/packages/codecs-core/src/combine-codec.ts
@@ -37,6 +37,9 @@ export function combineCodec<From, To extends From = From>(
         description: description ?? encoder.description,
         encode: encoder.encode,
         fixedSize: encoder.fixedSize,
+        getSize: encoder.getSize,
         maxSize: encoder.maxSize,
+        read: decoder.read,
+        write: encoder.write,
     };
 }

--- a/packages/codecs-core/src/combine-codec.ts
+++ b/packages/codecs-core/src/combine-codec.ts
@@ -7,39 +7,21 @@ import { Codec, Decoder, Encoder } from './codec';
  */
 export function combineCodec<From, To extends From = From>(
     encoder: Encoder<From>,
-    decoder: Decoder<To>,
-    description?: string,
+    decoder: Decoder<To>
 ): Codec<From, To> {
     if (encoder.fixedSize !== decoder.fixedSize) {
         // TODO: Coded error.
         throw new Error(
-            `Encoder and decoder must have the same fixed size, got [${encoder.fixedSize}] and [${decoder.fixedSize}].`,
+            `Encoder and decoder must have the same fixed size, got [${encoder.fixedSize}] and [${decoder.fixedSize}].`
         );
     }
 
-    if (encoder.maxSize !== decoder.maxSize) {
+    if (encoder.fixedSize === null && decoder.fixedSize === null && encoder.maxSize !== decoder.maxSize) {
         // TODO: Coded error.
         throw new Error(
-            `Encoder and decoder must have the same max size, got [${encoder.maxSize}] and [${decoder.maxSize}].`,
+            `Encoder and decoder must have the same max size, got [${encoder.maxSize}] and [${decoder.maxSize}].`
         );
     }
 
-    if (description === undefined && encoder.description !== decoder.description) {
-        // TODO: Coded error.
-        throw new Error(
-            `Encoder and decoder must have the same description, got [${encoder.description}] and [${decoder.description}]. ` +
-                `Pass a custom description as a third argument if you want to override the description and bypass this error.`,
-        );
-    }
-
-    return {
-        decode: decoder.decode,
-        description: description ?? encoder.description,
-        encode: encoder.encode,
-        fixedSize: encoder.fixedSize,
-        getSize: encoder.getSize,
-        maxSize: encoder.maxSize,
-        read: decoder.read,
-        write: encoder.write,
-    };
+    return { ...decoder, ...encoder };
 }

--- a/packages/codecs-core/src/map-codec.ts
+++ b/packages/codecs-core/src/map-codec.ts
@@ -1,15 +1,14 @@
-import { Codec, Decoder, Encoder } from './codec';
+import { Codec, createCodec, createDecoder, createEncoder, Decoder, Encoder } from './codec';
 
 /**
  * Converts an encoder A to a encoder B by mapping their values.
  */
 export function mapEncoder<T, U>(encoder: Encoder<T>, unmap: (value: U) => T): Encoder<U> {
-    return {
-        description: encoder.description,
-        encode: (value: U) => encoder.encode(unmap(value)),
-        fixedSize: encoder.fixedSize,
-        maxSize: encoder.maxSize,
-    };
+    return createEncoder({
+        ...encoder,
+        getSize: (value: U) => encoder.getSize(unmap(value)),
+        write: (value: U, bytes, offset) => encoder.write(unmap(value), bytes, offset),
+    });
 }
 
 /**
@@ -19,15 +18,13 @@ export function mapDecoder<T, U>(
     decoder: Decoder<T>,
     map: (value: T, bytes: Uint8Array, offset: number) => U,
 ): Decoder<U> {
-    return {
-        decode: (bytes: Uint8Array, offset = 0) => {
-            const [value, length] = decoder.decode(bytes, offset);
-            return [map(value, bytes, offset), length];
+    return createDecoder({
+        ...decoder,
+        read: (bytes: Uint8Array, offset = 0) => {
+            const [value, newOffset] = decoder.read(bytes, offset);
+            return [map(value, bytes, offset), newOffset];
         },
-        description: decoder.description,
-        fixedSize: decoder.fixedSize,
-        maxSize: decoder.maxSize,
-    };
+    });
 }
 
 /**
@@ -47,11 +44,10 @@ export function mapCodec<NewFrom, OldFrom, NewTo extends NewFrom = NewFrom, OldT
     unmap: (value: NewFrom) => OldFrom,
     map?: (value: OldTo, bytes: Uint8Array, offset: number) => NewTo,
 ): Codec<NewFrom, NewTo> {
-    return {
-        decode: map ? mapDecoder(codec, map).decode : (codec.decode as unknown as Decoder<NewTo>['decode']),
-        description: codec.description,
-        encode: mapEncoder(codec, unmap).encode,
-        fixedSize: codec.fixedSize,
-        maxSize: codec.maxSize,
-    };
+    return createCodec({
+        ...codec,
+        getSize: mapEncoder(codec, unmap).getSize,
+        read: map ? mapDecoder(codec, map).read : (codec.read as unknown as Decoder<NewTo>['read']),
+        write: mapEncoder(codec, unmap).write,
+    });
 }


### PR DESCRIPTION
_Note this is a draft PR focusing on `codecs-core` to gather feedback, I will continue to update the other libraries afterwards._

This PR updates the codecs API such that both encoding and decoding function **have access to the entire byte array**. Let’s first see the change this PR introduce and then see why this is a valuable change.

## API Changes

- **Encode**: The `Encoder` type contains a new function `write`. Contrary to the `encode` function which creates a new `Uint8Array` and returns it directly, the `write function` updates the provided `bytes` argument at the provided `offset`. It then returns the next offset that should be written to.

  ```ts
  // Before
  type Encoder<T> = {
    encode: (value: T) => Uint8Array;
    // ...
  };

  // After
  type Encoder<T> = {
    encode: (value: T) => Uint8Array;
    write: (value: T, bytes: Uint8Array, offset: Offset) => Offset;
    // ...
  };
  ```
  
  A new `createEncoder` function was provided to automatically fill the `encode` function from the `write` function.

  ```ts
  const myU8Encoder = createEncoder({
    fixedSize: 1,
    write: (value: number, bytes: Uint8Array, offset: Offset) {
      bytes.set(value, offset);
      return offset + 1;
    };
  });
  ```
  

- **Decode**: The `decode` function already following a similar approach by using offsets. The newly added function `read` takes over this responsibility. The only difference is we now make the offset a mandatory argument to stay consistent with the `write` function. The `decode` function now becomes syntactic sugar for accessing the value directly.

  ```ts
  // Before
  type Decoder<T> = {
    decode: (bytes: Uint8Array, offset?: Offset) => [T, Offset];
    // ...
  };

  // After
  type Decoder<T> = {
    decode: (bytes: Uint8Array, offset?: Offset) => T;
    read: (bytes: Uint8Array, offset: Offset) => [T, Offset];
    // ...
  };
  ```

  Similarly to the `Encoder` changes, a new `createDecoder` function is provided to fill the `decode` function using the `read` function.

  ```ts
  const myU8Decoder = createDecoder({
    fixedSize: 1,
    read: (bytes: Uint8Array, offset: Offset) {
      return [bytes[offset], offset + 1];
    };
  });
  ```

- **Sizes**: Because we now need to pre-build the entire byte array that will be encoded, we need a way to find the variable size of a given value. We introduce a new `variableSize` function and narrow the types so that it can only be provided when `fixedSize` is `null`.

  ```ts
  // Before
  type Encoder<T> = {
    fixedSize: number | null;
    maxSize: number | null;
  }

  // After
  type Encoder<T> = { ... } & (
    | { fixedSize: number; }
    | { fixedSize: null; variableSize: (value: T) => number; maxSize?: number }
  )
  ```

  We do something similar the `Decoder` except that this one doesn’t need to know about the variable size (it would make no sense as the type parameter `T` for decoder refers to the decoded type and not the type to encode).

  ```ts
  // Before
  type Decoder<T> = {
    fixedSize: number | null;
    maxSize: number | null;
  }

  // After
  type Decoder<T> = { ... } & (
    | { fixedSize: number; }
    | { fixedSize: null; maxSize?: number }
  )
  ```

- **Description**: This PR takes this refactoring opportunity to remove the `description` attribute from the codecs API which brings little value to the end-user.

## Why?

- **Consistent API**: The implementation of the `encode` / `decode` and `write` / `read` functions are now consistent with each other. Before one was using offsets to navigate through an entire byte array and the other was returning and merge byte arrays together. Now they both use offsets to navigate the byte array to encode or decode.

- **Performant API**: By pre-building the byte array once, we’re avoiding creating multiple instance of byte arrays and merging them together.

- **Non-linear serialisation**: The main reason why it’s important for the `encode` method to have access to the entire encoded byte array is that it allows us to offer more complex codec primitives that are able to jump back and forth within the buffer. Without it, we are locking ourselves to only supporting serialisation strategies that are read linearly which isn’t always the case. For instance, imagine we have the size of an array being stored at the very beginning of the account whereas the items themselves are being stored at the end. Because we now have the full byte array when encoding, we can push the size at the beginning whilst inserting all items at the requested offset. We could even offer a `getOffsetCodec` (or similar) that allows us to shift the offset forward or backward to compose more complex, non-linear data structures. This would be simply impossible with the current format of the `encode` function.

