### PR TITLE
refactor(experimental): helper functions that add signers to instructions and transactions

### DIFF
--- a/packages/signers/src/__tests__/__setup__.ts
+++ b/packages/signers/src/__tests__/__setup__.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { AccountRole } from '@solana/instructions';
+import { AccountRole, IInstruction } from '@solana/instructions';
 import {
     appendTransactionInstruction,
     Blockhash,
@@ -7,10 +7,9 @@ import {
     createTransaction,
     setTransactionFeePayer,
     setTransactionLifetimeUsingBlockhash,
-    TransactionVersion,
 } from '@solana/transactions';
 
-import { IAccountSignerMeta, IInstructionWithSigners } from '../account-signer-meta';
+import { IAccountSignerMeta, IInstructionWithSigners, ITransactionWithSigners } from '../account-signer-meta';
 import { MessageModifyingSigner } from '../message-modifying-signer';
 import { MessagePartialSigner } from '../message-partial-signer';
 import { TransactionModifyingSigner } from '../transaction-modifying-signer';
@@ -18,7 +17,7 @@ import { TransactionPartialSigner } from '../transaction-partial-signer';
 import { TransactionSendingSigner } from '../transaction-sending-signer';
 import { TransactionSigner } from '../transaction-signer';
 
-export function createMockInstructionWithSigners(signers: TransactionSigner[]): IInstructionWithSigners {
+export function createMockInstructionWithSigners(signers: TransactionSigner[]): IInstruction & IInstructionWithSigners {
     return {
         accounts: signers.map(
             (signer): IAccountSignerMeta => ({ address: signer.address, role: AccountRole.READONLY_SIGNER, signer })
@@ -30,7 +29,7 @@ export function createMockInstructionWithSigners(signers: TransactionSigner[]): 
 
 export function createMockTransactionWithSigners(
     signers: TransactionSigner[]
-): CompilableTransaction<TransactionVersion, IInstructionWithSigners> {
+): CompilableTransaction & ITransactionWithSigners {
     const transaction = createTransaction({ version: 0 });
     const transactionWithFeePayer = setTransactionFeePayer(signers[0]?.address ?? '1111', transaction);
     const compilableTransaction = setTransactionLifetimeUsingBlockhash(

--- a/packages/signers/src/__tests__/add-signers-test.ts
+++ b/packages/signers/src/__tests__/add-signers-test.ts
@@ -1,0 +1,225 @@
+import 'test-matchers/toBeFrozenObject';
+
+import { Address } from '@solana/addresses';
+import { AccountRole, IInstruction } from '@solana/instructions';
+import { BaseTransaction } from '@solana/transactions';
+
+import { IAccountSignerMeta, IInstructionWithSigners } from '../account-signer-meta';
+import { addSignersToInstruction, addSignersToTransaction } from '../add-signers';
+import { createMockTransactionModifyingSigner, createMockTransactionPartialSigner } from './__setup__';
+
+describe('addSignersToInstruction', () => {
+    it('adds signers to the account metas of the instruction', () => {
+        // Given an instruction with signer account metas.
+        const instruction: IInstruction = {
+            accounts: [
+                { address: '1111' as Address, role: AccountRole.READONLY_SIGNER },
+                { address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER },
+            ],
+            data: new Uint8Array([]),
+            programAddress: '9999' as Address,
+        };
+
+        // And two associated signers.
+        const signerA = createMockTransactionPartialSigner('1111' as Address);
+        const signerB = createMockTransactionModifyingSigner('2222' as Address);
+
+        // When we add the signers to the instruction.
+        const instructionWithSigners = addSignersToInstruction([signerA, signerB], instruction);
+
+        // Then the instruction's account metas now store the provided signers.
+        expect(instructionWithSigners.accounts).toStrictEqual([
+            { address: '1111' as Address, role: AccountRole.READONLY_SIGNER, signer: signerA },
+            { address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER, signer: signerB },
+        ]);
+    });
+
+    it('ignores account metas that already have a signer', () => {
+        // Given an instruction with a signer account metas that already has a signer A attached to it.
+        const signerA = createMockTransactionPartialSigner('1111' as Address);
+        const instruction: IInstruction & IInstructionWithSigners = {
+            accounts: [
+                {
+                    address: '1111' as Address,
+                    role: AccountRole.READONLY_SIGNER,
+                    signer: signerA,
+                } as IAccountSignerMeta,
+            ],
+            data: new Uint8Array([]),
+            programAddress: '9999' as Address,
+        };
+
+        // When we try to add a signer B to the instruction matching the signer A's address.
+        const signerB = createMockTransactionPartialSigner('1111' as Address);
+        const instructionWithSigners = addSignersToInstruction([signerB], instruction);
+
+        // Then the instruction's account meta still stores the signer A.
+        expect(instructionWithSigners.accounts).toStrictEqual([
+            { address: '1111' as Address, role: AccountRole.READONLY_SIGNER, signer: signerA },
+        ]);
+    });
+
+    it('ignores account metas that do not have a signer role', () => {
+        // Given an instruction with a non-signer account metas.
+        const instruction: IInstruction = {
+            accounts: [{ address: '1111' as Address, role: AccountRole.WRITABLE }],
+            data: new Uint8Array([]),
+            programAddress: '9999' as Address,
+        };
+
+        // When we try to add a signer to the instruction matching the non-signer account metas's address.
+        const signer = createMockTransactionPartialSigner('1111' as Address);
+        const instructionWithSigners = addSignersToInstruction([signer], instruction);
+
+        // Then the instruction's account meta still doesn't store the signer.
+        expect(instructionWithSigners.accounts).toStrictEqual([
+            { address: '1111' as Address, role: AccountRole.WRITABLE },
+        ]);
+    });
+
+    it('can add the same signer to multiple account metas', () => {
+        // Given an instruction with two signer account metas that share the same address.
+        const instruction: IInstruction = {
+            accounts: [
+                { address: '1111' as Address, role: AccountRole.READONLY_SIGNER },
+                { address: '1111' as Address, role: AccountRole.WRITABLE_SIGNER },
+            ],
+            data: new Uint8Array([]),
+            programAddress: '9999' as Address,
+        };
+
+        // When we add a signer matching this address to the instruction.
+        const signer = createMockTransactionPartialSigner('1111' as Address);
+        const instructionWithSigners = addSignersToInstruction([signer], instruction);
+
+        // Then the instruction's account metas now store the provided signer on both account metas.
+        expect(instructionWithSigners.accounts).toStrictEqual([
+            { address: '1111' as Address, role: AccountRole.READONLY_SIGNER, signer },
+            { address: '1111' as Address, role: AccountRole.WRITABLE_SIGNER, signer },
+        ]);
+    });
+
+    it('fails if two distincts signers are provided for the same address', () => {
+        // Given an instruction with a signer account meta.
+        const instruction: IInstruction = {
+            accounts: [{ address: '1111' as Address, role: AccountRole.READONLY_SIGNER }],
+            data: new Uint8Array([]),
+            programAddress: '9999' as Address,
+        };
+
+        // And two distinct signers for the same address.
+        const signerA = createMockTransactionPartialSigner('1111' as Address);
+        const signerB = createMockTransactionModifyingSigner('1111' as Address);
+
+        // When we try to add the signers to the instruction.
+        const fn = () => addSignersToInstruction([signerA, signerB], instruction);
+
+        // Then we expect an error to be thrown.
+        expect(fn).toThrow(
+            'Multiple distinct signers were identified for address "1111". ' +
+                'Please ensure that you are using the same signer instance for each address.'
+        );
+    });
+
+    it('freezes the returned instruction', () => {
+        // Given an instruction with a signer account metas.
+        const instruction: IInstruction = {
+            accounts: [{ address: '1111' as Address, role: AccountRole.READONLY_SIGNER }],
+            data: new Uint8Array([]),
+            programAddress: '9999' as Address,
+        };
+
+        // When we add a signer to the instruction.
+        const signer = createMockTransactionPartialSigner('1111' as Address);
+        const instructionWithSigners = addSignersToInstruction([signer], instruction);
+
+        // Then the returned instruction is frozen and so are its updated account metas.
+        expect(instructionWithSigners).toBeFrozenObject();
+        expect(instructionWithSigners.accounts![0]).toBeFrozenObject();
+    });
+
+    it('returns the instruction as-is if it has no account metas', () => {
+        // Given an instruction with no account metas.
+        const instruction: IInstruction = {
+            accounts: [],
+            data: new Uint8Array([]),
+            programAddress: '9999' as Address,
+        };
+
+        // When we try to add signers to the instruction.
+        const instructionWithSigners = addSignersToInstruction([], instruction);
+
+        // Then the returned instruction is the same as the original.
+        expect(instructionWithSigners).toBe(instruction);
+    });
+});
+
+describe('addSignersToTransaction', () => {
+    it('adds signers to the account metas of the transaction', () => {
+        // Given a transaction with two instructions with signer account metas.
+        const instructionA: IInstruction = {
+            accounts: [{ address: '1111' as Address, role: AccountRole.READONLY_SIGNER }],
+            data: new Uint8Array([]),
+            programAddress: '8888' as Address,
+        };
+        const instructionB: IInstruction = {
+            accounts: [{ address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER }],
+            data: new Uint8Array([]),
+            programAddress: '9999' as Address,
+        };
+        const transaction: BaseTransaction = {
+            instructions: [instructionA, instructionB],
+            version: 0,
+        };
+
+        // And two associated signers.
+        const signerA = createMockTransactionPartialSigner('1111' as Address);
+        const signerB = createMockTransactionModifyingSigner('2222' as Address);
+
+        // When we add the signers to the transaction.
+        const transactionWithSigners = addSignersToTransaction([signerA, signerB], transaction);
+
+        // Then the transaction's account metas now store the provided signers.
+        expect(transactionWithSigners.instructions[0].accounts).toStrictEqual([
+            { address: '1111' as Address, role: AccountRole.READONLY_SIGNER, signer: signerA },
+        ]);
+        expect(transactionWithSigners.instructions[1].accounts).toStrictEqual([
+            { address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER, signer: signerB },
+        ]);
+    });
+
+    it('freezes the returned transaction', () => {
+        // Given a one-instruction transaction with signer account metas.
+        const transaction: BaseTransaction = {
+            instructions: [
+                {
+                    accounts: [{ address: '1111' as Address, role: AccountRole.READONLY_SIGNER }],
+                    data: new Uint8Array([]),
+                    programAddress: '8888' as Address,
+                },
+            ],
+            version: 0,
+        };
+
+        // When we add signers to the transaction.
+        const signer = createMockTransactionPartialSigner('1111' as Address);
+        const transactionWithSigners = addSignersToTransaction([signer], transaction);
+
+        // Then the returned transaction is frozen and so are its updated instructions and account metas.
+        expect(transactionWithSigners).toBeFrozenObject();
+        expect(transactionWithSigners.instructions[0]).toBeFrozenObject();
+        expect(transactionWithSigners.instructions[0].accounts![0]).toBeFrozenObject();
+    });
+
+    it('returns the transaction as-is if it has no instructions', () => {
+        // Given transaction with no instructions.
+        const transaction: BaseTransaction = { instructions: [], version: 0 };
+
+        // When we try to add signers to the transaction.
+        const signer = createMockTransactionPartialSigner('1111' as Address);
+        const transactionWithSigners = addSignersToTransaction([signer], transaction);
+
+        // Then the returned transaction is the same as the original.
+        expect(transactionWithSigners).toBe(transaction);
+    });
+});

--- a/packages/signers/src/add-signers.ts
+++ b/packages/signers/src/add-signers.ts
@@ -1,0 +1,43 @@
+import { IInstruction, isSignerRole } from '@solana/instructions';
+import { BaseTransaction } from '@solana/transactions';
+
+import { IAccountSignerMeta, IInstructionWithSigners, ITransactionWithSigners } from './account-signer-meta';
+import { deduplicateSigners } from './deduplicate-signers';
+import { TransactionSigner } from './transaction-signer';
+
+/** Attaches the provided signers to the account metas of an instruction when applicable. */
+export function addSignersToInstruction<TInstruction extends IInstruction>(
+    signers: TransactionSigner[],
+    instruction: TInstruction | (TInstruction & IInstructionWithSigners)
+): TInstruction & IInstructionWithSigners {
+    if (!instruction.accounts || instruction.accounts.length === 0) {
+        return instruction as TInstruction & IInstructionWithSigners;
+    }
+
+    const signerByAddress = new Map(deduplicateSigners(signers).map(signer => [signer.address, signer]));
+    return Object.freeze({
+        ...instruction,
+        accounts: instruction.accounts.map(account => {
+            const signer = signerByAddress.get(account.address);
+            if (!isSignerRole(account.role) || 'signer' in account || !signer) {
+                return account;
+            }
+            return Object.freeze({ ...account, signer } as IAccountSignerMeta);
+        }),
+    });
+}
+
+/** Attaches the provided signers to the account metas of a transaction when applicable. */
+export function addSignersToTransaction<TTransaction extends BaseTransaction>(
+    signers: TransactionSigner[],
+    transaction: TTransaction | (TTransaction & ITransactionWithSigners)
+): TTransaction & ITransactionWithSigners {
+    if (transaction.instructions.length === 0) {
+        return transaction as TTransaction & ITransactionWithSigners;
+    }
+
+    return Object.freeze({
+        ...transaction,
+        instructions: transaction.instructions.map(instruction => addSignersToInstruction(signers, instruction)),
+    });
+}

--- a/packages/signers/src/index.ts
+++ b/packages/signers/src/index.ts
@@ -1,4 +1,5 @@
 export * from './account-signer-meta';
+export * from './add-signers';
 export * from './keypair-signer';
 export * from './message-modifying-signer';
 export * from './message-partial-signer';

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -4,20 +4,17 @@ import {
     CompilableTransaction,
     IFullySignedTransaction,
     ITransactionWithSignatures,
-    TransactionVersion,
 } from '@solana/transactions';
 
-import { getSignersFromTransaction, IInstructionWithSigners } from './account-signer-meta';
+import { getSignersFromTransaction, ITransactionWithSigners } from './account-signer-meta';
 import { deduplicateSigners } from './deduplicate-signers';
 import { isTransactionModifyingSigner, TransactionModifyingSigner } from './transaction-modifying-signer';
 import { isTransactionPartialSigner, TransactionPartialSigner } from './transaction-partial-signer';
 import { isTransactionSendingSigner, TransactionSendingSigner } from './transaction-sending-signer';
 import { isTransactionSigner, TransactionSigner } from './transaction-signer';
 
-type CompilableTransactionWithSigners = CompilableTransaction<
-    TransactionVersion,
-    IInstructionWithSigners<string, TransactionSigner>
-> &
+type CompilableTransactionWithSigners = CompilableTransaction &
+    ITransactionWithSigners &
     Partial<ITransactionWithSignatures>;
 
 /**


### PR DESCRIPTION
This PR provides two helper methods `addSignersToInstruction` and `addSignersToTransaction` which, given an array of signers, go through the account metas of the provided object and attach signers to them when applicable.

For an account meta to match a provided signer it:

-   Must have a signer role (`AccountRole.READONLY_SIGNER` or `AccountRole.WRITABLE_SIGNER`).
-   Must have the same address as the provided signer.
-   Must not have an attached signer already.

```ts
const myInstruction: IInstruction = {
    accounts: [
        { address: '1111' as Address, role: AccountRole.READONLY_SIGNER },
        { address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER },
    ],
    // ...
};

const signerA: TransactionSigner<'1111'>;
const signerB: TransactionSigner<'2222'>;
const myInstructionWithSigners = addSignersToInstruction([mySignerA, mySignerB], myInstruction);

// myInstructionWithSigners.accounts[0].signer === mySignerA
// myInstructionWithSigners.accounts[1].signer === mySignerB
```

It also redefines the `IInstructionWithSigners` type and introduce a new analogous `ITransactionWithSigners` type for transactions. Both of these types _add_ to the type definition of an instruction/transaction instead of defining the entire object like they were before.

Meaning you can now do `IInstruction & IInstructionWithSigners` or `BaseTransaction & ITransactionWithSigners` to compose types together just like you can with `ITransactionWithSignatures`.

This improvement was suggested by the reviews of https://github.com/solana-labs/solana-web3.js/pull/1792.