### PR TITLE
Update README.md

### DIFF
--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -34,17 +34,17 @@ In response to your feedback, we began a process of modernizing the library to p
 ### For use in Node.js or a web application
 
 ```shell
-npm install --save @solana/web3.js@ts
+npm install --save @solana/web3.js@tp
 ```
 
 ### For use in a browser, without a build system
 
 ```html
 <!-- Development (debug mode, unminified) -->
-<script src="https://unpkg.com/@solana/web3.js@ts/dist/index.development.js"></script>
+<script src="https://unpkg.com/@solana/web3.js@tp/dist/index.development.js"></script>
 
 <!-- Production (minified) -->
-<script src="https://unpkg.com/@solana/web3.js@ts/dist/index.production.min.js"></script>
+<script src="https://unpkg.com/@solana/web3.js@tp/dist/index.production.min.js"></script>
 ```
 
 What follows is an overview of *why* the library was re-engineered, what changes have been introduced, and how the JavaScript landscape might look across Solana in the near future.


### PR DESCRIPTION
The readme of the new web3.js package refers to the tag `ts` which does not exist. The tag should be `tp` (https://www.npmjs.com/package/@solana/web3.js?activeTab=versions)