### PR TITLE
refactor(experimental): build libraries at the highest ECMAScript target possible

### DIFF
--- a/packages/assertions/.vscode/settings.json
+++ b/packages/assertions/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -1,13 +1,19 @@
 import { env } from 'node:process';
 
+import browsersListToEsBuild from 'browserslist-to-esbuild';
 import path from 'path';
 import { Format, Options } from 'tsup';
 
+console.log(browsersListToEsBuild());
 type Platform =
     | 'browser'
     | 'node'
     // React Native
     | 'native';
+
+const BROWSERSLIST_TARGETS = browsersListToEsBuild()
+    // FIXME(https://github.com/evanw/esbuild/issues/3501) Have to filter out versions like `safariTP`
+    .filter(v => !v.endsWith('TP')) as Options['target'];
 
 export function getBaseConfig(platform: Platform, formats: Format[], _options: Options): Options[] {
     return [true, false].flatMap<Options>(isDebugBuild =>
@@ -27,6 +33,7 @@ export function getBaseConfig(platform: Platform, formats: Format[], _options: O
                         ...options.define,
                         __DEV__: `${isDebugBuild}`,
                     };
+                    options.target = BROWSERSLIST_TARGETS;
                 }
                 options.inject = [path.resolve(__dirname, 'env-shim.ts')];
             },

--- a/packages/build-scripts/package.json
+++ b/packages/build-scripts/package.json
@@ -9,6 +9,7 @@
     ],
     "devDependencies": {
         "@types/node": "^20",
+        "browserslist-to-esbuild": "^1.2.0",
         "tsconfig": "workspace:*",
         "tsup": "^8.0.1"
     }

--- a/packages/library-legacy/tsconfig.json
+++ b/packages/library-legacy/tsconfig.json
@@ -9,8 +9,7 @@
     "noImplicitReturns": true,
     "outDir": "lib",
     "resolveJsonModule": true,
-    "strict": true,
-    "target": "esnext"
+    "strict": true
   },
   "extends": "tsconfig/base.json",
   "include": ["src", "test"],

--- a/packages/test-matchers/tsconfig.json
+++ b/packages/test-matchers/tsconfig.json
@@ -16,7 +16,7 @@
         "preserveWatchOutput": true,
         "skipLibCheck": true,
         "strict": true,
-        "target": "ES2020"
+        "target": "ESNext"
     },
     "exclude": ["node_modules"]
 }

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -16,7 +16,7 @@
         "preserveWatchOutput": true,
         "skipLibCheck": true,
         "strict": true,
-        "target": "ES2020"
+        "target": "ESNext"
     },
     "exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.4.4
+      browserslist-to-esbuild:
+        specifier: ^1.2.0
+        version: 1.2.0
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -6642,6 +6645,13 @@ packages:
 
   /browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+    dev: true
+
+  /browserslist-to-esbuild@1.2.0:
+    resolution: {integrity: sha512-ftrrbI/VHBgEnmnSyhkqvQVMp6jAKybfs0qMIlm7SLBrQTGMsdCIP4q3BoKeLsZTBQllIQtY9kbxgRYV2WU47g==}
+    engines: {node: '>=12'}
+    dependencies:
+      browserslist: 4.22.1
     dev: true
 
   /browserslist@4.21.9:


### PR DESCRIPTION
# Summary

We're building a library. We don't deploy directly on the target – our customers do. They should have the final say what ECMA target they want to run against (eg. ES2020, ES2015, et cetera).

It's wise, therefore, to compile our _library_ at the highest possible target (ie. ESNext) so as not to lose any features/information on the way into our customers' build systems.

The only exception is the IIFE bundle that we ship, which we compile to the `browserslist` target "`supports bigint and not dead`".

Thanks to @hyrious for [the suggestion](https://github.com/evanw/esbuild/issues/3500#issuecomment-1820046687).

# Test Plan

Spot check the compiled source in `packages/library-legacy-sham`

1. The browser/node/native bundles still have all of the private property syntax intact
2. The developement/production IIFE bundles have the private property syntax compiled to an implementation based on `WeakMap`
