### PR TITLE
chore: run CI on pull requests to all branches

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -2,7 +2,6 @@ name: Pull requests
 
 on:
   pull_request:
-    branches: [master]
 
 env:
   # Enables Turborepo Remote Caching.


### PR DESCRIPTION
Our new Graphite workflow means that the mergebase of stacked PRs is the PR before it. Since that is by definition not `master` this pull request workflow wasn't running.
