### PR TITLE
ci: add manual trigger for "publish packages"

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,6 +1,9 @@
 name: CI/CD
 
 on:
+  workflow_dispatch:
+    branches:
+      - master
   push:
     branches:
       - master


### PR DESCRIPTION
This change adds a manual trigger for "publish packages" CI/CD, in case we ever want to trigger a "publish packages" CI run from GitHub manually.

<https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow>