### PR TITLE
refactor(experimental): a sham for `Transaction`

### DIFF
--- a/packages/library-legacy-sham/package.json
+++ b/packages/library-legacy-sham/package.json
@@ -67,7 +67,8 @@
     "dependencies": {
         "@noble/ed25519": "^2.0.0",
         "@noble/hashes": "^1.3.2",
-        "@solana/addresses": "workspace:*"
+        "@solana/addresses": "workspace:*",
+        "@solana/transactions": "workspace:*"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.2",

--- a/packages/library-legacy-sham/src/__tests__/transaction-test.ts
+++ b/packages/library-legacy-sham/src/__tests__/transaction-test.ts
@@ -1,0 +1,90 @@
+import { Transaction } from '../transaction';
+
+const TRANSACTION_MESSAGE_IN_WIRE_FORMAT =
+    // prettier-ignore
+    new Uint8Array([
+        /** MESSAGE HEADER */
+        1, // numSignerAccounts
+        0, // numReadonlySignerAccount
+        0, // numReadonlyNonSignerAccounts
+
+        /** STATIC ADDRESSES */
+        1, // Number of static accounts
+        11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+
+        /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+        33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
+
+        /* INSTRUCTIONS */
+        0, // Number of instructions
+    ]);
+
+describe('TransactionSham', () => {
+    it.each(['populate'] as (keyof typeof Transaction)[])('throws when calling `%s`', method => {
+        expect(() =>
+            // This is basically just complaining that `prototype` is not callable.
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            Transaction[method]()
+        ).toThrow(`Transaction#${method.toString()} is unimplemented`);
+    });
+    it('fatals when `from()` is called with a non-parseable transaction', () => {
+        expect(() => Transaction.from([])).toThrow();
+    });
+    describe('given a signed transaction', () => {
+        let signedTx: Transaction;
+        const MOCK_SIGNATURE = Array(64).fill(2);
+        beforeEach(() => {
+            signedTx = Transaction.from(
+                new Uint8Array([
+                    /** SIGNATURES */
+                    1, // Length of signatures array
+                    ...MOCK_SIGNATURE,
+
+                    ...TRANSACTION_MESSAGE_IN_WIRE_FORMAT,
+                ])
+            );
+        });
+        it('vends the signature of a transaction through the `signature` property', () => {
+            expect(signedTx).toHaveProperty('signature', expect.objectContaining(MOCK_SIGNATURE));
+        });
+        it.each([
+            'add',
+            'addSignature',
+            'compileMessage',
+            'getEstimatedFee',
+            'partialSign',
+            'serialize',
+            'serializeMessage',
+            'setSigners',
+            'sign',
+        ] as (keyof Transaction)[])('throws when calling `%s`', method => {
+            expect(() => {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                signedTx[method]();
+            }).toThrow(`Transaction#${method} is unimplemented`);
+        });
+        it.each(['instructions', 'signatures'] as (keyof Transaction)[])('fatals when accessing `%s`', property => {
+            expect(() => {
+                signedTx[property];
+            }).toThrow(`Transaction#${property} (getter) is unimplemented`);
+        });
+    });
+    describe('given an unsigned transaction', () => {
+        let unsignedTx: Transaction;
+        beforeEach(() => {
+            unsignedTx = Transaction.from(
+                new Uint8Array([
+                    /** SIGNATURES */
+                    0, // Length of signatures array
+
+                    ...TRANSACTION_MESSAGE_IN_WIRE_FORMAT,
+                ])
+            );
+        });
+        it('vends null for an unsigned transaction through the `signature` property', () => {
+            expect(unsignedTx).toHaveProperty('signature', null);
+        });
+    });
+});

--- a/packages/library-legacy-sham/src/__typetests__/transaction-typetests.ts
+++ b/packages/library-legacy-sham/src/__typetests__/transaction-typetests.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { Transaction as LegacyTransaction } from '@solana/web3.js-legacy';
+
+import { Transaction } from '../transaction';
+
+new Transaction().signature satisfies Buffer | null;
+
+new Transaction() satisfies LegacyTransaction;
+
+Transaction satisfies typeof LegacyTransaction;

--- a/packages/library-legacy-sham/src/index.ts
+++ b/packages/library-legacy-sham/src/index.ts
@@ -283,6 +283,7 @@ export type {
 export * from './connection';
 export * from './key-pair';
 export * from './public-key';
+export * from './transaction';
 export const LAMPORTS_PER_SOL = 1_000_000_000;
 export const MAX_SEED_LENGTH = 32;
 export const NONCE_ACCOUNT_LENGTH = 80;

--- a/packages/library-legacy-sham/src/transaction.ts
+++ b/packages/library-legacy-sham/src/transaction.ts
@@ -1,0 +1,57 @@
+import {
+    BaseTransaction,
+    createTransaction,
+    getTransactionDecoder,
+    ITransactionWithFeePayer,
+    ITransactionWithSignatures,
+} from '@solana/transactions';
+import {
+    SignaturePubkeyPair,
+    TransactionBlockhashCtor,
+    TransactionCtorFields_DEPRECATED,
+    TransactionInstruction,
+    TransactionNonceCtor,
+} from '@solana/web3.js-legacy/declarations';
+
+import { createUnimplementedFunction, getUnimplementedError } from './unimplemented';
+
+export class Transaction {
+    #tx: BaseTransaction | (BaseTransaction & ITransactionWithSignatures);
+    constructor(opts?: TransactionBlockhashCtor | TransactionNonceCtor | TransactionCtorFields_DEPRECATED) {
+        if (opts) {
+            throw getUnimplementedError('Constructing a `Transaction` with options');
+        }
+        this.#tx = createTransaction({ version: 'legacy' });
+    }
+    add = createUnimplementedFunction('Transaction#add');
+    addSignature = createUnimplementedFunction('Transaction#addSignature');
+    compileMessage = createUnimplementedFunction('Transaction#compileMessage');
+    getEstimatedFee = createUnimplementedFunction('Transaction#getEstimatedFee');
+    partialSign = createUnimplementedFunction('Transaction#partialSign');
+    serializeMessage = createUnimplementedFunction('Transaction#serializeMessage');
+    serialize = createUnimplementedFunction('Transaction#serialize');
+    setSigners = createUnimplementedFunction('Transaction#setSigners');
+    sign = createUnimplementedFunction('Transaction#sign');
+    verifySignatures = createUnimplementedFunction('Transaction#verifySignatures');
+    get instructions(): Array<TransactionInstruction> {
+        throw getUnimplementedError('Transaction#instructions (getter)');
+    }
+    get signature(): Buffer | null {
+        if ('feePayer' in this.#tx && 'signatures' in this.#tx) {
+            const signatureBytes = this.#tx.signatures[(this.#tx as ITransactionWithFeePayer).feePayer];
+            return __NODEJS__ ? Buffer.from(signatureBytes) : (signatureBytes as unknown as Buffer);
+        } else {
+            return null;
+        }
+    }
+    get signatures(): Array<SignaturePubkeyPair> {
+        throw getUnimplementedError('Transaction#signatures (getter)');
+    }
+    static from(data: Buffer | Uint8Array | Array<number>) {
+        const newTransaction = new this();
+        const byteArray = Array.isArray(data) ? new Uint8Array(data) : data;
+        newTransaction.#tx = getTransactionDecoder().decode(byteArray)[0];
+        return newTransaction;
+    }
+    static populate = createUnimplementedFunction('Transaction#populate');
+}

--- a/packages/library-legacy-sham/src/unimplemented.ts
+++ b/packages/library-legacy-sham/src/unimplemented.ts
@@ -1,10 +1,14 @@
+export function getUnimplementedError(name: string) {
+    return new Error(
+        `${name} is unimplemented in \`@solana/web3.js-legacy-sham\`. If the caller of this ` +
+            "method is code that you don't maintain, and part of a dependency that you can " +
+            'not replace, let us know: ' +
+            'https://github.com/solana-labs/solana-web3.js/issues/new/choose'
+    );
+}
+
 export function createUnimplementedFunction(name: string) {
     return () => {
-        throw new Error(
-            `${name} is unimplemented in \`@solana/web3.js-legacy-sham\`. If the caller of this ` +
-                "method is code that you don't maintain, and part of a dependency that you can " +
-                'not replace, let us know: ' +
-                'https://github.com/solana-labs/solana-web3.js/issues/new/choose'
-        );
+        throw getUnimplementedError(name);
     };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1178,6 +1178,9 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/transactions':
+        specifier: workspace:*
+        version: link:../transactions
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2


### PR DESCRIPTION
# Summary

This is a sham that lets you wrap some transaction bytes (in wire format) in a `Transaction`-like class that will vend you the signature. This is the minimum one might like to do given a sent transaction that they just want the signature of (eg. for lookup on a block explorer)

# Test Plan

```
cd packages/library-legacy-sham
pnpm test:unit:browser
pnpm test:unit:node
```
