### PR TITLE
refactor(experimental): rename isFixedSize and isVariableSize type guards

### DIFF
--- a/packages/codecs-core/src/__typetests__/codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/codec-typetest.ts
@@ -1,6 +1,6 @@
 import {
-    assertIsFixedSizeCodec,
-    assertIsVariableSizeCodec,
+    assertIsFixedSize,
+    assertIsVariableSize,
     Codec,
     createCodec,
     createDecoder,
@@ -10,8 +10,8 @@ import {
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
-    isFixedSizeCodec,
-    isVariableSizeCodec,
+    isFixedSize,
+    isVariableSize,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -53,61 +53,61 @@ import {
 }
 
 {
-    // [isFixedSizeCodec]: It returns true if the codec is fixed size and keeps the type information.
+    // [isFixedSize]: It returns true if the codec is fixed size and keeps the type information.
     const codec = {} as FixedSizeCodec<string, string, 42> | VariableSizeCodec<string>;
-    if (isFixedSizeCodec(codec)) {
+    if (isFixedSize(codec)) {
         codec satisfies FixedSizeCodec<string, string, 42>;
     }
 }
 
 {
-    // [isFixedSizeCodec]: It works with codec sizes only.
+    // [isFixedSize]: It works with codec sizes only.
     const codec = {} as { fixedSize: 42 } | { maxSize?: number };
-    if (isFixedSizeCodec(codec)) {
+    if (isFixedSize(codec)) {
         codec satisfies { fixedSize: 42 };
     }
 }
 
 {
-    // [assertIsFixedSizeCodec]: It asserts the codec is fixed size and keeps the type information.
+    // [assertIsFixedSize]: It asserts the codec is fixed size and keeps the type information.
     const codec = {} as FixedSizeCodec<string, string, 42> | VariableSizeCodec<string>;
-    assertIsFixedSizeCodec(codec);
+    assertIsFixedSize(codec);
     codec satisfies FixedSizeCodec<string, string, 42>;
 }
 
 {
-    // [assertIsFixedSizeCodec]: It works with codec sizes only.
+    // [assertIsFixedSize]: It works with codec sizes only.
     const codec = {} as { fixedSize: 42 } | { maxSize?: number };
-    assertIsFixedSizeCodec(codec);
+    assertIsFixedSize(codec);
     codec satisfies { fixedSize: 42 };
 }
 
 {
-    // [isVariableSizeCodec]: It returns true if the codec is variable size.
+    // [isVariableSize]: It returns true if the codec is variable size.
     const codec = {} as FixedSizeCodec<string, string, 42> | VariableSizeCodec<string>;
-    if (isVariableSizeCodec(codec)) {
+    if (isVariableSize(codec)) {
         codec satisfies VariableSizeCodec<string>;
     }
 }
 
 {
-    // [isVariableSizeCodec]: It works with codec sizes only.
+    // [isVariableSize]: It works with codec sizes only.
     const codec = {} as { fixedSize: 42 } | { maxSize?: number; foo: 'bar' };
-    if (isVariableSizeCodec(codec)) {
+    if (isVariableSize(codec)) {
         codec satisfies { maxSize?: number; foo: 'bar' };
     }
 }
 
 {
-    // [assertIsVariableSizeCodec]: It asserts the codec is variable size.
+    // [assertIsVariableSize]: It asserts the codec is variable size.
     const codec = {} as FixedSizeCodec<string, string, 42> | VariableSizeCodec<string>;
-    assertIsVariableSizeCodec(codec);
+    assertIsVariableSize(codec);
     codec satisfies VariableSizeCodec<string>;
 }
 
 {
-    // [assertIsVariableSizeCodec]: It works with codec sizes only.
+    // [assertIsVariableSize]: It works with codec sizes only.
     const codec = {} as { fixedSize: 42 } | { maxSize?: number; foo: 'bar' };
-    assertIsVariableSizeCodec(codec);
+    assertIsVariableSize(codec);
     codec satisfies { maxSize?: number; foo: 'bar' };
 }

--- a/packages/codecs-core/src/codec.ts
+++ b/packages/codecs-core/src/codec.ts
@@ -150,81 +150,79 @@ export function createCodec<TFrom, TTo extends TFrom = TFrom>(
     });
 }
 
-export function isFixedSizeCodec<TFrom, TSize extends number>(
+export function isFixedSize<TFrom, TSize extends number>(
     encoder: FixedSizeEncoder<TFrom, TSize> | VariableSizeEncoder<TFrom>
 ): encoder is FixedSizeEncoder<TFrom, TSize>;
-export function isFixedSizeCodec<TTo, TSize extends number>(
+export function isFixedSize<TTo, TSize extends number>(
     decoder: FixedSizeDecoder<TTo, TSize> | VariableSizeDecoder<TTo>
 ): decoder is FixedSizeDecoder<TTo, TSize>;
-export function isFixedSizeCodec<TFrom, TTo extends TFrom, TSize extends number>(
+export function isFixedSize<TFrom, TTo extends TFrom, TSize extends number>(
     codec: FixedSizeCodec<TFrom, TTo, TSize> | VariableSizeCodec<TFrom, TTo>
 ): codec is FixedSizeCodec<TFrom, TTo, TSize>;
-export function isFixedSizeCodec<TSize extends number>(
+export function isFixedSize<TSize extends number>(
     codec: { fixedSize: TSize } | { maxSize?: number }
 ): codec is { fixedSize: TSize };
-export function isFixedSizeCodec(codec: { fixedSize: number } | { maxSize?: number }): codec is { fixedSize: number } {
+export function isFixedSize(codec: { fixedSize: number } | { maxSize?: number }): codec is { fixedSize: number } {
     return 'fixedSize' in codec && typeof codec.fixedSize === 'number';
 }
 
-export function assertIsFixedSizeCodec<TFrom, TSize extends number>(
+export function assertIsFixedSize<TFrom, TSize extends number>(
     encoder: FixedSizeEncoder<TFrom, TSize> | VariableSizeEncoder<TFrom>,
     message?: string
 ): asserts encoder is FixedSizeEncoder<TFrom, TSize>;
-export function assertIsFixedSizeCodec<TTo, TSize extends number>(
+export function assertIsFixedSize<TTo, TSize extends number>(
     decoder: FixedSizeDecoder<TTo, TSize> | VariableSizeDecoder<TTo>,
     message?: string
 ): asserts decoder is FixedSizeDecoder<TTo, TSize>;
-export function assertIsFixedSizeCodec<TFrom, TTo extends TFrom, TSize extends number>(
+export function assertIsFixedSize<TFrom, TTo extends TFrom, TSize extends number>(
     codec: FixedSizeCodec<TFrom, TTo, TSize> | VariableSizeCodec<TFrom, TTo>,
     message?: string
 ): asserts codec is FixedSizeCodec<TFrom, TTo, TSize>;
-export function assertIsFixedSizeCodec<TSize extends number>(
+export function assertIsFixedSize<TSize extends number>(
     codec: { fixedSize: TSize } | { maxSize?: number },
     message?: string
 ): asserts codec is { fixedSize: TSize };
-export function assertIsFixedSizeCodec(
+export function assertIsFixedSize(
     codec: { fixedSize: number } | { maxSize?: number },
     message?: string
 ): asserts codec is { fixedSize: number } {
-    if (!isFixedSizeCodec(codec)) {
+    if (!isFixedSize(codec)) {
         // TODO: Coded error.
         throw new Error(message ?? 'Expected a fixed-size codec, got a variable-size one.');
     }
 }
 
-export function isVariableSizeCodec<TFrom>(encoder: Encoder<TFrom>): encoder is VariableSizeEncoder<TFrom>;
-export function isVariableSizeCodec<TTo>(decoder: Decoder<TTo>): decoder is VariableSizeDecoder<TTo>;
-export function isVariableSizeCodec<TFrom, TTo extends TFrom>(
+export function isVariableSize<TFrom>(encoder: Encoder<TFrom>): encoder is VariableSizeEncoder<TFrom>;
+export function isVariableSize<TTo>(decoder: Decoder<TTo>): decoder is VariableSizeDecoder<TTo>;
+export function isVariableSize<TFrom, TTo extends TFrom>(
     codec: Codec<TFrom, TTo>
 ): codec is VariableSizeCodec<TFrom, TTo>;
-export function isVariableSizeCodec(codec: { fixedSize: number } | { maxSize?: number }): codec is { maxSize?: number };
-export function isVariableSizeCodec(
-    codec: { fixedSize: number } | { maxSize?: number }
-): codec is { maxSize?: number } {
-    return !isFixedSizeCodec(codec);
+export function isVariableSize(codec: { fixedSize: number } | { maxSize?: number }): codec is { maxSize?: number };
+export function isVariableSize(codec: { fixedSize: number } | { maxSize?: number }): codec is { maxSize?: number } {
+    return !isFixedSize(codec);
 }
 
-export function assertIsVariableSizeCodec<T>(
+export function assertIsVariableSize<T>(
     encoder: Encoder<T>,
     message?: string
 ): asserts encoder is VariableSizeEncoder<T>;
-export function assertIsVariableSizeCodec<T>(
+export function assertIsVariableSize<T>(
     decoder: Decoder<T>,
     message?: string
 ): asserts decoder is VariableSizeDecoder<T>;
-export function assertIsVariableSizeCodec<TFrom, TTo extends TFrom>(
+export function assertIsVariableSize<TFrom, TTo extends TFrom>(
     codec: Codec<TFrom, TTo>,
     message?: string
 ): asserts codec is VariableSizeCodec<TFrom, TTo>;
-export function assertIsVariableSizeCodec(
+export function assertIsVariableSize(
     codec: { fixedSize: number } | { maxSize?: number },
     message?: string
 ): asserts codec is { maxSize?: number };
-export function assertIsVariableSizeCodec(
+export function assertIsVariableSize(
     codec: { fixedSize: number } | { maxSize?: number },
     message?: string
 ): asserts codec is { maxSize?: number } {
-    if (!isVariableSizeCodec(codec)) {
+    if (!isVariableSize(codec)) {
         // TODO: Coded error.
         throw new Error(message ?? 'Expected a variable-size codec, got a fixed-size one.');
     }

--- a/packages/codecs-core/src/combine-codec.ts
+++ b/packages/codecs-core/src/combine-codec.ts
@@ -5,7 +5,7 @@ import {
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
-    isFixedSizeCodec,
+    isFixedSize,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -32,19 +32,19 @@ export function combineCodec<TFrom, TTo extends TFrom>(
     encoder: Encoder<TFrom>,
     decoder: Decoder<TTo>
 ): Codec<TFrom, TTo> {
-    if (isFixedSizeCodec(encoder) !== isFixedSizeCodec(decoder)) {
+    if (isFixedSize(encoder) !== isFixedSize(decoder)) {
         // TODO: Coded error.
         throw new Error(`Encoder and decoder must either both be fixed-size or variable-size.`);
     }
 
-    if (isFixedSizeCodec(encoder) && isFixedSizeCodec(decoder) && encoder.fixedSize !== decoder.fixedSize) {
+    if (isFixedSize(encoder) && isFixedSize(decoder) && encoder.fixedSize !== decoder.fixedSize) {
         // TODO: Coded error.
         throw new Error(
             `Encoder and decoder must have the same fixed size, got [${encoder.fixedSize}] and [${decoder.fixedSize}].`
         );
     }
 
-    if (!isFixedSizeCodec(encoder) && !isFixedSizeCodec(decoder) && encoder.maxSize !== decoder.maxSize) {
+    if (!isFixedSize(encoder) && !isFixedSize(decoder) && encoder.maxSize !== decoder.maxSize) {
         // TODO: Coded error.
         throw new Error(
             `Encoder and decoder must have the same max size, got [${encoder.maxSize}] and [${decoder.maxSize}].`

--- a/packages/codecs-core/src/fix-codec.ts
+++ b/packages/codecs-core/src/fix-codec.ts
@@ -9,7 +9,7 @@ import {
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
-    isFixedSizeCodec,
+    isFixedSize,
     Offset,
 } from './codec';
 import { combineCodec } from './combine-codec';
@@ -58,7 +58,7 @@ export function fixDecoder<TTo, TSize extends number>(
                 bytes = bytes.slice(offset, offset + fixedBytes);
             }
             // If the nested decoder is fixed-size, pad and truncate the byte array accordingly.
-            if (isFixedSizeCodec(decoder)) {
+            if (isFixedSize(decoder)) {
                 bytes = fixBytes(bytes, decoder.fixedSize);
             }
             // Decode the value using the nested decoder.

--- a/packages/codecs-core/src/map-codec.ts
+++ b/packages/codecs-core/src/map-codec.ts
@@ -8,7 +8,7 @@ import {
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
-    isVariableSizeCodec,
+    isVariableSize,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -34,7 +34,7 @@ export function mapEncoder<TOldFrom, TNewFrom>(
     unmap: (value: TNewFrom) => TOldFrom
 ): Encoder<TNewFrom> {
     return createEncoder({
-        ...(isVariableSizeCodec(encoder)
+        ...(isVariableSize(encoder)
             ? { ...encoder, getSizeFromValue: (value: TNewFrom) => encoder.getSizeFromValue(unmap(value)) }
             : encoder),
         write: (value: TNewFrom, bytes, offset) => encoder.write(unmap(value), bytes, offset),

--- a/packages/codecs-core/src/reverse-codec.ts
+++ b/packages/codecs-core/src/reverse-codec.ts
@@ -1,5 +1,5 @@
 import {
-    assertIsFixedSizeCodec,
+    assertIsFixedSize,
     createDecoder,
     createEncoder,
     FixedSizeCodec,
@@ -14,7 +14,7 @@ import { combineCodec } from './combine-codec';
 export function reverseEncoder<TFrom, TSize extends number>(
     encoder: FixedSizeEncoder<TFrom, TSize>
 ): FixedSizeEncoder<TFrom, TSize> {
-    assertIsFixedSizeCodec(encoder, 'Cannot reverse a codec of variable size.');
+    assertIsFixedSize(encoder, 'Cannot reverse a codec of variable size.');
     return createEncoder({
         ...encoder,
         write: (value: TFrom, bytes, offset) => {
@@ -32,7 +32,7 @@ export function reverseEncoder<TFrom, TSize extends number>(
 export function reverseDecoder<TTo, TSize extends number>(
     decoder: FixedSizeDecoder<TTo, TSize>
 ): FixedSizeDecoder<TTo, TSize> {
-    assertIsFixedSizeCodec(decoder, 'Cannot reverse a codec of variable size.');
+    assertIsFixedSize(decoder, 'Cannot reverse a codec of variable size.');
     return createDecoder({
         ...decoder,
         read: (bytes, offset) => {

--- a/packages/codecs-data-structures/src/__tests__/data-enum-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/data-enum-test.ts
@@ -1,9 +1,4 @@
-import {
-    assertIsFixedSizeCodec,
-    assertIsVariableSizeCodec,
-    isFixedSizeCodec,
-    isVariableSizeCodec,
-} from '@solana/codecs-core';
+import { assertIsFixedSize, assertIsVariableSize, isFixedSize, isVariableSize } from '@solana/codecs-core';
 import { getU8Codec, getU16Codec, getU32Codec, getU64Codec } from '@solana/codecs-numbers';
 import { getStringCodec } from '@solana/codecs-strings';
 
@@ -134,8 +129,8 @@ describe('getDataEnumCodec', () => {
 
     it('has the right sizes', () => {
         const webEvent = dataEnum(getWebEvent());
-        expect(isVariableSizeCodec(webEvent)).toBe(true);
-        assertIsVariableSizeCodec(webEvent);
+        expect(isVariableSize(webEvent)).toBe(true);
+        assertIsVariableSize(webEvent);
         expect(webEvent.getSizeFromValue({ __kind: 'PageLoad' })).toBe(1);
         expect(webEvent.getSizeFromValue({ __kind: 'PageUnload' })).toBe(1);
         expect(webEvent.getSizeFromValue({ __kind: 'Click', x: 0, y: 1 })).toBe(1 + 2);
@@ -143,18 +138,18 @@ describe('getDataEnumCodec', () => {
         expect(webEvent.maxSize).toBeUndefined();
 
         const sameSize = dataEnum(getSameSizeVariants());
-        expect(isFixedSizeCodec(sameSize)).toBe(true);
-        assertIsFixedSizeCodec(sameSize);
+        expect(isFixedSize(sameSize)).toBe(true);
+        assertIsFixedSize(sameSize);
         expect(sameSize.fixedSize).toBe(3);
 
         const sameSizeU32 = dataEnum(getSameSizeVariants(), { size: u32() });
-        expect(isFixedSizeCodec(sameSizeU32)).toBe(true);
-        assertIsFixedSizeCodec(sameSizeU32);
+        expect(isFixedSize(sameSizeU32)).toBe(true);
+        assertIsFixedSize(sameSizeU32);
         expect(sameSizeU32.fixedSize).toBe(6);
 
         const u64Enum = dataEnum(getU64Enum());
-        expect(isVariableSizeCodec(u64Enum)).toBe(true);
-        assertIsVariableSizeCodec(u64Enum);
+        expect(isVariableSize(u64Enum)).toBe(true);
+        assertIsVariableSize(u64Enum);
         expect(u64Enum.maxSize).toBe(9);
     });
 });

--- a/packages/codecs-data-structures/src/array.ts
+++ b/packages/codecs-data-structures/src/array.ts
@@ -1,5 +1,5 @@
 import {
-    assertIsFixedSizeCodec,
+    assertIsFixedSize,
     Codec,
     combineCodec,
     createDecoder,
@@ -73,7 +73,7 @@ export function getArrayEncoder<TFrom>(
 ): Encoder<TFrom[]> {
     const size = config.size ?? getU32Encoder();
     if (size === 'remainder') {
-        assertIsFixedSizeCodec(item, 'Codecs of "remainder" size must have fixed-size items.');
+        assertIsFixedSize(item, 'Codecs of "remainder" size must have fixed-size items.');
     }
 
     const fixedSize = computeArrayLikeCodecSize(size, getFixedSize(item));
@@ -129,7 +129,7 @@ export function getArrayDecoder<TTo>(
 export function getArrayDecoder<TTo>(item: Decoder<TTo>, config: ArrayCodecConfig<NumberDecoder> = {}): Decoder<TTo[]> {
     const size = config.size ?? getU32Decoder();
     if (size === 'remainder') {
-        assertIsFixedSizeCodec(item, 'Codecs of "remainder" size must have fixed-size items.');
+        assertIsFixedSize(item, 'Codecs of "remainder" size must have fixed-size items.');
     }
 
     const itemSize = getFixedSize(item);

--- a/packages/codecs-data-structures/src/boolean.ts
+++ b/packages/codecs-data-structures/src/boolean.ts
@@ -1,5 +1,5 @@
 import {
-    assertIsFixedSizeCodec,
+    assertIsFixedSize,
     Codec,
     combineCodec,
     Decoder,
@@ -42,7 +42,7 @@ export function getBooleanEncoder<TSize extends number>(
 export function getBooleanEncoder(config: BooleanCodecConfig<NumberEncoder>): Encoder<boolean>;
 export function getBooleanEncoder(config: BooleanCodecConfig<NumberEncoder> = {}): Encoder<boolean> {
     const size = config.size ?? getU8Encoder();
-    assertIsFixedSizeCodec(size, 'Codec [bool] requires a fixed size.');
+    assertIsFixedSize(size, 'Codec [bool] requires a fixed size.');
     return mapEncoder(size, (value: boolean) => (value ? 1 : 0));
 }
 
@@ -58,7 +58,7 @@ export function getBooleanDecoder<TSize extends number>(
 export function getBooleanDecoder(config: BooleanCodecConfig<NumberDecoder>): Decoder<boolean>;
 export function getBooleanDecoder(config: BooleanCodecConfig<NumberDecoder> = {}): Decoder<boolean> {
     const size = config.size ?? getU8Decoder();
-    assertIsFixedSizeCodec(size, 'Codec [bool] requires a fixed size.');
+    assertIsFixedSize(size, 'Codec [bool] requires a fixed size.');
     return mapDecoder(size, (value: number | bigint): boolean => Number(value) === 1);
 }
 

--- a/packages/codecs-data-structures/src/data-enum.ts
+++ b/packages/codecs-data-structures/src/data-enum.ts
@@ -7,7 +7,7 @@ import {
     Decoder,
     Encoder,
     getEncodedSize,
-    isFixedSizeCodec,
+    isFixedSize,
 } from '@solana/codecs-core';
 import { getU8Decoder, getU8Encoder, NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
 
@@ -186,14 +186,14 @@ function getDataEnumFixedSize<T extends DataEnum>(
     variants: DataEnumToEncoderTuple<T> | DataEnumToDecoderTuple<T>,
     prefix: { fixedSize: number } | object
 ): number | null {
-    if (variants.length === 0) return isFixedSizeCodec(prefix) ? prefix.fixedSize : null;
-    if (!isFixedSizeCodec(variants[0][1])) return null;
+    if (variants.length === 0) return isFixedSize(prefix) ? prefix.fixedSize : null;
+    if (!isFixedSize(variants[0][1])) return null;
     const variantSize = variants[0][1].fixedSize;
     const sameSizedVariants = variants.every(
-        variant => isFixedSizeCodec(variant[1]) && variant[1].fixedSize === variantSize
+        variant => isFixedSize(variant[1]) && variant[1].fixedSize === variantSize
     );
     if (!sameSizedVariants) return null;
-    return isFixedSizeCodec(prefix) ? prefix.fixedSize + variantSize : null;
+    return isFixedSize(prefix) ? prefix.fixedSize + variantSize : null;
 }
 
 function getDataEnumMaxSize<T extends DataEnum>(

--- a/packages/codecs-data-structures/src/nullable.ts
+++ b/packages/codecs-data-structures/src/nullable.ts
@@ -1,5 +1,5 @@
 import {
-    assertIsFixedSizeCodec,
+    assertIsFixedSize,
     Codec,
     combineCodec,
     createDecoder,
@@ -10,7 +10,7 @@ import {
     FixedSizeDecoder,
     FixedSizeEncoder,
     getEncodedSize,
-    isFixedSizeCodec,
+    isFixedSize,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -72,10 +72,10 @@ export function getNullableEncoder<TFrom>(
     const prefix = config.prefix ?? getU8Encoder();
     const fixed = config.fixed ?? false;
 
-    const isZeroSizeItem = isFixedSizeCodec(item) && isFixedSizeCodec(prefix) && item.fixedSize === 0;
+    const isZeroSizeItem = isFixedSize(item) && isFixedSize(prefix) && item.fixedSize === 0;
     if (fixed || isZeroSizeItem) {
-        assertIsFixedSizeCodec(item, 'Fixed nullables can only be used with fixed-size codecs.');
-        assertIsFixedSizeCodec(prefix, 'Fixed nullables can only be used with fixed-size prefix.');
+        assertIsFixedSize(item, 'Fixed nullables can only be used with fixed-size codecs.');
+        assertIsFixedSize(prefix, 'Fixed nullables can only be used with fixed-size prefix.');
         const fixedSize = prefix.fixedSize + item.fixedSize;
         return createEncoder({
             fixedSize,
@@ -129,10 +129,10 @@ export function getNullableDecoder<TTo>(
     const fixed = config.fixed ?? false;
 
     let fixedSize: number | null = null;
-    const isZeroSizeItem = isFixedSizeCodec(item) && isFixedSizeCodec(prefix) && item.fixedSize === 0;
+    const isZeroSizeItem = isFixedSize(item) && isFixedSize(prefix) && item.fixedSize === 0;
     if (fixed || isZeroSizeItem) {
-        assertIsFixedSizeCodec(item, 'Fixed nullables can only be used with fixed-size codecs.');
-        assertIsFixedSizeCodec(prefix, 'Fixed nullables can only be used with fixed-size prefix.');
+        assertIsFixedSize(item, 'Fixed nullables can only be used with fixed-size codecs.');
+        assertIsFixedSize(prefix, 'Fixed nullables can only be used with fixed-size prefix.');
         fixedSize = prefix.fixedSize + item.fixedSize;
     }
 

--- a/packages/codecs-data-structures/src/utils.ts
+++ b/packages/codecs-data-structures/src/utils.ts
@@ -1,9 +1,9 @@
-import { isFixedSizeCodec } from '@solana/codecs-core';
+import { isFixedSize } from '@solana/codecs-core';
 
 export function maxCodecSizes(sizes: (number | null)[]): number | null {
     return sizes.reduce(
         (all, size) => (all === null || size === null ? null : Math.max(all, size)),
-        0 as number | null,
+        0 as number | null
     );
 }
 
@@ -12,9 +12,9 @@ export function sumCodecSizes(sizes: (number | null)[]): number | null {
 }
 
 export function getFixedSize(codec: { fixedSize: number } | { maxSize?: number }): number | null {
-    return isFixedSizeCodec(codec) ? codec.fixedSize : null;
+    return isFixedSize(codec) ? codec.fixedSize : null;
 }
 
 export function getMaxSize(codec: { fixedSize: number } | { maxSize?: number }): number | null {
-    return isFixedSizeCodec(codec) ? codec.fixedSize : codec.maxSize ?? null;
+    return isFixedSize(codec) ? codec.fixedSize : codec.maxSize ?? null;
 }


### PR DESCRIPTION
Applies [this suggestion](https://github.com/solana-labs/solana-web3.js/pull/1903#discussion_r1409663647) from a previous PR.
