### PR TITLE
refactor(experimental): deduplicate signers by reference

### DIFF
--- a/packages/signers/src/__tests__/account-signer-meta-test.ts
+++ b/packages/signers/src/__tests__/account-signer-meta-test.ts
@@ -5,7 +5,6 @@ import {
     createMockInstructionWithSigners,
     createMockTransactionModifyingSigner,
     createMockTransactionPartialSigner,
-    createMockTransactionSendingSigner,
     createMockTransactionWithSigners,
 } from './__setup__';
 
@@ -25,17 +24,11 @@ describe('getSignersFromInstruction', () => {
         expect(extractedSigners[1]).toBe(signerB);
     });
 
-    it('removes duplicated signers', () => {
-        // Given an instruction with duplicated signers.
-        const addressA = '1111' as Address;
-        const addressB = '2222' as Address;
-        const signers = [
-            createMockTransactionPartialSigner(addressA),
-            createMockTransactionPartialSigner(addressB),
-            createMockTransactionModifyingSigner(addressA),
-            createMockTransactionSendingSigner(addressA),
-        ];
-        const instruction = createMockInstructionWithSigners(signers);
+    it('removes duplicated signers by reference', () => {
+        // Given an instruction with duplicated signers using the same reference.
+        const signerA = createMockTransactionPartialSigner('1111' as Address);
+        const signerB = createMockTransactionModifyingSigner('2222' as Address);
+        const instruction = createMockInstructionWithSigners([signerA, signerB, signerA, signerA]);
 
         // When we extract the signers from the instruction's account metas.
         const extractedSigners = getSignersFromInstruction(instruction);
@@ -63,16 +56,10 @@ describe('getSignersFromTransaction', () => {
     });
 
     it('removes duplicated signers', () => {
-        // Given a transaction with duplicated signers.
-        const addressA = '1111' as Address;
-        const addressB = '2222' as Address;
-        const signers = [
-            createMockTransactionPartialSigner(addressA),
-            createMockTransactionPartialSigner(addressB),
-            createMockTransactionModifyingSigner(addressA),
-            createMockTransactionSendingSigner(addressA),
-        ];
-        const transaction = createMockTransactionWithSigners(signers);
+        // Given a transaction with duplicated signers using the same reference.
+        const signerA = createMockTransactionPartialSigner('1111' as Address);
+        const signerB = createMockTransactionModifyingSigner('2222' as Address);
+        const transaction = createMockTransactionWithSigners([signerA, signerB, signerA, signerA]);
 
         // When we extract the signers from the transaction's account metas.
         const extractedSigners = getSignersFromTransaction(transaction);

--- a/packages/signers/src/deduplicate-signers.ts
+++ b/packages/signers/src/deduplicate-signers.ts
@@ -11,6 +11,12 @@ export function deduplicateSigners<TSigner extends MessageSigner | TransactionSi
     signers.forEach(signer => {
         if (!deduplicated[signer.address]) {
             deduplicated[signer.address] = signer;
+        } else if (deduplicated[signer.address] !== signer) {
+            // TODO: Coded error.
+            throw new Error(
+                `Multiple distinct signers were identified for address "${signer.address}". ` +
+                    `Please ensure that you are using the same signer instance for each address.`
+            );
         }
     });
     return Object.values(deduplicated);


### PR DESCRIPTION
Deduplicate signers by reference only. Meaning, when extracting all signers in a transaction, we will remove duplicated reference of the same signer object. However, if we identity two different signer objects for the same address, we will fail as it is impossible to come up with a heuristic that works with every use-cases.

```ts
const signerA = await generateKeyPairSigner();
const signerB = await generateKeyPairSigner();

deduplicateSigners([signerA, signerB, signerA, signerB]);
// ^ [signerA, signerB]

deduplicateSigners([signerA, signerB, { ...signerA }]);
// ^ Error: Multiple distinct signers were identified for address A.
```

This improvement was suggested by the reviews of #1792.
