### PR TITLE
chore: stop building every package twice

### DIFF
--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -15,63 +15,69 @@ const BROWSERSLIST_TARGETS = browsersListToEsBuild()
     .filter(v => !v.endsWith('TP')) as Options['target'];
 
 export function getBaseConfig(platform: Platform, formats: Format[], _options: Options): Options[] {
-    return [true, false].flatMap<Options>(isDebugBuild =>
-        formats.map(format => ({
-            define: {
-                __BROWSER__: `${platform === 'browser'}`,
-                __NODEJS__: `${platform === 'node'}`,
-                __REACTNATIVE__: `${platform === 'native'}`,
-                __VERSION__: `"${env.npm_package_version}"`,
-            },
-            entry: [`./src/index.ts`],
-            esbuildOptions(options, context) {
-                const { format } = context;
-                options.minify = format === 'iife' && !isDebugBuild;
-                if (format === 'iife') {
-                    options.define = {
-                        ...options.define,
-                        __DEV__: `${isDebugBuild}`,
-                    };
-                    options.target = BROWSERSLIST_TARGETS;
-                }
-                options.inject = [path.resolve(__dirname, 'env-shim.ts')];
-            },
-            external: [
-                // Despite inlining `text-encoding-impl`, do not recursively inline `fastestsmallesttextencoderdecoder`.
-                'fastestsmallesttextencoderdecoder',
-                // Despite inlining `fetch-impl`, do not recursively inline `node-fetch`.
-                'node-fetch',
-                // Despite inlining `ws-impl`, do not recursively inline `ws`.
-                'ws',
-            ],
-            format,
-            globalName: 'globalThis.solanaWeb3',
-            name: platform,
-            // Inline private, non-published packages.
-            // WARNING: This inlines packages recursively. Make sure these don't have deep dep trees.
-            noExternal: [
-                // @noble/ed25519 is an ESM-only module, so we have to inline it in CJS builds.
-                ...(format === 'cjs' ? ['@noble/ed25519'] : []),
-                'crypto-impl',
-                'fetch-impl',
-                'text-encoding-impl',
-                'ws-impl',
-            ],
-            outExtension({ format }) {
-                let extension;
-                if (format === 'iife') {
-                    extension = `.${isDebugBuild ? 'development' : 'production.min'}.js`;
-                } else {
-                    extension = `.${platform}.${format === 'cjs' ? 'cjs' : 'js'}`;
-                }
-                return {
-                    js: extension,
-                };
-            },
-            platform: platform === 'node' ? 'node' : 'browser',
-            pure: ['process'],
-            sourcemap: isDebugBuild,
-            treeshake: true,
-        }))
-    );
+    return [true, false]
+        .flatMap<Options | null>(isDebugBuild =>
+            formats.map(format =>
+                format !== 'iife' && isDebugBuild
+                    ? null // We don't build debug builds for packages; only for the iife bundle.
+                    : {
+                          define: {
+                              __BROWSER__: `${platform === 'browser'}`,
+                              __NODEJS__: `${platform === 'node'}`,
+                              __REACTNATIVE__: `${platform === 'native'}`,
+                              __VERSION__: `"${env.npm_package_version}"`,
+                          },
+                          entry: [`./src/index.ts`],
+                          esbuildOptions(options, context) {
+                              const { format } = context;
+                              options.minify = format === 'iife' && !isDebugBuild;
+                              if (format === 'iife') {
+                                  options.define = {
+                                      ...options.define,
+                                      __DEV__: `${isDebugBuild}`,
+                                  };
+                                  options.target = BROWSERSLIST_TARGETS;
+                              }
+                              options.inject = [path.resolve(__dirname, 'env-shim.ts')];
+                          },
+                          external: [
+                              // Despite inlining `text-encoding-impl`, do not recursively inline `fastestsmallesttextencoderdecoder`.
+                              'fastestsmallesttextencoderdecoder',
+                              // Despite inlining `fetch-impl`, do not recursively inline `node-fetch`.
+                              'node-fetch',
+                              // Despite inlining `ws-impl`, do not recursively inline `ws`.
+                              'ws',
+                          ],
+                          format,
+                          globalName: 'globalThis.solanaWeb3',
+                          name: platform,
+                          // Inline private, non-published packages.
+                          // WARNING: This inlines packages recursively. Make sure these don't have deep dep trees.
+                          noExternal: [
+                              // @noble/ed25519 is an ESM-only module, so we have to inline it in CJS builds.
+                              ...(format === 'cjs' ? ['@noble/ed25519'] : []),
+                              'crypto-impl',
+                              'fetch-impl',
+                              'text-encoding-impl',
+                              'ws-impl',
+                          ],
+                          outExtension({ format }) {
+                              let extension;
+                              if (format === 'iife') {
+                                  extension = `.${isDebugBuild ? 'development' : 'production.min'}.js`;
+                              } else {
+                                  extension = `.${platform}.${format === 'cjs' ? 'cjs' : 'js'}`;
+                              }
+                              return {
+                                  js: extension,
+                              };
+                          },
+                          platform: platform === 'node' ? 'node' : 'browser',
+                          pure: ['process'],
+                          sourcemap: format !== 'iife' || isDebugBuild,
+                          treeshake: true,
+                      },
+            ),
+        )
+        .filter(Boolean) as Options[];
 }


### PR DESCRIPTION
`__DEV__` is only supposed to be replaced for the IIFE library builds. We were building every package twice here for no reason.

In limited testing, seems to speed up total-repo `compile:js` by about 5%.
