### PR TITLE
feat: specify which account is missing/has an invalid signature on signature verification failure

### DIFF
--- a/packages/library-legacy/src/transaction/legacy.ts
+++ b/packages/library-legacy/src/transaction/legacy.ts
@@ -760,7 +760,7 @@ export class Transaction {
    */
   verifySignatures(requireAllSignatures?: boolean): boolean {
     return (
-      this._findSigError(
+      this._findSigErrors(
         this.serializeMessage(),
         requireAllSignatures === undefined ? true : requireAllSignatures,
       ).length === 0
@@ -770,7 +770,7 @@ export class Transaction {
   /**
    * @internal
    */
-  _findSigError(
+  _findSigErrors(
     signData: Uint8Array,
     requireAllSignatures: boolean,
   ): Pair<PublicKey, string>[] {
@@ -804,7 +804,7 @@ export class Transaction {
 
     const signData = this.serializeMessage();
     const sigErrors = verifySignatures
-      ? this._findSigError(signData, requireAllSignatures)
+      ? this._findSigErrors(signData, requireAllSignatures)
       : [];
     if (sigErrors.length > 0) {
       const errMessage = sigErrors.reduceRight(

--- a/packages/library-legacy/src/transaction/legacy.ts
+++ b/packages/library-legacy/src/transaction/legacy.ts
@@ -776,8 +776,6 @@ export class Transaction {
   ): Pair<PublicKey, string>[] {
     const errAggregator: Pair<PublicKey, string>[] = [];
     for (const {signature, publicKey} of this.signatures) {
-      console.log(publicKey.toString());
-      console.log(signature);
       if (signature === null) {
         if (requireAllSignatures) {
           errAggregator.push({fst: publicKey, snd: 'Missing Signature'});

--- a/packages/library-legacy/src/utils/Pair.ts
+++ b/packages/library-legacy/src/utils/Pair.ts
@@ -1,4 +1,0 @@
-export type Pair<T, V> = {
-  fst: T;
-  snd: V;
-};

--- a/packages/library-legacy/src/utils/Pair.ts
+++ b/packages/library-legacy/src/utils/Pair.ts
@@ -1,0 +1,4 @@
+export type Pair<T, V> = {
+  fst: T;
+  snd: V;
+};

--- a/packages/library-legacy/test/transaction.test.ts
+++ b/packages/library-legacy/test/transaction.test.ts
@@ -795,30 +795,6 @@ describe('Transaction', () => {
 
     expectedTransaction.feePayer = sender.publicKey;
 
-    // Transactions with missing signatures will fail sigverify.
-    expect(() => {
-      expectedTransaction.serialize();
-    }).to.throw(
-      'Missing signature for public key: ' + sender.publicKey.toBase58(),
-    );
-
-    // Serializing without signatures is allowed if sigverify disabled.
-    expectedTransaction.serialize({verifySignatures: false});
-
-    // Serializing the message is allowed when signature array has null signatures
-    expectedTransaction.serializeMessage();
-
-    expectedTransaction.feePayer = undefined;
-    expectedTransaction.setSigners(sender.publicKey);
-    expect(expectedTransaction.signatures).to.have.length(1);
-
-    // Transactions with invalid signature will fail sigverify.
-    expect(() => {
-      expectedTransaction.serialize();
-    }).to.throw(
-      'Invalid signature for public key: ' + sender.publicKey.toBase58(),
-    );
-
     // Serializing without signatures is allowed if sigverify disabled.
     expectedTransaction.serialize({verifySignatures: false});
 
@@ -849,6 +825,66 @@ describe('Transaction', () => {
     );
     expect(expectedTransaction.serialize()).to.eql(expectedSerialization);
     expect(expectedTransaction.signatures).to.have.length(1);
+  });
+
+  it('throws for invalid signatures', () => {
+    const sender = Keypair.fromSeed(Uint8Array.from(Array(32).fill(8))); // Arbitrary known account
+    const recentBlockhash = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k'; // Arbitrary known recentBlockhash
+    const recipient = new PublicKey(
+      'J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i99',
+    ); // Arbitrary known public key
+    const transfer = SystemProgram.transfer({
+      fromPubkey: sender.publicKey,
+      toPubkey: recipient,
+      lamports: 49,
+    });
+    const sampleTransaction = new Transaction({
+      blockhash: recentBlockhash,
+      lastValidBlockHeight: 9999,
+    }).add(transfer);
+    sampleTransaction.feePayer = sender.publicKey;
+
+    // Transactions with missing signatures will fail sigverify.
+    expect(() => {
+      sampleTransaction.serialize();
+    }).to.throw(sender.publicKey.toBase58() + ': Missing Signature');
+
+    // Serializing without signatures is allowed if sigverify disabled.
+    sampleTransaction.serialize({verifySignatures: false});
+
+    // Serializing the message is allowed when signature array has null signatures
+    sampleTransaction.serializeMessage();
+
+    sampleTransaction.feePayer = undefined;
+    sampleTransaction.setSigners(sender.publicKey);
+    expect(sampleTransaction.signatures).to.have.length(1);
+    sampleTransaction.signatures[0].signature = Buffer.allocUnsafe(64).fill(0);
+
+    // Transactions with invalid signature will fail sigverify.
+    expect(() => {
+      sampleTransaction.serialize();
+    }).to.throw(sender.publicKey.toBase58() + ': Invalid Signature');
+
+    const tempKey = Keypair.generate();
+    sampleTransaction.feePayer = tempKey.publicKey;
+    sampleTransaction.signatures[0] = {
+      signature: null,
+      publicKey: tempKey.publicKey,
+    };
+    sampleTransaction.signatures[1] = {
+      signature: Buffer.allocUnsafe(64).fill(42),
+      publicKey: sender.publicKey,
+    };
+
+    // Transactions with invalid signature and missing signature will fail sigverify and throw both.
+    expect(() => {
+      sampleTransaction.serialize();
+    }).to.throw(
+      sender.publicKey.toBase58() +
+        ': Invalid Signature\n' +
+        tempKey.publicKey.toBase58() +
+        ': Missing Signature\n',
+    );
   });
 
   describe('partially signed transaction signature verification tests', () => {

--- a/packages/library-legacy/test/transaction.test.ts
+++ b/packages/library-legacy/test/transaction.test.ts
@@ -798,7 +798,10 @@ describe('Transaction', () => {
     // Transactions with missing signatures will fail sigverify.
     expect(() => {
       expectedTransaction.serialize();
-    }).to.throw('Signature verification failed');
+    }).to.throw(
+      'Signature verification failed for account ' +
+        sender.publicKey.toBase58(),
+    );
 
     // Serializing without signatures is allowed if sigverify disabled.
     expectedTransaction.serialize({verifySignatures: false});
@@ -813,7 +816,10 @@ describe('Transaction', () => {
     // Transactions with missing signatures will fail sigverify.
     expect(() => {
       expectedTransaction.serialize();
-    }).to.throw('Signature verification failed');
+    }).to.throw(
+      'Signature verification failed for account ' +
+        sender.publicKey.toBase58(),
+    );
 
     // Serializing without signatures is allowed if sigverify disabled.
     expectedTransaction.serialize({verifySignatures: false});

--- a/packages/library-legacy/test/transaction.test.ts
+++ b/packages/library-legacy/test/transaction.test.ts
@@ -847,7 +847,9 @@ describe('Transaction', () => {
     // Transactions with missing signatures will fail sigverify.
     expect(() => {
       sampleTransaction.serialize();
-    }).to.throw(sender.publicKey.toBase58() + ': Missing Signature');
+    }).to.throw(
+      `Signature verification failed.\nMissing signature for public key [\`${sender.publicKey.toBase58()}\`].`,
+    );
 
     // Serializing without signatures is allowed if sigverify disabled.
     sampleTransaction.serialize({verifySignatures: false});
@@ -863,7 +865,9 @@ describe('Transaction', () => {
     // Transactions with invalid signature will fail sigverify.
     expect(() => {
       sampleTransaction.serialize();
-    }).to.throw(sender.publicKey.toBase58() + ': Invalid Signature');
+    }).to.throw(
+      `Signature verification failed.\nInvalid signature for public key [\`${sender.publicKey.toBase58()}\`].`,
+    );
 
     const tempKey = Keypair.generate();
     sampleTransaction.feePayer = tempKey.publicKey;
@@ -880,10 +884,7 @@ describe('Transaction', () => {
     expect(() => {
       sampleTransaction.serialize();
     }).to.throw(
-      sender.publicKey.toBase58() +
-        ': Invalid Signature\n' +
-        tempKey.publicKey.toBase58() +
-        ': Missing Signature\n',
+      `Signature verification failed.\nInvalid signature for public key [\`${sender.publicKey.toBase58()}\`].\nMissing signature for public key [\`${tempKey.publicKey.toBase58()}\`].`,
     );
   });
 

--- a/packages/library-legacy/test/transaction.test.ts
+++ b/packages/library-legacy/test/transaction.test.ts
@@ -799,8 +799,7 @@ describe('Transaction', () => {
     expect(() => {
       expectedTransaction.serialize();
     }).to.throw(
-      'Signature verification failed for account ' +
-        sender.publicKey.toBase58(),
+      'Missing signature for public key: ' + sender.publicKey.toBase58(),
     );
 
     // Serializing without signatures is allowed if sigverify disabled.
@@ -813,12 +812,11 @@ describe('Transaction', () => {
     expectedTransaction.setSigners(sender.publicKey);
     expect(expectedTransaction.signatures).to.have.length(1);
 
-    // Transactions with missing signatures will fail sigverify.
+    // Transactions with invalid signature will fail sigverify.
     expect(() => {
       expectedTransaction.serialize();
     }).to.throw(
-      'Signature verification failed for account ' +
-        sender.publicKey.toBase58(),
+      'Invalid signature for public key: ' + sender.publicKey.toBase58(),
     );
 
     // Serializing without signatures is allowed if sigverify disabled.


### PR DESCRIPTION
In my experience, an annoying error to get because it doesn't give you the information you really want (which account has the problem) even though it clearly can. This PR fixes this.

Also seems I'm not the only that finds this annoying: https://twitter.com/redacted_noah/status/1742943786299191741