### PR TITLE
fix: make custodian signer for authorize and withdraw

### DIFF
--- a/packages/library-legacy/src/programs/stake.ts
+++ b/packages/library-legacy/src/programs/stake.ts
@@ -734,7 +734,7 @@ export class StakeProgram {
     if (custodianPubkey) {
       keys.push({
         pubkey: custodianPubkey,
-        isSigner: false,
+        isSigner: true,
         isWritable: false,
       });
     }
@@ -776,7 +776,7 @@ export class StakeProgram {
     if (custodianPubkey) {
       keys.push({
         pubkey: custodianPubkey,
-        isSigner: false,
+        isSigner: true,
         isWritable: false,
       });
     }
@@ -903,7 +903,7 @@ export class StakeProgram {
     if (custodianPubkey) {
       keys.push({
         pubkey: custodianPubkey,
-        isSigner: false,
+        isSigner: true,
         isWritable: false,
       });
     }


### PR DESCRIPTION
The `StakeProgram` instructions that considers the custodian does not allow to use it as a signer. That's an issue.
When the `authorize` is called then for staker the custodian on `Lockup` is not needed but for withdrawer the `custodian` signature is needed.
For `withdraw` when the custodian is provided then the signature should be expected as well.

https://github.com/solana-labs/solana/blob/v1.17.7/programs/stake/src/stake_state.rs#L1110
https://github.com/solana-labs/solana/blob/v1.17.7/sdk/program/src/stake/state.rs#L326

This PR is a kind of issue report with suggestion to fix. I can adjust when demanded.
