### PR TITLE
refactor(experimental): wrap subscription tests in `try...finally`

### DIFF
--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/slot-notifications-test.ts
@@ -20,13 +20,16 @@ describe('slotNotifications', () => {
     it('produces slot notifications', async () => {
         expect.assertions(1);
         const abortController = new AbortController();
-        const slotNotifications = await rpc.slotNotifications().subscribe({ abortSignal: abortController.signal });
-        const iterator = slotNotifications[Symbol.asyncIterator]();
-        await expect(iterator.next()).resolves.toHaveProperty('value', {
-            parent: expect.any(BigInt),
-            root: expect.any(BigInt),
-            slot: expect.any(BigInt),
-        });
-        abortController.abort();
+        try {
+            const slotNotifications = await rpc.slotNotifications().subscribe({ abortSignal: abortController.signal });
+            const iterator = slotNotifications[Symbol.asyncIterator]();
+            await expect(iterator.next()).resolves.toHaveProperty('value', {
+                parent: expect.any(BigInt),
+                root: expect.any(BigInt),
+                slot: expect.any(BigInt),
+            });
+        } finally {
+            abortController.abort();
+        }
     });
 });

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/slots-updates-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/slots-updates-notifications-test.ts
@@ -24,18 +24,21 @@ describe('slotsUpdatesNotifications', () => {
     it('produces slots updates notifications', async () => {
         expect.assertions(1);
         const abortController = new AbortController();
-        const slotsUpdatesNotifications = await rpc
-            .slotsUpdatesNotifications()
-            .subscribe({ abortSignal: abortController.signal });
-        const iterator = slotsUpdatesNotifications[Symbol.asyncIterator]();
-        await expect(iterator.next()).resolves.toHaveProperty(
-            'value',
-            expect.objectContaining({
-                slot: expect.any(BigInt),
-                timestamp: expect.any(BigInt),
-                type: expect.any(String),
-            }),
-        );
-        abortController.abort();
+        try {
+            const slotsUpdatesNotifications = await rpc
+                .slotsUpdatesNotifications()
+                .subscribe({ abortSignal: abortController.signal });
+            const iterator = slotsUpdatesNotifications[Symbol.asyncIterator]();
+            await expect(iterator.next()).resolves.toHaveProperty(
+                'value',
+                expect.objectContaining({
+                    slot: expect.any(BigInt),
+                    timestamp: expect.any(BigInt),
+                    type: expect.any(String),
+                }),
+            );
+        } finally {
+            abortController.abort();
+        }
     });
 });

--- a/packages/rpc-core/src/rpc-subscriptions/__tests__/vote-notifications-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__tests__/vote-notifications-test.ts
@@ -24,19 +24,22 @@ describe('voteNotifications', () => {
     it('produces vote notifications', async () => {
         expect.assertions(1);
         const abortController = new AbortController();
-        const voteNotifications = await rpc.voteNotifications().subscribe({ abortSignal: abortController.signal });
-        const iterator = voteNotifications[Symbol.asyncIterator]();
-        await expect(iterator.next()).resolves.toHaveProperty(
-            'value',
-            expect.objectContaining({
-                hash: expect.any(String),
-                signature: expect.any(String),
-                slots: expect.arrayContaining([expect.any(BigInt)]),
-                // TODO: Test for null. It appears this is maybe non-deterministic? Seems to maybe occur on delayed votes?
-                timestamp: expect.any(BigInt),
-                votePubkey: expect.any(String),
-            }),
-        );
-        abortController.abort();
+        try {
+            const voteNotifications = await rpc.voteNotifications().subscribe({ abortSignal: abortController.signal });
+            const iterator = voteNotifications[Symbol.asyncIterator]();
+            await expect(iterator.next()).resolves.toHaveProperty(
+                'value',
+                expect.objectContaining({
+                    hash: expect.any(String),
+                    signature: expect.any(String),
+                    slots: expect.arrayContaining([expect.any(BigInt)]),
+                    // TODO: Test for null. It appears this is maybe non-deterministic? Seems to maybe occur on delayed votes?
+                    timestamp: expect.any(BigInt),
+                    votePubkey: expect.any(String),
+                }),
+            );
+        } finally {
+            abortController.abort();
+        }
     });
 });


### PR DESCRIPTION
This PR adds `try...finally` wrappers around the subscriptions tests to make
sure the subscription is closed even if the test fails.
