### PR TITLE
Update encoding in the transaction config

### DIFF
--- a/packages/rpc-graphql/src/loaders/transaction.ts
+++ b/packages/rpc-graphql/src/loaders/transaction.ts
@@ -40,8 +40,9 @@ async function loadTransaction(rpc: Rpc, { signature, ...config }: ReturnType<ty
     // then fetch it again with `jsonParsed` encoding.
     // This ensures the response always has the full transaction meta.
     if (encoding !== 'jsonParsed') {
+        const jsonParsedConfig = { ...config, encoding: 'jsonParsed' };
         const transactionJsonParsed = await rpc
-            .getTransaction(signature, config as unknown as Parameters<SolanaRpcMethods['getTransaction']>[1])
+            .getTransaction(signature, jsonParsedConfig as unknown as Parameters<SolanaRpcMethods['getTransaction']>[1])
             .send()
             .catch(e => {
                 throw e;


### PR DESCRIPTION
**Issue:**
The intention here seems to be to fetch the transaction again with jsonParsed encoding if the requested encoding is not jsonParsed.  but the config object passed to rpc.getTransaction in this block is the same as the original call and will still contain the original encoding. It does not change to jsonParsed as intended.

**Fix:**
Created a new jsonParsedConfig object with encoding explicitly set to jsonParsed. This ensures the second call to rpc.getTransaction fetches the transaction with the jsonParsed encoding.