### PR TITLE
refactor(experimental): export the TransactionError type to consumers of @solana/rpc-core

### DIFF
--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -1,2 +1,3 @@
 export * from './rpc-methods';
 export * from './rpc-subscriptions';
+export * from './transaction-error';


### PR DESCRIPTION
This PR adds the `TransactionError` type to the exports of the `@solana/rpc-core` package. Note that this package is not currently re-exported by `@solana/web3.js`. 

This is useful for writing a wrapper function around `simulateTransaction` or `sendTransaction`, where you want to return a `TransactionError` if one is returned by the RPC calls.