### PR TITLE
refactor(experimental): fix memo instructions in GraphQL

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1385,6 +1385,9 @@ export const mockTransactionStake = {
     },
 };
 
+// There's a memo instruction in this one
+export const mockTransactionMemo = mockTransactionStake;
+
 export const mockTransactionVote = {
     blockTime: 1699617237,
     meta: {

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -16,6 +16,7 @@ import {
     mockTransactionBase58,
     mockTransactionBase64,
     mockTransactionGeneric,
+    mockTransactionMemo,
     mockTransactionSystem,
     mockTransactionToken,
     mockTransactionVote,
@@ -557,6 +558,45 @@ describe('transaction', () => {
                                     ]),
                                 },
                             ]),
+                        },
+                    },
+                },
+            });
+        });
+        it('can get a `SplMemoInstruction` instruction', async () => {
+            expect.assertions(1);
+            fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionMemo)));
+            const source = /* GraphQL */ `
+                query testQuery {
+                    transaction(signature: "${defaultTransactionSignature}") {
+                        ... on TransactionParsed {
+                            data {
+                                message {
+                                    instructions {
+                                            programId
+                                        ... on SplMemoInstruction {
+                                            memo
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source);
+            expect(result).toMatchObject({
+                data: {
+                    transaction: {
+                        data: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        memo: 'fb_07ce1448',
+                                        programId: 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr',
+                                    },
+                                ]),
+                            },
                         },
                     },
                 },

--- a/packages/rpc-graphql/src/loaders/transformers/transaction.ts
+++ b/packages/rpc-graphql/src/loaders/transformers/transaction.ts
@@ -2,6 +2,11 @@
 
 function transformParsedInstruction(parsedInstruction: any) {
     if ('parsed' in parsedInstruction) {
+        if (typeof parsedInstruction.parsed === 'string' && parsedInstruction.program === 'spl-memo') {
+            const { parsed: memo, program: programName, programId } = parsedInstruction;
+            const instructionType = 'memo';
+            return { instructionType, memo, programId, programName };
+        }
         const {
             parsed: { info: data, type: instructionType },
             program: programName,

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -189,7 +189,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     # SplMemo
     type SplMemoInstruction implements TransactionInstruction {
         programId: Address
-        data: String
+        memo: String
     }
 
     # SplToken: InitializeMint


### PR DESCRIPTION
This PR fixes the `transformParsedInstruction(..)` function to support proper
parsing of `spl-memo` instructions.
