### PR TITLE
refactor(experimental): close leaky open handles in subscriptions tests

### DIFF
--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
@@ -19,14 +19,14 @@ describe('slotNotifications', () => {
 
     it('produces slot notifications', async () => {
         expect.assertions(1);
-        const slotNotifications = await rpc
-            .slotNotifications()
-            .subscribe({ abortSignal: new AbortController().signal });
+        const abortController = new AbortController();
+        const slotNotifications = await rpc.slotNotifications().subscribe({ abortSignal: abortController.signal });
         const iterator = slotNotifications[Symbol.asyncIterator]();
         await expect(iterator.next()).resolves.toHaveProperty('value', {
             parent: expect.any(BigInt),
             root: expect.any(BigInt),
             slot: expect.any(BigInt),
         });
+        abortController.abort();
     });
 });

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/slots-updates-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/slots-updates-notifications-test.ts
@@ -23,9 +23,10 @@ describe('slotsUpdatesNotifications', () => {
 
     it('produces slots updates notifications', async () => {
         expect.assertions(1);
+        const abortController = new AbortController();
         const slotsUpdatesNotifications = await rpc
             .slotsUpdatesNotifications()
-            .subscribe({ abortSignal: new AbortController().signal });
+            .subscribe({ abortSignal: abortController.signal });
         const iterator = slotsUpdatesNotifications[Symbol.asyncIterator]();
         await expect(iterator.next()).resolves.toHaveProperty(
             'value',
@@ -35,5 +36,6 @@ describe('slotsUpdatesNotifications', () => {
                 type: expect.any(String),
             }),
         );
+        abortController.abort();
     });
 });

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/vote-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/vote-notifications-test.ts
@@ -23,9 +23,8 @@ describe('voteNotifications', () => {
 
     it('produces vote notifications', async () => {
         expect.assertions(1);
-        const voteNotifications = await rpc
-            .voteNotifications()
-            .subscribe({ abortSignal: new AbortController().signal });
+        const abortController = new AbortController();
+        const voteNotifications = await rpc.voteNotifications().subscribe({ abortSignal: abortController.signal });
         const iterator = voteNotifications[Symbol.asyncIterator]();
         await expect(iterator.next()).resolves.toHaveProperty(
             'value',
@@ -38,5 +37,6 @@ describe('voteNotifications', () => {
                 votePubkey: expect.any(String),
             }),
         );
+        abortController.abort();
     });
 });


### PR DESCRIPTION
Some of our Jest tests have leaky open handles, many of which are tied to
subscriptions tests that leave the subscription open.

This PR adds abort signals for closing subscriptions after each test.

Part of #1948 
