### PR TITLE
refactor(experimental): use scoped APIs in rpc-core tests

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-account-info-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-account-info-test.ts
@@ -4,18 +4,18 @@ import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetAccountInfoApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getAccountInfo', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetAccountInfoApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetAccountInfoApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-balance-test.ts
@@ -4,14 +4,14 @@ import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetBalanceApi } from '../index';
 
 describe('getBalance', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetBalanceApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetBalanceApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-block-height.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-block-height.ts
@@ -3,14 +3,14 @@ import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetBlockHeightApi } from '../index';
 
 describe('getBlockHeight', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetBlockHeightApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetBlockHeightApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-block-production-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-block-production-test.ts
@@ -4,18 +4,18 @@ import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetBlockProductionApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getBlockProduction', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetBlockProductionApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetBlockProductionApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-block-time-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-block-time-test.ts
@@ -1,14 +1,14 @@
 import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCode } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetBlockTimeApi } from '../index';
 
 describe('getBlockTime', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetBlockTimeApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetBlockTimeApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-cluster-nodes-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-cluster-nodes-test.ts
@@ -4,7 +4,7 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import fetchMock from 'jest-fetch-mock-fork';
 import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetClusterNodesApi } from '../index';
 
 const logFilePath = path.resolve(__dirname, '../../../../../test-ledger/validator.log');
 
@@ -61,11 +61,11 @@ async function getNodeInfoFromLogFile() {
 }
 
 describe('getClusterNodes', () => {
-    let mockRpc: Rpc<SolanaRpcMethods>;
+    let mockRpc: Rpc<GetClusterNodesApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        mockRpc = createJsonRpc<SolanaRpcMethods>({
+        mockRpc = createJsonRpc<GetClusterNodesApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-epoch-info-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-epoch-info-test.ts
@@ -2,14 +2,14 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetEpochInfoApi } from '../index';
 
 describe('getEpochInfo', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetEpochInfoApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetEpochInfoApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-epoch-schedule-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-epoch-schedule-test.ts
@@ -1,14 +1,14 @@
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetEpochScheduleApi } from '../index';
 
 describe('getEpochSchedule', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetEpochScheduleApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetEpochScheduleApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-fee-for-message-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-fee-for-message-test.ts
@@ -5,7 +5,7 @@ import { Commitment } from '@solana/rpc-types';
 import { Blockhash, SerializedMessageBytesBase64 } from '@solana/transactions';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetFeeForMessageApi, GetLatestBlockhashApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
@@ -55,11 +55,11 @@ function getMockTransactionMessage(blockhash: Blockhash) {
 }
 
 describe('getFeeForMessage', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetFeeForMessageApi & GetLatestBlockhashApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetFeeForMessageApi & GetLatestBlockhashApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-first-available-block-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-first-available-block-test.ts
@@ -1,14 +1,14 @@
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetFirstAvailableBlockApi } from '../index';
 
 describe('getFirstAvailableBlock', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetFirstAvailableBlockApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetFirstAvailableBlockApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-genesis-hash-test.ts
@@ -4,7 +4,7 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import fetchMock from 'jest-fetch-mock-fork';
 import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetGenesisHashApi } from '../index';
 
 const logFilePath = path.resolve(__dirname, '../../../../../test-ledger/validator.log');
 const genesisHashPattern = /genesis hash: ([\d\w]{32,})/;
@@ -25,11 +25,11 @@ async function getGenesisHashFromLogFile() {
 }
 
 describe('getGenesisHash', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetGenesisHashApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetGenesisHashApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-health-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-health-test.ts
@@ -1,14 +1,14 @@
 import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCode } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetHealthApi } from '../index';
 
 describe('getHealth', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetHealthApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetHealthApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-identity-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-identity-test.ts
@@ -6,7 +6,7 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import fetchMock from 'jest-fetch-mock-fork';
 import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetIdentityApi } from '../index';
 
 const validatorKeypairPath = path.resolve(__dirname, '../../../../../test-ledger/validator-keypair.json');
 
@@ -30,11 +30,11 @@ async function getValidatorAddress() {
 }
 
 describe('getIdentity', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetIdentityApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetIdentityApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-governor-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-governor-test.ts
@@ -2,14 +2,14 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetInflationGovernorApi } from '../index';
 
 describe('getInflationGovernor', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetInflationGovernorApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetInflationGovernorApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-rate-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-rate-test.ts
@@ -1,14 +1,14 @@
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetInflationRateApi } from '../index';
 
 describe('getInflationRate', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetInflationRateApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetInflationRateApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-reward-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-inflation-reward-test.ts
@@ -2,14 +2,14 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetInflationRewardApi } from '../index';
 
 describe('getInflationReward', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetInflationRewardApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetInflationRewardApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-largest-accounts-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-largest-accounts-test.ts
@@ -7,7 +7,7 @@ import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetLargestAccountsApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
@@ -37,11 +37,11 @@ async function getNodeAddress(path: string) {
 }
 
 describe('getLargestAccounts', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetLargestAccountsApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetLargestAccountsApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-latest-blockhash-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-latest-blockhash-test.ts
@@ -2,18 +2,18 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetLatestBlockhashApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getLatestBlockhash', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetLatestBlockhashApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetLatestBlockhashApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
@@ -7,7 +7,7 @@ import { open } from 'fs/promises';
 import fetchMock from 'jest-fetch-mock-fork';
 import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetLeaderScheduleApi } from '../index';
 
 const validatorKeypairPath = path.resolve(__dirname, '../../../../../test-ledger/validator-keypair.json');
 
@@ -31,11 +31,11 @@ async function getValidatorAddress() {
 }
 
 describe('getLeaderSchedule', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetLeaderScheduleApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetLeaderScheduleApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-max-retransmit-slot-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-max-retransmit-slot-test.ts
@@ -1,14 +1,14 @@
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetMaxRetransmitSlotApi } from '../index';
 
 describe('getMaxRetransmitSlot', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetMaxRetransmitSlotApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetMaxRetransmitSlotApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-max-shred-insert-slot-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-max-shred-insert-slot-test.ts
@@ -1,14 +1,14 @@
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetMaxShredInsertSlotApi } from '../index';
 
 describe('getMaxShredInsertSlot', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetMaxShredInsertSlotApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetMaxShredInsertSlotApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-minimum-balance-for-rent-exemption-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-minimum-balance-for-rent-exemption-test.ts
@@ -2,14 +2,14 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetMinimumBalanceForRentExemptionApi } from '../index';
 
 describe('getMinimumBalanceForRentExemption', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetMinimumBalanceForRentExemptionApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-multiple-accounts-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-multiple-accounts-test.ts
@@ -3,18 +3,18 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetMultipleAccountsApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getMultipleAccounts', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetMultipleAccountsApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetMultipleAccountsApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-program-accounts-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-program-accounts-test.ts
@@ -7,7 +7,7 @@ import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetProgramAccountsApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
@@ -36,11 +36,11 @@ async function getNodeAddress(path: string) {
 }
 
 describe('getProgramAccounts', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetProgramAccountsApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetProgramAccountsApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-recent-prioritization-fees-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-recent-prioritization-fees-test.ts
@@ -2,14 +2,14 @@ import { Address } from '@solana/addresses';
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetRecentPrioritizationFeesApi } from '../index';
 
 describe('getRecentPrioritizationFees', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetRecentPrioritizationFeesApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetRecentPrioritizationFeesApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-signature-statuses-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-signature-statuses-test.ts
@@ -2,18 +2,18 @@ import { Signature } from '@solana/keys';
 import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCode } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetSignatureStatusesApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getSignatureStatuses', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetSignatureStatusesApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetSignatureStatusesApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-signatures-for-address-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-signatures-for-address-test.ts
@@ -2,14 +2,14 @@ import { Address } from '@solana/addresses';
 import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCode } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../../index';
+import { createSolanaRpcApi, GetSignaturesForAddressApi } from '../../index';
 
 describe('getSignaturesForAddress', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetSignaturesForAddressApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetSignaturesForAddressApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leader-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leader-test.ts
@@ -7,7 +7,7 @@ import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetSlotLeaderApi } from '../index';
 
 const validatorKeypairPath = path.resolve(__dirname, '../../../../../test-ledger/validator-keypair.json');
 
@@ -31,11 +31,11 @@ async function getValidatorAddress() {
 }
 
 describe('getSlotLeader', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetSlotLeaderApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetSlotLeaderApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leaders-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-slot-leaders-test.ts
@@ -6,7 +6,7 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import fetchMock from 'jest-fetch-mock-fork';
 import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetSlotLeadersApi } from '../index';
 
 const validatorKeypairPath = path.resolve(__dirname, '../../../../../test-ledger/validator-keypair.json');
 
@@ -30,11 +30,11 @@ async function getValidatorAddress() {
 }
 
 describe('getSlotLeaders', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetSlotLeadersApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetSlotLeadersApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-slot-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-slot-test.ts
@@ -2,14 +2,14 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetSlotApi } from '../index';
 
 describe('getSlot', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetSlotApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetSlotApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-stake-activation-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-stake-activation-test.ts
@@ -3,17 +3,17 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetStakeActivationApi } from '../index';
 
 // See scripts/fixtures/stake-account.json
 const stakeAccountAddress = 'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN' as Address;
 
 describe('getStakeActivation', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetStakeActivationApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetStakeActivationApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-stake-minimum-delegation-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-stake-minimum-delegation-test.ts
@@ -2,14 +2,14 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetStakeMinimumDelegationApi } from '../index';
 
 describe('getStakeMinimumDelegation', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetStakeMinimumDelegationApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetStakeMinimumDelegationApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-supply-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-supply-test.ts
@@ -2,18 +2,18 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetSupplyApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getSupply', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetSupplyApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetSupplyApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-token-account-balance-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-token-account-balance-test.ts
@@ -3,18 +3,18 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetTokenAccountBalanceApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getTokenAccountBalance', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetTokenAccountBalanceApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetTokenAccountBalanceApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-token-accounts-by-delegate-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-token-accounts-by-delegate-test.ts
@@ -3,18 +3,18 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetTokenAccountsByDelegateApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getTokenAccountsByDelegate', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetTokenAccountsByDelegateApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetTokenAccountsByDelegateApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-token-accounts-by-owner-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-token-accounts-by-owner-test.ts
@@ -3,18 +3,18 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetTokenAccountsByOwnerApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getTokenAccountsByOwner', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetTokenAccountsByOwnerApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetTokenAccountsByOwnerApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-token-largest-accounts-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-token-largest-accounts-test.ts
@@ -3,18 +3,18 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetTokenLargestAccountsApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getTokenLargestAccounts', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetTokenLargestAccountsApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetTokenLargestAccountsApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-token-supply-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-token-supply-test.ts
@@ -3,18 +3,18 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetTokenSupplyApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
 });
 
 describe('getTokenSupply', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetTokenSupplyApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetTokenSupplyApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-transaction-count-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-transaction-count-test.ts
@@ -2,14 +2,14 @@ import { createHttpTransport, createJsonRpc, type Rpc, type SolanaJsonRpcErrorCo
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetTransactionCountApi } from '../index';
 
 describe('getTransactionCount', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetTransactionCountApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetTransactionCountApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-transaction-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-transaction-test.ts
@@ -1,13 +1,13 @@
 // import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
-// import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+// import { createSolanaRpcApi, GetTransactionApi } from '../index';
 
 describe('getTransaction', () => {
-    // let rpc: Rpc<SolanaRpcMethods>;
+    // let rpc: Rpc<GetTransactionApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        // rpc = createJsonRpc<SolanaRpcMethods>({
+        // rpc = createJsonRpc<GetTransactionApi>({
         //   api: createSolanaRpcApi(),
         //   transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         // });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-version-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-version-test.ts
@@ -4,7 +4,7 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import fetchMock from 'jest-fetch-mock-fork';
 import path from 'path';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetVersionApi } from '../index';
 
 const logFilePath = path.resolve(__dirname, '../../../../../test-ledger/validator.log');
 const featureSetPattern = /feat:([\d]+)/;
@@ -35,11 +35,11 @@ async function getVersionFromLogFile() {
 }
 
 describe('getVersion', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetVersionApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetVersionApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/get-vote-accounts.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-vote-accounts.ts
@@ -3,14 +3,14 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import { Commitment } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetVoteAccountsApi } from '../index';
 
 describe('getVoteAccounts', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetVoteAccountsApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetVoteAccountsApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/is-blockhash-valid-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/is-blockhash-valid-test.ts
@@ -3,14 +3,14 @@ import { Commitment } from '@solana/rpc-types';
 import { Blockhash } from '@solana/transactions';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, IsBlockhashValidApi } from '../index';
 
 describe('isBlockhashValid', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<IsBlockhashValidApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<IsBlockhashValidApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/minimum-ledger-slot-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/minimum-ledger-slot-test.ts
@@ -1,14 +1,14 @@
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, MinimumLedgerSlotApi } from '../index';
 
 describe('minimumLedgerSlot', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<MinimumLedgerSlotApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<MinimumLedgerSlotApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/request-airdrop-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/request-airdrop-test.ts
@@ -4,14 +4,14 @@ import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transp
 import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, RequestAirdropApi } from '../index';
 
 describe('requestAirdrop', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<RequestAirdropApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<RequestAirdropApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/send-transaction-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/send-transaction-test.ts
@@ -6,7 +6,7 @@ import { Commitment } from '@solana/rpc-types';
 import { Base64EncodedWireTransaction } from '@solana/transactions';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetLatestBlockhashApi, SendTransactionApi } from '../index';
 
 function getMockTransactionMessage({
     blockhash,
@@ -68,11 +68,11 @@ async function getSecretKey() {
 }
 
 describe('sendTransaction', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<SendTransactionApi & GetLatestBlockhashApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<SendTransactionApi & GetLatestBlockhashApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__tests__/simulate-transaction-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/simulate-transaction-test.ts
@@ -8,7 +8,7 @@ import { Base64EncodedWireTransaction } from '@solana/transactions';
 import fetchMock from 'jest-fetch-mock-fork';
 
 import { Base58EncodedBytes } from '../common';
-import { createSolanaRpcApi, SolanaRpcMethods } from '../index';
+import { createSolanaRpcApi, GetLatestBlockhashApi, SimulateTransactionApi } from '../index';
 
 const CONTEXT_MATCHER = expect.objectContaining({
     slot: expect.any(BigInt),
@@ -122,11 +122,11 @@ async function getSecretKey() {
 }
 
 describe('simulateTransaction', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<SimulateTransactionApi & GetLatestBlockhashApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<SimulateTransactionApi & GetLatestBlockhashApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-block-type-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-block-type-test.ts
@@ -4,7 +4,7 @@ import { LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 import { Blockhash, TransactionVersion } from '@solana/transactions';
 
 import { TransactionError } from '../../transaction-error';
-import { SolanaRpcMethods } from '..';
+import { GetBlockApi } from '..';
 import {
     Base58EncodedBytes,
     Base58EncodedDataResponse,
@@ -19,7 +19,7 @@ function assertNotAProperty<T extends object, TPropName extends string>(
     _propName: TPropName,
 ): void {}
 
-const rpc = null as unknown as Rpc<SolanaRpcMethods>;
+const rpc = null as unknown as Rpc<GetBlockApi>;
 
 function assertBase(
     response: {

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -156,6 +156,7 @@ export type {
     GetSignatureStatusesApi,
     GetSlotApi,
     GetSlotLeaderApi,
+    GetSlotLeadersApi,
     GetStakeActivationApi,
     GetStakeMinimumDelegationApi,
     GetSupplyApi,

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
@@ -1,14 +1,14 @@
 import { createJsonSubscriptionRpc, createWebSocketTransport, type RpcSubscriptions } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { createSolanaRpcSubscriptionsApi, SolanaRpcSubscriptions } from '../index';
+import { createSolanaRpcSubscriptionsApi, SlotNotificationsApi } from '../index';
 
 describe('slotNotifications', () => {
-    let rpc: RpcSubscriptions<SolanaRpcSubscriptions>;
+    let rpc: RpcSubscriptions<SlotNotificationsApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonSubscriptionRpc<SolanaRpcSubscriptions>({
+        rpc = createJsonSubscriptionRpc<SlotNotificationsApi>({
             api: createSolanaRpcSubscriptionsApi(),
             transport: createWebSocketTransport({
                 sendBufferHighWatermark: Number.POSITIVE_INFINITY,

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/slots-updates-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/slots-updates-notifications-test.ts
@@ -1,18 +1,14 @@
 import { createJsonSubscriptionRpc, createWebSocketTransport, type RpcSubscriptions } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import {
-    createSolanaRpcSubscriptionsApi_UNSTABLE,
-    SolanaRpcSubscriptions,
-    SolanaRpcSubscriptionsUnstable,
-} from '../index';
+import { createSolanaRpcSubscriptionsApi_UNSTABLE, SlotsUpdatesNotificationsApi } from '../index';
 
 describe('slotsUpdatesNotifications', () => {
-    let rpc: RpcSubscriptions<SolanaRpcSubscriptions & SolanaRpcSubscriptionsUnstable>;
+    let rpc: RpcSubscriptions<SlotsUpdatesNotificationsApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonSubscriptionRpc<SolanaRpcSubscriptions & SolanaRpcSubscriptionsUnstable>({
+        rpc = createJsonSubscriptionRpc<SlotsUpdatesNotificationsApi>({
             api: createSolanaRpcSubscriptionsApi_UNSTABLE(),
             transport: createWebSocketTransport({
                 sendBufferHighWatermark: Number.POSITIVE_INFINITY,

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/vote-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/vote-notifications-test.ts
@@ -1,18 +1,14 @@
 import { createJsonSubscriptionRpc, createWebSocketTransport, type RpcSubscriptions } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import {
-    createSolanaRpcSubscriptionsApi_UNSTABLE,
-    SolanaRpcSubscriptions,
-    SolanaRpcSubscriptionsUnstable,
-} from '../index';
+import { createSolanaRpcSubscriptionsApi_UNSTABLE, VoteNotificationsApi } from '../index';
 
 describe('voteNotifications', () => {
-    let rpc: RpcSubscriptions<SolanaRpcSubscriptions & SolanaRpcSubscriptionsUnstable>;
+    let rpc: RpcSubscriptions<VoteNotificationsApi>;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonSubscriptionRpc<SolanaRpcSubscriptions & SolanaRpcSubscriptionsUnstable>({
+        rpc = createJsonSubscriptionRpc<VoteNotificationsApi>({
             api: createSolanaRpcSubscriptionsApi_UNSTABLE(),
             transport: createWebSocketTransport({
                 sendBufferHighWatermark: Number.POSITIVE_INFINITY,

--- a/packages/rpc-core/src/rpc-subscriptions/index.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/index.ts
@@ -48,4 +48,14 @@ export function createSolanaRpcSubscriptionsApi_UNSTABLE(
     >;
 }
 
-export type { AccountNotificationsApi, SignatureNotificationsApi, SlotNotificationsApi };
+export type {
+    AccountNotificationsApi,
+    BlockNotificationsApi,
+    LogsNotificationsApi,
+    ProgramNotificationsApi,
+    RootNotificationsApi,
+    SignatureNotificationsApi,
+    SlotNotificationsApi,
+    SlotsUpdatesNotificationsApi,
+    VoteNotificationsApi,
+};


### PR DESCRIPTION
This PR enforces the use of scoped RPC APIs in tests for `@solana/rpc-core`.
