### PR TITLE
refactor(experimental): move rpc-transport type tests into `src`

### DIFF
--- a/packages/rpc-transport/src/__typetests__/methods-api-typetest.ts
+++ b/packages/rpc-transport/src/__typetests__/methods-api-typetest.ts
@@ -1,6 +1,6 @@
-import { IRpcApi } from '../../json-rpc-types';
-import { IRpcApiMethods } from '../api-types';
-import { createJsonRpcApi } from '../methods/methods-api';
+import { IRpcApiMethods } from '../apis/api-types';
+import { createJsonRpcApi } from '../apis/methods/methods-api';
+import { IRpcApi } from '../json-rpc-types';
 
 type NftCollectionDetailsApiResponse = Readonly<{
     address: string;

--- a/packages/rpc-transport/src/__typetests__/subscriptions-api-typetest.ts
+++ b/packages/rpc-transport/src/__typetests__/subscriptions-api-typetest.ts
@@ -1,6 +1,6 @@
-import { IRpcSubscriptionsApi } from '../../json-rpc-types';
-import { IRpcApiMethods } from '../api-types';
-import { createJsonRpcSubscriptionsApi } from '../subscriptions/subscriptions-api';
+import { IRpcApiMethods } from '../apis/api-types';
+import { createJsonRpcSubscriptionsApi } from '../apis/subscriptions/subscriptions-api';
+import { IRpcSubscriptionsApi } from '../json-rpc-types';
 
 type NftCollectionDetailsApiResponse = Readonly<{
     address: string;


### PR DESCRIPTION
This PR moves the type tests for `@solana/rpc-transport` into the main `src`
directory.
