### PR TITLE
refactor(experimental): remove `{ fixedSize: null }` from variable size codecs

### DIFF
--- a/packages/codecs-core/src/__tests__/__setup__.ts
+++ b/packages/codecs-core/src/__tests__/__setup__.ts
@@ -3,12 +3,11 @@ import { Codec, createCodec } from '../codec';
 export const b = (s: string) => base16.encode(s);
 
 export const base16: Codec<string> = createCodec({
-    fixedSize: null,
+    getSizeFromValue: (value: string) => Math.ceil(value.length / 2),
     read(bytes, offset) {
         const value = bytes.slice(offset).reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
         return [value, bytes.length];
     },
-    getSizeFromValue: (value: string) => Math.ceil(value.length / 2),
     write(value: string, bytes, offset) {
         const matches = value.toLowerCase().match(/.{1,2}/g);
         const hexBytes = matches ? matches.map((byte: string) => parseInt(byte, 16)) : [];
@@ -25,10 +24,8 @@ export const getMockCodec = (
     } = {}
 ) =>
     createCodec({
-        fixedSize: config.size ?? null,
-        maxSize: config.size ?? undefined,
+        ...(config.size != null ? { fixedSize: config.size } : { getSizeFromValue: jest.fn().mockReturnValue(0) }),
         read: jest.fn().mockReturnValue([config.defaultValue ?? '', 0]),
-        getSizeFromValue: jest.fn().mockReturnValue(config.size ?? 0),
         write: jest.fn().mockReturnValue(0),
     }) as Codec<unknown> & {
         readonly read: jest.Mock;

--- a/packages/codecs-core/src/__tests__/codec-test.ts
+++ b/packages/codecs-core/src/__tests__/codec-test.ts
@@ -1,4 +1,4 @@
-import { Codec, createCodec, createDecoder, createEncoder, Decoder, Encoder } from '../codec';
+import { Codec, createCodec, createDecoder, createEncoder, Encoder } from '../codec';
 
 describe('Encoder', () => {
     it('can define Encoder instances', () => {
@@ -25,7 +25,7 @@ describe('Encoder', () => {
 
 describe('Decoder', () => {
     it('can define Decoder instances', () => {
-        const myDecoder: Decoder<string> = createDecoder({
+        const myDecoder = createDecoder({
             fixedSize: 32,
             read: (bytes: Uint8Array, offset) => {
                 const slice = bytes.slice(offset, offset + 32);

--- a/packages/codecs-core/src/__tests__/combine-codec.ts
+++ b/packages/codecs-core/src/__tests__/combine-codec.ts
@@ -1,9 +1,9 @@
-import { Codec, createDecoder, createEncoder, Decoder, Encoder } from '../codec';
+import { createDecoder, createEncoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '../codec';
 import { combineCodec } from '../combine-codec';
 
 describe('combineCodec', () => {
     it('can join encoders and decoders with the same type', () => {
-        const u8Encoder: Encoder<number> = createEncoder({
+        const u8Encoder = createEncoder({
             fixedSize: 1,
             write: (value: number, buffer, offset) => {
                 buffer.set([value], offset);
@@ -11,12 +11,12 @@ describe('combineCodec', () => {
             },
         });
 
-        const u8Decoder: Decoder<number> = createDecoder({
+        const u8Decoder = createDecoder({
             fixedSize: 1,
             read: (bytes: Uint8Array, offset = 0) => [bytes[offset], offset + 1],
         });
 
-        const u8Codec: Codec<number> = combineCodec(u8Encoder, u8Decoder);
+        const u8Codec = combineCodec(u8Encoder, u8Decoder);
 
         expect(u8Codec.fixedSize).toBe(1);
         expect(u8Codec.encode(42)).toStrictEqual(new Uint8Array([42]));
@@ -24,7 +24,7 @@ describe('combineCodec', () => {
     });
 
     it('can join encoders and decoders with different but matching types', () => {
-        const u8Encoder: Encoder<number | bigint> = createEncoder({
+        const u8Encoder: FixedSizeEncoder<number | bigint> = createEncoder({
             fixedSize: 1,
             write: (value: number | bigint, buffer, offset) => {
                 buffer.set([Number(value)], offset);
@@ -32,12 +32,12 @@ describe('combineCodec', () => {
             },
         });
 
-        const u8Decoder: Decoder<bigint> = createDecoder({
+        const u8Decoder: FixedSizeDecoder<bigint> = createDecoder({
             fixedSize: 1,
             read: (bytes: Uint8Array, offset = 0) => [BigInt(bytes[offset]), offset + 1],
         });
 
-        const u8Codec: Codec<number | bigint, bigint> = combineCodec(u8Encoder, u8Decoder);
+        const u8Codec: FixedSizeCodec<number | bigint, bigint> = combineCodec(u8Encoder, u8Decoder);
 
         expect(u8Codec.fixedSize).toBe(1);
         expect(u8Codec.encode(42)).toStrictEqual(new Uint8Array([42]));
@@ -55,8 +55,8 @@ describe('combineCodec', () => {
 
         expect(() =>
             combineCodec(
-                createEncoder({ fixedSize: null, maxSize: 1, getSizeFromValue: jest.fn(), write: jest.fn() }),
-                createDecoder({ fixedSize: null, read: jest.fn() })
+                createEncoder({ getSizeFromValue: jest.fn(), maxSize: 1, write: jest.fn() }),
+                createDecoder({ read: jest.fn() })
             )
         ).toThrow('Encoder and decoder must have the same max size, got [1] and [undefined]');
     });

--- a/packages/codecs-core/src/__tests__/map-codec-test.ts
+++ b/packages/codecs-core/src/__tests__/map-codec-test.ts
@@ -1,4 +1,4 @@
-import { Codec, createCodec, createDecoder, createEncoder, Decoder, Encoder } from '../codec';
+import { Codec, createCodec, createDecoder, createEncoder } from '../codec';
 import { mapCodec, mapDecoder, mapEncoder } from '../map-codec';
 
 const numberCodec: Codec<number> = createCodec({
@@ -144,7 +144,7 @@ describe('mapCodec', () => {
 
 describe('mapEncoder', () => {
     it('can map an encoder to another encoder', () => {
-        const encoderA: Encoder<number> = createEncoder({
+        const encoderA = createEncoder({
             fixedSize: 1,
             write: (value: number, bytes, offset) => {
                 bytes.set([value], offset);
@@ -161,7 +161,7 @@ describe('mapEncoder', () => {
 
 describe('mapDecoder', () => {
     it('can map an encoder to another encoder', () => {
-        const decoder: Decoder<number> = createDecoder({
+        const decoder = createDecoder({
             fixedSize: 1,
             read: (bytes: Uint8Array, offset = 0) => [bytes[offset], offset + 1],
         });

--- a/packages/codecs-core/src/__typetests__/codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/codec-typetest.ts
@@ -20,7 +20,6 @@ import {
         write: (_: string) => 1,
     }) satisfies FixedSizeEncoder<string>;
     createEncoder({
-        fixedSize: null,
         getSizeFromValue: (_: string) => 42,
         write: (_: string) => 1,
     }) satisfies VariableSizeEncoder<string>;
@@ -29,14 +28,8 @@ import {
 
 {
     // [createDecoder]: It knows if the decoder is fixed size or variable size.
-    createDecoder({
-        fixedSize: 42,
-        read: (): [string, number] => ['', 1],
-    }) satisfies FixedSizeDecoder<string>;
-    createDecoder({
-        fixedSize: null,
-        read: (): [string, number] => ['', 1],
-    }) satisfies VariableSizeDecoder<string>;
+    createDecoder({ fixedSize: 42, read: (): [string, number] => ['', 1] }) satisfies FixedSizeDecoder<string>;
+    createDecoder({ read: (): [string, number] => ['', 1] }) satisfies VariableSizeDecoder<string>;
     createDecoder({} as Decoder<string>) satisfies Decoder<string>;
 }
 
@@ -48,9 +41,8 @@ import {
         write: (_: string) => 1,
     }) satisfies FixedSizeCodec<string>;
     createCodec({
-        fixedSize: null,
-        read: (): [string, number] => ['', 1],
         getSizeFromValue: (_: string) => 42,
+        read: (): [string, number] => ['', 1],
         write: (_: string) => 1,
     }) satisfies VariableSizeCodec<string>;
     createCodec({} as Codec<string>) satisfies Codec<string>;

--- a/packages/codecs-core/src/assertions.ts
+++ b/packages/codecs-core/src/assertions.ts
@@ -23,16 +23,3 @@ export function assertByteArrayHasEnoughBytesForCodec(
         throw new Error(`Codec [${codecDescription}] expected ${expected} bytes, got ${bytesLength}.`);
     }
 }
-
-/**
- * Asserts that a given codec is fixed-size codec.
- */
-export function assertFixedSizeCodec(
-    data: { fixedSize: number | null },
-    message?: string
-): asserts data is { fixedSize: number } {
-    if (data.fixedSize === null) {
-        // TODO: Coded error.
-        throw new Error(message ?? 'Expected a fixed-size codec, got a variable-size one.');
-    }
-}

--- a/packages/codecs-core/src/combine-codec.ts
+++ b/packages/codecs-core/src/combine-codec.ts
@@ -5,6 +5,7 @@ import {
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
+    isFixedSizeCodec,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -31,14 +32,19 @@ export function combineCodec<From, To extends From = From>(
     encoder: Encoder<From>,
     decoder: Decoder<To>
 ): Codec<From, To> {
-    if (encoder.fixedSize !== decoder.fixedSize) {
+    if (isFixedSizeCodec(encoder) !== isFixedSizeCodec(decoder)) {
+        // TODO: Coded error.
+        throw new Error(`Encoder and decoder must either both be fixed-size or variable-size.`);
+    }
+
+    if (isFixedSizeCodec(encoder) && isFixedSizeCodec(decoder) && encoder.fixedSize !== decoder.fixedSize) {
         // TODO: Coded error.
         throw new Error(
             `Encoder and decoder must have the same fixed size, got [${encoder.fixedSize}] and [${decoder.fixedSize}].`
         );
     }
 
-    if (encoder.fixedSize === null && decoder.fixedSize === null && encoder.maxSize !== decoder.maxSize) {
+    if (!isFixedSizeCodec(encoder) && !isFixedSizeCodec(decoder) && encoder.maxSize !== decoder.maxSize) {
         // TODO: Coded error.
         throw new Error(
             `Encoder and decoder must have the same max size, got [${encoder.maxSize}] and [${decoder.maxSize}].`

--- a/packages/codecs-core/src/fix-codec.ts
+++ b/packages/codecs-core/src/fix-codec.ts
@@ -9,6 +9,7 @@ import {
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
+    isFixedSizeCodec,
     Offset,
 } from './codec';
 import { combineCodec } from './combine-codec';
@@ -53,7 +54,7 @@ export function fixDecoder<T>(decoder: Decoder<T>, fixedBytes: number): FixedSiz
                 bytes = bytes.slice(offset, offset + fixedBytes);
             }
             // If the nested decoder is fixed-size, pad and truncate the byte array accordingly.
-            if (decoder.fixedSize !== null) {
+            if (isFixedSizeCodec(decoder)) {
                 bytes = fixBytes(bytes, decoder.fixedSize);
             }
             // Decode the value using the nested decoder.

--- a/packages/codecs-core/src/map-codec.ts
+++ b/packages/codecs-core/src/map-codec.ts
@@ -8,6 +8,7 @@ import {
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
+    isVariableSizeCodec,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -21,7 +22,7 @@ export function mapEncoder<T, U>(encoder: VariableSizeEncoder<T>, unmap: (value:
 export function mapEncoder<T, U>(encoder: Encoder<T>, unmap: (value: U) => T): Encoder<U>;
 export function mapEncoder<T, U>(encoder: Encoder<T>, unmap: (value: U) => T): Encoder<U> {
     return createEncoder({
-        ...(encoder.fixedSize === null
+        ...(isVariableSizeCodec(encoder)
             ? { ...encoder, getSizeFromValue: (value: U) => encoder.getSizeFromValue(unmap(value)) }
             : encoder),
         write: (value: U, bytes, offset) => encoder.write(unmap(value), bytes, offset),

--- a/packages/codecs-core/src/reverse-codec.ts
+++ b/packages/codecs-core/src/reverse-codec.ts
@@ -1,12 +1,18 @@
-import { assertFixedSizeCodec } from './assertions';
-import { createDecoder, createEncoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from './codec';
+import {
+    assertIsFixedSizeCodec,
+    createDecoder,
+    createEncoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+} from './codec';
 import { combineCodec } from './combine-codec';
 
 /**
  * Reverses the bytes of a fixed-size encoder.
  */
 export function reverseEncoder<T>(encoder: FixedSizeEncoder<T>): FixedSizeEncoder<T> {
-    assertFixedSizeCodec(encoder, 'Cannot reverse a codec of variable size.');
+    assertIsFixedSizeCodec(encoder, 'Cannot reverse a codec of variable size.');
     return createEncoder({
         ...encoder,
         write: (value: T, bytes, offset) => {
@@ -22,7 +28,7 @@ export function reverseEncoder<T>(encoder: FixedSizeEncoder<T>): FixedSizeEncode
  * Reverses the bytes of a fixed-size decoder.
  */
 export function reverseDecoder<T>(decoder: FixedSizeDecoder<T>): FixedSizeDecoder<T> {
-    assertFixedSizeCodec(decoder, 'Cannot reverse a codec of variable size.');
+    assertIsFixedSizeCodec(decoder, 'Cannot reverse a codec of variable size.');
     return createDecoder({
         ...decoder,
         read: (bytes, offset) => {

--- a/packages/codecs-numbers/src/__tests__/__setup__.ts
+++ b/packages/codecs-numbers/src/__tests__/__setup__.ts
@@ -22,12 +22,11 @@ export const assertRangeError = <T>(encoder: Encoder<T>, number: T): void => {
 };
 
 export const base16: Codec<string> = createCodec({
-    fixedSize: null,
+    getSizeFromValue: (value: string) => Math.ceil(value.length / 2),
     read(bytes, offset) {
         const value = bytes.slice(offset).reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
         return [value, bytes.length];
     },
-    getSizeFromValue: (value: string) => Math.ceil(value.length / 2),
     write(value: string, bytes, offset) {
         const matches = value.toLowerCase().match(/.{1,2}/g);
         const hexBytes = matches ? matches.map((byte: string) => parseInt(byte, 16)) : [];

--- a/packages/codecs-numbers/src/__tests__/short-u16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/short-u16-test.ts
@@ -37,7 +37,11 @@ describe('getShortU16Codec', () => {
     });
 
     it('has the right sizes', () => {
-        expect(shortU16().fixedSize).toBeNull();
         expect(shortU16().maxSize).toBe(3);
+        expect(shortU16().getSizeFromValue(1)).toBe(1);
+        expect(shortU16().getSizeFromValue(127)).toBe(1);
+        expect(shortU16().getSizeFromValue(128)).toBe(2);
+        expect(shortU16().getSizeFromValue(16383)).toBe(2);
+        expect(shortU16().getSizeFromValue(16384)).toBe(3);
     });
 });

--- a/packages/codecs-numbers/src/short-u16.ts
+++ b/packages/codecs-numbers/src/short-u16.ts
@@ -16,13 +16,12 @@ import { assertNumberIsBetweenForCodec } from './assertions';
  */
 export const getShortU16Encoder = (): VariableSizeEncoder<number> =>
     createEncoder({
-        fixedSize: null,
-        maxSize: 3,
         getSizeFromValue: (value: number): number => {
             if (value <= 0b01111111) return 1;
             if (value <= 0b0011111111111111) return 2;
             return 3;
         },
+        maxSize: 3,
         write: (value: number, bytes: Uint8Array, offset: Offset): Offset => {
             assertNumberIsBetweenForCodec('shortU16', 0, 65535, value);
             const shortU16Bytes = [0];
@@ -52,7 +51,6 @@ export const getShortU16Encoder = (): VariableSizeEncoder<number> =>
  */
 export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
     createDecoder({
-        fixedSize: null,
         maxSize: 3,
         read: (bytes: Uint8Array, offset): [number, Offset] => {
             let value = 0;

--- a/packages/codecs-strings/src/__tests__/string-test.ts
+++ b/packages/codecs-strings/src/__tests__/string-test.ts
@@ -88,11 +88,11 @@ describe('getStringCodec', () => {
     });
 
     it('has the right sizes', () => {
-        expect(string().fixedSize).toBeNull();
+        expect(string().getSizeFromValue('ABC')).toBe(4 + 3);
         expect(string().maxSize).toBeUndefined();
-        expect(string({ size: u8() }).fixedSize).toBeNull();
+        expect(string({ size: u8() }).getSizeFromValue('ABC')).toBe(1 + 3);
         expect(string({ size: u8() }).maxSize).toBeUndefined();
-        expect(string({ size: 'variable' }).fixedSize).toBeNull();
+        expect(string({ size: 'variable' }).getSizeFromValue('ABC')).toBe(3);
         expect(string({ size: 'variable' }).maxSize).toBeUndefined();
         expect(string({ size: 42 }).fixedSize).toBe(42);
     });

--- a/packages/codecs-strings/src/base16.ts
+++ b/packages/codecs-strings/src/base16.ts
@@ -12,7 +12,6 @@ import { assertValidBaseString } from './assertions';
 /** Encodes strings in base16. */
 export const getBase16Encoder = (): VariableSizeEncoder<string> =>
     createEncoder({
-        fixedSize: null,
         getSizeFromValue: (value: string) => Math.ceil(value.length / 2),
         write(value: string, bytes, offset) {
             const lowercaseValue = value.toLowerCase();
@@ -27,7 +26,6 @@ export const getBase16Encoder = (): VariableSizeEncoder<string> =>
 /** Decodes strings in base16. */
 export const getBase16Decoder = (): VariableSizeDecoder<string> =>
     createDecoder({
-        fixedSize: null,
         read(bytes, offset) {
             const value = bytes.slice(offset).reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
             return [value, bytes.length];

--- a/packages/codecs-strings/src/base64.ts
+++ b/packages/codecs-strings/src/base64.ts
@@ -18,7 +18,6 @@ const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789
 export const getBase64Encoder = (): VariableSizeEncoder<string> => {
     if (__BROWSER__) {
         return createEncoder({
-            fixedSize: null,
             getSizeFromValue: (value: string) => {
                 try {
                     return (atob as Window['atob'])(value).length;
@@ -44,7 +43,6 @@ export const getBase64Encoder = (): VariableSizeEncoder<string> => {
 
     if (__NODEJS__) {
         return createEncoder({
-            fixedSize: null,
             getSizeFromValue: (value: string) => Buffer.from(value, 'base64').length,
             write(value: string, bytes, offset) {
                 assertValidBaseString(alphabet, value.replace(/=/g, ''));
@@ -62,7 +60,6 @@ export const getBase64Encoder = (): VariableSizeEncoder<string> => {
 export const getBase64Decoder = (): VariableSizeDecoder<string> => {
     if (__BROWSER__) {
         return createDecoder({
-            fixedSize: null,
             read(bytes, offset = 0) {
                 const slice = bytes.slice(offset);
                 const value = (btoa as Window['btoa'])(String.fromCharCode(...slice));
@@ -73,7 +70,6 @@ export const getBase64Decoder = (): VariableSizeDecoder<string> => {
 
     if (__NODEJS__) {
         return createDecoder({
-            fixedSize: null,
             read: (bytes, offset = 0) => [Buffer.from(bytes, offset).toString('base64'), bytes.length],
         });
     }

--- a/packages/codecs-strings/src/baseX-reslice.ts
+++ b/packages/codecs-strings/src/baseX-reslice.ts
@@ -15,7 +15,6 @@ import { assertValidBaseString } from './assertions';
  */
 export const getBaseXResliceEncoder = (alphabet: string, bits: number): VariableSizeEncoder<string> =>
     createEncoder({
-        fixedSize: null,
         getSizeFromValue: (value: string) => Math.floor((value.length * bits) / 8),
         write(value: string, bytes, offset) {
             assertValidBaseString(alphabet, value);
@@ -33,7 +32,6 @@ export const getBaseXResliceEncoder = (alphabet: string, bits: number): Variable
  */
 export const getBaseXResliceDecoder = (alphabet: string, bits: number): VariableSizeDecoder<string> =>
     createDecoder({
-        fixedSize: null,
         read(rawBytes, offset = 0): [string, number] {
             const bytes = offset === 0 ? rawBytes : rawBytes.slice(offset);
             if (bytes.length === 0) return ['', rawBytes.length];

--- a/packages/codecs-strings/src/baseX.ts
+++ b/packages/codecs-strings/src/baseX.ts
@@ -16,7 +16,6 @@ import { assertValidBaseString } from './assertions';
  */
 export const getBaseXEncoder = (alphabet: string): VariableSizeEncoder<string> => {
     return createEncoder({
-        fixedSize: null,
         getSizeFromValue: (value: string): number => {
             const [leadingZeroes, tailChars] = partitionLeadingZeroes(value, alphabet[0]);
             if (tailChars === '') return value.length;
@@ -60,7 +59,6 @@ export const getBaseXEncoder = (alphabet: string): VariableSizeEncoder<string> =
  */
 export const getBaseXDecoder = (alphabet: string): VariableSizeDecoder<string> => {
     return createDecoder({
-        fixedSize: null,
         read(rawBytes, offset): [string, number] {
             const bytes = offset === 0 ? rawBytes : rawBytes.slice(offset);
             if (bytes.length === 0) return ['', 0];

--- a/packages/codecs-strings/src/string.ts
+++ b/packages/codecs-strings/src/string.ts
@@ -62,7 +62,6 @@ export function getStringEncoder(config: StringCodecConfig<NumberEncoder, Encode
     }
 
     return createEncoder({
-        fixedSize: null,
         getSizeFromValue: (value: string) => {
             const contentSize = getEncodedSize(value, encoding);
             return getEncodedSize(contentSize, size) + contentSize;
@@ -95,7 +94,6 @@ export function getStringDecoder(config: StringCodecConfig<NumberDecoder, Decode
     }
 
     return createDecoder({
-        fixedSize: null,
         read: (bytes: Uint8Array, offset = 0) => {
             assertByteArrayIsNotEmptyForCodec('string', bytes, offset);
             const [lengthBigInt, lengthOffset] = size.read(bytes, offset);

--- a/packages/codecs-strings/src/utf8.ts
+++ b/packages/codecs-strings/src/utf8.ts
@@ -14,7 +14,6 @@ import { removeNullCharacters } from './null-characters';
 export const getUtf8Encoder = (): VariableSizeEncoder<string> => {
     let textEncoder: TextEncoder;
     return createEncoder({
-        fixedSize: null,
         getSizeFromValue: value => (textEncoder ||= new TextEncoder()).encode(value).length,
         write: (value: string, bytes, offset) => {
             const bytesToAdd = (textEncoder ||= new TextEncoder()).encode(value);
@@ -28,7 +27,6 @@ export const getUtf8Encoder = (): VariableSizeEncoder<string> => {
 export const getUtf8Decoder = (): VariableSizeDecoder<string> => {
     let textDecoder: TextDecoder;
     return createDecoder({
-        fixedSize: null,
         read(bytes, offset) {
             const value = (textDecoder ||= new TextDecoder()).decode(bytes.slice(offset));
             return [removeNullCharacters(value), bytes.length];


### PR DESCRIPTION
As suggested [here](https://github.com/solana-labs/solana-web3.js/pull/1865#discussion_r1407939794), this PR removes the `{ fixedSize: null }` attribute from `VariableSize*` types. This makes it easier and less confusing the create and use variable-size codecs.

Since it's now slightly less convinient to find out if a codec if fixed-size or not, this PR also offers type guards to make this easier.
