### PR TITLE
refactor(experimental): a sham for `VersionedTransaction`

### DIFF
--- a/packages/library-legacy-sham/src/__tests__/versioned-transaction-test.ts
+++ b/packages/library-legacy-sham/src/__tests__/versioned-transaction-test.ts
@@ -1,0 +1,100 @@
+import { VersionedTransaction } from '../versioned-transaction';
+
+const TRANSACTION_MESSAGE_IN_WIRE_FORMAT =
+    // prettier-ignore
+    new Uint8Array([
+        /** VERSION HEADER */
+        128, // 0 + version mask
+
+        /** MESSAGE HEADER */
+        1, // numSignerAccounts
+        0, // numReadonlySignerAccount
+        0, // numReadonlyNonSignerAccounts
+
+        /** STATIC ADDRESSES */
+        1, // Number of static accounts
+        11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+
+        /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+        33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
+
+        /* INSTRUCTIONS */
+        0, // Number of instructions
+
+        /** ADDRESS TABLE LOOKUPS */
+        0, // Number of address table lookups
+    ]);
+
+describe('VersionedTransactionSham', () => {
+    it('fatals when `deserialize()` is called with a non-parseable transaction', () => {
+        expect(() => VersionedTransaction.deserialize(new Uint8Array([]))).toThrow();
+    });
+    describe('given a signed transaction', () => {
+        let signedTx: VersionedTransaction;
+        const MOCK_SIGNATURE = Array(64).fill(2);
+        beforeEach(() => {
+            signedTx = VersionedTransaction.deserialize(
+                new Uint8Array([
+                    /** SIGNATURES */
+                    1, // Length of signatures array
+                    ...MOCK_SIGNATURE,
+
+                    ...TRANSACTION_MESSAGE_IN_WIRE_FORMAT,
+                ])
+            );
+        });
+        it('vends the signature of a transaction through the `signatures` property', () => {
+            expect(signedTx).toHaveProperty('signatures', [expect.objectContaining(MOCK_SIGNATURE)]);
+        });
+        it.each(['addSignature', 'serialize', 'sign'] as (keyof VersionedTransaction)[])(
+            'throws when calling `%s`',
+            method => {
+                expect(() => {
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    signedTx[method]();
+                }).toThrow(`VersionedTransaction#${method} is unimplemented`);
+            }
+        );
+        it.each(['message'] as (keyof VersionedTransaction)[])('fatals when accessing `%s`', property => {
+            expect(() => {
+                signedTx[property];
+            }).toThrow(`VersionedTransaction#${property} (getter) is unimplemented`);
+        });
+    });
+    describe('given an unsigned transaction', () => {
+        let unsignedTx: VersionedTransaction;
+        beforeEach(() => {
+            unsignedTx = VersionedTransaction.deserialize(
+                new Uint8Array([
+                    /** SIGNATURES */
+                    0, // Length of signatures array
+
+                    ...TRANSACTION_MESSAGE_IN_WIRE_FORMAT,
+                ])
+            );
+        });
+        it('vends an all-zero signature for an unsigned transaction through the `signatures` property', () => {
+            expect(unsignedTx).toHaveProperty('signatures', [new Uint8Array(64)]);
+        });
+    });
+    describe('given a version 42 transaction', () => {
+        let version42Transaction: VersionedTransaction;
+        beforeEach(() => {
+            version42Transaction = VersionedTransaction.deserialize(
+                new Uint8Array([
+                    /** SIGNATURES */
+                    0, // Length of signatures array
+
+                    /** VERSION HEADER */
+                    42 + 128, // 42 + version mask
+
+                    ...TRANSACTION_MESSAGE_IN_WIRE_FORMAT.slice(1),
+                ])
+            );
+        });
+        it('vends `42` through the `version` property', () => {
+            expect(version42Transaction.version).toBe(42);
+        });
+    });
+});

--- a/packages/library-legacy-sham/src/__typetests__/versioned-transaction-typetest.ts
+++ b/packages/library-legacy-sham/src/__typetests__/versioned-transaction-typetest.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { VersionedMessage, VersionedTransaction as LegacyVersionedTransaction } from '@solana/web3.js-legacy';
+
+import { VersionedTransaction } from '../versioned-transaction';
+
+const versionedMessage = null as unknown as VersionedMessage;
+
+new VersionedTransaction(versionedMessage).signatures satisfies Uint8Array[];
+
+new VersionedTransaction(versionedMessage) satisfies LegacyVersionedTransaction;
+
+VersionedTransaction satisfies typeof LegacyVersionedTransaction;

--- a/packages/library-legacy-sham/src/index.ts
+++ b/packages/library-legacy-sham/src/index.ts
@@ -284,6 +284,7 @@ export * from './connection';
 export * from './key-pair';
 export * from './public-key';
 export * from './transaction';
+export * from './versioned-transaction';
 export const LAMPORTS_PER_SOL = 1_000_000_000;
 export const MAX_SEED_LENGTH = 32;
 export const NONCE_ACCOUNT_LENGTH = 80;

--- a/packages/library-legacy-sham/src/versioned-transaction.ts
+++ b/packages/library-legacy-sham/src/versioned-transaction.ts
@@ -1,0 +1,48 @@
+import {
+    BaseTransaction,
+    CompilableTransaction,
+    compileMessage,
+    createTransaction,
+    getTransactionDecoder,
+    ITransactionWithSignatures,
+} from '@solana/transactions';
+import { VersionedMessage } from '@solana/web3.js-legacy/declarations';
+
+import { createUnimplementedFunction, getUnimplementedError } from './unimplemented';
+
+export class VersionedTransaction {
+    #tx: BaseTransaction | (BaseTransaction & ITransactionWithSignatures);
+    constructor(message: VersionedMessage, _signatures?: Array<Uint8Array>) {
+        if (message) {
+            throw getUnimplementedError('Constructing a `VersionedTransaction`');
+        }
+        this.#tx = createTransaction({ version: 0 });
+    }
+    addSignature = createUnimplementedFunction('VersionedTransaction#addSignature');
+    serialize = createUnimplementedFunction('VersionedTransaction#serialize');
+    sign = createUnimplementedFunction('VersionedTransaction#sign');
+    get message(): VersionedMessage {
+        throw getUnimplementedError('VersionedTransaction#message (getter)');
+    }
+    get signatures(): Uint8Array[] {
+        const {
+            header: { numSignerAccounts },
+            staticAccounts,
+        } = compileMessage(this.#tx as unknown as CompilableTransaction);
+        return staticAccounts.slice(0, numSignerAccounts).reduce((acc, account) => {
+            acc.push('signatures' in this.#tx ? this.#tx.signatures[account] : new Uint8Array(64));
+            return acc;
+        }, [] as Uint8Array[]);
+    }
+    get version() {
+        return this.#tx.version;
+    }
+    static deserialize(serializedTransaction: Uint8Array): VersionedTransaction {
+        const newTransaction =
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore Hack to allow this method to construct an instance.
+            new this();
+        newTransaction.#tx = getTransactionDecoder().decode(serializedTransaction)[0];
+        return newTransaction;
+    }
+}


### PR DESCRIPTION
# Summary

This is a sham that lets you wrap some transaction bytes (in wire format) in a `VersionedTransaction`-like class that will vend you the signatures. This is the minimum one might like to do given a sent transaction that they just want the signatures of (eg. for lookup on a block explorer)

# Test Plan

```
cd packages/library-legacy-sham
pnpm test:unit:browser
pnpm test:unit:node
```
