### PR TITLE
refactor(experimental): add size type param to fixed-size codecs

### DIFF
--- a/packages/codecs-core/src/__typetests__/codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/codec-typetest.ts
@@ -1,4 +1,6 @@
 import {
+    assertIsFixedSizeCodec,
+    assertIsVariableSizeCodec,
     Codec,
     createCodec,
     createDecoder,
@@ -8,6 +10,8 @@ import {
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
+    isFixedSizeCodec,
+    isVariableSizeCodec,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -18,7 +22,7 @@ import {
     createEncoder({
         fixedSize: 42,
         write: (_: string) => 1,
-    }) satisfies FixedSizeEncoder<string>;
+    }) satisfies FixedSizeEncoder<string, 42>;
     createEncoder({
         getSizeFromValue: (_: string) => 42,
         write: (_: string) => 1,
@@ -28,7 +32,7 @@ import {
 
 {
     // [createDecoder]: It knows if the decoder is fixed size or variable size.
-    createDecoder({ fixedSize: 42, read: (): [string, number] => ['', 1] }) satisfies FixedSizeDecoder<string>;
+    createDecoder({ fixedSize: 42, read: (): [string, number] => ['', 1] }) satisfies FixedSizeDecoder<string, 42>;
     createDecoder({ read: (): [string, number] => ['', 1] }) satisfies VariableSizeDecoder<string>;
     createDecoder({} as Decoder<string>) satisfies Decoder<string>;
 }
@@ -39,11 +43,71 @@ import {
         fixedSize: 42,
         read: (): [string, number] => ['', 1],
         write: (_: string) => 1,
-    }) satisfies FixedSizeCodec<string>;
+    }) satisfies FixedSizeCodec<string, string, 42>;
     createCodec({
         getSizeFromValue: (_: string) => 42,
         read: (): [string, number] => ['', 1],
         write: (_: string) => 1,
     }) satisfies VariableSizeCodec<string>;
     createCodec({} as Codec<string>) satisfies Codec<string>;
+}
+
+{
+    // [isFixedSizeCodec]: It returns true if the codec is fixed size and keeps the type information.
+    const codec = {} as FixedSizeCodec<string, string, 42> | VariableSizeCodec<string>;
+    if (isFixedSizeCodec(codec)) {
+        codec satisfies FixedSizeCodec<string, string, 42>;
+    }
+}
+
+{
+    // [isFixedSizeCodec]: It works with codec sizes only.
+    const codec = {} as { fixedSize: 42 } | { maxSize?: number };
+    if (isFixedSizeCodec(codec)) {
+        codec satisfies { fixedSize: 42 };
+    }
+}
+
+{
+    // [assertIsFixedSizeCodec]: It asserts the codec is fixed size and keeps the type information.
+    const codec = {} as FixedSizeCodec<string, string, 42> | VariableSizeCodec<string>;
+    assertIsFixedSizeCodec(codec);
+    codec satisfies FixedSizeCodec<string, string, 42>;
+}
+
+{
+    // [assertIsFixedSizeCodec]: It works with codec sizes only.
+    const codec = {} as { fixedSize: 42 } | { maxSize?: number };
+    assertIsFixedSizeCodec(codec);
+    codec satisfies { fixedSize: 42 };
+}
+
+{
+    // [isVariableSizeCodec]: It returns true if the codec is variable size.
+    const codec = {} as FixedSizeCodec<string, string, 42> | VariableSizeCodec<string>;
+    if (isVariableSizeCodec(codec)) {
+        codec satisfies VariableSizeCodec<string>;
+    }
+}
+
+{
+    // [isVariableSizeCodec]: It works with codec sizes only.
+    const codec = {} as { fixedSize: 42 } | { maxSize?: number; foo: 'bar' };
+    if (isVariableSizeCodec(codec)) {
+        codec satisfies { maxSize?: number; foo: 'bar' };
+    }
+}
+
+{
+    // [assertIsVariableSizeCodec]: It asserts the codec is variable size.
+    const codec = {} as FixedSizeCodec<string, string, 42> | VariableSizeCodec<string>;
+    assertIsVariableSizeCodec(codec);
+    codec satisfies VariableSizeCodec<string>;
+}
+
+{
+    // [assertIsVariableSizeCodec]: It works with codec sizes only.
+    const codec = {} as { fixedSize: 42 } | { maxSize?: number; foo: 'bar' };
+    assertIsVariableSizeCodec(codec);
+    codec satisfies { maxSize?: number; foo: 'bar' };
 }

--- a/packages/codecs-core/src/__typetests__/combine-codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/combine-codec-typetest.ts
@@ -13,7 +13,11 @@ import { combineCodec } from '../combine-codec';
 
 {
     // [combineCodec]: It keeps track of the fixed or variable size types.
-    combineCodec({} as FixedSizeEncoder<string>, {} as FixedSizeDecoder<string>) satisfies FixedSizeCodec<string>;
+    combineCodec({} as FixedSizeEncoder<string, 42>, {} as FixedSizeDecoder<string, 42>) satisfies FixedSizeCodec<
+        string,
+        string,
+        42
+    >;
     combineCodec(
         {} as VariableSizeEncoder<string>,
         {} as VariableSizeDecoder<string>

--- a/packages/codecs-core/src/__typetests__/fix-codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/fix-codec-typetest.ts
@@ -13,21 +13,21 @@ import { fixCodec, fixDecoder, fixEncoder } from '../fix-codec';
 
 {
     // [fixEncoder]: It transforms any encoder into a fixed size encoder.
-    fixEncoder({} as FixedSizeEncoder<string>, 42) satisfies FixedSizeEncoder<string>;
-    fixEncoder({} as VariableSizeEncoder<string>, 42) satisfies FixedSizeEncoder<string>;
-    fixEncoder({} as Encoder<string>, 42) satisfies FixedSizeEncoder<string>;
+    fixEncoder({} as FixedSizeEncoder<string>, 42) satisfies FixedSizeEncoder<string, 42>;
+    fixEncoder({} as VariableSizeEncoder<string>, 42) satisfies FixedSizeEncoder<string, 42>;
+    fixEncoder({} as Encoder<string>, 42) satisfies FixedSizeEncoder<string, 42>;
 }
 
 {
     // [fixDecoder]: It transforms any decoder into a fixed size decoder.
-    fixDecoder({} as FixedSizeDecoder<string>, 42) satisfies FixedSizeDecoder<string>;
-    fixDecoder({} as VariableSizeDecoder<string>, 42) satisfies FixedSizeDecoder<string>;
-    fixDecoder({} as Decoder<string>, 42) satisfies FixedSizeDecoder<string>;
+    fixDecoder({} as FixedSizeDecoder<string>, 42) satisfies FixedSizeDecoder<string, 42>;
+    fixDecoder({} as VariableSizeDecoder<string>, 42) satisfies FixedSizeDecoder<string, 42>;
+    fixDecoder({} as Decoder<string>, 42) satisfies FixedSizeDecoder<string, 42>;
 }
 
 {
     // [fixCodec]: It transforms any codec into a fixed size codec.
-    fixCodec({} as FixedSizeCodec<string>, 42) satisfies FixedSizeCodec<string>;
-    fixCodec({} as VariableSizeCodec<string>, 42) satisfies FixedSizeCodec<string>;
-    fixCodec({} as Codec<string>, 42) satisfies FixedSizeCodec<string>;
+    fixCodec({} as FixedSizeCodec<string>, 42) satisfies FixedSizeCodec<string, string, 42>;
+    fixCodec({} as VariableSizeCodec<string>, 42) satisfies FixedSizeCodec<string, string, 42>;
+    fixCodec({} as Codec<string>, 42) satisfies FixedSizeCodec<string, string, 42>;
 }

--- a/packages/codecs-core/src/__typetests__/map-codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/map-codec-typetest.ts
@@ -13,14 +13,14 @@ import { mapCodec, mapDecoder, mapEncoder } from '../map-codec';
 
 {
     // [mapEncoder]: It keeps track of the nested encoder's size.
-    mapEncoder({} as FixedSizeEncoder<string>, (_: number) => '42') satisfies FixedSizeEncoder<number>;
+    mapEncoder({} as FixedSizeEncoder<string, 42>, (_: number) => '42') satisfies FixedSizeEncoder<number, 42>;
     mapEncoder({} as VariableSizeEncoder<string>, (_: number) => '42') satisfies VariableSizeEncoder<number>;
     mapEncoder({} as Encoder<string>, (_: number) => '42') satisfies Encoder<number>;
 }
 
 {
     // [mapDecoder]: It keeps track of the nested decoder's size.
-    mapDecoder({} as FixedSizeDecoder<string>, (_: string) => 42) satisfies FixedSizeDecoder<number>;
+    mapDecoder({} as FixedSizeDecoder<string, 42>, (_: string) => 42) satisfies FixedSizeDecoder<number, 42>;
     mapDecoder({} as VariableSizeDecoder<string>, (_: string) => 42) satisfies VariableSizeDecoder<number>;
     mapDecoder({} as Decoder<string>, (_: string) => 42) satisfies Decoder<number>;
 }
@@ -28,10 +28,10 @@ import { mapCodec, mapDecoder, mapEncoder } from '../map-codec';
 {
     // [mapCodec]: It keeps track of the nested codec's size.
     mapCodec(
-        {} as FixedSizeCodec<string>,
+        {} as FixedSizeCodec<string, string, 42>,
         (_: number) => '42',
         (_: string) => 42
-    ) satisfies FixedSizeCodec<number>;
+    ) satisfies FixedSizeCodec<number, number, 42>;
     mapCodec(
         {} as VariableSizeCodec<string>,
         (_: number) => '42',

--- a/packages/codecs-core/src/__typetests__/reverse-codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/reverse-codec-typetest.ts
@@ -13,7 +13,7 @@ import { reverseCodec, reverseDecoder, reverseEncoder } from '../reverse-codec';
 
 {
     // [reverseEncoder]: It only works with fixed size encoders.
-    reverseEncoder({} as FixedSizeEncoder<string>) satisfies FixedSizeEncoder<string>;
+    reverseEncoder({} as FixedSizeEncoder<string, 42>) satisfies FixedSizeEncoder<string, 42>;
     // @ts-expect-error Expected a fixed size encoder.
     reverseEncoder({} as VariableSizeEncoder<string>);
     // @ts-expect-error Expected a fixed size encoder.
@@ -22,7 +22,7 @@ import { reverseCodec, reverseDecoder, reverseEncoder } from '../reverse-codec';
 
 {
     // [reverseDecoder]: It only works with fixed size decoders.
-    reverseDecoder({} as FixedSizeDecoder<string>) satisfies FixedSizeDecoder<string>;
+    reverseDecoder({} as FixedSizeDecoder<string, 42>) satisfies FixedSizeDecoder<string, 42>;
     // @ts-expect-error Expected a fixed size decoder.
     reverseDecoder({} as VariableSizeDecoder<string>);
     // @ts-expect-error Expected a fixed size decoder.
@@ -31,7 +31,7 @@ import { reverseCodec, reverseDecoder, reverseEncoder } from '../reverse-codec';
 
 {
     // [reverseCodec]: It only works with fixed size codecs.
-    reverseCodec({} as FixedSizeCodec<string>) satisfies FixedSizeCodec<string>;
+    reverseCodec({} as FixedSizeCodec<string, string, 42>) satisfies FixedSizeCodec<string, string, 42>;
     // @ts-expect-error Expected a fixed size codec.
     reverseCodec({} as VariableSizeCodec<string>);
     // @ts-expect-error Expected a fixed size codec.

--- a/packages/codecs-core/src/combine-codec.ts
+++ b/packages/codecs-core/src/combine-codec.ts
@@ -16,22 +16,22 @@ import {
  * The encoder and decoder must have the same fixed size, max size and description.
  * If a description is provided, it will override the encoder and decoder descriptions.
  */
-export function combineCodec<From, To extends From = From>(
-    encoder: FixedSizeEncoder<From>,
-    decoder: FixedSizeDecoder<To>
-): FixedSizeCodec<From, To>;
-export function combineCodec<From, To extends From = From>(
-    encoder: VariableSizeEncoder<From>,
-    decoder: VariableSizeDecoder<To>
-): VariableSizeCodec<From, To>;
-export function combineCodec<From, To extends From = From>(
-    encoder: Encoder<From>,
-    decoder: Decoder<To>
-): Codec<From, To>;
-export function combineCodec<From, To extends From = From>(
-    encoder: Encoder<From>,
-    decoder: Decoder<To>
-): Codec<From, To> {
+export function combineCodec<TFrom, TTo extends TFrom, TSize extends number>(
+    encoder: FixedSizeEncoder<TFrom, TSize>,
+    decoder: FixedSizeDecoder<TTo, TSize>
+): FixedSizeCodec<TFrom, TTo, TSize>;
+export function combineCodec<TFrom, TTo extends TFrom>(
+    encoder: VariableSizeEncoder<TFrom>,
+    decoder: VariableSizeDecoder<TTo>
+): VariableSizeCodec<TFrom, TTo>;
+export function combineCodec<TFrom, TTo extends TFrom>(
+    encoder: Encoder<TFrom>,
+    decoder: Decoder<TTo>
+): Codec<TFrom, TTo>;
+export function combineCodec<TFrom, TTo extends TFrom>(
+    encoder: Encoder<TFrom>,
+    decoder: Decoder<TTo>
+): Codec<TFrom, TTo> {
     if (isFixedSizeCodec(encoder) !== isFixedSizeCodec(decoder)) {
         // TODO: Coded error.
         throw new Error(`Encoder and decoder must either both be fixed-size or variable-size.`);

--- a/packages/codecs-core/src/fix-codec.ts
+++ b/packages/codecs-core/src/fix-codec.ts
@@ -19,12 +19,14 @@ import { combineCodec } from './combine-codec';
  *
  * @param encoder - The encoder to wrap into a fixed-size encoder.
  * @param fixedBytes - The fixed number of bytes to write.
- * @param description - A custom description for the encoder.
  */
-export function fixEncoder<T>(encoder: Encoder<T>, fixedBytes: number): FixedSizeEncoder<T> {
+export function fixEncoder<TFrom, TSize extends number>(
+    encoder: Encoder<TFrom>,
+    fixedBytes: TSize
+): FixedSizeEncoder<TFrom, TSize> {
     return createEncoder({
         fixedSize: fixedBytes,
-        write: (value: T, bytes: Uint8Array, offset: Offset) => {
+        write: (value: TFrom, bytes: Uint8Array, offset: Offset) => {
             // Here we exceptionally use the `encode` function instead of the `write`
             // function as using the nested `write` function on a fixed-sized byte
             // array may result in a out-of-bounds error on the nested encoder.
@@ -42,9 +44,11 @@ export function fixEncoder<T>(encoder: Encoder<T>, fixedBytes: number): FixedSiz
  *
  * @param decoder - The decoder to wrap into a fixed-size decoder.
  * @param fixedBytes - The fixed number of bytes to read.
- * @param description - A custom description for the decoder.
  */
-export function fixDecoder<T>(decoder: Decoder<T>, fixedBytes: number): FixedSizeDecoder<T> {
+export function fixDecoder<TTo, TSize extends number>(
+    decoder: Decoder<TTo>,
+    fixedBytes: TSize
+): FixedSizeDecoder<TTo, TSize> {
     return createDecoder({
         fixedSize: fixedBytes,
         read: (bytes: Uint8Array, offset: Offset) => {
@@ -69,8 +73,10 @@ export function fixDecoder<T>(decoder: Decoder<T>, fixedBytes: number): FixedSiz
  *
  * @param codec - The codec to wrap into a fixed-size codec.
  * @param fixedBytes - The fixed number of bytes to read/write.
- * @param description - A custom description for the codec.
  */
-export function fixCodec<T, U extends T = T>(codec: Codec<T, U>, fixedBytes: number): FixedSizeCodec<T, U> {
+export function fixCodec<TFrom, TTo extends TFrom, TSize extends number>(
+    codec: Codec<TFrom, TTo>,
+    fixedBytes: TSize
+): FixedSizeCodec<TFrom, TTo, TSize> {
     return combineCodec(fixEncoder(codec, fixedBytes), fixDecoder(codec, fixedBytes));
 }

--- a/packages/codecs-core/src/map-codec.ts
+++ b/packages/codecs-core/src/map-codec.ts
@@ -17,37 +17,49 @@ import {
 /**
  * Converts an encoder A to a encoder B by mapping their values.
  */
-export function mapEncoder<T, U>(encoder: FixedSizeEncoder<T>, unmap: (value: U) => T): FixedSizeEncoder<U>;
-export function mapEncoder<T, U>(encoder: VariableSizeEncoder<T>, unmap: (value: U) => T): VariableSizeEncoder<U>;
-export function mapEncoder<T, U>(encoder: Encoder<T>, unmap: (value: U) => T): Encoder<U>;
-export function mapEncoder<T, U>(encoder: Encoder<T>, unmap: (value: U) => T): Encoder<U> {
+export function mapEncoder<TOldFrom, TNewFrom, TSize extends number>(
+    encoder: FixedSizeEncoder<TOldFrom, TSize>,
+    unmap: (value: TNewFrom) => TOldFrom
+): FixedSizeEncoder<TNewFrom, TSize>;
+export function mapEncoder<TOldFrom, TNewFrom>(
+    encoder: VariableSizeEncoder<TOldFrom>,
+    unmap: (value: TNewFrom) => TOldFrom
+): VariableSizeEncoder<TNewFrom>;
+export function mapEncoder<TOldFrom, TNewFrom>(
+    encoder: Encoder<TOldFrom>,
+    unmap: (value: TNewFrom) => TOldFrom
+): Encoder<TNewFrom>;
+export function mapEncoder<TOldFrom, TNewFrom>(
+    encoder: Encoder<TOldFrom>,
+    unmap: (value: TNewFrom) => TOldFrom
+): Encoder<TNewFrom> {
     return createEncoder({
         ...(isVariableSizeCodec(encoder)
-            ? { ...encoder, getSizeFromValue: (value: U) => encoder.getSizeFromValue(unmap(value)) }
+            ? { ...encoder, getSizeFromValue: (value: TNewFrom) => encoder.getSizeFromValue(unmap(value)) }
             : encoder),
-        write: (value: U, bytes, offset) => encoder.write(unmap(value), bytes, offset),
+        write: (value: TNewFrom, bytes, offset) => encoder.write(unmap(value), bytes, offset),
     });
 }
 
 /**
  * Converts an decoder A to a decoder B by mapping their values.
  */
-export function mapDecoder<T, U>(
-    decoder: FixedSizeDecoder<T>,
-    map: (value: T, bytes: Uint8Array, offset: number) => U
-): FixedSizeDecoder<U>;
-export function mapDecoder<T, U>(
-    decoder: VariableSizeDecoder<T>,
-    map: (value: T, bytes: Uint8Array, offset: number) => U
-): VariableSizeDecoder<U>;
-export function mapDecoder<T, U>(
-    decoder: Decoder<T>,
-    map: (value: T, bytes: Uint8Array, offset: number) => U
-): Decoder<U>;
-export function mapDecoder<T, U>(
-    decoder: Decoder<T>,
-    map: (value: T, bytes: Uint8Array, offset: number) => U,
-): Decoder<U> {
+export function mapDecoder<TOldTo, TNewTo, TSize extends number>(
+    decoder: FixedSizeDecoder<TOldTo, TSize>,
+    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo
+): FixedSizeDecoder<TNewTo, TSize>;
+export function mapDecoder<TOldTo, TNewTo>(
+    decoder: VariableSizeDecoder<TOldTo>,
+    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo
+): VariableSizeDecoder<TNewTo>;
+export function mapDecoder<TOldTo, TNewTo>(
+    decoder: Decoder<TOldTo>,
+    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo
+): Decoder<TNewTo>;
+export function mapDecoder<TOldTo, TNewTo>(
+    decoder: Decoder<TOldTo>,
+    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo
+): Decoder<TNewTo> {
     return createDecoder({
         ...decoder,
         read: (bytes: Uint8Array, offset) => {
@@ -60,40 +72,40 @@ export function mapDecoder<T, U>(
 /**
  * Converts a codec A to a codec B by mapping their values.
  */
-export function mapCodec<NewFrom, OldFrom, To extends NewFrom & OldFrom>(
-    codec: FixedSizeCodec<OldFrom, To>,
-    unmap: (value: NewFrom) => OldFrom
-): FixedSizeCodec<NewFrom, To>;
-export function mapCodec<NewFrom, OldFrom, To extends NewFrom & OldFrom>(
-    codec: VariableSizeCodec<OldFrom, To>,
-    unmap: (value: NewFrom) => OldFrom
-): VariableSizeCodec<NewFrom, To>;
-export function mapCodec<NewFrom, OldFrom, To extends NewFrom & OldFrom>(
-    codec: Codec<OldFrom, To>,
-    unmap: (value: NewFrom) => OldFrom,
-): Codec<NewFrom, To>;
-export function mapCodec<NewFrom, OldFrom, NewTo extends NewFrom = NewFrom, OldTo extends OldFrom = OldFrom>(
-    codec: FixedSizeCodec<OldFrom, OldTo>,
-    unmap: (value: NewFrom) => OldFrom,
-    map: (value: OldTo, bytes: Uint8Array, offset: number) => NewTo
-): FixedSizeCodec<NewFrom, NewTo>;
-export function mapCodec<NewFrom, OldFrom, NewTo extends NewFrom = NewFrom, OldTo extends OldFrom = OldFrom>(
-    codec: VariableSizeCodec<OldFrom, OldTo>,
-    unmap: (value: NewFrom) => OldFrom,
-    map: (value: OldTo, bytes: Uint8Array, offset: number) => NewTo
-): VariableSizeCodec<NewFrom, NewTo>;
-export function mapCodec<NewFrom, OldFrom, NewTo extends NewFrom = NewFrom, OldTo extends OldFrom = OldFrom>(
-    codec: Codec<OldFrom, OldTo>,
-    unmap: (value: NewFrom) => OldFrom,
-    map: (value: OldTo, bytes: Uint8Array, offset: number) => NewTo,
-): Codec<NewFrom, NewTo>;
-export function mapCodec<NewFrom, OldFrom, NewTo extends NewFrom = NewFrom, OldTo extends OldFrom = OldFrom>(
-    codec: Codec<OldFrom, OldTo>,
-    unmap: (value: NewFrom) => OldFrom,
-    map?: (value: OldTo, bytes: Uint8Array, offset: number) => NewTo,
-): Codec<NewFrom, NewTo> {
+export function mapCodec<TOldFrom, TNewFrom, TTo extends TNewFrom & TOldFrom, TSize extends number>(
+    codec: FixedSizeCodec<TOldFrom, TTo, TSize>,
+    unmap: (value: TNewFrom) => TOldFrom
+): FixedSizeCodec<TNewFrom, TTo, TSize>;
+export function mapCodec<TOldFrom, TNewFrom, TTo extends TNewFrom & TOldFrom>(
+    codec: VariableSizeCodec<TOldFrom, TTo>,
+    unmap: (value: TNewFrom) => TOldFrom
+): VariableSizeCodec<TNewFrom, TTo>;
+export function mapCodec<TOldFrom, TNewFrom, TTo extends TNewFrom & TOldFrom>(
+    codec: Codec<TOldFrom, TTo>,
+    unmap: (value: TNewFrom) => TOldFrom
+): Codec<TNewFrom, TTo>;
+export function mapCodec<TOldFrom, TNewFrom, TOldTo extends TOldFrom, TNewTo extends TNewFrom, TSize extends number>(
+    codec: FixedSizeCodec<TOldFrom, TOldTo, TSize>,
+    unmap: (value: TNewFrom) => TOldFrom,
+    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo
+): FixedSizeCodec<TNewFrom, TNewTo, TSize>;
+export function mapCodec<TOldFrom, TNewFrom, TOldTo extends TOldFrom, TNewTo extends TNewFrom>(
+    codec: VariableSizeCodec<TOldFrom, TOldTo>,
+    unmap: (value: TNewFrom) => TOldFrom,
+    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo
+): VariableSizeCodec<TNewFrom, TNewTo>;
+export function mapCodec<TOldFrom, TNewFrom, TOldTo extends TOldFrom, TNewTo extends TNewFrom>(
+    codec: Codec<TOldFrom, TOldTo>,
+    unmap: (value: TNewFrom) => TOldFrom,
+    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo
+): Codec<TNewFrom, TNewTo>;
+export function mapCodec<TOldFrom, TNewFrom, TOldTo extends TOldFrom, TNewTo extends TNewFrom>(
+    codec: Codec<TOldFrom, TOldTo>,
+    unmap: (value: TNewFrom) => TOldFrom,
+    map?: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo
+): Codec<TNewFrom, TNewTo> {
     return createCodec({
         ...mapEncoder(codec, unmap),
-        read: map ? mapDecoder(codec, map).read : (codec.read as unknown as Decoder<NewTo>['read']),
+        read: map ? mapDecoder(codec, map).read : (codec.read as unknown as Decoder<TNewTo>['read']),
     });
 }

--- a/packages/codecs-core/src/reverse-codec.ts
+++ b/packages/codecs-core/src/reverse-codec.ts
@@ -11,11 +11,13 @@ import { combineCodec } from './combine-codec';
 /**
  * Reverses the bytes of a fixed-size encoder.
  */
-export function reverseEncoder<T>(encoder: FixedSizeEncoder<T>): FixedSizeEncoder<T> {
+export function reverseEncoder<TFrom, TSize extends number>(
+    encoder: FixedSizeEncoder<TFrom, TSize>
+): FixedSizeEncoder<TFrom, TSize> {
     assertIsFixedSizeCodec(encoder, 'Cannot reverse a codec of variable size.');
     return createEncoder({
         ...encoder,
-        write: (value: T, bytes, offset) => {
+        write: (value: TFrom, bytes, offset) => {
             const newOffset = encoder.write(value, bytes, offset);
             const slice = bytes.slice(offset, offset + encoder.fixedSize).reverse();
             bytes.set(slice, offset);
@@ -27,7 +29,9 @@ export function reverseEncoder<T>(encoder: FixedSizeEncoder<T>): FixedSizeEncode
 /**
  * Reverses the bytes of a fixed-size decoder.
  */
-export function reverseDecoder<T>(decoder: FixedSizeDecoder<T>): FixedSizeDecoder<T> {
+export function reverseDecoder<TTo, TSize extends number>(
+    decoder: FixedSizeDecoder<TTo, TSize>
+): FixedSizeDecoder<TTo, TSize> {
     assertIsFixedSizeCodec(decoder, 'Cannot reverse a codec of variable size.');
     return createDecoder({
         ...decoder,
@@ -46,6 +50,8 @@ export function reverseDecoder<T>(decoder: FixedSizeDecoder<T>): FixedSizeDecode
 /**
  * Reverses the bytes of a fixed-size codec.
  */
-export function reverseCodec<T, U extends T = T>(codec: FixedSizeCodec<T, U>): FixedSizeCodec<T, U> {
+export function reverseCodec<TFrom, TTo extends TFrom, TSize extends number>(
+    codec: FixedSizeCodec<TFrom, TTo, TSize>
+): FixedSizeCodec<TFrom, TTo, TSize> {
     return combineCodec(reverseEncoder(codec), reverseDecoder(codec));
 }

--- a/packages/codecs-numbers/src/common.ts
+++ b/packages/codecs-numbers/src/common.ts
@@ -1,13 +1,28 @@
-import { Codec, Decoder, Encoder } from '@solana/codecs-core';
+import { Codec, Decoder, Encoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 /** Defines a encoder for numbers and bigints. */
 export type NumberEncoder = Encoder<number> | Encoder<number | bigint>;
 
+/** Defines a fixed-size encoder for numbers and bigints. */
+export type FixedSizeNumberEncoder<TSize extends number = number> =
+    | FixedSizeEncoder<number, TSize>
+    | FixedSizeEncoder<number | bigint, TSize>;
+
 /** Defines a decoder for numbers and bigints. */
 export type NumberDecoder = Decoder<number> | Decoder<bigint>;
 
+/** Defines a fixed-size decoder for numbers and bigints. */
+export type FixedSizeNumberDecoder<TSize extends number = number> =
+    | FixedSizeDecoder<number, TSize>
+    | FixedSizeDecoder<bigint, TSize>;
+
 /** Defines a codec for numbers and bigints. */
 export type NumberCodec = Codec<number> | Codec<number | bigint, bigint>;
+
+/** Defines a fixed-size codec for numbers and bigints. */
+export type FixedSizeNumberCodec<TSize extends number = number> =
+    | FixedSizeCodec<number, number, TSize>
+    | FixedSizeCodec<number | bigint, bigint, TSize>;
 
 /** Defines the config for number codecs that use more than one byte. */
 export type NumberCodecConfig = {

--- a/packages/codecs-numbers/src/f32.ts
+++ b/packages/codecs-numbers/src/f32.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
+export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 4> =>
     numberEncoderFactory({
         config,
         name: 'f32',
@@ -11,7 +11,7 @@ export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 4,
     });
 
-export const getF32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
+export const getF32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 4> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getFloat32(0, le),
@@ -19,5 +19,5 @@ export const getF32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
-export const getF32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
+export const getF32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 4> =>
     combineCodec(getF32Encoder(config), getF32Decoder(config));

--- a/packages/codecs-numbers/src/f64.ts
+++ b/packages/codecs-numbers/src/f64.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
+export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 8> =>
     numberEncoderFactory({
         config,
         name: 'f64',
@@ -11,7 +11,7 @@ export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 8,
     });
 
-export const getF64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
+export const getF64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 8> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getFloat64(0, le),
@@ -19,5 +19,5 @@ export const getF64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
-export const getF64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
+export const getF64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 8> =>
     combineCodec(getF64Encoder(config), getF64Decoder(config));

--- a/packages/codecs-numbers/src/i128.ts
+++ b/packages/codecs-numbers/src/i128.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint> =>
+export const getI128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint, 16> =>
     numberEncoderFactory({
         config,
         name: 'i128',
@@ -18,7 +18,7 @@ export const getI128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder
         size: 16,
     });
 
-export const getI128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint> =>
+export const getI128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 16> =>
     numberDecoderFactory({
         config,
         get: (view, le) => {
@@ -32,5 +32,5 @@ export const getI128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder
         size: 16,
     });
 
-export const getI128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint> =>
+export const getI128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint, 16> =>
     combineCodec(getI128Encoder(config), getI128Decoder(config));

--- a/packages/codecs-numbers/src/i16.ts
+++ b/packages/codecs-numbers/src/i16.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
+export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 2> =>
     numberEncoderFactory({
         config,
         name: 'i16',
@@ -12,7 +12,7 @@ export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 2,
     });
 
-export const getI16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
+export const getI16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 2> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getInt16(0, le),
@@ -20,5 +20,5 @@ export const getI16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 2,
     });
 
-export const getI16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
+export const getI16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 2> =>
     combineCodec(getI16Encoder(config), getI16Decoder(config));

--- a/packages/codecs-numbers/src/i32.ts
+++ b/packages/codecs-numbers/src/i32.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
+export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 4> =>
     numberEncoderFactory({
         config,
         name: 'i32',
@@ -12,7 +12,7 @@ export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 4,
     });
 
-export const getI32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
+export const getI32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 4> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getInt32(0, le),
@@ -20,5 +20,5 @@ export const getI32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
-export const getI32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
+export const getI32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 4> =>
     combineCodec(getI32Encoder(config), getI32Decoder(config));

--- a/packages/codecs-numbers/src/i64.ts
+++ b/packages/codecs-numbers/src/i64.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint> =>
+export const getI64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint, 8> =>
     numberEncoderFactory({
         config,
         name: 'i64',
@@ -12,7 +12,7 @@ export const getI64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 8,
     });
 
-export const getI64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint> =>
+export const getI64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 8> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getBigInt64(0, le),
@@ -20,5 +20,5 @@ export const getI64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
-export const getI64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint> =>
+export const getI64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint, 8> =>
     combineCodec(getI64Encoder(config), getI64Decoder(config));

--- a/packages/codecs-numbers/src/i8.ts
+++ b/packages/codecs-numbers/src/i8.ts
@@ -2,7 +2,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI8Encoder = (): FixedSizeEncoder<number> =>
+export const getI8Encoder = (): FixedSizeEncoder<number, 1> =>
     numberEncoderFactory({
         name: 'i8',
         range: [-Number('0x7f') - 1, Number('0x7f')],
@@ -10,11 +10,11 @@ export const getI8Encoder = (): FixedSizeEncoder<number> =>
         size: 1,
     });
 
-export const getI8Decoder = (): FixedSizeDecoder<number> =>
+export const getI8Decoder = (): FixedSizeDecoder<number, 1> =>
     numberDecoderFactory({
         get: view => view.getInt8(0),
         name: 'i8',
         size: 1,
     });
 
-export const getI8Codec = (): FixedSizeCodec<number> => combineCodec(getI8Encoder(), getI8Decoder());
+export const getI8Codec = (): FixedSizeCodec<number, number, 1> => combineCodec(getI8Encoder(), getI8Decoder());

--- a/packages/codecs-numbers/src/u128.ts
+++ b/packages/codecs-numbers/src/u128.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint> =>
+export const getU128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint, 16> =>
     numberEncoderFactory({
         config,
         name: 'u128',
@@ -18,7 +18,7 @@ export const getU128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder
         size: 16,
     });
 
-export const getU128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint> =>
+export const getU128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 16> =>
     numberDecoderFactory({
         config,
         get: (view, le) => {
@@ -32,5 +32,5 @@ export const getU128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder
         size: 16,
     });
 
-export const getU128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint> =>
+export const getU128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint, 16> =>
     combineCodec(getU128Encoder(config), getU128Decoder(config));

--- a/packages/codecs-numbers/src/u16.ts
+++ b/packages/codecs-numbers/src/u16.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
+export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 2> =>
     numberEncoderFactory({
         config,
         name: 'u16',
@@ -12,7 +12,7 @@ export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 2,
     });
 
-export const getU16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
+export const getU16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 2> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getUint16(0, le),
@@ -20,5 +20,5 @@ export const getU16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 2,
     });
 
-export const getU16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
+export const getU16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 2> =>
     combineCodec(getU16Encoder(config), getU16Decoder(config));

--- a/packages/codecs-numbers/src/u32.ts
+++ b/packages/codecs-numbers/src/u32.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number> =>
+export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 4> =>
     numberEncoderFactory({
         config,
         name: 'u32',
@@ -12,7 +12,7 @@ export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 4,
     });
 
-export const getU32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number> =>
+export const getU32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 4> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getUint32(0, le),
@@ -20,5 +20,5 @@ export const getU32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
-export const getU32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number> =>
+export const getU32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 4> =>
     combineCodec(getU32Encoder(config), getU32Decoder(config));

--- a/packages/codecs-numbers/src/u64.ts
+++ b/packages/codecs-numbers/src/u64.ts
@@ -3,7 +3,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint> =>
+export const getU64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number | bigint, 8> =>
     numberEncoderFactory({
         config,
         name: 'u64',
@@ -12,7 +12,7 @@ export const getU64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 8,
     });
 
-export const getU64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint> =>
+export const getU64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 8> =>
     numberDecoderFactory({
         config,
         get: (view, le) => view.getBigUint64(0, le),
@@ -20,5 +20,5 @@ export const getU64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
-export const getU64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint> =>
+export const getU64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number | bigint, bigint, 8> =>
     combineCodec(getU64Encoder(config), getU64Decoder(config));

--- a/packages/codecs-numbers/src/u8.ts
+++ b/packages/codecs-numbers/src/u8.ts
@@ -2,7 +2,7 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU8Encoder = (): FixedSizeEncoder<number> =>
+export const getU8Encoder = (): FixedSizeEncoder<number, 1> =>
     numberEncoderFactory({
         name: 'u8',
         range: [0, Number('0xff')],
@@ -10,11 +10,11 @@ export const getU8Encoder = (): FixedSizeEncoder<number> =>
         size: 1,
     });
 
-export const getU8Decoder = (): FixedSizeDecoder<number> =>
+export const getU8Decoder = (): FixedSizeDecoder<number, 1> =>
     numberDecoderFactory({
         get: view => view.getUint8(0),
         name: 'u8',
         size: 1,
     });
 
-export const getU8Codec = (): FixedSizeCodec<number> => combineCodec(getU8Encoder(), getU8Decoder());
+export const getU8Codec = (): FixedSizeCodec<number, number, 1> => combineCodec(getU8Encoder(), getU8Decoder());

--- a/packages/codecs-strings/src/__typetests__/string-typetest.ts
+++ b/packages/codecs-strings/src/__typetests__/string-typetest.ts
@@ -1,0 +1,55 @@
+import {
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '@solana/codecs-core';
+
+import { getStringCodec, getStringDecoder, getStringEncoder } from '../string';
+
+{
+    // [getStringEncoder]: It knows if the encoder is fixed size or variable size.
+    getStringEncoder() satisfies VariableSizeEncoder<string>;
+    getStringEncoder({ size: 42 }) satisfies FixedSizeEncoder<string, 42>;
+    getStringEncoder({ size: 'variable' }) satisfies VariableSizeEncoder<string>;
+    getStringEncoder({
+        encoding: {} as VariableSizeEncoder<string>,
+        size: 'variable',
+    }) satisfies VariableSizeEncoder<string>;
+    getStringEncoder({
+        encoding: {} as FixedSizeEncoder<string, 42>,
+        size: 'variable',
+    }) satisfies FixedSizeEncoder<string, 42>;
+}
+
+{
+    // [getStringDecoder]: It knows if the decoder is fixed size or variable size.
+    getStringDecoder() satisfies VariableSizeDecoder<string>;
+    getStringDecoder({ size: 42 }) satisfies FixedSizeDecoder<string, 42>;
+    getStringDecoder({ size: 'variable' }) satisfies VariableSizeDecoder<string>;
+    getStringDecoder({
+        encoding: {} as VariableSizeDecoder<string>,
+        size: 'variable',
+    }) satisfies VariableSizeDecoder<string>;
+    getStringDecoder({
+        encoding: {} as FixedSizeDecoder<string, 42>,
+        size: 'variable',
+    }) satisfies FixedSizeDecoder<string, 42>;
+}
+
+{
+    // [getStringCodec]: It knows if the codec is fixed size or variable size.
+    getStringCodec() satisfies VariableSizeCodec<string>;
+    getStringCodec({ size: 42 }) satisfies FixedSizeCodec<string, string, 42>;
+    getStringCodec({ size: 'variable' }) satisfies VariableSizeCodec<string>;
+    getStringCodec({
+        encoding: {} as VariableSizeCodec<string>,
+        size: 'variable',
+    }) satisfies VariableSizeCodec<string>;
+    getStringCodec({
+        encoding: {} as FixedSizeCodec<string, string, 42>,
+        size: 'variable',
+    }) satisfies FixedSizeCodec<string, string, 42>;
+}

--- a/packages/codecs-strings/src/string.ts
+++ b/packages/codecs-strings/src/string.ts
@@ -43,9 +43,15 @@ export type StringCodecConfig<
 };
 
 /** Encodes strings from a given encoding and size strategy. */
-export function getStringEncoder(
-    config: StringCodecConfig<NumberEncoder, Encoder<string>> & { size: number }
-): FixedSizeEncoder<string>;
+export function getStringEncoder<TSize extends number>(
+    config: StringCodecConfig<NumberEncoder, Encoder<string>> & { size: TSize }
+): FixedSizeEncoder<string, TSize>;
+export function getStringEncoder<TSize extends number>(
+    config: StringCodecConfig<NumberEncoder, Encoder<string>> & {
+        size: 'variable';
+        encoding: FixedSizeEncoder<string, TSize>;
+    }
+): FixedSizeEncoder<string, TSize>;
 export function getStringEncoder(
     config?: StringCodecConfig<NumberEncoder, Encoder<string>>
 ): VariableSizeEncoder<string>;
@@ -75,9 +81,15 @@ export function getStringEncoder(config: StringCodecConfig<NumberEncoder, Encode
 }
 
 /** Decodes strings from a given encoding and size strategy. */
-export function getStringDecoder(
-    config: StringCodecConfig<NumberDecoder, Decoder<string>> & { size: number }
-): FixedSizeDecoder<string>;
+export function getStringDecoder<TSize extends number>(
+    config: StringCodecConfig<NumberDecoder, Decoder<string>> & { size: TSize }
+): FixedSizeDecoder<string, TSize>;
+export function getStringDecoder<TSize extends number>(
+    config: StringCodecConfig<NumberDecoder, Decoder<string>> & {
+        size: 'variable';
+        encoding: FixedSizeDecoder<string, TSize>;
+    }
+): FixedSizeDecoder<string, TSize>;
 export function getStringDecoder(
     config?: StringCodecConfig<NumberDecoder, Decoder<string>>
 ): VariableSizeDecoder<string>;
@@ -109,9 +121,15 @@ export function getStringDecoder(config: StringCodecConfig<NumberDecoder, Decode
 }
 
 /** Encodes and decodes strings from a given encoding and size strategy. */
-export function getStringCodec(
-    config: StringCodecConfig<NumberCodec, Codec<string>> & { size: number }
-): FixedSizeCodec<string>;
+export function getStringCodec<TSize extends number>(
+    config: StringCodecConfig<NumberCodec, Codec<string>> & { size: TSize }
+): FixedSizeCodec<string, string, TSize>;
+export function getStringCodec<TSize extends number>(
+    config: StringCodecConfig<NumberCodec, Codec<string>> & {
+        size: 'variable';
+        encoding: FixedSizeCodec<string, string, TSize>;
+    }
+): FixedSizeCodec<string, string, TSize>;
 export function getStringCodec(config?: StringCodecConfig<NumberCodec, Codec<string>>): VariableSizeCodec<string>;
 export function getStringCodec(config: StringCodecConfig<NumberCodec, Codec<string>> = {}): Codec<string> {
     return combineCodec(getStringEncoder(config), getStringDecoder(config));


### PR DESCRIPTION
This PR adds the `TSize extends number` type parameter to fixed-size encoder, decoder and codecs. This makes it possible to make TypeScript assertions based on the codec's size.

It also renames all existing type parameters to make them consistent with the rest of the library.
