### PR TITLE
refactor(experimental): create a `Connection` sham that only exposes `rpcEndpoint`

### DIFF
--- a/packages/library-legacy-sham/src/__tests__/connection-test.ts
+++ b/packages/library-legacy-sham/src/__tests__/connection-test.ts
@@ -1,0 +1,12 @@
+import { Connection } from '../connection';
+
+describe('ConnectionSham', () => {
+    it.each(['gopher:', 'tel:', 'ws://', 'wss://'])('fatals if the endpoint supplied starts with `%s`', scheme => {
+        expect(() => new Connection(scheme + 'url')).toThrow();
+    });
+    it.each(['https', 'http'])('offers the `%s` endpoint URL through the `rpcEndpoint` property', scheme => {
+        const endpoint = scheme + '://url';
+        const connection = new Connection(endpoint);
+        expect(connection).toHaveProperty('rpcEndpoint', endpoint);
+    });
+});

--- a/packages/library-legacy-sham/src/__typetests__/connection-typetests.ts
+++ b/packages/library-legacy-sham/src/__typetests__/connection-typetests.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { Connection as LegacyConnection } from '@solana/web3.js-legacy';
+
+import { Connection } from '../connection';
+
+new Connection('https://some.rpc').rpcEndpoint satisfies 'https://some.rpc';
+
+// @ts-expect-error This is only a partial sham
+new Connection('https://some.rpc') satisfies LegacyConnection;
+
+// @ts-expect-error This is only a partial sham
+Connection satisfies typeof LegacyConnection;

--- a/packages/library-legacy-sham/src/connection.ts
+++ b/packages/library-legacy-sham/src/connection.ts
@@ -1,0 +1,12 @@
+export class Connection<TRpcEndpoint extends string> {
+    #endpoint: TRpcEndpoint;
+    constructor(putativeEndpoint: TRpcEndpoint) {
+        if (/^https?:/.test(putativeEndpoint) === false) {
+            throw new TypeError('Endpoint URL must start with `http:` or `https:`.');
+        }
+        this.#endpoint = putativeEndpoint;
+    }
+    get rpcEndpoint() {
+        return this.#endpoint;
+    }
+}


### PR DESCRIPTION
# Summary

The target of this sham is to be a drop-in replacement for `@solana/wallet-adapter` and nothing else. That library (unfortunately) uses `useConnection` solely to obtain the `rpcEndpoint`.

# Test plan

TBD
