### PR TITLE
refactor(experimental): use scoped APIs in rpc-graphql

### DIFF
--- a/packages/rpc-graphql/src/loaders/account.ts
+++ b/packages/rpc-graphql/src/loaders/account.ts
@@ -1,4 +1,3 @@
-import { SolanaRpcMethods } from '@solana/rpc-core';
 import DataLoader from 'dataloader';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -24,7 +23,7 @@ function normalizeArgs({
 /* Load an account from the RPC, transform it, then return it */
 async function loadAccount(rpc: Rpc, { address, ...config }: ReturnType<typeof normalizeArgs>) {
     const account = await rpc
-        .getAccountInfo(address, config as Parameters<SolanaRpcMethods['getAccountInfo']>[1])
+        .getAccountInfo(address, config)
         .send()
         .then(res => res.value)
         .catch(e => {

--- a/packages/rpc-graphql/src/loaders/block.ts
+++ b/packages/rpc-graphql/src/loaders/block.ts
@@ -1,4 +1,3 @@
-import { SolanaRpcMethods } from '@solana/rpc-core';
 import DataLoader from 'dataloader';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -30,7 +29,11 @@ function normalizeArgs({
 /* Load a block from the RPC, transform it, then return it */
 async function loadBlock(rpc: Rpc, { slot, ...config }: ReturnType<typeof normalizeArgs>) {
     const block = await rpc
-        .getBlock(slot, config as unknown as Parameters<SolanaRpcMethods['getBlock']>[1])
+        .getBlock(
+            slot,
+            // @ts-expect-error FIXME: https://github.com/solana-labs/solana-web3.js/issues/1984
+            config,
+        )
         .send()
         .catch(e => {
             throw e;

--- a/packages/rpc-graphql/src/loaders/program-accounts.ts
+++ b/packages/rpc-graphql/src/loaders/program-accounts.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { SolanaRpcMethods } from '@solana/rpc-core';
 import DataLoader from 'dataloader';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -26,14 +24,8 @@ function normalizeArgs({
 /* Load a program's accounts from the RPC, transform them, then return them */
 async function loadProgramAccounts(rpc: Rpc, { programAddress, ...config }: ReturnType<typeof normalizeArgs>) {
     const programAccounts = await rpc
-        .getProgramAccounts(programAddress, config as Parameters<SolanaRpcMethods['getProgramAccounts']>[1])
+        .getProgramAccounts(programAddress, config)
         .send()
-        .then(res => {
-            if ('value' in res) {
-                return res.value as ReturnType<SolanaRpcMethods['getProgramAccounts']>;
-            }
-            return res as ReturnType<SolanaRpcMethods['getProgramAccounts']>;
-        })
         .catch(e => {
             throw e;
         });

--- a/packages/rpc-graphql/src/loaders/transaction.ts
+++ b/packages/rpc-graphql/src/loaders/transaction.ts
@@ -1,10 +1,10 @@
-import { SolanaRpcMethods } from '@solana/rpc-core';
 import DataLoader from 'dataloader';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import fastStableStringify from 'fast-stable-stringify';
 import { GraphQLResolveInfo } from 'graphql';
 
+import { TransactionVersion } from '../../../transactions/dist/types';
 import type { Rpc } from '../context';
 import { TransactionQueryArgs } from '../schema/transaction';
 import { onlyPresentFieldRequested } from './common/resolve-info';
@@ -16,7 +16,7 @@ function normalizeArgs({ commitment = 'confirmed', encoding = 'jsonParsed', sign
         commitment,
         encoding,
         // Always use 0 to avoid silly errors
-        maxSupportedTransactionVersion: 0,
+        maxSupportedTransactionVersion: 0 as TransactionVersion,
         signature,
     };
 }
@@ -26,7 +26,11 @@ async function loadTransaction(rpc: Rpc, { signature, ...config }: ReturnType<ty
     const { encoding } = config;
 
     const transaction = await rpc
-        .getTransaction(signature, config as unknown as Parameters<SolanaRpcMethods['getTransaction']>[1])
+        .getTransaction(
+            signature,
+            // @ts-expect-error FIXME: https://github.com/solana-labs/solana-web3.js/issues/1984
+            config,
+        )
         .send()
         .catch(e => {
             throw e;
@@ -42,7 +46,11 @@ async function loadTransaction(rpc: Rpc, { signature, ...config }: ReturnType<ty
     if (encoding !== 'jsonParsed') {
         const jsonParsedConfig = { ...config, encoding: 'jsonParsed' };
         const transactionJsonParsed = await rpc
-            .getTransaction(signature, jsonParsedConfig as unknown as Parameters<SolanaRpcMethods['getTransaction']>[1])
+            .getTransaction(
+                signature,
+                // @ts-expect-error FIXME: https://github.com/solana-labs/solana-web3.js/issues/1984
+                jsonParsedConfig,
+            )
             .send()
             .catch(e => {
                 throw e;


### PR DESCRIPTION
This PR enforces use of scoped RPC APIs in the loaders of `@solana/rpc-graphql`.
