### PR TITLE
refactor(experimental): add build script that adds .js to type imports

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/build-scripts/add-js-extension-to-types.mjs
+++ b/packages/build-scripts/add-js-extension-to-types.mjs
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+// eslint-disable-next-line no-undef
+handleDirectory(process.argv[2] ?? path.join('dist', 'types'));
+
+/**
+ * Go through all `.d.ts` files in the given directory recursively and
+ * call the `handleFile` function defined below on each of them.
+ */
+async function handleDirectory(directory) {
+    const files = await fs.promises.readdir(directory);
+    return Promise.all(
+        files.map(async fileName => {
+            const filePath = path.join(directory, fileName);
+            const stats = fs.statSync(filePath);
+            if (stats.isDirectory()) {
+                return handleDirectory(filePath);
+            }
+            if (stats.isFile() && fileName.endsWith('.d.ts')) {
+                return handleFile(directory, filePath);
+            }
+        }),
+    );
+}
+
+/**
+ * Replace the content of all relative import and export statements inside the
+ * given `.d.ts` file such that it adds the `.js` extension to all paths.
+ * If the imported path is a directory, it adds `/index.js` instead.
+ */
+async function handleFile(directory, filePath) {
+    let content = await fs.promises.readFile(filePath, 'utf8');
+
+    content = content.replace(
+        /((?:import|export).+from[^']+')(\.+\/[^']+)(';)/g,
+        (_match, prefix, importPath, suffix) => {
+            // Get the import path relative to the main directory.
+            const absoluteImportPath = path.join(directory, importPath);
+
+            // Identify whether the import path is a directory or a file.
+            const isDirectory = fs.existsSync(absoluteImportPath) && fs.statSync(absoluteImportPath).isDirectory();
+
+            // Add the `.js` extension and `/index` if it's a directory.
+            return `${prefix}${importPath}${isDirectory ? '/index.js' : '.js'}${suffix}`;
+        },
+    );
+
+    return fs.promises.writeFile(filePath, content, 'utf8');
+}

--- a/packages/build-scripts/package.json
+++ b/packages/build-scripts/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.0",
     "private": true,
     "files": [
+        "add-js-extension-to-types.mjs",
         "env-shim.ts",
         "tsup.config.library.ts",
         "tsup.config.package.ts"

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/library-legacy-sham/package.json
+++ b/packages/library-legacy-sham/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -37,7 +37,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "sed -i 's/@solana\\/web3\\.js-experimental/@solana\\/web3\\.js/g' package.json && sed -i 's/@solana\\/web3\\.js/@solana\\/web3\\.js-bak/g' ../library-legacy/package.json && pnpm publish --tag experimental --access public --no-git-checks && git reset --hard",

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.package.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --globalSetup test-config/test-validator-setup.js --globalTeardown test-config/test-validator-teardown.js --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.package.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --globalSetup test-config/test-validator-setup.js --globalTeardown test-config/test-validator-teardown.js --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/rpc-transport/package.json
+++ b/packages/rpc-transport/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.package.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.package.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --globalSetup test-config/test-validator-setup.js --globalTeardown test-config/test-validator-teardown.js --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -34,7 +34,7 @@
     ],
     "scripts": {
         "compile:js": "tsup --config build-scripts/tsup.config.library.ts",
-        "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
+        "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "version-from-git --no-git-tag-version --template experimental.short",
         "publish-packages": "pnpm publish --tag experimental --access public --no-git-checks",


### PR DESCRIPTION
This is an alternative solution to #1902 and #1904.

It essentially goes through all the compiled `dist/**/**.d.ts` files and add the `.js` extension to relative import and exports.

For instance, it transforms `packages/addresses/dist/types/index.d.ts` from this:

```ts
export * from './address';
export * from './program-derived-address';
export * from './public-key';
//# sourceMappingURL=index.d.ts.map
```

To this:

```ts
export * from './address.js';
export * from './program-derived-address.js';
export * from './public-key.js';
//# sourceMappingURL=index.d.ts.map
```

It also checks whether the imported relative path is a folder and, when it is, adds `/index.js` instead of `.js`.

For instance, it transforms `packages/rpc-core/dist/types/index.d.ts` from this:

```ts
export * from './rpc-methods';
export * from './rpc-subscriptions';
//# sourceMappingURL=index.d.ts.map
```

To this:

```ts
export * from './rpc-methods/index.js';
export * from './rpc-subscriptions/index.js';
//# sourceMappingURL=index.d.ts.map
```