### PR TITLE
refactor(experimental): use scoped APIs in rpc-graphql tests

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1,16 +1,22 @@
-import { createSolanaRpcApi, SolanaRpcMethods } from '@solana/rpc-core';
+import {
+    createSolanaRpcApi,
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+} from '@solana/rpc-core';
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
 import { createRpcGraphQL, RpcGraphQL } from '../rpc';
 
 describe('account', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>;
     let rpcGraphQL: RpcGraphQL;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -1,4 +1,11 @@
-import { createSolanaRpcApi, type Slot, type SolanaRpcMethods } from '@solana/rpc-core';
+import {
+    createSolanaRpcApi,
+    type GetAccountInfoApi,
+    GetBlockApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    type Slot,
+} from '@solana/rpc-core';
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
@@ -14,7 +21,7 @@ import {
 } from './__setup__';
 
 describe('block', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>;
     let rpcGraphQL: RpcGraphQL;
 
     // Random slot for testing.
@@ -24,7 +31,7 @@ describe('block', () => {
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -1,16 +1,22 @@
-import { createSolanaRpcApi, SolanaRpcMethods } from '@solana/rpc-core';
+import {
+    createSolanaRpcApi,
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+} from '@solana/rpc-core';
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
 import { createRpcGraphQL, RpcGraphQL } from '../rpc';
 
 describe('programAccounts', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>;
     let rpcGraphQL: RpcGraphQL;
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1,5 +1,11 @@
 import { Signature } from '@solana/keys';
-import { createSolanaRpcApi, SolanaRpcMethods } from '@solana/rpc-core';
+import {
+    createSolanaRpcApi,
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+} from '@solana/rpc-core';
 import { createHttpTransport, createJsonRpc, type Rpc } from '@solana/rpc-transport';
 import fetchMock from 'jest-fetch-mock-fork';
 
@@ -16,7 +22,7 @@ import {
 } from './__setup__';
 
 describe('transaction', () => {
-    let rpc: Rpc<SolanaRpcMethods>;
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>;
     let rpcGraphQL: RpcGraphQL;
 
     // Random signature for testing.
@@ -27,7 +33,7 @@ describe('transaction', () => {
     beforeEach(() => {
         fetchMock.resetMocks();
         fetchMock.dontMock();
-        rpc = createJsonRpc<SolanaRpcMethods>({
+        rpc = createJsonRpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>({
             api: createSolanaRpcApi(),
             transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
         });


### PR DESCRIPTION
This PR enforces scoped RPC APIs in tests for `@solana/rpc-graphql`.
