### PR TITLE
Export `@solana/functional` from the main library

### DIFF
--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@solana/addresses';
+export * from '@solana/functional';
 export * from '@solana/instructions';
 export * from '@solana/keys';
 export * from '@solana/rpc-types';


### PR DESCRIPTION
It's wierd for `@solana/functional` to be the only thing that you have to add as a dependency separate from `@solana/web3.js`, if that's the way you're going.
