### PR TITLE
You can now post-process params at selected keypaths

### DIFF
--- a/packages/rpc-core/src/__tests__/params-patcher-test.ts
+++ b/packages/rpc-core/src/__tests__/params-patcher-test.ts
@@ -1,4 +1,5 @@
 import { patchParamsForSolanaLabsRpc } from '../params-patcher';
+import { KeyPath, KEYPATH_WILDCARD } from '../patcher-types';
 
 describe('patchParamsForSolanaLabsRpc', () => {
     [10, '10', null, undefined, Symbol()].forEach(input => {
@@ -53,30 +54,77 @@ describe('patchParamsForSolanaLabsRpc', () => {
             'value below `Number.MAX_SAFE_INTEGER`': -BigInt(Number.MAX_SAFE_INTEGER) - 1n,
         }).forEach(([description, value]) => {
             it('calls `onIntegerOverflow` when passed a value ' + description, () => {
-                patchParamsForSolanaLabsRpc(value, onIntegerOverflow);
+                patchParamsForSolanaLabsRpc(value, { onIntegerOverflow });
                 expect(onIntegerOverflow).toHaveBeenCalledWith(
                     [], // Equivalent to `params`
                     value,
                 );
             });
             it('calls `onIntegerOverflow` when passed a nested array having a value ' + description, () => {
-                patchParamsForSolanaLabsRpc([1, 2, [3, value]], onIntegerOverflow);
+                patchParamsForSolanaLabsRpc([1, 2, [3, value]], { onIntegerOverflow });
                 expect(onIntegerOverflow).toHaveBeenCalledWith(
                     [2, 1], // Equivalent to `params[2][1]`.
                     value,
                 );
             });
             it('calls `onIntegerOverflow` when passed a nested object having a value ' + description, () => {
-                patchParamsForSolanaLabsRpc({ a: 1, b: { b1: 2, b2: value } }, onIntegerOverflow);
+                patchParamsForSolanaLabsRpc({ a: 1, b: { b1: 2, b2: value } }, { onIntegerOverflow });
                 expect(onIntegerOverflow).toHaveBeenCalledWith(
                     ['b', 'b2'], // Equivalent to `params.b.b2`.
                     value,
                 );
             });
             it('does not call `onIntegerOverflow` when passed `Number.MAX_SAFE_INTEGER`', () => {
-                patchParamsForSolanaLabsRpc(BigInt(Number.MAX_SAFE_INTEGER), onIntegerOverflow);
+                patchParamsForSolanaLabsRpc(BigInt(Number.MAX_SAFE_INTEGER), { onIntegerOverflow });
                 expect(onIntegerOverflow).not.toHaveBeenCalled();
             });
         });
     });
+    describe.each`
+        replacement      | keyPaths                     | params                                 | expectedTransformees           | expectedPatchedParams
+        ${'🍕'}          | ${[[KEYPATH_WILDCARD]]}      | ${[1, [2, 22], { foo: 3 }, 4]}         | ${[1, [2, 22], { foo: 3 }, 4]} | ${['🍕', '🍕', '🍕', '🍕']}
+        ${'🍕'}          | ${[[1, 1], [2, 'foo']]}      | ${[1, [2, 22], { foo: 3 }, 4]}         | ${[22, 3]}                     | ${[1, [2, '🍕'], { foo: '🍕' }, 4]}
+        ${'🍕'}          | ${[['foo', 1, 'bar']]}       | ${{ baz: 1, foo: [2, { bar: 3 }, 4] }} | ${[3]}                         | ${{ baz: 1, foo: [2, { bar: '🍕' }, 4] }}
+        ${'🍕'}          | ${[['foo'], ['foo', 'bar']]} | ${{ foo: { bar: 1 } }}                 | ${[{ bar: 1 }]}                | ${{ foo: '🍕' }}
+        ${'🍕'}          | ${[['foo'], ['foo']]}        | ${{ foo: { bar: 1 } }}                 | ${[{ bar: 1 }, '🍕']}          | ${{ foo: '🍕' }}
+        ${{ bar: '🍕' }} | ${[['foo'], ['foo', 'bar']]} | ${{ foo: 1 }}                          | ${[1, '🍕']}                   | ${{ foo: { bar: { bar: '🍕' } } }}
+        ${{ bar: '🍕' }} | ${[['foo', 'bar'], ['foo']]} | ${{ foo: 1 }}                          | ${[1, '🍕']}                   | ${{ foo: { bar: { bar: '🍕' } } }}
+    `(
+        'given a transformer with the key paths from test case $#',
+        ({
+            expectedTransformees,
+            expectedPatchedParams,
+            keyPaths,
+            params,
+            replacement,
+        }: {
+            expectedPatchedParams: unknown;
+            expectedTransformees: unknown[];
+            keyPaths: KeyPath[];
+            params: unknown;
+            replacement: unknown;
+        }) => {
+            let nodeTransformersForKeyPaths: NonNullable<
+                NonNullable<Parameters<typeof patchParamsForSolanaLabsRpc>[1]>['nodeTransformersForKeyPaths']
+            >;
+            let nodeTransformer: jest.Mock;
+            beforeEach(() => {
+                nodeTransformer = jest.fn().mockReturnValue(replacement);
+                nodeTransformersForKeyPaths = keyPaths.map(keyPath => [keyPath, nodeTransformer]);
+            });
+            it('calls the transformer with the expected nodes', () => {
+                expect.hasAssertions();
+                patchParamsForSolanaLabsRpc(params, { nodeTransformersForKeyPaths });
+                expectedTransformees.forEach((transformee, ii) => {
+                    expect(nodeTransformer).toHaveBeenNthCalledWith(ii + 1, transformee);
+                });
+                expect(nodeTransformer).toHaveBeenCalledTimes(expectedTransformees.length);
+            });
+            it('replaces the nodes with the output of the transformer', () => {
+                expect(patchParamsForSolanaLabsRpc(params, { nodeTransformersForKeyPaths })).toStrictEqual(
+                    expectedPatchedParams,
+                );
+            });
+        },
+    );
 });

--- a/packages/rpc-core/src/__tests__/response-patcher-test.ts
+++ b/packages/rpc-core/src/__tests__/response-patcher-test.ts
@@ -1,6 +1,6 @@
+import { KEYPATH_WILDCARD } from '../patcher-types';
 import { patchResponseForSolanaLabsRpc } from '../response-patcher';
 import { getAllowedNumericKeypathsForResponse } from '../response-patcher-allowed-numeric-values';
-import { KEYPATH_WILDCARD } from '../response-patcher-types';
 
 jest.mock('../response-patcher-allowed-numeric-values');
 

--- a/packages/rpc-core/src/params-patcher.ts
+++ b/packages/rpc-core/src/params-patcher.ts
@@ -1,35 +1,77 @@
+import { KeyPath, KEYPATH_WILDCARD } from './patcher-types';
+
+type Config = Readonly<{
+    nodeTransformersForKeyPaths?: readonly NodeTransformerForKeyPath[];
+    onIntegerOverflow?: IntegerOverflowHandler;
+}>;
 type IntegerOverflowHandler = (keyPath: (number | string)[], value: bigint) => void;
+type NodeTransformer = <T>(node: T) => unknown;
+type NodeTransformerForKeyPath = readonly [KeyPath, NodeTransformer];
 type Patched<T> = T extends object ? { [Property in keyof T]: Patched<T[Property]> } : T extends bigint ? number : T;
 // FIXME(https://github.com/microsoft/TypeScript/issues/33014)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TypescriptBug33014 = any;
 
-function visitNode<T>(value: T, keyPath: (number | string)[], onIntegerOverflow?: IntegerOverflowHandler): Patched<T> {
-    if (Array.isArray(value)) {
-        return value.map((element, ii) =>
-            visitNode(element, [...keyPath, ii], onIntegerOverflow),
-        ) as TypescriptBug33014;
-    } else if (typeof value === 'object' && value !== null) {
+function getNextNodeTransformersForKeyPaths(
+    nodeTransformersForKeyPaths: readonly NodeTransformerForKeyPath[],
+    property: number | string,
+): NodeTransformerForKeyPath[] {
+    return nodeTransformersForKeyPaths
+        .filter(
+            ([keyPath]) => (keyPath[0] === KEYPATH_WILDCARD && typeof property === 'number') || keyPath[0] === property,
+        )
+        .map(([keyPath, ...rest]) => [keyPath.slice(1), ...rest]);
+}
+
+function visitNode<T>(
+    value: T,
+    keyPath: (number | string)[],
+    nodeTransformersForKeyPaths: readonly NodeTransformerForKeyPath[],
+    onIntegerOverflow?: IntegerOverflowHandler,
+): Patched<T> {
+    const transformedValue = nodeTransformersForKeyPaths
+        // Select transformers whose key path has been fully consumed on the way to this node.
+        // This implies that the transformer is destined for this node and should be applied now.
+        .filter(([keyPath]) => keyPath.length === 0)
+        .reduce<unknown>((acc, [_, nodeTransformer]) => nodeTransformer(acc), value) as T;
+    if (Array.isArray(transformedValue)) {
+        return transformedValue.map((element, ii) => {
+            const nextTransformersForKeyPaths = getNextNodeTransformersForKeyPaths(nodeTransformersForKeyPaths, ii);
+            return visitNode(element, [...keyPath, ii], nextTransformersForKeyPaths, onIntegerOverflow);
+        }) as TypescriptBug33014;
+    } else if (typeof transformedValue === 'object' && transformedValue !== null) {
         const out = {} as TypescriptBug33014;
-        for (const propName in value) {
-            if (Object.prototype.hasOwnProperty.call(value, propName)) {
-                out[propName] = visitNode(value[propName], [...keyPath, propName], onIntegerOverflow);
+        for (const propName in transformedValue) {
+            if (Object.prototype.hasOwnProperty.call(transformedValue, propName)) {
+                const nextTransformersForKeyPaths = getNextNodeTransformersForKeyPaths(
+                    nodeTransformersForKeyPaths,
+                    propName,
+                );
+                out[propName] = visitNode(
+                    transformedValue[propName],
+                    [...keyPath, propName],
+                    nextTransformersForKeyPaths,
+                    onIntegerOverflow,
+                );
             }
         }
         return out as TypescriptBug33014;
-    } else if (typeof value === 'bigint') {
+    } else if (typeof transformedValue === 'bigint') {
         // FIXME(solana-labs/solana/issues/30341) Create a data type to represent u64 in the Solana
         // JSON RPC implementation so that we can throw away this entire patcher instead of unsafely
         // downcasting `bigints` to `numbers`.
-        if (onIntegerOverflow && (value > Number.MAX_SAFE_INTEGER || value < -Number.MAX_SAFE_INTEGER)) {
-            onIntegerOverflow(keyPath, value);
+        if (
+            onIntegerOverflow &&
+            (transformedValue > Number.MAX_SAFE_INTEGER || transformedValue < -Number.MAX_SAFE_INTEGER)
+        ) {
+            onIntegerOverflow(keyPath, transformedValue);
         }
-        return Number(value) as TypescriptBug33014;
+        return Number(transformedValue) as TypescriptBug33014;
     } else {
-        return value as TypescriptBug33014;
+        return transformedValue as Patched<T>;
     }
 }
 
-export function patchParamsForSolanaLabsRpc<T>(params: T, onIntegerOverflow?: IntegerOverflowHandler): Patched<T> {
-    return visitNode(params, [], onIntegerOverflow);
+export function patchParamsForSolanaLabsRpc<T>(params: T, config?: Config): Patched<T> {
+    return visitNode(params, [], config?.nodeTransformersForKeyPaths ?? [], config?.onIntegerOverflow);
 }

--- a/packages/rpc-core/src/patcher-types.ts
+++ b/packages/rpc-core/src/patcher-types.ts
@@ -1,3 +1,4 @@
+export type KeyPath = ReadonlyArray<KeyPathWildcard | number | string | KeyPath>;
 export type KeyPathWildcard = { readonly __brand: unique symbol };
 
 export const KEYPATH_WILDCARD = {} as KeyPathWildcard;

--- a/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
+++ b/packages/rpc-core/src/response-patcher-allowed-numeric-values.ts
@@ -1,7 +1,6 @@
 import type { IRpcSubscriptionsApi } from '@solana/rpc-transport';
 
-import { KeyPath } from './response-patcher';
-import { KEYPATH_WILDCARD } from './response-patcher-types';
+import { KeyPath, KEYPATH_WILDCARD } from './patcher-types';
 import { createSolanaRpcApi } from './rpc-methods';
 import { SolanaRpcSubscriptions, SolanaRpcSubscriptionsUnstable } from './rpc-subscriptions';
 

--- a/packages/rpc-core/src/response-patcher.ts
+++ b/packages/rpc-core/src/response-patcher.ts
@@ -1,12 +1,11 @@
+import { KeyPath, KEYPATH_WILDCARD } from './patcher-types';
 import {
     getAllowedNumericKeypathsForNotification,
     getAllowedNumericKeypathsForResponse,
 } from './response-patcher-allowed-numeric-values';
-import { KEYPATH_WILDCARD, KeyPathWildcard } from './response-patcher-types';
 import { createSolanaRpcApi } from './rpc-methods';
 import { createSolanaRpcSubscriptionsApi } from './rpc-subscriptions';
 
-export type KeyPath = ReadonlyArray<KeyPathWildcard | number | string | KeyPath>;
 // FIXME(https://github.com/microsoft/TypeScript/issues/33014)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TypescriptBug33014 = any;


### PR DESCRIPTION
# Summary

The goal of the next PR is to default the commitment to `confirmed` for all methods that involve commitment. This overrides the server default of `finalized`, which we believe not to be practical for most use cases.

This PR adds infrastructure to allow you to inject node transformers that operate at key paths. See how this is used in the next PR.

# Test plan

```
cd packages/rpc-core/
pnpm test:unit:browser
pnpm test:unit:node
```
