### PR TITLE
Fix bug where decompileTransaction would return empty signatures instead of excluding the field

### DIFF
--- a/packages/transactions/src/__tests__/decompile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/decompile-transaction-test.ts
@@ -316,6 +316,51 @@ describe('decompileTransaction', () => {
                 lastValidBlockHeight: 100n,
             });
         });
+
+        it('excludes the signatures field if the transaction has no signatures', () => {
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 0,
+                        numReadonlySignerAccounts: 0,
+                        numSignerAccounts: 1,
+                    },
+                    instructions: [],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [feePayer],
+                    version: 0,
+                },
+                signatures: [],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction, {});
+            expect(transaction).not.toHaveProperty('signatures');
+        });
+
+        it('excludes the signatures field if the transaction has only all-zero signatures', () => {
+            // when we compile a transaction we insert all-zero signatures where they're missing
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage: {
+                    header: {
+                        numReadonlyNonSignerAccounts: 0,
+                        numReadonlySignerAccounts: 0,
+                        numSignerAccounts: 1,
+                    },
+                    instructions: [],
+                    lifetimeToken: blockhash,
+                    staticAccounts: [feePayer],
+                    version: 0,
+                },
+                signatures: [
+                    new Uint8Array(64) as SignatureBytes,
+                    new Uint8Array(64) as SignatureBytes,
+                    new Uint8Array(64) as SignatureBytes,
+                ],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction, {});
+            expect(transaction).not.toHaveProperty('signatures');
+        });
     });
 
     describe('for a transaction with a durable nonce lifetime', () => {

--- a/packages/transactions/src/decompile-transaction.ts
+++ b/packages/transactions/src/decompile-transaction.ts
@@ -231,6 +231,6 @@ export function decompileTransaction(
             'blockhash' in lifetimeConstraint
                 ? setTransactionLifetimeUsingBlockhash(lifetimeConstraint, tx)
                 : setTransactionLifetimeUsingDurableNonce(lifetimeConstraint, tx),
-        tx => (compiledTransaction.signatures.length ? { ...tx, signatures } : tx),
+        tx => (Object.keys(signatures).length > 0 ? { ...tx, signatures } : tx),
     );
 }


### PR DESCRIPTION
This PR fixes a bug where decompiling a transaction that had no real signatures would result in returning `signatures: {}` instead of excluding that field. This meant that compiling and then decompiling such a transaction would not give an identical result when it should.

When we compile a transaction, we insert an all-zero 64-byte Uint8Array in place of all missing signatures.

We already had logic to exclude these signatures when we decompile a transaction, since we don't store them on our `Transaction` model. They're simply an artifact of compiling a transaction.

But the logic that determined whether to include the `signatures` field used the input `compiledTransaction.signatures` instead of our filtered and reshaped signatures to determine whether there were any signatures. This meant that it included the field even if there were only all-zero signatures that we removed.
