### PR TITLE
Add a dependsOn line for publish-packages in turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -38,6 +38,7 @@
         },
         "publish-packages": {
             "cache": false,
+            "dependsOn": ["^publish-packages"],
             "outputs": []
         },
         "style:fix": {


### PR DESCRIPTION
There's an issue with my change in #1879 but I'm not too sure what it is

```bash
$ npm install @solana/web3.js@experimental
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @solana/codecs-core@2.0.0-development.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist
```

The latest experimental tagged version of [@solana/web3.js is 2.0.0-experimental.d93c93b](https://www.npmjs.com/package/@solana/web3.js?activeTab=versions)
And for the child packages eg [@solana/codecs-core  mentioned in that error, it's also 2.0.0-experimental.d93c93b](https://www.npmjs.com/package/@solana/codecs-core?activeTab=versions)

So it is correctly publishing the packages with the right versions, but seems to have somehow not updated the workspace dependency versions, ie it's looking for the version `2.0.0-experimental` instead of `2.0.0-experimental.d93c93b`

In the previous PR I removed the line from `publish-packages` in `turbo.json`: `"dependsOn": ["build", "^publish-packages"],`

We want to remove `build` here, because it should be separate (run without the `--continue` flag)
But we might still need the `^publish-packages` dependency. 

I'm not sure what the difference is between no `dependsOn` and a `dependsOn: ["^publish-packages"]`, but I'm hoping it's responsible for whatever the missing piece is here. 