### PR TITLE
refactor(experimental): a `createPrivateKeyFromBytes` helper

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -66,6 +66,7 @@
     },
     "dependencies": {
         "@solana/functional": "workspace:*",
+        "@solana/keys": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/transactions": "workspace:*"
     },

--- a/packages/compat/src/keypair.ts
+++ b/packages/compat/src/keypair.ts
@@ -1,41 +1,5 @@
+import { createPrivateKeyFromBytes } from '@solana/keys';
 import { Keypair } from '@solana/web3.js';
-
-function addPkcs8Header(bytes: Uint8Array): Uint8Array {
-    // prettier-ignore
-    return new Uint8Array([
-        /**
-         * PKCS#8 header
-         */
-        0x30, // ASN.1 sequence tag
-        0x2e, // Length of sequence (46 more bytes)
-
-            0x02, // ASN.1 integer tag
-            0x01, // Length of integer
-                0x00, // Version number
-
-            0x30, // ASN.1 sequence tag
-            0x05, // Length of sequence
-                0x06, // ASN.1 object identifier tag
-                0x03, // Length of object identifier
-                    // Edwards curve algorithms identifier https://oid-rep.orange-labs.fr/get/1.3.101.112
-                        0x2b, // iso(1) / identified-organization(3) (The first node is multiplied by the decimal 40 and the result is added to the value of the second node)
-                        0x65, // thawte(101)
-                    // Ed25519 identifier
-                        0x70, // id-Ed25519(112)
-
-        /**
-         * Private key payload
-         */
-        0x04, // ASN.1 octet string tag
-        0x22, // String length (34 more bytes)
-
-            // Private key bytes as octet string
-            0x04, // ASN.1 octet string tag
-            0x20, // String length (32 bytes)
-
-        ...bytes
-    ]);
-}
 
 /**
  * Convert from a Legacy Web3 JS Keypair to a CryptoKeyPair
@@ -43,17 +7,10 @@ function addPkcs8Header(bytes: Uint8Array): Uint8Array {
  * @returns         A CryptoKeyPair
  */
 export async function fromLegacyKeypair(keypair: Keypair, extractable?: boolean): Promise<CryptoKeyPair> {
-    const publicKey: CryptoKey = await crypto.subtle.importKey('raw', keypair.publicKey.toBytes(), 'Ed25519', true, [
-        'verify',
+    const [publicKey, privateKey] = await Promise.all([
+        crypto.subtle.importKey('raw', keypair.publicKey.toBytes(), 'Ed25519', true, ['verify']),
+        createPrivateKeyFromBytes(keypair.secretKey.slice(0, 32), extractable),
     ]);
-    const privateKeyBytesPkcs8 = addPkcs8Header(keypair.secretKey.slice(0, 32));
-    const privateKey: CryptoKey = await crypto.subtle.importKey(
-        'pkcs8',
-        privateKeyBytesPkcs8,
-        'Ed25519',
-        extractable ?? false,
-        ['sign'],
-    );
     return {
         privateKey,
         publicKey,

--- a/packages/keys/src/__tests__/private-key-test.ts
+++ b/packages/keys/src/__tests__/private-key-test.ts
@@ -1,0 +1,104 @@
+import { createPrivateKeyFromBytes } from '../private-key';
+
+const MOCK_DATA = new Uint8Array([1, 2, 3]);
+const MOCK_DATA_SIGNATURE = new Uint8Array([
+    66, 111, 184, 228, 239, 189, 127, 46, 23, 168, 117, 69, 58, 143, 132, 164, 112, 189, 203, 228, 183, 151, 0, 23, 179,
+    181, 52, 75, 112, 225, 150, 128, 184, 164, 36, 21, 101, 205, 115, 28, 127, 221, 24, 135, 229, 8, 69, 232, 16, 225,
+    44, 229, 17, 236, 206, 174, 102, 207, 79, 253, 96, 7, 174, 10,
+]);
+const MOCK_PRIVATE_KEY_BYTES = new Uint8Array([
+    0xeb, 0xfa, 0x65, 0xeb, 0x93, 0xdc, 0x79, 0x15, 0x7a, 0xba, 0xde, 0xa2, 0xf7, 0x94, 0x37, 0x9d, 0xfc, 0x07, 0x1d,
+    0x68, 0x86, 0x87, 0x37, 0x6d, 0xc5, 0xd5, 0xa0, 0x54, 0x12, 0x1d, 0x34, 0x4a,
+]);
+
+describe('createPrivateKeyFromBytes', () => {
+    it.each([0, 16, 31, 33])('throws when the bytes are of length %s', async length => {
+        expect.assertions(1);
+        await expect(createPrivateKeyFromBytes(new Uint8Array(length))).rejects.toThrow();
+    });
+    describe('given a key created from valid private key bytes', () => {
+        let privateKey: CryptoKey;
+        beforeEach(async () => {
+            privateKey = await createPrivateKeyFromBytes(MOCK_PRIVATE_KEY_BYTES);
+        });
+        it('is non-extractable', async () => {
+            expect.assertions(1);
+            expect(privateKey).toHaveProperty('extractable', false);
+        });
+        it('has the expected metadata', () => {
+            expect(privateKey).toMatchObject({
+                [Symbol.toStringTag]: 'CryptoKey',
+                algorithm: { name: 'Ed25519' },
+                type: 'private',
+                usages: ['sign'],
+            });
+        });
+        it('can be used to produce the expected signature', async () => {
+            expect.assertions(1);
+            const signature = await crypto.subtle.sign('Ed25519', privateKey, MOCK_DATA);
+            expect(new Uint8Array(signature)).toEqual(MOCK_DATA_SIGNATURE);
+        });
+    });
+    describe.each([true, false])(
+        'given a key created with the `extractable` option set to `%s`',
+        expectedExtractability => {
+            let privateKey: CryptoKey;
+            beforeEach(async () => {
+                privateKey = await createPrivateKeyFromBytes(
+                    MOCK_PRIVATE_KEY_BYTES,
+                    /* extractable */ expectedExtractability,
+                );
+            });
+            it('has the expected extractability', () => {
+                expect(privateKey).toHaveProperty('extractable', expectedExtractability);
+            });
+            if (expectedExtractability) {
+                it('can be exported', async () => {
+                    expect.assertions(1);
+                    expect(new Uint8Array(await crypto.subtle.exportKey('pkcs8', privateKey))).toEqual(
+                        // prettier-ignore
+                        new Uint8Array([
+                            /**
+                             * PKCS#8 header
+                             */
+                            0x30, // ASN.1 sequence tag
+                            0x2e, // Length of sequence (46 more bytes)
+
+                                0x02, // ASN.1 integer tag
+                                0x01, // Length of integer
+                                    0x00, // Version number
+
+                                0x30, // ASN.1 sequence tag
+                                0x05, // Length of sequence
+                                    0x06, // ASN.1 object identifier tag
+                                    0x03, // Length of object identifier
+                                        // Edwards curve algorithms identifier https://oid-rep.orange-labs.fr/get/1.3.101.112
+                                            0x2b, // iso(1) / identified-organization(3) (The first node is multiplied by the decimal 40 and the result is added to the value of the second node)
+                                            0x65, // thawte(101)
+                                        // Ed25519 identifier
+                                            0x70, // id-Ed25519(112)
+
+                            /**
+                             * Private key payload
+                             */
+                            0x04, // ASN.1 octet string tag
+                            0x22, // String length (34 more bytes)
+
+                                // Private key bytes as octet string
+                                0x04, // ASN.1 octet string tag
+                                0x20, // String length (32 bytes)
+                                ...MOCK_PRIVATE_KEY_BYTES,
+                        ]),
+                    );
+                });
+            } else {
+                it('throws if you try to export it', async () => {
+                    expect.assertions(1);
+                    await expect(crypto.subtle.exportKey('pkcs8', privateKey)).rejects.toThrow(
+                        'key is not extractable',
+                    );
+                });
+            }
+        },
+    );
+});

--- a/packages/keys/src/__tests__/signatures-test.ts
+++ b/packages/keys/src/__tests__/signatures-test.ts
@@ -1,6 +1,7 @@
 import { Encoder } from '@solana/codecs-core';
 import { getBase58Encoder } from '@solana/codecs-strings';
 
+import { createPrivateKeyFromBytes } from '../private-key';
 import { SignatureBytes, signBytes, verifySignature } from '../signatures';
 
 jest.mock('@solana/codecs-strings', () => ({
@@ -14,43 +15,10 @@ const MOCK_DATA_SIGNATURE = new Uint8Array([
     181, 52, 75, 112, 225, 150, 128, 184, 164, 36, 21, 101, 205, 115, 28, 127, 221, 24, 135, 229, 8, 69, 232, 16, 225,
     44, 229, 17, 236, 206, 174, 102, 207, 79, 253, 96, 7, 174, 10,
 ]) as SignatureBytes;
-const MOCK_PKCS8_PRIVATE_KEY =
-    // prettier-ignore
-    new Uint8Array([
-        /**
-         * PKCS#8 header
-         */
-        0x30, // ASN.1 sequence tag
-        0x2e, // Length of sequence (46 more bytes)
-
-            0x02, // ASN.1 integer tag
-            0x01, // Length of integer
-                0x00, // Version number
-
-            0x30, // ASN.1 sequence tag
-            0x05, // Length of sequence
-                0x06, // ASN.1 object identifier tag
-                0x03, // Length of object identifier
-                    // Edwards curve algorithms identifier https://oid-rep.orange-labs.fr/get/1.3.101.112
-                        0x2b, // iso(1) / identified-organization(3) (The first node is multiplied by the decimal 40 and the result is added to the value of the second node)
-                        0x65, // thawte(101)
-                    // Ed25519 identifier
-                        0x70, // id-Ed25519(112)
-
-        /**
-         * Private key payload
-         */
-        0x04, // ASN.1 octet string tag
-        0x22, // String length (34 more bytes)
-
-            // Private key bytes as octet string
-            0x04, // ASN.1 octet string tag
-            0x20, // String length (32 bytes)
-                0xeb, 0xfa, 0x65, 0xeb, 0x93, 0xdc, 0x79, 0x15,
-                0x7a, 0xba, 0xde, 0xa2, 0xf7, 0x94, 0x37, 0x9d,
-                0xfc, 0x07, 0x1d, 0x68, 0x86, 0x87, 0x37, 0x6d,
-                0xc5, 0xd5, 0xa0, 0x54, 0x12, 0x1d, 0x34, 0x4a,
-    ]);
+const MOCK_PRIVATE_KEY_BYTES = new Uint8Array([
+    0xeb, 0xfa, 0x65, 0xeb, 0x93, 0xdc, 0x79, 0x15, 0x7a, 0xba, 0xde, 0xa2, 0xf7, 0x94, 0x37, 0x9d, 0xfc, 0x07, 0x1d,
+    0x68, 0x86, 0x87, 0x37, 0x6d, 0xc5, 0xd5, 0xa0, 0x54, 0x12, 0x1d, 0x34, 0x4a,
+]);
 const MOCK_PUBLIC_KEY_BYTES = new Uint8Array([
     0x1d, 0x0e, 0x93, 0x86, 0x4d, 0xcc, 0x81, 0x5f, 0xc3, 0xf2, 0x86, 0x18, 0x09, 0x11, 0xd0, 0x0a, 0x3f, 0xd2, 0x06,
     0xde, 0x31, 0xa1, 0xc9, 0x42, 0x87, 0xcb, 0x43, 0xf0, 0x5f, 0xc9, 0xf2, 0xb5,
@@ -173,13 +141,7 @@ describe('assertIsSignature()', () => {
 describe('sign', () => {
     it('produces the expected signature given a private key', async () => {
         expect.assertions(1);
-        const privateKey = await crypto.subtle.importKey(
-            'pkcs8',
-            MOCK_PKCS8_PRIVATE_KEY,
-            'Ed25519',
-            /* extractable */ false,
-            ['sign'],
-        );
+        const privateKey = await createPrivateKeyFromBytes(MOCK_PRIVATE_KEY_BYTES, /* extractable */ false);
         const signature = await signBytes(privateKey, MOCK_DATA);
         expect(signature).toEqual(MOCK_DATA_SIGNATURE);
     });

--- a/packages/keys/src/index.ts
+++ b/packages/keys/src/index.ts
@@ -1,2 +1,3 @@
 export * from './key-pair';
+export * from './private-key';
 export * from './signatures';

--- a/packages/keys/src/private-key.ts
+++ b/packages/keys/src/private-key.ts
@@ -1,0 +1,45 @@
+function addPkcs8Header(bytes: Uint8Array): Uint8Array {
+    // prettier-ignore
+    return new Uint8Array([
+        /**
+         * PKCS#8 header
+         */
+        0x30, // ASN.1 sequence tag
+        0x2e, // Length of sequence (46 more bytes)
+
+            0x02, // ASN.1 integer tag
+            0x01, // Length of integer
+                0x00, // Version number
+
+            0x30, // ASN.1 sequence tag
+            0x05, // Length of sequence
+                0x06, // ASN.1 object identifier tag
+                0x03, // Length of object identifier
+                    // Edwards curve algorithms identifier https://oid-rep.orange-labs.fr/get/1.3.101.112
+                        0x2b, // iso(1) / identified-organization(3) (The first node is multiplied by the decimal 40 and the result is added to the value of the second node)
+                        0x65, // thawte(101)
+                    // Ed25519 identifier
+                        0x70, // id-Ed25519(112)
+
+        /**
+         * Private key payload
+         */
+        0x04, // ASN.1 octet string tag
+        0x22, // String length (34 more bytes)
+
+            // Private key bytes as octet string
+            0x04, // ASN.1 octet string tag
+            0x20, // String length (32 bytes)
+
+        ...bytes
+    ]);
+}
+
+export async function createPrivateKeyFromBytes(bytes: Uint8Array, extractable?: boolean): Promise<CryptoKey> {
+    if (bytes.byteLength !== 32) {
+        // TODO: Coded error.
+        throw new Error('Private key bytes must be of length 32');
+    }
+    const privateKeyBytesPkcs8 = addPkcs8Header(bytes);
+    return await crypto.subtle.importKey('pkcs8', privateKeyBytesPkcs8, 'Ed25519', extractable ?? false, ['sign']);
+}

--- a/packages/rpc-core/src/rpc-methods/__tests__/send-transaction-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/send-transaction-test.ts
@@ -1,5 +1,6 @@
 import { fixEncoder } from '@solana/codecs-core';
 import { getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
+import { createPrivateKeyFromBytes } from '@solana/keys';
 import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCode } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import { Base64EncodedWireTransaction } from '@solana/transactions';
@@ -50,43 +51,10 @@ function getMockTransactionMessage({
         0x00, // Number of address table lookups
     ]);
 }
-const MOCK_PKCS8_PRIVATE_KEY =
-    // prettier-ignore
-    new Uint8Array([
-        /**
-         * PKCS#8 header
-         */
-        0x30, // ASN.1 sequence tag
-        0x2e, // Length of sequence (46 more bytes)
-
-            0x02, // ASN.1 integer tag
-            0x01, // Length of integer
-                0x00, // Version number
-
-            0x30, // ASN.1 sequence tag
-            0x05, // Length of sequence
-                0x06, // ASN.1 object identifier tag
-                0x03, // Length of object identifier
-                    // Edwards curve algorithms identifier https://oid-rep.orange-labs.fr/get/1.3.101.112
-                        0x2b, // iso(1) / identified-organization(3) (The first node is multiplied by the decimal 40 and the result is added to the value of the second node)
-                        0x65, // thawte(101)
-                    // Ed25519 identifier
-                        0x70, // id-Ed25519(112)
-
-        /**
-         * Private key payload
-         */
-        0x04, // ASN.1 octet string tag
-        0x22, // String length (34 more bytes)
-
-            // Private key bytes as octet string
-            0x04, // ASN.1 octet string tag
-            0x20, // String length (32 bytes)
-                16, 192, 67, 187, 170, 210, 152, 95,
-                180, 204, 123, 21, 81, 45, 171, 85,
-                188, 91, 164, 34, 8, 0, 244, 56,
-                209, 190, 255, 201, 212, 94, 45, 186,
-    ]);
+const MOCK_PRIVATE_KEY_BYTES = new Uint8Array([
+    16, 192, 67, 187, 170, 210, 152, 95, 180, 204, 123, 21, 81, 45, 171, 85, 188, 91, 164, 34, 8, 0, 244, 56, 209, 190,
+    255, 201, 212, 94, 45, 186,
+]);
 // See scripts/fixtures/send-transaction-fee-payer.json
 const MOCK_PUBLIC_KEY_BYTES = // DRtXHDgC312wpNdNCSb8vCoXDcofCJcPHdAw4VkJ8L9i
     // prettier-ignore
@@ -96,7 +64,7 @@ const MOCK_PUBLIC_KEY_BYTES = // DRtXHDgC312wpNdNCSb8vCoXDcofCJcPHdAw4VkJ8L9i
     ]);
 
 async function getSecretKey() {
-    return await crypto.subtle.importKey('pkcs8', MOCK_PKCS8_PRIVATE_KEY, 'Ed25519', /* extractable */ false, ['sign']);
+    return await createPrivateKeyFromBytes(MOCK_PRIVATE_KEY_BYTES, /* extractable */ false);
 }
 
 describe('sendTransaction', () => {

--- a/packages/rpc-core/src/rpc-methods/__tests__/simulate-transaction-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/simulate-transaction-test.ts
@@ -1,6 +1,7 @@
 import { Address } from '@solana/addresses';
 import { fixEncoder } from '@solana/codecs-core';
 import { getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
+import { createPrivateKeyFromBytes } from '@solana/keys';
 import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCode } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import { Base64EncodedWireTransaction } from '@solana/transactions';
@@ -104,43 +105,10 @@ function getMockTransactionMessageWithAdditionalAccount({
     ]);
 }
 
-const MOCK_PKCS8_PRIVATE_KEY =
-    // prettier-ignore
-    new Uint8Array([
-        /**
-         * PKCS#8 header
-         */
-        0x30, // ASN.1 sequence tag
-        0x2e, // Length of sequence (46 more bytes)
-
-        0x02, // ASN.1 integer tag
-        0x01, // Length of integer
-        0x00, // Version number
-
-        0x30, // ASN.1 sequence tag
-        0x05, // Length of sequence
-        0x06, // ASN.1 object identifier tag
-        0x03, // Length of object identifier
-        // Edwards curve algorithms identifier https://oid-rep.orange-labs.fr/get/1.3.101.112
-        0x2b, // iso(1) / identified-organization(3) (The first node is multiplied by the decimal 40 and the result is added to the value of the second node)
-        0x65, // thawte(101)
-        // Ed25519 identifier
-        0x70, // id-Ed25519(112)
-
-        /**
-         * Private key payload
-         */
-        0x04, // ASN.1 octet string tag
-        0x22, // String length (34 more bytes)
-
-        // Private key bytes as octet string
-        0x04, // ASN.1 octet string tag
-        0x20, // String length (32 bytes)
-        16, 192, 67, 187, 170, 210, 152, 95,
-        180, 204, 123, 21, 81, 45, 171, 85,
-        188, 91, 164, 34, 8, 0, 244, 56,
-        209, 190, 255, 201, 212, 94, 45, 186,
-    ]);
+const MOCK_PRIVATE_KEY_BYTES = new Uint8Array([
+    16, 192, 67, 187, 170, 210, 152, 95, 180, 204, 123, 21, 81, 45, 171, 85, 188, 91, 164, 34, 8, 0, 244, 56, 209, 190,
+    255, 201, 212, 94, 45, 186,
+]);
 // See scripts/fixtures/send-transaction-fee-payer.json
 const MOCK_PUBLIC_KEY_BYTES = // DRtXHDgC312wpNdNCSb8vCoXDcofCJcPHdAw4VkJ8L9i
     // prettier-ignore
@@ -150,7 +118,7 @@ const MOCK_PUBLIC_KEY_BYTES = // DRtXHDgC312wpNdNCSb8vCoXDcofCJcPHdAw4VkJ8L9i
     ]);
 
 async function getSecretKey() {
-    return await crypto.subtle.importKey('pkcs8', MOCK_PKCS8_PRIVATE_KEY, 'Ed25519', /* extractable */ false, ['sign']);
+    return await createPrivateKeyFromBytes(MOCK_PRIVATE_KEY_BYTES, /* extractable */ false);
 }
 
 describe('simulateTransaction', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,9 @@ importers:
       '@solana/instructions':
         specifier: workspace:*
         version: link:../instructions
+      '@solana/keys':
+        specifier: workspace:*
+        version: link:../keys
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
@@ -483,9 +486,6 @@ importers:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
         version: 1.0.2(@typescript-eslint/eslint-plugin@6.7.0)(@typescript-eslint/parser@6.3.0)(eslint-plugin-jest@27.4.2)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-simple-import-sort@10.0.0)(eslint-plugin-sort-keys-fix@1.1.2)(eslint@8.45.0)(typescript@5.2.2)
-      '@solana/keys':
-        specifier: workspace:*
-        version: link:../keys
       '@solana/web3.js':
         specifier: workspace:*
         version: link:../library-legacy


### PR DESCRIPTION
# Summary

Sometimes you just have the bytes already, but you don't want to have to futz with crafting your own PKCS#8 payload. This helper will do it for you.

Note: I left the PKCS#8 header alone in the polyfill, because it's designed to eventually go away.

# Test Plan

```
cd packages/keys/
pnpm test:unit:browser
pnpm test:unit:node
```

Closes #1813.