### PR TITLE
Fix return type of getTokenAccountsByDelegate/Owner

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__typetests__/rpc-methods-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/rpc-methods-test.ts
@@ -1,0 +1,36 @@
+import { Address } from '@solana/addresses';
+import { Rpc } from '@solana/rpc-transport';
+
+import { SolanaRpcMethods } from '..';
+
+const rpc = {} as unknown as Rpc<SolanaRpcMethods>;
+
+// getTokenAccountsByDelegate
+async () => {
+    const tokenAccountsByDelegate = await rpc
+        .getTokenAccountsByDelegate(
+            'delegate' as Address,
+            { programId: 'program' as Address },
+            { encoding: 'jsonParsed' },
+        )
+        .send();
+
+    const firstAccount = tokenAccountsByDelegate.value[0];
+    firstAccount.pubkey satisfies Address;
+    firstAccount.account.data.program satisfies Address;
+    firstAccount.account.data.parsed.type satisfies 'account';
+    firstAccount.account.data.parsed.info.mint satisfies Address;
+};
+
+// getTokenAccountsByOwner
+async () => {
+    const tokenAccountsByOwner = await rpc
+        .getTokenAccountsByOwner('owner' as Address, { programId: 'program' as Address }, { encoding: 'jsonParsed' })
+        .send();
+
+    const firstAccount = tokenAccountsByOwner.value[0];
+    firstAccount.pubkey satisfies Address;
+    firstAccount.account.data.program satisfies Address;
+    firstAccount.account.data.parsed.type satisfies 'account';
+    firstAccount.account.data.parsed.info.mint satisfies Address;
+};

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountsByDelegate.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountsByDelegate.ts
@@ -19,11 +19,11 @@ import {
 type TokenAccountInfoWithJsonData = Readonly<{
     data: Readonly<{
         /** Name of the program that owns this account. */
-        program: {
+        program: Address;
+        parsed: {
             info: TokenAccount;
             type: 'account';
         };
-        parsed: unknown;
         space: U64UnsafeBeyond2Pow53Minus1;
     }>;
 }>;

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountsByOwner.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountsByOwner.ts
@@ -19,11 +19,11 @@ import {
 type TokenAccountInfoWithJsonData = Readonly<{
     data: Readonly<{
         /** Name of the program that owns this account. */
-        program: {
+        program: Address;
+        parsed: {
             info: TokenAccount;
             type: 'account';
         };
-        parsed: unknown;
         space: U64UnsafeBeyond2Pow53Minus1;
     }>;
 }>;


### PR DESCRIPTION
These data stuctures were messed up, with the `TokenAccount` nested under the `program` instead of `data`

I've added typetests to verify the fix. I don't think we had these when we first wrote most of these methods, but they're better than the unit tests we have for rpc-methods TBH. Probably worth adding them at least where we find bugs!
