### PR TITLE
refactor(experimental): remove extra signers option

### DIFF
--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -452,12 +452,11 @@ If a composite signer implements both interfaces, it will be used as a modifying
 const mySignedTransaction = partiallySignTransactionWithSigners(myTransaction);
 ```
 
-It also accepts an optional `AbortSignal` and an additional array of signers that will be merged with the ones extracted from the transaction, if any.
+It also accepts an optional `AbortSignal` that will be propagated to all signers.
 
 ```ts
 const mySignedTransaction = partiallySignTransactionWithSigners(myTransaction, {
     abortSignal: myAbortController.signal,
-    signers: [myOtherSigner],
 });
 ```
 
@@ -473,7 +472,6 @@ const mySignedTransaction = signTransactionWithSigners(myTransaction);
 // With additional config.
 const mySignedTransaction = signTransactionWithSigners(myTransaction, {
     abortSignal: myAbortController.signal,
-    signers: [myOtherSigner],
 });
 
 // We now know the transaction is fully signed.
@@ -490,7 +488,6 @@ const myTransactionSignature = signAndSendTransactionWithSigners(myTransaction);
 // With additional config.
 const myTransactionSignature = signAndSendTransactionWithSigners(myTransaction, {
     abortSignal: myAbortController.signal,
-    signers: [myOtherSigner],
 });
 ```
 

--- a/packages/signers/src/__tests__/sign-transaction-test.ts
+++ b/packages/signers/src/__tests__/sign-transaction-test.ts
@@ -45,34 +45,6 @@ describe('partiallySignTransactionWithSigners', () => {
         expect(signerB.signTransactions).toHaveBeenCalledWith([modifiedTransaction], { abortSignal: undefined });
     });
 
-    it('signs the transaction with extra signers', async () => {
-        expect.assertions(3);
-
-        // Given two mocked signers A and B.
-        const signerA = createMockTransactionPartialSigner('1111' as Address);
-        const signerB = createMockTransactionPartialSigner('2222' as Address);
-        signerA.signTransactions.mockResolvedValueOnce([{ '1111': '1111_signature' }]);
-        signerB.signTransactions.mockResolvedValueOnce([{ '2222': '2222_signature' }]);
-
-        // And given a transaction that only contains signer A in its account metas.
-        const transaction = createMockTransactionWithSigners([signerA]);
-
-        // When we partially sign this transaction whilst providing signer B as an extra signer.
-        const signedTransaction = await partiallySignTransactionWithSigners(transaction, {
-            signers: [signerB],
-        });
-
-        // Then it contains the expected signatures.
-        expect(signedTransaction.signatures).toStrictEqual({
-            '1111': '1111_signature',
-            '2222': '2222_signature',
-        });
-
-        // And both signers were called with the expected parameters.
-        expect(signerA.signTransactions).toHaveBeenCalledWith([transaction], { abortSignal: undefined });
-        expect(signerB.signTransactions).toHaveBeenCalledWith([transaction], { abortSignal: undefined });
-    });
-
     it('signs modifying signers before partial signers', async () => {
         expect.assertions(2);
 
@@ -398,34 +370,6 @@ describe('signAndSendTransactionWithSigners', () => {
         const transactionSignature = await signAndSendTransactionWithSigners(transaction);
 
         // Then the sending signer was used to send the transaction.
-        expect(signerA.signTransactions).toHaveBeenCalledWith([transaction], { abortSignal: undefined });
-        expect(signerB.signAndSendTransactions).toHaveBeenCalledWith(
-            [{ ...transaction, signatures: { '1111': '1111_signature' } }],
-            { abortSignal: undefined }
-        );
-
-        // And the returned signature matches the one returned by the sending signer.
-        expect(transactionSignature).toStrictEqual(new Uint8Array([1, 2, 3]));
-    });
-
-    it('signs and sends the transaction with extra signers', async () => {
-        expect.assertions(3);
-
-        // Given a partial signer A and a sending signer B with the following mocked return values.
-        const signerA = createMockTransactionPartialSigner('1111' as Address);
-        const signerB = createMockTransactionSendingSigner('2222' as Address);
-        signerA.signTransactions.mockResolvedValueOnce([{ '1111': '1111_signature' }]);
-        signerB.signAndSendTransactions.mockResolvedValueOnce([new Uint8Array([1, 2, 3])]);
-
-        // And given a transaction that only contains signer A in its account metas.
-        const transaction = createMockTransactionWithSigners([signerA]);
-
-        // When we sign and send this transaction whilst providing signer B as an extra signer.
-        const transactionSignature = await signAndSendTransactionWithSigners(transaction, {
-            signers: [signerB],
-        });
-
-        // Then both signers were called with the expected parameters.
         expect(signerA.signTransactions).toHaveBeenCalledWith([transaction], { abortSignal: undefined });
         expect(signerB.signAndSendTransactions).toHaveBeenCalledWith(
             [{ ...transaction, signatures: { '1111': '1111_signature' } }],

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -29,14 +29,10 @@ export async function partiallySignTransactionWithSigners<
     TTransaction extends CompilableTransactionWithSigners = CompilableTransactionWithSigners
 >(
     transaction: TTransaction,
-    config: {
-        abortSignal?: AbortSignal;
-        signers?: readonly TransactionSigner[];
-    } = {}
+    config: { abortSignal?: AbortSignal } = {}
 ): Promise<TTransaction & ITransactionWithSignatures> {
-    const signers = config.signers ?? [];
     const { partialSigners, modifyingSigners } = categorizeTransactionSigners(
-        deduplicateSigners([...getSignersFromTransaction(transaction).filter(isTransactionSigner), ...signers]),
+        deduplicateSigners(getSignersFromTransaction(transaction).filter(isTransactionSigner)),
         { identifySendingSigner: false }
     );
 
@@ -53,10 +49,7 @@ export async function signTransactionWithSigners<
     TTransaction extends CompilableTransactionWithSigners = CompilableTransactionWithSigners
 >(
     transaction: TTransaction,
-    config: {
-        abortSignal?: AbortSignal;
-        signers?: readonly TransactionSigner[];
-    } = {}
+    config: { abortSignal?: AbortSignal } = {}
 ): Promise<TTransaction & IFullySignedTransaction> {
     const signedTransaction = await partiallySignTransactionWithSigners(transaction, config);
     assertTransactionIsFullySigned(signedTransaction);
@@ -76,13 +69,11 @@ export async function signAndSendTransactionWithSigners<
     config: {
         abortSignal?: AbortSignal;
         fallbackSender?: (transaction: TTransaction & IFullySignedTransaction) => Promise<SignatureBytes>;
-        signers?: readonly TransactionSigner[];
     } = {}
 ): Promise<SignatureBytes> {
-    const signers = config.signers ?? [];
     const abortSignal = config.abortSignal;
     const { partialSigners, modifyingSigners, sendingSigner } = categorizeTransactionSigners(
-        deduplicateSigners([...getSignersFromTransaction(transaction).filter(isTransactionSigner), ...signers])
+        deduplicateSigners(getSignersFromTransaction(transaction).filter(isTransactionSigner))
     );
 
     abortSignal?.throwIfAborted();


### PR DESCRIPTION
This PR removes the optional `signers` array that allowed users to manually inject additional signers to the signing flow.

It removes it in favour of new helpers methods `addSignersToInstruction` and `addSignersToTransaction` introduces in the following PR (#1873).

This improvement was suggested by the reviews of #1792.
