### PR TITLE
refactor(experimental): export from messages in @solana/transactions

### DIFF
--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -4,6 +4,7 @@ export * from './create-transaction';
 export * from './durable-nonce';
 export * from './fee-payer';
 export * from './instructions';
+export * from './message';
 export * from './serializers';
 export * from './signatures';
 export * from './types';

--- a/packages/transactions/src/serializers/index.ts
+++ b/packages/transactions/src/serializers/index.ts
@@ -1,1 +1,2 @@
+export * from './message';
 export * from './transaction';


### PR DESCRIPTION
This allows consumers to perform signing logic manually:

```ts
const compiledMessage = compileMessage(transaction);
const bytes = getCompiledMessageEncoder().encode(compiledMessage);

// app logic
const signature = signTransaction(bytes);
```

This is probably not a super common use case, but it's necessary for eg a wallet that doesn't necessarily have `CryptoKeyPair` objects available for accounts it is signing for, and therefore can't use our `signTransaction` helper function. 