### PR TITLE
Detect block height exceedences using a combination of slot notifications and `getEpochInfo`

### DIFF
--- a/packages/library/src/__tests__/transaction-confirmation-strategy-blockheight-test.ts
+++ b/packages/library/src/__tests__/transaction-confirmation-strategy-blockheight-test.ts
@@ -1,3 +1,5 @@
+import { Commitment } from '@solana/rpc-types';
+
 import { createBlockHeightExceedencePromiseFactory } from '../transaction-confirmation-strategy-blockheight';
 
 const FOREVER_PROMISE = new Promise(() => {
@@ -7,9 +9,15 @@ const FOREVER_PROMISE = new Promise(() => {
 describe('createBlockHeightExceedencePromiseFactory', () => {
     let createSubscriptionIterable: jest.Mock;
     let getBlockHeightExceedencePromise: ReturnType<typeof createBlockHeightExceedencePromiseFactory>;
+    let getEpochInfoMock: jest.Mock;
+    let getEpochInfoRequestSender: jest.Mock;
     let slotNotificationsGenerator: jest.Mock;
     beforeEach(() => {
         jest.useFakeTimers();
+        getEpochInfoRequestSender = jest.fn();
+        getEpochInfoMock = jest.fn().mockReturnValue({
+            send: getEpochInfoRequestSender,
+        });
         slotNotificationsGenerator = jest.fn().mockImplementation(async function* () {
             yield await FOREVER_PROMISE;
         });
@@ -21,57 +29,155 @@ describe('createBlockHeightExceedencePromiseFactory', () => {
                 subscribe: createSubscriptionIterable,
             }),
         };
-        getBlockHeightExceedencePromise = createBlockHeightExceedencePromiseFactory(rpcSubscriptions);
-    });
-    it('continues to pend when the slot received is less than the last valid slot', async () => {
-        expect.assertions(1);
-        slotNotificationsGenerator.mockImplementation(async function* () {
-            yield { slot: 120n };
-            yield { slot: 121n };
-            yield { slot: 122n };
-            yield await FOREVER_PROMISE;
+        const rpc = {
+            getEpochInfo: getEpochInfoMock,
+        };
+        getBlockHeightExceedencePromise = createBlockHeightExceedencePromiseFactory({
+            rpc,
+            rpcSubscriptions,
         });
+    });
+    it('throws when the block height has already been exceeded when called', async () => {
+        expect.assertions(1);
+        getEpochInfoRequestSender.mockResolvedValue({ absoluteSlot: 101n, blockHeight: 101n });
         const exceedencePromise = getBlockHeightExceedencePromise({
             abortSignal: new AbortController().signal,
-            lastValidBlockHeight: 123n,
+            lastValidBlockHeight: 100n,
+        });
+        await expect(exceedencePromise).rejects.toThrow();
+    });
+    it('continues to pend when the block height in the initial fetch is lower than the last valid block height', async () => {
+        expect.assertions(1);
+        getEpochInfoRequestSender.mockResolvedValue({ absoluteSlot: 100n, blockHeight: 100n });
+        const exceedencePromise = getBlockHeightExceedencePromise({
+            abortSignal: new AbortController().signal,
+            lastValidBlockHeight: 100n,
         });
         await jest.runAllTimersAsync();
         await expect(Promise.race([exceedencePromise, 'pending'])).resolves.toBe('pending');
     });
-    it('continues to pend when the slot received is equal to the last valid slot', async () => {
+    it('throws when the slot at which the block height is expected to be exceeded is reached', async () => {
         expect.assertions(1);
+        // Mock a delta between the slot height and the block height of 100 slots.
+        getEpochInfoRequestSender.mockResolvedValueOnce({ absoluteSlot: 198n, blockHeight: 98n });
         slotNotificationsGenerator.mockImplementation(async function* () {
-            yield { slot: 123n };
+            yield { slot: 199n };
+            yield { slot: 200n };
+            yield { slot: 201n }; // Expected to be exceeded here.
             yield await FOREVER_PROMISE;
         });
+        // Mock the block height recheck at the end
+        getEpochInfoRequestSender.mockResolvedValueOnce({ absoluteSlot: 201n, blockHeight: 101n });
         const exceedencePromise = getBlockHeightExceedencePromise({
             abortSignal: new AbortController().signal,
-            lastValidBlockHeight: 123n,
+            lastValidBlockHeight: 100n,
         });
-        await jest.runAllTimersAsync();
+        await expect(exceedencePromise).rejects.toThrow();
+    });
+    it('continues to pend when slot at which the block height is expected to be exceeded has not been reached', async () => {
+        expect.assertions(1);
+        // Mock a delta between the slot height and the block height of 100 slots.
+        getEpochInfoRequestSender.mockResolvedValue({ absoluteSlot: 198n, blockHeight: 98n });
+        slotNotificationsGenerator.mockImplementation(async function* () {
+            yield { slot: 199n };
+            yield { slot: 200n };
+            yield await FOREVER_PROMISE;
+        });
+        // Mock the block height recheck at the end
+        getEpochInfoRequestSender.mockResolvedValueOnce({ absoluteSlot: 200n, blockHeight: 100n });
+        const exceedencePromise = getBlockHeightExceedencePromise({
+            abortSignal: new AbortController().signal,
+            lastValidBlockHeight: 100n,
+        });
+        await jest.runOnlyPendingTimersAsync();
         await expect(Promise.race([exceedencePromise, 'pending'])).resolves.toBe('pending');
     });
-    it('throws when the slot received is higher than the last valid slot', async () => {
+    it('throws when the slot height / block height delta eventually satisfies the slot at which the block height is expected to be exceeded being reached', async () => {
         expect.assertions(1);
+        // Mock a delta between the slot height and the block height of 100 slots.
+        getEpochInfoRequestSender.mockResolvedValueOnce({ absoluteSlot: 198n, blockHeight: 98n });
         slotNotificationsGenerator.mockImplementation(async function* () {
-            yield { slot: 124n };
+            yield { slot: 199n };
+            yield { slot: 200n };
+            yield { slot: 201n }; // Expected to be exceeded here.
+            yield { slot: 202n }; // Actually exceeded here.
             yield await FOREVER_PROMISE;
         });
+        // Mock the slot height / block height delta having grown by one.
+        getEpochInfoRequestSender.mockResolvedValueOnce({ absoluteSlot: 201n, blockHeight: 100n });
+        // Mock the final recheck where the block height catches up.
+        getEpochInfoRequestSender.mockResolvedValueOnce({ absoluteSlot: 202n, blockHeight: 101n });
         const exceedencePromise = getBlockHeightExceedencePromise({
             abortSignal: new AbortController().signal,
-            lastValidBlockHeight: 123n,
+            lastValidBlockHeight: 100n,
         });
-        await expect(exceedencePromise).rejects.toThrow(
-            'The network has progressed past the last block for which this transaction could have committed.',
-        );
+        await expect(exceedencePromise).rejects.toThrow();
+    });
+    it('continues to pend when the slot height / block height delta grows by the time the slot at which the block height is expected to be exceeded is reached', async () => {
+        expect.assertions(1);
+        // Mock a delta between the slot height and the block height of 100 slots.
+        getEpochInfoRequestSender.mockResolvedValueOnce({ absoluteSlot: 198n, blockHeight: 98n });
+        slotNotificationsGenerator.mockImplementation(async function* () {
+            yield { slot: 199n };
+            yield { slot: 200n };
+            yield { slot: 201n }; // Expected to be exceeded here.
+            yield await FOREVER_PROMISE;
+        });
+        // Mock the slot height / block height delta having grown by one by the end
+        getEpochInfoRequestSender.mockResolvedValueOnce({ absoluteSlot: 201n, blockHeight: 100n });
+        const exceedencePromise = getBlockHeightExceedencePromise({
+            abortSignal: new AbortController().signal,
+            lastValidBlockHeight: 100n,
+        });
+        await jest.runOnlyPendingTimersAsync();
+        await expect(Promise.race([exceedencePromise, 'pending'])).resolves.toBe('pending');
+    });
+    it.each(['processed', 'confirmed', 'finalized'] as Commitment[])(
+        'calls the epoch info getter with the configured commitment when configured with `%s` commitment',
+        commitment => {
+            getEpochInfoRequestSender.mockResolvedValue({ absoluteSlot: 100n, blockHeight: 100n });
+            getBlockHeightExceedencePromise({
+                abortSignal: new AbortController().signal,
+                commitment,
+                lastValidBlockHeight: 100n,
+            });
+            expect(getEpochInfoMock).toHaveBeenCalledWith({ commitment });
+        },
+    );
+    it('calls the abort signal passed to the epoch info fetcher when aborted', async () => {
+        expect.assertions(2);
+        const abortController = new AbortController();
+        (async () => {
+            try {
+                await getBlockHeightExceedencePromise({
+                    abortSignal: abortController.signal,
+                    lastValidBlockHeight: 100n,
+                });
+            } catch {
+                /* empty */
+            }
+        })();
+        expect(getEpochInfoRequestSender).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: false }),
+        });
+        abortController.abort();
+        expect(getEpochInfoRequestSender).toHaveBeenCalledWith({
+            abortSignal: expect.objectContaining({ aborted: true }),
+        });
     });
     it('calls the abort signal passed to the slot subscription when aborted', async () => {
         expect.assertions(2);
         const abortController = new AbortController();
-        getBlockHeightExceedencePromise({
-            abortSignal: abortController.signal,
-            lastValidBlockHeight: 123n,
-        });
+        (async () => {
+            try {
+                await getBlockHeightExceedencePromise({
+                    abortSignal: abortController.signal,
+                    lastValidBlockHeight: 100n,
+                });
+            } catch {
+                /* empty */
+            }
+        })();
         expect(createSubscriptionIterable).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: false }),
         });
@@ -79,5 +185,29 @@ describe('createBlockHeightExceedencePromiseFactory', () => {
         expect(createSubscriptionIterable).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: true }),
         });
+    });
+    it('throws errors thrown from the epoch info fetcher', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        abortController.abort();
+        getEpochInfoRequestSender.mockRejectedValue(new Error('o no'));
+        await expect(
+            getBlockHeightExceedencePromise({
+                abortSignal: abortController.signal,
+                lastValidBlockHeight: 100n,
+            }),
+        ).rejects.toThrow('o no');
+    });
+    it('throws errors thrown from the slot subscription', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        abortController.abort();
+        createSubscriptionIterable.mockRejectedValue(new Error('o no'));
+        await expect(
+            getBlockHeightExceedencePromise({
+                abortSignal: abortController.signal,
+                lastValidBlockHeight: 100n,
+            }),
+        ).rejects.toThrow('o no');
     });
 });

--- a/packages/library/src/__tests__/transaction-confirmation-test.ts
+++ b/packages/library/src/__tests__/transaction-confirmation-test.ts
@@ -223,6 +223,7 @@ describe('waitForRecentTransactionConfirmation', () => {
         });
         expect(getBlockHeightExceedencePromise).toHaveBeenCalledWith({
             abortSignal: expect.any(AbortSignal),
+            commitment: 'finalized',
             lastValidBlockHeight: MOCK_TRANSACTION.lifetimeConstraint.lastValidBlockHeight,
         });
     });

--- a/packages/library/src/transaction-confirmation-strategy-blockheight.ts
+++ b/packages/library/src/transaction-confirmation-strategy-blockheight.ts
@@ -1,33 +1,73 @@
-import type { Slot, SlotNotificationsApi } from '@solana/rpc-core';
-import type { RpcSubscriptions } from '@solana/rpc-transport';
+import type { GetEpochInfoApi, SlotNotificationsApi } from '@solana/rpc-core';
+import type { Rpc, RpcSubscriptions } from '@solana/rpc-transport';
+import { Commitment } from '@solana/rpc-types';
 
 type GetBlockHeightExceedencePromiseFn = (config: {
     abortSignal: AbortSignal;
-    lastValidBlockHeight: Slot;
+    commitment?: Commitment;
+    lastValidBlockHeight: bigint;
 }) => Promise<void>;
 
-export function createBlockHeightExceedencePromiseFactory(
-    rpcSubscriptions: RpcSubscriptions<SlotNotificationsApi>,
-): GetBlockHeightExceedencePromiseFn {
-    return async function getBlockHeightExceedencePromise({ abortSignal: callerAbortSignal, lastValidBlockHeight }) {
+export function createBlockHeightExceedencePromiseFactory({
+    rpc,
+    rpcSubscriptions,
+}: Readonly<{
+    rpc: Rpc<GetEpochInfoApi>;
+    rpcSubscriptions: RpcSubscriptions<SlotNotificationsApi>;
+}>): GetBlockHeightExceedencePromiseFn {
+    return async function getBlockHeightExceedencePromise({
+        abortSignal: callerAbortSignal,
+        commitment,
+        lastValidBlockHeight,
+    }) {
         const abortController = new AbortController();
-        function handleAbort() {
+        const handleAbort = () => {
             abortController.abort();
-        }
+        };
         callerAbortSignal.addEventListener('abort', handleAbort, { signal: abortController.signal });
-        const slotNotifications = await rpcSubscriptions
-            .slotNotifications()
-            .subscribe({ abortSignal: abortController.signal });
+        async function getBlockHeightAndDifferenceBetweenSlotHeightAndBlockHeight() {
+            const { absoluteSlot, blockHeight } = await rpc
+                .getEpochInfo({ commitment })
+                .send({ abortSignal: abortController.signal });
+            return {
+                blockHeight,
+                differenceBetweenSlotHeightAndBlockHeight: absoluteSlot - blockHeight,
+            };
+        }
         try {
-            for await (const slotNotification of slotNotifications) {
-                if (slotNotification.slot > lastValidBlockHeight) {
-                    // TODO: Coded error.
-                    throw new Error(
-                        'The network has progressed past the last block for which this transaction ' +
-                            'could have committed.',
-                    );
+            const [slotNotifications, { blockHeight, differenceBetweenSlotHeightAndBlockHeight }] = await Promise.all([
+                rpcSubscriptions.slotNotifications().subscribe({ abortSignal: abortController.signal }),
+                getBlockHeightAndDifferenceBetweenSlotHeightAndBlockHeight(),
+            ]);
+            if (blockHeight <= lastValidBlockHeight) {
+                let lastKnownDifferenceBetweenSlotHeightAndBlockHeight = differenceBetweenSlotHeightAndBlockHeight;
+                for await (const slotNotification of slotNotifications) {
+                    const { slot } = slotNotification;
+                    if (slot - lastKnownDifferenceBetweenSlotHeightAndBlockHeight > lastValidBlockHeight) {
+                        // Before making a final decision, recheck the actual block height.
+                        const {
+                            blockHeight: currentBlockHeight,
+                            differenceBetweenSlotHeightAndBlockHeight: currentDifferenceBetweenSlotHeightAndBlockHeight,
+                        } = await getBlockHeightAndDifferenceBetweenSlotHeightAndBlockHeight();
+                        if (currentBlockHeight > lastValidBlockHeight) {
+                            // Verfied; the block height has been exceeded.
+                            break;
+                        } else {
+                            // The block height has not been exceeded, which implies that the
+                            // difference between the slot height and the block height has grown
+                            // (ie. some blocks have been skipped since we started). Recalibrate the
+                            // difference and keep waiting.
+                            lastKnownDifferenceBetweenSlotHeightAndBlockHeight =
+                                currentDifferenceBetweenSlotHeightAndBlockHeight;
+                        }
+                    }
                 }
             }
+            // TODO: Coded error.
+            throw new Error(
+                'The network has progressed past the last block for which this transaction could ' +
+                    'have been committed.',
+            );
         } finally {
             abortController.abort();
         }


### PR DESCRIPTION
# Summary

This PR repairs the block height exceedence detection in the transaction confirmer. Previously, we mistakenly compared slot height to the last valid block height. Those are not equivalent values.

Since there is no subscription API for block height, this implementation determines the difference between the slot height and the block height, then subscribes to the slot height. It waits until the slot when the block height is expected to be exceeded to be reached.

Finally, in consideration that one or more blocks might have been skipped since having started to wait, it rechecks the slot height / block height difference before failing.

# Test plan

```
cd packages/library/
pnpm turbo test:unit:browser
pnpm turbo test:unit:node
```

Fixes #1985.