### PR TITLE
refactor(experimental): bring `jsonParsed` types to parity

### DIFF
--- a/packages/rpc-core/src/rpc-methods/common-transactions.ts
+++ b/packages/rpc-core/src/rpc-methods/common-transactions.ts
@@ -23,8 +23,8 @@ type AddressTableLookup = Readonly<{
 
 type ParsedTransactionInstruction = Readonly<{
     parsed: {
-        type: string;
         info?: object;
+        type: string;
     };
     program: string;
     programId: Address;

--- a/packages/rpc-core/src/rpc-methods/common.ts
+++ b/packages/rpc-core/src/rpc-methods/common.ts
@@ -83,7 +83,10 @@ export type AccountInfoWithJsonData = Readonly<{
         | Readonly<{
               // Name of the program that owns this account.
               program: string;
-              parsed: unknown;
+              parsed: {
+                  info?: object;
+                  type: string;
+              };
               space: U64UnsafeBeyond2Pow53Minus1;
           }>
         // If `jsonParsed` encoding is requested but a parser cannot be found for the given


### PR DESCRIPTION
The types for `jsonParsed` encoding on `AccountInfo` and
`ParsedTransactionInstruction` are not matching, even though both response types
implement the same `jsonParsed` interface.

Bring these types to parity.
