### PR TITLE
Re-export @solana/accounts from @solana/web3.js

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -65,6 +65,7 @@
         "maintained node versions"
     ],
     "dependencies": {
+        "@solana/accounts": "workspace:*",
         "@solana/addresses": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
         "@solana/functional": "workspace:*",

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -1,3 +1,4 @@
+export * from '@solana/accounts';
 export * from '@solana/addresses';
 export * from '@solana/functional';
 export * from '@solana/instructions';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   jsdom: ^22
   mock-socket: ^9.3.0
@@ -256,7 +260,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.0.1
-        version: 8.0.1(@swc/core@1.3.93)(ts-node@10.9.1)(typescript@5.1.6)
+        version: 8.0.1(@swc/core@1.3.93)(ts-node@10.9.1)(typescript@5.2.2)
 
   packages/codecs-core:
     devDependencies:
@@ -934,6 +938,9 @@ importers:
 
   packages/library:
     dependencies:
+      '@solana/accounts':
+        specifier: workspace:*
+        version: link:../accounts
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
@@ -5114,7 +5121,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 6.13.2(@typescript-eslint/parser@6.8.0)(eslint@8.51.0)(typescript@5.2.2)
       '@typescript-eslint/parser': 6.8.0(eslint@8.51.0)(typescript@5.2.2)
       eslint: 8.51.0
-      eslint-plugin-jest: 27.4.2(@typescript-eslint/eslint-plugin@6.13.2)(eslint@8.45.0)(jest@29.7.0)(typescript@5.1.6)
+      eslint-plugin-jest: 27.4.2(@typescript-eslint/eslint-plugin@6.13.2)(eslint@8.51.0)(jest@29.7.0)(typescript@5.2.2)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.51.0)
       eslint-plugin-simple-import-sort: 10.0.0(eslint@8.51.0)
       eslint-plugin-sort-keys-fix: 1.1.2
@@ -13972,7 +13979,3 @@ packages:
   /zstd-codec@0.1.4:
     resolution: {integrity: sha512-KYnWoFWgGtWyQEKNnUcb3u8ZtKO8dn5d8u+oGpxPlopqsPyv60U8suDyfk7Z7UtAO6Sk5i1aVcAs9RbaB1n36A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
Same logic as https://github.com/solana-labs/solana-web3.js/pull/2007

`accounts` is a relatively high level package and you shouldn't need to install it separately from `@solana/web3.js` if you're using the main package. 