### PR TITLE
refactor(experimental): add read write functions to codecs-numbers

### DIFF
--- a/packages/codecs-numbers/src/__tests__/f32-test.ts
+++ b/packages/codecs-numbers/src/__tests__/f32-test.ts
@@ -29,15 +29,7 @@ describe('getF32Codec', () => {
         assertValid(f32BE, -Math.PI, 'c0490fdb', -APPROX_PI);
     });
 
-    it('has the right description', () => {
-        expect(f32().description).toBe('f32(le)');
-        expect(f32({ endian: Endian.LITTLE }).description).toBe('f32(le)');
-        expect(f32({ endian: Endian.BIG }).description).toBe('f32(be)');
-        expect(f32({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(f32().fixedSize).toBe(4);
-        expect(f32().maxSize).toBe(4);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/f64-test.ts
+++ b/packages/codecs-numbers/src/__tests__/f64-test.ts
@@ -29,15 +29,7 @@ describe('getF64Codec', () => {
         assertValid(f64BE, -Math.PI, 'c00921fb54442d18', -APPROX_PI);
     });
 
-    it('has the right description', () => {
-        expect(f64().description).toBe('f64(le)');
-        expect(f64({ endian: Endian.LITTLE }).description).toBe('f64(le)');
-        expect(f64({ endian: Endian.BIG }).description).toBe('f64(be)');
-        expect(f64({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(f64().fixedSize).toBe(8);
-        expect(f64().maxSize).toBe(8);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/i128-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i128-test.ts
@@ -42,15 +42,7 @@ describe('getI128Codec', () => {
         assertRangeError(i128BE, MAX + 1n);
     });
 
-    it('has the right description', () => {
-        expect(i128().description).toBe('i128(le)');
-        expect(i128({ endian: Endian.LITTLE }).description).toBe('i128(le)');
-        expect(i128({ endian: Endian.BIG }).description).toBe('i128(be)');
-        expect(i128({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(i128().fixedSize).toBe(16);
-        expect(i128().maxSize).toBe(16);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/i16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i16-test.ts
@@ -42,15 +42,7 @@ describe('getI16Codec', () => {
         assertRangeError(i16BE, MAX + 1);
     });
 
-    it('has the right description', () => {
-        expect(i16().description).toBe('i16(le)');
-        expect(i16({ endian: Endian.LITTLE }).description).toBe('i16(le)');
-        expect(i16({ endian: Endian.BIG }).description).toBe('i16(be)');
-        expect(i16({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(i16().fixedSize).toBe(2);
-        expect(i16().maxSize).toBe(2);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/i32-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i32-test.ts
@@ -42,15 +42,7 @@ describe('getI32Codec', () => {
         assertRangeError(i32BE, MAX + 1);
     });
 
-    it('has the right description', () => {
-        expect(i32().description).toBe('i32(le)');
-        expect(i32({ endian: Endian.LITTLE }).description).toBe('i32(le)');
-        expect(i32({ endian: Endian.BIG }).description).toBe('i32(be)');
-        expect(i32({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(i32().fixedSize).toBe(4);
-        expect(i32().maxSize).toBe(4);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/i64-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i64-test.ts
@@ -42,15 +42,7 @@ describe('getI64Codec', () => {
         assertRangeError(i64BE, MAX + 1n);
     });
 
-    it('has the right description', () => {
-        expect(i64().description).toBe('i64(le)');
-        expect(i64({ endian: Endian.LITTLE }).description).toBe('i64(le)');
-        expect(i64({ endian: Endian.BIG }).description).toBe('i64(be)');
-        expect(i64({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(i64().fixedSize).toBe(8);
-        expect(i64().maxSize).toBe(8);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/i8-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i8-test.ts
@@ -27,13 +27,7 @@ describe('getI8Codec', () => {
         assertRangeError(i8(), MAX + 1);
     });
 
-    it('has the right description', () => {
-        expect(i8().description).toBe('i8');
-        expect(i8({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(i8().fixedSize).toBe(1);
-        expect(i8().maxSize).toBe(1);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/short-u16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/short-u16-test.ts
@@ -32,13 +32,8 @@ describe('getShortU16Codec', () => {
         const codec = shortU16();
         for (let i = 0; i <= 0b1111111111111111; i += 1) {
             const bytes = codec.encode(i);
-            expect(codec.decode(bytes)[0]).toBe(i);
+            expect(codec.decode(bytes)).toBe(i);
         }
-    });
-
-    it('has the right description', () => {
-        expect(shortU16().description).toBe('shortU16');
-        expect(shortU16({ description: 'custom' }).description).toBe('custom');
     });
 
     it('has the right sizes', () => {

--- a/packages/codecs-numbers/src/__tests__/u128-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u128-test.ts
@@ -41,15 +41,7 @@ describe('getU128Codec', () => {
         assertRangeError(u128BE, MAX + 1n);
     });
 
-    it('has the right description', () => {
-        expect(u128().description).toBe('u128(le)');
-        expect(u128({ endian: Endian.LITTLE }).description).toBe('u128(le)');
-        expect(u128({ endian: Endian.BIG }).description).toBe('u128(be)');
-        expect(u128({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(u128().fixedSize).toBe(16);
-        expect(u128().maxSize).toBe(16);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/u16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u16-test.ts
@@ -41,15 +41,7 @@ describe('getU16Codec', () => {
         assertRangeError(u16BE, MAX + 1);
     });
 
-    it('has the right description', () => {
-        expect(u16().description).toBe('u16(le)');
-        expect(u16({ endian: Endian.LITTLE }).description).toBe('u16(le)');
-        expect(u16({ endian: Endian.BIG }).description).toBe('u16(be)');
-        expect(u16({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(u16().fixedSize).toBe(2);
-        expect(u16().maxSize).toBe(2);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/u32-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u32-test.ts
@@ -41,15 +41,7 @@ describe('getU32Codec', () => {
         assertRangeError(u32BE, MAX + 1);
     });
 
-    it('has the right description', () => {
-        expect(u32().description).toBe('u32(le)');
-        expect(u32({ endian: Endian.LITTLE }).description).toBe('u32(le)');
-        expect(u32({ endian: Endian.BIG }).description).toBe('u32(be)');
-        expect(u32({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(u32().fixedSize).toBe(4);
-        expect(u32().maxSize).toBe(4);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/u64-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u64-test.ts
@@ -41,15 +41,7 @@ describe('getU64Codec', () => {
         assertRangeError(u64BE, MAX + 1n);
     });
 
-    it('has the right description', () => {
-        expect(u64().description).toBe('u64(le)');
-        expect(u64({ endian: Endian.LITTLE }).description).toBe('u64(le)');
-        expect(u64({ endian: Endian.BIG }).description).toBe('u64(be)');
-        expect(u64({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(u64().fixedSize).toBe(8);
-        expect(u64().maxSize).toBe(8);
     });
 });

--- a/packages/codecs-numbers/src/__tests__/u8-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u8-test.ts
@@ -24,13 +24,7 @@ describe('getU8Codec', () => {
         assertRangeError(u8(), MAX + 1);
     });
 
-    it('has the right description', () => {
-        expect(u8().description).toBe('u8');
-        expect(u8({ description: 'custom' }).description).toBe('custom');
-    });
-
-    it('has the right sizes', () => {
+    it('has the right size', () => {
         expect(u8().fixedSize).toBe(1);
-        expect(u8().maxSize).toBe(1);
     });
 });

--- a/packages/codecs-numbers/src/common.ts
+++ b/packages/codecs-numbers/src/common.ts
@@ -1,4 +1,4 @@
-import { BaseCodecConfig, Codec, Decoder, Encoder } from '@solana/codecs-core';
+import { Codec, Decoder, Encoder } from '@solana/codecs-core';
 
 /** Defines a encoder for numbers and bigints. */
 export type NumberEncoder = Encoder<number> | Encoder<number | bigint>;
@@ -9,11 +9,8 @@ export type NumberDecoder = Decoder<number> | Decoder<bigint>;
 /** Defines a codec for numbers and bigints. */
 export type NumberCodec = Codec<number> | Codec<number | bigint, bigint>;
 
-/** Defines the config for u8 and i8 codecs. */
-export type SingleByteNumberCodecConfig = BaseCodecConfig;
-
 /** Defines the config for number codecs that use more than one byte. */
-export type NumberCodecConfig = BaseCodecConfig & {
+export type NumberCodecConfig = {
     /**
      * Whether the serializer should use little-endian or big-endian encoding.
      * @defaultValue `Endian.LITTLE`

--- a/packages/codecs-numbers/src/f32.ts
+++ b/packages/codecs-numbers/src/f32.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getF32Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
+export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
     numberEncoderFactory({
         config,
         name: 'f32',
@@ -11,7 +11,7 @@ export const getF32Encoder = (config: NumberCodecConfig = {}): Encoder<number> =
         size: 4,
     });
 
-export const getF32Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
+export const getF32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getFloat32(0, le),
@@ -19,5 +19,5 @@ export const getF32Decoder = (config: NumberCodecConfig = {}): Decoder<number> =
         size: 4,
     });
 
-export const getF32Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+export const getF32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
     combineCodec(getF32Encoder(config), getF32Decoder(config));

--- a/packages/codecs-numbers/src/f64.ts
+++ b/packages/codecs-numbers/src/f64.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getF64Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
+export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
     numberEncoderFactory({
         config,
         name: 'f64',
@@ -11,7 +11,7 @@ export const getF64Encoder = (config: NumberCodecConfig = {}): Encoder<number> =
         size: 8,
     });
 
-export const getF64Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
+export const getF64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getFloat64(0, le),
@@ -19,5 +19,5 @@ export const getF64Decoder = (config: NumberCodecConfig = {}): Decoder<number> =
         size: 8,
     });
 
-export const getF64Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+export const getF64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
     combineCodec(getF64Encoder(config), getF64Decoder(config));

--- a/packages/codecs-numbers/src/i128.ts
+++ b/packages/codecs-numbers/src/i128.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI128Encoder = (config: NumberCodecConfig = {}): Encoder<number | bigint> =>
+export const getI128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint> =>
     numberEncoderFactory({
         config,
         name: 'i128',
@@ -18,7 +18,7 @@ export const getI128Encoder = (config: NumberCodecConfig = {}): Encoder<number |
         size: 16,
     });
 
-export const getI128Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =>
+export const getI128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint> =>
     numberDecoderFactory({
         config,
         get: (view, le) => {
@@ -32,5 +32,5 @@ export const getI128Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> 
         size: 16,
     });
 
-export const getI128Codec = (config: NumberCodecConfig = {}): Codec<number | bigint, bigint> =>
+export const getI128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint> =>
     combineCodec(getI128Encoder(config), getI128Decoder(config));

--- a/packages/codecs-numbers/src/i16.ts
+++ b/packages/codecs-numbers/src/i16.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI16Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
+export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
     numberEncoderFactory({
         config,
         name: 'i16',
@@ -12,7 +12,7 @@ export const getI16Encoder = (config: NumberCodecConfig = {}): Encoder<number> =
         size: 2,
     });
 
-export const getI16Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
+export const getI16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getInt16(0, le),
@@ -20,5 +20,5 @@ export const getI16Decoder = (config: NumberCodecConfig = {}): Decoder<number> =
         size: 2,
     });
 
-export const getI16Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+export const getI16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
     combineCodec(getI16Encoder(config), getI16Decoder(config));

--- a/packages/codecs-numbers/src/i32.ts
+++ b/packages/codecs-numbers/src/i32.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI32Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
+export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
     numberEncoderFactory({
         config,
         name: 'i32',
@@ -12,7 +12,7 @@ export const getI32Encoder = (config: NumberCodecConfig = {}): Encoder<number> =
         size: 4,
     });
 
-export const getI32Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
+export const getI32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getInt32(0, le),
@@ -20,5 +20,5 @@ export const getI32Decoder = (config: NumberCodecConfig = {}): Decoder<number> =
         size: 4,
     });
 
-export const getI32Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+export const getI32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
     combineCodec(getI32Encoder(config), getI32Decoder(config));

--- a/packages/codecs-numbers/src/i64.ts
+++ b/packages/codecs-numbers/src/i64.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI64Encoder = (config: NumberCodecConfig = {}): Encoder<number | bigint> =>
+export const getI64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint> =>
     numberEncoderFactory({
         config,
         name: 'i64',
@@ -12,7 +12,7 @@ export const getI64Encoder = (config: NumberCodecConfig = {}): Encoder<number | 
         size: 8,
     });
 
-export const getI64Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =>
+export const getI64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getBigInt64(0, le),
@@ -20,5 +20,5 @@ export const getI64Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =
         size: 8,
     });
 
-export const getI64Codec = (config: NumberCodecConfig = {}): Codec<number | bigint, bigint> =>
+export const getI64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint> =>
     combineCodec(getI64Encoder(config), getI64Decoder(config));

--- a/packages/codecs-numbers/src/i8.ts
+++ b/packages/codecs-numbers/src/i8.ts
@@ -1,24 +1,20 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
-import { SingleByteNumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI8Encoder = (config: SingleByteNumberCodecConfig = {}): Encoder<number> =>
+export const getI8Encoder = (): FixedSizeEncoder<number> =>
     numberEncoderFactory({
-        config,
         name: 'i8',
         range: [-Number('0x7f') - 1, Number('0x7f')],
         set: (view, value) => view.setInt8(0, value),
         size: 1,
     });
 
-export const getI8Decoder = (config: SingleByteNumberCodecConfig = {}): Decoder<number> =>
+export const getI8Decoder = (): FixedSizeDecoder<number> =>
     numberDecoderFactory({
-        config,
         get: view => view.getInt8(0),
         name: 'i8',
         size: 1,
     });
 
-export const getI8Codec = (config: SingleByteNumberCodecConfig = {}): Codec<number> =>
-    combineCodec(getI8Encoder(config), getI8Decoder(config));
+export const getI8Codec = (): FixedSizeCodec<number> => combineCodec(getI8Encoder(), getI8Decoder());

--- a/packages/codecs-numbers/src/short-u16.ts
+++ b/packages/codecs-numbers/src/short-u16.ts
@@ -1,67 +1,76 @@
-import { BaseCodecConfig, Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import {
+    combineCodec,
+    createDecoder,
+    createEncoder,
+    Offset,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '@solana/codecs-core';
 
 import { assertNumberIsBetweenForCodec } from './assertions';
-
-/**
- * Defines the config for the shortU16 serializer.
- */
-export type ShortU16CodecConfig = BaseCodecConfig;
 
 /**
  * Encodes short u16 numbers.
  * @see {@link getShortU16Codec} for a more detailed description.
  */
-export const getShortU16Encoder = (config: ShortU16CodecConfig = {}): Encoder<number> => ({
-    description: config.description ?? 'shortU16',
-    encode: (value: number): Uint8Array => {
-        assertNumberIsBetweenForCodec('shortU16', 0, 65535, value);
-        const bytes = [0];
-        for (let ii = 0; ; ii += 1) {
-            // Shift the bits of the value over such that the next 7 bits are at the right edge.
-            const alignedValue = value >> (ii * 7);
-            if (alignedValue === 0) {
-                // No more bits to consume.
-                break;
+export const getShortU16Encoder = (): VariableSizeEncoder<number> =>
+    createEncoder({
+        fixedSize: null,
+        maxSize: 3,
+        variableSize: (value: number): number => {
+            if (value <= 0b01111111) return 1;
+            if (value <= 0b0011111111111111) return 2;
+            return 3;
+        },
+        write: (value: number, bytes: Uint8Array, offset: Offset): Offset => {
+            assertNumberIsBetweenForCodec('shortU16', 0, 65535, value);
+            const shortU16Bytes = [0];
+            for (let ii = 0; ; ii += 1) {
+                // Shift the bits of the value over such that the next 7 bits are at the right edge.
+                const alignedValue = value >> (ii * 7);
+                if (alignedValue === 0) {
+                    // No more bits to consume.
+                    break;
+                }
+                // Extract those 7 bits using a mask.
+                const nextSevenBits = 0b1111111 & alignedValue;
+                shortU16Bytes[ii] = nextSevenBits;
+                if (ii > 0) {
+                    // Set the continuation bit of the previous slice.
+                    shortU16Bytes[ii - 1] |= 0b10000000;
+                }
             }
-            // Extract those 7 bits using a mask.
-            const nextSevenBits = 0b1111111 & alignedValue;
-            bytes[ii] = nextSevenBits;
-            if (ii > 0) {
-                // Set the continuation bit of the previous slice.
-                bytes[ii - 1] |= 0b10000000;
-            }
-        }
-        return new Uint8Array(bytes);
-    },
-    fixedSize: null,
-    maxSize: 3,
-});
+            bytes.set(shortU16Bytes, offset);
+            return offset + shortU16Bytes.length;
+        },
+    });
 
 /**
  * Decodes short u16 numbers.
  * @see {@link getShortU16Codec} for a more detailed description.
  */
-export const getShortU16Decoder = (config: ShortU16CodecConfig = {}): Decoder<number> => ({
-    decode: (bytes: Uint8Array, offset = 0): [number, number] => {
-        let value = 0;
-        let byteCount = 0;
-        while (++byteCount) {
-            const byteIndex = byteCount - 1;
-            const currentByte = bytes[offset + byteIndex];
-            const nextSevenBits = 0b1111111 & currentByte;
-            // Insert the next group of seven bits into the correct slot of the output value.
-            value |= nextSevenBits << (byteIndex * 7);
-            if ((currentByte & 0b10000000) === 0) {
-                // This byte does not have its continuation bit set. We're done.
-                break;
+export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
+    createDecoder({
+        fixedSize: null,
+        maxSize: 3,
+        read: (bytes: Uint8Array, offset): [number, Offset] => {
+            let value = 0;
+            let byteCount = 0;
+            while (++byteCount) {
+                const byteIndex = byteCount - 1;
+                const currentByte = bytes[offset + byteIndex];
+                const nextSevenBits = 0b1111111 & currentByte;
+                // Insert the next group of seven bits into the correct slot of the output value.
+                value |= nextSevenBits << (byteIndex * 7);
+                if ((currentByte & 0b10000000) === 0) {
+                    // This byte does not have its continuation bit set. We're done.
+                    break;
+                }
             }
-        }
-        return [value, offset + byteCount];
-    },
-    description: config.description ?? 'shortU16',
-    fixedSize: null,
-    maxSize: 3,
-});
+            return [value, offset + byteCount];
+        },
+    });
 
 /**
  * Encodes and decodes short u16 numbers.
@@ -72,5 +81,5 @@ export const getShortU16Decoder = (config: ShortU16CodecConfig = {}): Decoder<nu
  * pattern until the 3rd byte. The 3rd byte, if needed, uses
  * all 8 bits to store the last byte of the original value.
  */
-export const getShortU16Codec = (config: ShortU16CodecConfig = {}): Codec<number> =>
-    combineCodec(getShortU16Encoder(config), getShortU16Decoder(config));
+export const getShortU16Codec = (): VariableSizeCodec<number> =>
+    combineCodec(getShortU16Encoder(), getShortU16Decoder());

--- a/packages/codecs-numbers/src/u128.ts
+++ b/packages/codecs-numbers/src/u128.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU128Encoder = (config: NumberCodecConfig = {}): Encoder<number | bigint> =>
+export const getU128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint> =>
     numberEncoderFactory({
         config,
         name: 'u128',
@@ -18,7 +18,7 @@ export const getU128Encoder = (config: NumberCodecConfig = {}): Encoder<number |
         size: 16,
     });
 
-export const getU128Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =>
+export const getU128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint> =>
     numberDecoderFactory({
         config,
         get: (view, le) => {
@@ -32,5 +32,5 @@ export const getU128Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> 
         size: 16,
     });
 
-export const getU128Codec = (config: NumberCodecConfig = {}): Codec<number | bigint, bigint> =>
+export const getU128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint> =>
     combineCodec(getU128Encoder(config), getU128Decoder(config));

--- a/packages/codecs-numbers/src/u16.ts
+++ b/packages/codecs-numbers/src/u16.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU16Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
+export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
     numberEncoderFactory({
         config,
         name: 'u16',
@@ -12,7 +12,7 @@ export const getU16Encoder = (config: NumberCodecConfig = {}): Encoder<number> =
         size: 2,
     });
 
-export const getU16Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
+export const getU16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getUint16(0, le),
@@ -20,5 +20,5 @@ export const getU16Decoder = (config: NumberCodecConfig = {}): Decoder<number> =
         size: 2,
     });
 
-export const getU16Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+export const getU16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
     combineCodec(getU16Encoder(config), getU16Decoder(config));

--- a/packages/codecs-numbers/src/u32.ts
+++ b/packages/codecs-numbers/src/u32.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU32Encoder = (config: NumberCodecConfig = {}): Encoder<number> =>
+export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
     numberEncoderFactory({
         config,
         name: 'u32',
@@ -12,7 +12,7 @@ export const getU32Encoder = (config: NumberCodecConfig = {}): Encoder<number> =
         size: 4,
     });
 
-export const getU32Decoder = (config: NumberCodecConfig = {}): Decoder<number> =>
+export const getU32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getUint32(0, le),
@@ -20,5 +20,5 @@ export const getU32Decoder = (config: NumberCodecConfig = {}): Decoder<number> =
         size: 4,
     });
 
-export const getU32Codec = (config: NumberCodecConfig = {}): Codec<number> =>
+export const getU32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
     combineCodec(getU32Encoder(config), getU32Decoder(config));

--- a/packages/codecs-numbers/src/u64.ts
+++ b/packages/codecs-numbers/src/u64.ts
@@ -1,9 +1,9 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU64Encoder = (config: NumberCodecConfig = {}): Encoder<number | bigint> =>
+export const getU64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint> =>
     numberEncoderFactory({
         config,
         name: 'u64',
@@ -12,7 +12,7 @@ export const getU64Encoder = (config: NumberCodecConfig = {}): Encoder<number | 
         size: 8,
     });
 
-export const getU64Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =>
+export const getU64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getBigUint64(0, le),
@@ -20,5 +20,5 @@ export const getU64Decoder = (config: NumberCodecConfig = {}): Decoder<bigint> =
         size: 8,
     });
 
-export const getU64Codec = (config: NumberCodecConfig = {}): Codec<number | bigint, bigint> =>
+export const getU64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint> =>
     combineCodec(getU64Encoder(config), getU64Decoder(config));

--- a/packages/codecs-numbers/src/u8.ts
+++ b/packages/codecs-numbers/src/u8.ts
@@ -1,24 +1,20 @@
-import { Codec, combineCodec, Decoder, Encoder } from '@solana/codecs-core';
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
-import { SingleByteNumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU8Encoder = (config: SingleByteNumberCodecConfig = {}): Encoder<number> =>
+export const getU8Encoder = (): FixedSizeEncoder<number> =>
     numberEncoderFactory({
-        config,
         name: 'u8',
         range: [0, Number('0xff')],
         set: (view, value) => view.setUint8(0, value),
         size: 1,
     });
 
-export const getU8Decoder = (config: SingleByteNumberCodecConfig = {}): Decoder<number> =>
+export const getU8Decoder = (): FixedSizeDecoder<number> =>
     numberDecoderFactory({
-        config,
         get: view => view.getUint8(0),
         name: 'u8',
         size: 1,
     });
 
-export const getU8Codec = (config: SingleByteNumberCodecConfig = {}): Codec<number> =>
-    combineCodec(getU8Encoder(config), getU8Decoder(config));
+export const getU8Codec = (): FixedSizeCodec<number> => combineCodec(getU8Encoder(), getU8Decoder());


### PR DESCRIPTION
This PR continues to refactor the codecs libraries as described in PR #1865. This one focuses on `@solana/codecs-numbers`.
