### PR TITLE
Update transaction decoder to use lookup tables

### DIFF
--- a/packages/transactions/src/__tests__/decompile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/decompile-transaction-test.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { AccountRole, IInstruction } from '@solana/instructions';
+import { AccountRole, IAccountLookupMeta, IAccountMeta, IInstruction } from '@solana/instructions';
 import { SignatureBytes } from '@solana/keys';
 
 import { decompileTransaction } from '../decompile-transaction';
@@ -682,6 +682,914 @@ describe('decompileTransaction', () => {
             expect(transaction.signatures).toStrictEqual({
                 [extraSignerAddress]: extraSignerSignature,
                 [feePayer]: feePayerSignature,
+            });
+        });
+    });
+
+    describe('for a transaction with address lookup tables', () => {
+        const blockhash = 'J4yED2jcMAHyQUg61DBmm4njmEydUr2WqrV9cdEcDDgL';
+        const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+        describe('for one lookup table', () => {
+            const lookupTableAddress = '9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw' as Address;
+
+            it('converts an instruction with a single readonly lookup', () => {
+                const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const lookupTables = {
+                    [lookupTableAddress]: [addressInLookup],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [0],
+                                writableIndices: [],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMeta: IAccountLookupMeta = {
+                    address: addressInLookup,
+                    addressIndex: 0,
+                    lookupTableAddress,
+                    role: AccountRole.READONLY,
+                };
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: [expectedAccountLookupMeta],
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('converts an instruction with multiple readonly lookups', () => {
+                const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+                const lookupTables = {
+                    [lookupTableAddress]: [
+                        addressInLookup1,
+                        'HAv2PXRjwr4AL1odpoMNfvsw6bWxjDzURy1nPA6QBhDj' as Address,
+                        addressInLookup2,
+                    ],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [0, 2],
+                                writableIndices: [],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2, 3],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                    {
+                        address: addressInLookup1,
+                        addressIndex: 0,
+                        lookupTableAddress,
+                        role: AccountRole.READONLY,
+                    },
+                    {
+                        address: addressInLookup2,
+                        addressIndex: 2,
+                        lookupTableAddress,
+                        role: AccountRole.READONLY,
+                    },
+                ];
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: expectedAccountLookupMetas,
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('converts an instruction with a single writable lookup', () => {
+                const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const lookupTables = {
+                    [lookupTableAddress]: [addressInLookup],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [],
+                                writableIndices: [0],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMeta: IAccountLookupMeta = {
+                    address: addressInLookup,
+                    addressIndex: 0,
+                    lookupTableAddress,
+                    role: AccountRole.WRITABLE,
+                };
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: [expectedAccountLookupMeta],
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('converts an instruction with multiple writable lookups', () => {
+                const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+                const lookupTables = {
+                    [lookupTableAddress]: [
+                        addressInLookup1,
+                        'HAv2PXRjwr4AL1odpoMNfvsw6bWxjDzURy1nPA6QBhDj' as Address,
+                        addressInLookup2,
+                    ],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [],
+                                writableIndices: [0, 2],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2, 3],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                    {
+                        address: addressInLookup1,
+                        addressIndex: 0,
+                        lookupTableAddress,
+                        role: AccountRole.WRITABLE,
+                    },
+                    {
+                        address: addressInLookup2,
+                        addressIndex: 2,
+                        lookupTableAddress,
+                        role: AccountRole.WRITABLE,
+                    },
+                ];
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: expectedAccountLookupMetas,
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('converts an instruction with a readonly and a writable lookup', () => {
+                const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+                const lookupTables = {
+                    [lookupTableAddress]: [
+                        addressInLookup1,
+                        'HAv2PXRjwr4AL1odpoMNfvsw6bWxjDzURy1nPA6QBhDj' as Address,
+                        addressInLookup2,
+                    ],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [0],
+                                writableIndices: [2],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2, 3],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                    // writable is first since we used account indices [2,3]
+                    {
+                        address: addressInLookup2,
+                        addressIndex: 2,
+                        lookupTableAddress,
+                        role: AccountRole.WRITABLE,
+                    },
+                    {
+                        address: addressInLookup1,
+                        addressIndex: 0,
+                        lookupTableAddress,
+                        role: AccountRole.READONLY,
+                    },
+                ];
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: expectedAccountLookupMetas,
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('converts an instruction with a combination of static and lookup accounts', () => {
+                const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const lookupTables = {
+                    [lookupTableAddress]: [addressInLookup],
+                };
+
+                const staticAddress = 'GbRuWcHyNaVuE9rJE4sKpkHYa9k76VJBCCwGtf87ikH3' as Address;
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [0],
+                                writableIndices: [],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 2, // 1 static address, 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [1, 3],
+                                programAddressIndex: 2,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, staticAddress, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountMeta: IAccountMeta = {
+                    address: staticAddress,
+                    role: AccountRole.READONLY,
+                };
+
+                const expectedAccountLookupMeta: IAccountLookupMeta = {
+                    address: addressInLookup,
+                    addressIndex: 0,
+                    lookupTableAddress,
+                    role: AccountRole.READONLY,
+                };
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: [expectedAccountMeta, expectedAccountLookupMeta],
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('converts multiple instructions with lookup accounts', () => {
+                const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+                const lookupTables = {
+                    [lookupTableAddress]: [
+                        addressInLookup1,
+                        'HAv2PXRjwr4AL1odpoMNfvsw6bWxjDzURy1nPA6QBhDj' as Address,
+                        addressInLookup2,
+                    ],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [0],
+                                writableIndices: [2],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2],
+                                programAddressIndex: 1,
+                            },
+                            {
+                                accountIndices: [3],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMeta1: IAccountLookupMeta = {
+                    address: addressInLookup1,
+                    addressIndex: 0,
+                    lookupTableAddress,
+                    role: AccountRole.READONLY,
+                };
+
+                const expectedAccountLookupMeta2: IAccountLookupMeta = {
+                    address: addressInLookup2,
+                    addressIndex: 2,
+                    lookupTableAddress,
+                    role: AccountRole.WRITABLE,
+                };
+
+                expect(transaction.instructions).toStrictEqual([
+                    // first instruction uses index 2, which is the writable lookup
+                    {
+                        accounts: [expectedAccountLookupMeta2],
+                        programAddress,
+                    },
+                    // second instruction uses index 3, the readonly lookup
+                    {
+                        accounts: [expectedAccountLookupMeta1],
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('throws if the lookup table is not passed in', () => {
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [0],
+                                writableIndices: [],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const fn = () => decompileTransaction(compiledTransaction, {});
+                expect(fn).toThrow(
+                    'Transaction includes missing address lookup tables: [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw]',
+                );
+            });
+
+            it('throws if a read index is outside the lookup table', () => {
+                const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const lookupTables = {
+                    [lookupTableAddress]: [addressInLookup],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [1],
+                                writableIndices: [],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const fn = () => decompileTransaction(compiledTransaction, lookupTables);
+                expect(fn).toThrow(
+                    'Cannot look up index 1 in lookup table 9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw',
+                );
+            });
+
+            it('throws if a write index is outside the lookup table', () => {
+                const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const lookupTables = {
+                    [lookupTableAddress]: [addressInLookup],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress,
+                                readableIndices: [],
+                                writableIndices: [1],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const fn = () => decompileTransaction(compiledTransaction, lookupTables);
+                expect(fn).toThrow(
+                    'Cannot look up index 1 in lookup table 9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw',
+                );
+            });
+        });
+
+        describe('for multiple lookup tables', () => {
+            const lookupTableAddress1 = '9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw' as Address;
+            const lookupTableAddress2 = 'GS7Rphk6CZLoCGbTcbRaPZzD3k4ZK8XiA5BAj89Fi2Eg' as Address;
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            it('converts an instruction with readonly accounts from two lookup tables', () => {
+                const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const addressInLookup2 = 'E7p56hzZZEs9vJ1yjxAFjhUP3fN2UJNk2nWvcY7Hz3ee' as Address;
+                const lookupTables = {
+                    [lookupTableAddress1]: [addressInLookup1],
+                    [lookupTableAddress2]: [addressInLookup2],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress: lookupTableAddress1,
+                                readableIndices: [0],
+                                writableIndices: [],
+                            },
+                            {
+                                lookupTableAddress: lookupTableAddress2,
+                                readableIndices: [0],
+                                writableIndices: [],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2, 3],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                    {
+                        address: addressInLookup1,
+                        addressIndex: 0,
+                        lookupTableAddress: lookupTableAddress1,
+                        role: AccountRole.READONLY,
+                    },
+                    {
+                        address: addressInLookup2,
+                        addressIndex: 0,
+                        lookupTableAddress: lookupTableAddress2,
+                        role: AccountRole.READONLY,
+                    },
+                ];
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: expectedAccountLookupMetas,
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('converts an instruction with writable accounts from two lookup tables', () => {
+                const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const addressInLookup2 = 'E7p56hzZZEs9vJ1yjxAFjhUP3fN2UJNk2nWvcY7Hz3ee' as Address;
+                const lookupTables = {
+                    [lookupTableAddress1]: [addressInLookup1],
+                    [lookupTableAddress2]: [addressInLookup2],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress: lookupTableAddress1,
+                                readableIndices: [],
+                                writableIndices: [0],
+                            },
+                            {
+                                lookupTableAddress: lookupTableAddress2,
+                                readableIndices: [],
+                                writableIndices: [0],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2, 3],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                    {
+                        address: addressInLookup1,
+                        addressIndex: 0,
+                        lookupTableAddress: lookupTableAddress1,
+                        role: AccountRole.WRITABLE,
+                    },
+                    {
+                        address: addressInLookup2,
+                        addressIndex: 0,
+                        lookupTableAddress: lookupTableAddress2,
+                        role: AccountRole.WRITABLE,
+                    },
+                ];
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: expectedAccountLookupMetas,
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('converts an instruction with readonly and writable accounts from two lookup tables', () => {
+                const readOnlyaddressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const readonlyAddressInLookup2 = 'E7p56hzZZEs9vJ1yjxAFjhUP3fN2UJNk2nWvcY7Hz3ee' as Address;
+                const writableAddressInLookup1 = 'FgNrG1D7AoqNJuLc5eqmsXSHWta6Tfu41mQ9dgc5yaXo' as Address;
+                const writableAddressInLookup2 = '9jEBzMuJfwWH1qcG4g1bj24iSLGCmTsedgisui7SVHes' as Address;
+
+                const lookupTables = {
+                    [lookupTableAddress1]: [readOnlyaddressInLookup1, writableAddressInLookup1],
+                    [lookupTableAddress2]: [readonlyAddressInLookup2, writableAddressInLookup2],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress: lookupTableAddress1,
+                                readableIndices: [0],
+                                writableIndices: [1],
+                            },
+                            {
+                                lookupTableAddress: lookupTableAddress2,
+                                readableIndices: [0],
+                                writableIndices: [1],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        /*
+                            accountIndices:
+                            0 - feePayer
+                            1 - program
+                            2 - writable from lookup1
+                            3 - writable from lookup2
+                            4 - readonly from lookup1
+                            5 - readonly from lookup2
+                        */
+                        instructions: [
+                            {
+                                accountIndices: [2, 3, 4, 5],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                    {
+                        address: writableAddressInLookup1,
+                        addressIndex: 1,
+                        lookupTableAddress: lookupTableAddress1,
+                        role: AccountRole.WRITABLE,
+                    },
+                    {
+                        address: writableAddressInLookup2,
+                        addressIndex: 1,
+                        lookupTableAddress: lookupTableAddress2,
+                        role: AccountRole.WRITABLE,
+                    },
+                    {
+                        address: readOnlyaddressInLookup1,
+                        addressIndex: 0,
+                        lookupTableAddress: lookupTableAddress1,
+                        role: AccountRole.READONLY,
+                    },
+                    {
+                        address: readonlyAddressInLookup2,
+                        addressIndex: 0,
+                        lookupTableAddress: lookupTableAddress2,
+                        role: AccountRole.READONLY,
+                    },
+                ];
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: expectedAccountLookupMetas,
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('converts multiple instructions with readonly and writable accounts from two lookup tables', () => {
+                const readOnlyaddressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+                const readonlyAddressInLookup2 = 'E7p56hzZZEs9vJ1yjxAFjhUP3fN2UJNk2nWvcY7Hz3ee' as Address;
+                const writableAddressInLookup1 = 'FgNrG1D7AoqNJuLc5eqmsXSHWta6Tfu41mQ9dgc5yaXo' as Address;
+                const writableAddressInLookup2 = '9jEBzMuJfwWH1qcG4g1bj24iSLGCmTsedgisui7SVHes' as Address;
+
+                const lookupTables = {
+                    [lookupTableAddress1]: [readOnlyaddressInLookup1, writableAddressInLookup1],
+                    [lookupTableAddress2]: [readonlyAddressInLookup2, writableAddressInLookup2],
+                };
+
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress: lookupTableAddress1,
+                                readableIndices: [0],
+                                writableIndices: [1],
+                            },
+                            {
+                                lookupTableAddress: lookupTableAddress2,
+                                readableIndices: [0],
+                                writableIndices: [1],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        /*
+                            accountIndices:
+                            0 - feePayer
+                            1 - program
+                            2 - writable from lookup1
+                            3 - writable from lookup2
+                            4 - readonly from lookup1
+                            5 - readonly from lookup2
+                        */
+                        instructions: [
+                            {
+                                accountIndices: [2, 5],
+                                programAddressIndex: 1,
+                            },
+                            {
+                                accountIndices: [3, 4],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+
+                const expectedAccountLookupMetasInstruction1: IAccountLookupMeta[] = [
+                    // index 2 - writable from lookup1
+                    {
+                        address: writableAddressInLookup1,
+                        addressIndex: 1,
+                        lookupTableAddress: lookupTableAddress1,
+                        role: AccountRole.WRITABLE,
+                    },
+                    // index 5 - readonly from lookup2
+                    {
+                        address: readonlyAddressInLookup2,
+                        addressIndex: 0,
+                        lookupTableAddress: lookupTableAddress2,
+                        role: AccountRole.READONLY,
+                    },
+                ];
+
+                const expectedAccountLookupMetasInstruction2: IAccountLookupMeta[] = [
+                    // index 3 - writable from lookup2
+                    {
+                        address: writableAddressInLookup2,
+                        addressIndex: 1,
+                        lookupTableAddress: lookupTableAddress2,
+                        role: AccountRole.WRITABLE,
+                    },
+                    // index 4 - readonly from lookup1
+                    {
+                        address: readOnlyaddressInLookup1,
+                        addressIndex: 0,
+                        lookupTableAddress: lookupTableAddress1,
+                        role: AccountRole.READONLY,
+                    },
+                ];
+
+                expect(transaction.instructions).toStrictEqual([
+                    {
+                        accounts: expectedAccountLookupMetasInstruction1,
+                        programAddress,
+                    },
+                    {
+                        accounts: expectedAccountLookupMetasInstruction2,
+                        programAddress,
+                    },
+                ]);
+            });
+
+            it('throws if multiple lookup tables are not passed in', () => {
+                const compiledTransaction: CompiledTransaction = {
+                    compiledMessage: {
+                        addressTableLookups: [
+                            {
+                                lookupTableAddress: lookupTableAddress1,
+                                readableIndices: [0],
+                                writableIndices: [],
+                            },
+                            {
+                                lookupTableAddress: lookupTableAddress2,
+                                readableIndices: [0],
+                                writableIndices: [],
+                            },
+                        ],
+                        header: {
+                            numReadonlyNonSignerAccounts: 1, // 1 program
+                            numReadonlySignerAccounts: 0,
+                            numSignerAccounts: 1, // fee payer
+                        },
+                        instructions: [
+                            {
+                                accountIndices: [2],
+                                programAddressIndex: 1,
+                            },
+                        ],
+                        lifetimeToken: blockhash,
+                        staticAccounts: [feePayer, programAddress],
+                        version: 0,
+                    },
+                    signatures: [],
+                };
+
+                const fn = () => decompileTransaction(compiledTransaction, {});
+                expect(fn).toThrow(
+                    'Transaction includes missing address lookup tables: [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw, GS7Rphk6CZLoCGbTcbRaPZzD3k4ZK8XiA5BAj89Fi2Eg]',
+                );
             });
         });
     });

--- a/packages/transactions/src/__tests__/decompile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/decompile-transaction-test.ts
@@ -35,7 +35,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {});
+            const transaction = decompileTransaction(compiledTransaction);
 
             expect(transaction.version).toBe(0);
             expect(transaction.feePayer).toEqual(feePayer);
@@ -61,7 +61,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {});
+            const transaction = decompileTransaction(compiledTransaction);
             expect(transaction.version).toBe('legacy');
         });
 
@@ -84,7 +84,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {});
+            const transaction = decompileTransaction(compiledTransaction);
             const expectedInstruction: IInstruction = {
                 programAddress,
             };
@@ -126,7 +126,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {});
+            const transaction = decompileTransaction(compiledTransaction);
 
             const expectedInstruction: IInstruction = {
                 accounts: [
@@ -175,7 +175,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {});
+            const transaction = decompileTransaction(compiledTransaction);
 
             const expectedInstructions: IInstruction[] = [
                 {
@@ -210,7 +210,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
             expect(transaction.signatures).toStrictEqual({
                 [feePayer]: feePayerSignature as SignatureBytes,
             });
@@ -247,7 +247,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature, otherSigner1Signature, otherSigner2Signature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
             expect(transaction.signatures).toStrictEqual({
                 [feePayer]: feePayerSignature,
                 [otherSigner1Address]: otherSigner1Signature,
@@ -287,7 +287,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature, noSignature, otherSigner2Signature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
             expect(transaction.signatures).toStrictEqual({
                 [feePayer]: feePayerSignature,
                 [otherSigner2Address]: otherSigner2Signature,
@@ -310,7 +310,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {}, 100n);
+            const transaction = decompileTransaction(compiledTransaction, { lastValidBlockHeight: 100n });
             expect(transaction.lifetimeConstraint).toEqual({
                 blockhash,
                 lastValidBlockHeight: 100n,
@@ -365,7 +365,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {});
+            const transaction = decompileTransaction(compiledTransaction);
 
             const expectedInstruction: IInstruction = {
                 accounts: [
@@ -427,7 +427,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {});
+            const transaction = decompileTransaction(compiledTransaction);
 
             const expectedInstruction: IInstruction = {
                 accounts: [
@@ -493,7 +493,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {});
+            const transaction = decompileTransaction(compiledTransaction);
 
             const expectedInstructions: IInstruction[] = [
                 {
@@ -574,7 +574,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
 
             expect(transaction.signatures).toStrictEqual({
                 [nonceAuthorityAddress]: feePayerSignature,
@@ -620,7 +620,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature, authoritySignature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
 
             expect(transaction.signatures).toStrictEqual({
                 [feePayer]: feePayerSignature,
@@ -677,7 +677,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature, noSignature, extraSignerSignature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
 
             expect(transaction.signatures).toStrictEqual({
                 [extraSignerAddress]: extraSignerSignature,
@@ -726,7 +726,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMeta: IAccountLookupMeta = {
                     address: addressInLookup,
@@ -781,7 +783,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMetas: IAccountLookupMeta[] = [
                     {
@@ -839,7 +843,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMeta: IAccountLookupMeta = {
                     address: addressInLookup,
@@ -894,7 +900,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMetas: IAccountLookupMeta[] = [
                     {
@@ -957,7 +965,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMetas: IAccountLookupMeta[] = [
                     // writable is first since we used account indices [2,3]
@@ -1018,7 +1028,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountMeta: IAccountMeta = {
                     address: staticAddress,
@@ -1082,7 +1094,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMeta1: IAccountLookupMeta = {
                     address: addressInLookup1,
@@ -1140,7 +1154,7 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const fn = () => decompileTransaction(compiledTransaction, {});
+                const fn = () => decompileTransaction(compiledTransaction);
                 expect(fn).toThrow(
                     'Addresses not provided for lookup tables: [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw]',
                 );
@@ -1179,7 +1193,8 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const fn = () => decompileTransaction(compiledTransaction, lookupTables);
+                const fn = () =>
+                    decompileTransaction(compiledTransaction, { addressesByLookupTableAddress: lookupTables });
                 expect(fn).toThrow(
                     'Cannot look up index 1 in lookup table [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw]. The lookup table may have been extended since the addresses provided were retrieved.',
                 );
@@ -1218,7 +1233,8 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const fn = () => decompileTransaction(compiledTransaction, lookupTables);
+                const fn = () =>
+                    decompileTransaction(compiledTransaction, { addressesByLookupTableAddress: lookupTables });
                 expect(fn).toThrow(
                     'Cannot look up index 1 in lookup table [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw]. The lookup table may have been extended since the addresses provided were retrieved.',
                 );
@@ -1270,7 +1286,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMetas: IAccountLookupMeta[] = [
                     {
@@ -1335,7 +1353,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMetas: IAccountLookupMeta[] = [
                     {
@@ -1412,7 +1432,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMetas: IAccountLookupMeta[] = [
                     {
@@ -1505,7 +1527,9 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const transaction = decompileTransaction(compiledTransaction, lookupTables);
+                const transaction = decompileTransaction(compiledTransaction, {
+                    addressesByLookupTableAddress: lookupTables,
+                });
 
                 const expectedAccountLookupMetasInstruction1: IAccountLookupMeta[] = [
                     // index 2 - writable from lookup1
@@ -1586,7 +1610,7 @@ describe('decompileTransaction', () => {
                     signatures: [],
                 };
 
-                const fn = () => decompileTransaction(compiledTransaction, {});
+                const fn = () => decompileTransaction(compiledTransaction);
                 expect(fn).toThrow(
                     'Addresses not provided for lookup tables: [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw, GS7Rphk6CZLoCGbTcbRaPZzD3k4ZK8XiA5BAj89Fi2Eg]',
                 );

--- a/packages/transactions/src/__tests__/decompile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/decompile-transaction-test.ts
@@ -1142,7 +1142,7 @@ describe('decompileTransaction', () => {
 
                 const fn = () => decompileTransaction(compiledTransaction, {});
                 expect(fn).toThrow(
-                    'Transaction includes missing address lookup tables: [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw]',
+                    'Addresses not provided for lookup tables: [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw]',
                 );
             });
 
@@ -1181,7 +1181,7 @@ describe('decompileTransaction', () => {
 
                 const fn = () => decompileTransaction(compiledTransaction, lookupTables);
                 expect(fn).toThrow(
-                    'Cannot look up index 1 in lookup table 9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw',
+                    'Cannot look up index 1 in lookup table [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw]. The lookup table may have been extended since the addresses provided were retrieved.',
                 );
             });
 
@@ -1220,7 +1220,7 @@ describe('decompileTransaction', () => {
 
                 const fn = () => decompileTransaction(compiledTransaction, lookupTables);
                 expect(fn).toThrow(
-                    'Cannot look up index 1 in lookup table 9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw',
+                    'Cannot look up index 1 in lookup table [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw]. The lookup table may have been extended since the addresses provided were retrieved.',
                 );
             });
         });
@@ -1588,7 +1588,7 @@ describe('decompileTransaction', () => {
 
                 const fn = () => decompileTransaction(compiledTransaction, {});
                 expect(fn).toThrow(
-                    'Transaction includes missing address lookup tables: [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw, GS7Rphk6CZLoCGbTcbRaPZzD3k4ZK8XiA5BAj89Fi2Eg]',
+                    'Addresses not provided for lookup tables: [9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw, GS7Rphk6CZLoCGbTcbRaPZzD3k4ZK8XiA5BAj89Fi2Eg]',
                 );
             });
         });

--- a/packages/transactions/src/__tests__/decompile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/decompile-transaction-test.ts
@@ -35,7 +35,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction);
+            const transaction = decompileTransaction(compiledTransaction, {});
 
             expect(transaction.version).toBe(0);
             expect(transaction.feePayer).toEqual(feePayer);
@@ -61,7 +61,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction);
+            const transaction = decompileTransaction(compiledTransaction, {});
             expect(transaction.version).toBe('legacy');
         });
 
@@ -84,7 +84,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction);
+            const transaction = decompileTransaction(compiledTransaction, {});
             const expectedInstruction: IInstruction = {
                 programAddress,
             };
@@ -126,7 +126,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction);
+            const transaction = decompileTransaction(compiledTransaction, {});
 
             const expectedInstruction: IInstruction = {
                 accounts: [
@@ -175,7 +175,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction);
+            const transaction = decompileTransaction(compiledTransaction, {});
 
             const expectedInstructions: IInstruction[] = [
                 {
@@ -210,7 +210,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
             expect(transaction.signatures).toStrictEqual({
                 [feePayer]: feePayerSignature as SignatureBytes,
             });
@@ -247,7 +247,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature, otherSigner1Signature, otherSigner2Signature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
             expect(transaction.signatures).toStrictEqual({
                 [feePayer]: feePayerSignature,
                 [otherSigner1Address]: otherSigner1Signature,
@@ -287,7 +287,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature, noSignature, otherSigner2Signature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
             expect(transaction.signatures).toStrictEqual({
                 [feePayer]: feePayerSignature,
                 [otherSigner2Address]: otherSigner2Signature,
@@ -310,7 +310,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction, 100n);
+            const transaction = decompileTransaction(compiledTransaction, {}, 100n);
             expect(transaction.lifetimeConstraint).toEqual({
                 blockhash,
                 lastValidBlockHeight: 100n,
@@ -365,7 +365,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction);
+            const transaction = decompileTransaction(compiledTransaction, {});
 
             const expectedInstruction: IInstruction = {
                 accounts: [
@@ -427,7 +427,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction);
+            const transaction = decompileTransaction(compiledTransaction, {});
 
             const expectedInstruction: IInstruction = {
                 accounts: [
@@ -493,7 +493,7 @@ describe('decompileTransaction', () => {
                 signatures: [],
             };
 
-            const transaction = decompileTransaction(compiledTransaction);
+            const transaction = decompileTransaction(compiledTransaction, {});
 
             const expectedInstructions: IInstruction[] = [
                 {
@@ -574,7 +574,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
 
             expect(transaction.signatures).toStrictEqual({
                 [nonceAuthorityAddress]: feePayerSignature,
@@ -620,7 +620,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature, authoritySignature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
 
             expect(transaction.signatures).toStrictEqual({
                 [feePayer]: feePayerSignature,
@@ -677,7 +677,7 @@ describe('decompileTransaction', () => {
                 signatures: [feePayerSignature, noSignature, extraSignerSignature],
             };
 
-            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            const transaction = decompileTransaction(compiledTransaction, {}) as ITransactionWithSignatures;
 
             expect(transaction.signatures).toStrictEqual({
                 [extraSignerAddress]: extraSignerSignature,

--- a/packages/transactions/src/decompile-transaction.ts
+++ b/packages/transactions/src/decompile-transaction.ts
@@ -66,12 +66,12 @@ function getAddressLookupMetas(
     addressesByLookupTableAddress: AddressesByLookupTableAddress,
 ): IAccountLookupMeta[] {
     // check that all message lookups are known
-    const transactionLookupAddresses = compiledAddressTableLookups.map(l => l.lookupTableAddress);
-    const missing = transactionLookupAddresses.filter(a => addressesByLookupTableAddress[a] === undefined);
+    const compiledAddressTableLookupAddresses = compiledAddressTableLookups.map(l => l.lookupTableAddress);
+    const missing = compiledAddressTableLookupAddresses.filter(a => addressesByLookupTableAddress[a] === undefined);
     if (missing.length > 0) {
         const missingAddresses = missing.join(', ');
         // TODO: coded error.
-        throw new Error(`Transaction includes missing address lookup tables: [${missingAddresses}]`);
+        throw new Error(`Addresses not provided for lookup tables: [${missingAddresses}]`);
     }
 
     const readOnlyMetas: IAccountLookupMeta[] = [];
@@ -84,7 +84,9 @@ function getAddressLookupMetas(
         const highestIndex = Math.max(...lookup.readableIndices, ...lookup.writableIndices);
         if (highestIndex >= addresses.length) {
             // TODO coded error
-            throw new Error(`Cannot look up index ${highestIndex} in lookup table ${lookup.lookupTableAddress}`);
+            throw new Error(
+                `Cannot look up index ${highestIndex} in lookup table [${lookup.lookupTableAddress}]. The lookup table may have been extended since the addresses provided were retrieved.`,
+            );
         }
 
         const readOnlyForLookup: IAccountLookupMeta[] = lookup.readableIndices.map(r => ({

--- a/packages/transactions/src/decompile-transaction.ts
+++ b/packages/transactions/src/decompile-transaction.ts
@@ -183,10 +183,14 @@ function convertSignatures(compiledTransaction: CompiledTransaction): ITransacti
     }, {});
 }
 
+export type DecompileTransactionConfig = {
+    addressesByLookupTableAddress?: AddressesByLookupTableAddress;
+    lastValidBlockHeight?: bigint;
+};
+
 export function decompileTransaction(
     compiledTransaction: CompiledTransaction,
-    addressesByLookupTableAddress: AddressesByLookupTableAddress,
-    lastValidBlockHeight?: bigint,
+    config?: DecompileTransactionConfig,
 ): CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures) {
     const { compiledMessage } = compiledTransaction;
 
@@ -199,7 +203,7 @@ export function decompileTransaction(
         'addressTableLookups' in compiledMessage &&
         compiledMessage.addressTableLookups !== undefined &&
         compiledMessage.addressTableLookups.length > 0
-            ? getAddressLookupMetas(compiledMessage.addressTableLookups, addressesByLookupTableAddress)
+            ? getAddressLookupMetas(compiledMessage.addressTableLookups, config?.addressesByLookupTableAddress ?? {})
             : [];
     const transactionMetas = [...accountMetas, ...accountLookupMetas];
 
@@ -211,7 +215,7 @@ export function decompileTransaction(
     const lifetimeConstraint = getLifetimeConstraint(
         compiledMessage.lifetimeToken,
         firstInstruction,
-        lastValidBlockHeight,
+        config?.lastValidBlockHeight,
     );
 
     const signatures = convertSignatures(compiledTransaction);

--- a/packages/transactions/src/serializers/__tests__/transaction-test.ts
+++ b/packages/transactions/src/serializers/__tests__/transaction-test.ts
@@ -1,7 +1,7 @@
 import { Address } from '@solana/addresses';
 import { AccountRole } from '@solana/instructions';
 
-import { decompileTransaction, LookupTables } from '../../decompile-transaction';
+import { AddressesByLookupTableAddress, decompileTransaction } from '../../decompile-transaction';
 import { CompiledMessage, compileMessage } from '../../message';
 import { getCompiledMessageDecoder, getCompiledMessageEncoder } from '../message';
 import { getTransactionCodec, getTransactionDecoder, getTransactionEncoder } from '../transaction';
@@ -260,7 +260,7 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deseria
             ...mockCompiledWireMessage,
         ]);
 
-        const lookupTables: LookupTables = {
+        const lookupTables: AddressesByLookupTableAddress = {
             ['1111' as Address]: ['2222' as Address, '3333' as Address],
             ['4444' as Address]: ['5555' as Address, '6666' as Address],
         };

--- a/packages/transactions/src/serializers/__tests__/transaction-test.ts
+++ b/packages/transactions/src/serializers/__tests__/transaction-test.ts
@@ -149,7 +149,7 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deseria
         });
         (decompileTransaction as jest.Mock).mockReturnValue(mockDecompiledTransaction);
 
-        transaction = deserializerFactory({});
+        transaction = deserializerFactory();
     });
     it('deserializes a transaction with no signatures', () => {
         const noSignature = new Uint8Array(Array(64).fill(0));
@@ -170,7 +170,6 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deseria
                 compiledMessage: mockCompiledMessage,
                 signatures: [noSignature, noSignature],
             },
-            {},
             undefined,
         );
     });
@@ -195,7 +194,6 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deseria
                 compiledMessage: mockCompiledMessage,
                 signatures: [noSignature, mockSignatureA],
             },
-            {},
             undefined,
         );
     });
@@ -220,7 +218,6 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deseria
                 compiledMessage: mockCompiledMessage,
                 signatures: [mockSignatureB, mockSignatureA],
             },
-            {},
             undefined,
         );
     });
@@ -236,7 +233,7 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deseria
             ...mockCompiledWireMessage,
         ]);
 
-        const transaction = deserializerFactory({}, 100n);
+        const transaction = deserializerFactory({ lastValidBlockHeight: 100n });
         const decodedTransaction = transaction.decode(bytes);
         expect(decodedTransaction).toStrictEqual(mockDecompiledTransaction);
         expect(decompileTransaction).toHaveBeenCalledWith(
@@ -244,8 +241,9 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deseria
                 compiledMessage: mockCompiledMessage,
                 signatures: [noSignature, noSignature],
             },
-            {},
-            100n,
+            {
+                lastValidBlockHeight: 100n,
+            },
         );
     });
     it('passes lookupTables to decompileTransaction', () => {
@@ -265,7 +263,7 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deseria
             ['4444' as Address]: ['5555' as Address, '6666' as Address],
         };
 
-        const transaction = deserializerFactory(lookupTables);
+        const transaction = deserializerFactory({ addressesByLookupTableAddress: lookupTables });
         const decodedTransaction = transaction.decode(bytes);
         expect(decodedTransaction).toStrictEqual(mockDecompiledTransaction);
         expect(decompileTransaction).toHaveBeenCalledWith(
@@ -273,8 +271,9 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction deseria
                 compiledMessage: mockCompiledMessage,
                 signatures: [noSignature, noSignature],
             },
-            lookupTables,
-            undefined,
+            {
+                addressesByLookupTableAddress: lookupTables,
+            },
         );
     });
 });

--- a/packages/transactions/src/serializers/transaction.ts
+++ b/packages/transactions/src/serializers/transaction.ts
@@ -20,7 +20,7 @@ import { SignatureBytes } from '@solana/keys';
 
 import { CompilableTransaction } from '../compilable-transaction';
 import { CompiledTransaction, getCompiledTransaction } from '../compile-transaction';
-import { decompileTransaction, LookupTables } from '../decompile-transaction';
+import { AddressesByLookupTableAddress, decompileTransaction } from '../decompile-transaction';
 import { ITransactionWithSignatures } from '../signatures';
 import { getCompiledMessageDecoder, getCompiledMessageEncoder } from './message';
 
@@ -50,7 +50,7 @@ export function getTransactionEncoder(): VariableSizeEncoder<
 }
 
 export function getTransactionDecoder(
-    lookupTables: LookupTables,
+    lookupTables: AddressesByLookupTableAddress,
     lastValidBlockHeight?: bigint,
 ): VariableSizeDecoder<CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)> {
     return mapDecoder(getCompiledTransactionDecoder(), compiledTransaction =>
@@ -59,7 +59,7 @@ export function getTransactionDecoder(
 }
 
 export function getTransactionCodec(
-    lookupTables: LookupTables,
+    lookupTables: AddressesByLookupTableAddress,
     lastValidBlockHeight?: bigint,
 ): VariableSizeCodec<CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)> {
     return combineCodec(getTransactionEncoder(), getTransactionDecoder(lookupTables, lastValidBlockHeight));

--- a/packages/transactions/src/serializers/transaction.ts
+++ b/packages/transactions/src/serializers/transaction.ts
@@ -20,7 +20,7 @@ import { SignatureBytes } from '@solana/keys';
 
 import { CompilableTransaction } from '../compilable-transaction';
 import { CompiledTransaction, getCompiledTransaction } from '../compile-transaction';
-import { AddressesByLookupTableAddress, decompileTransaction } from '../decompile-transaction';
+import { decompileTransaction, DecompileTransactionConfig } from '../decompile-transaction';
 import { ITransactionWithSignatures } from '../signatures';
 import { getCompiledMessageDecoder, getCompiledMessageEncoder } from './message';
 
@@ -50,17 +50,15 @@ export function getTransactionEncoder(): VariableSizeEncoder<
 }
 
 export function getTransactionDecoder(
-    lookupTables: AddressesByLookupTableAddress,
-    lastValidBlockHeight?: bigint,
+    config?: DecompileTransactionConfig,
 ): VariableSizeDecoder<CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)> {
     return mapDecoder(getCompiledTransactionDecoder(), compiledTransaction =>
-        decompileTransaction(compiledTransaction, lookupTables, lastValidBlockHeight),
+        decompileTransaction(compiledTransaction, config),
     );
 }
 
 export function getTransactionCodec(
-    lookupTables: AddressesByLookupTableAddress,
-    lastValidBlockHeight?: bigint,
+    config?: DecompileTransactionConfig,
 ): VariableSizeCodec<CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)> {
-    return combineCodec(getTransactionEncoder(), getTransactionDecoder(lookupTables, lastValidBlockHeight));
+    return combineCodec(getTransactionEncoder(), getTransactionDecoder(config));
 }

--- a/packages/transactions/src/serializers/transaction.ts
+++ b/packages/transactions/src/serializers/transaction.ts
@@ -20,7 +20,7 @@ import { SignatureBytes } from '@solana/keys';
 
 import { CompilableTransaction } from '../compilable-transaction';
 import { CompiledTransaction, getCompiledTransaction } from '../compile-transaction';
-import { decompileTransaction } from '../decompile-transaction';
+import { decompileTransaction, LookupTables } from '../decompile-transaction';
 import { ITransactionWithSignatures } from '../signatures';
 import { getCompiledMessageDecoder, getCompiledMessageEncoder } from './message';
 
@@ -50,15 +50,17 @@ export function getTransactionEncoder(): VariableSizeEncoder<
 }
 
 export function getTransactionDecoder(
+    lookupTables: LookupTables,
     lastValidBlockHeight?: bigint,
 ): VariableSizeDecoder<CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)> {
     return mapDecoder(getCompiledTransactionDecoder(), compiledTransaction =>
-        decompileTransaction(compiledTransaction, lastValidBlockHeight),
+        decompileTransaction(compiledTransaction, lookupTables, lastValidBlockHeight),
     );
 }
 
 export function getTransactionCodec(
+    lookupTables: LookupTables,
     lastValidBlockHeight?: bigint,
 ): VariableSizeCodec<CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures)> {
-    return combineCodec(getTransactionEncoder(), getTransactionDecoder(lastValidBlockHeight));
+    return combineCodec(getTransactionEncoder(), getTransactionDecoder(lookupTables, lastValidBlockHeight));
 }


### PR DESCRIPTION
This PR updates `decompileTransaction` to support transactions that include address lookup tables. It is passed a dictionary of `Address -> Address[]` mapping each lookup table address to its addresses. These are used to generate `IAccountLookupMeta` objects for the instructions that use addresses from the lookup tables. An error is thrown for any lookup table required by the transaction that is missing from the mapping passed in.

The `getTransactionDecoder` and `getTransactionCodec` functions are both modified to receive this mapping of address lookups and pass it to `decompileTransaction`. It is the responsibility of the caller to fetch the required lookups and pass them in.

A follow up PR will add an async `decodeTransaction` helper function to the `library` package that uses an `RPC<GetMultipleAccountsApi>` to fetch them. This will be the recommended method of decoding transactions. 
