### PR TITLE
refactor(experimental): add codecs to main library

### DIFF
--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -784,6 +784,8 @@ Solana’s codecs libraries are broken up into modular components so you only ne
 - `@solana/codecs-data-structures`: Codecs and serializers for structs
 - `@solana/options`: Designed to build codecs and serializers for types that mimic Rust’s enums, which can include embedded data within their variants such as values, tuples, and structs
 
+These packages are included in the main `@solana/web3.js` library but you may also import them from `@solana/codecs` if you only need the codecs.
+
 Here’s an example of encoding and decoding a custom struct with some strings and numbers:
 
 ```tsx

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -67,7 +67,7 @@
     "dependencies": {
         "@solana/accounts": "workspace:*",
         "@solana/addresses": "workspace:*",
-        "@solana/codecs-strings": "workspace:*",
+        "@solana/codecs": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",

--- a/packages/library/src/__tests__/transaction-confirmation-strategy-nonce-test.ts
+++ b/packages/library/src/__tests__/transaction-confirmation-strategy-nonce-test.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { getBase58Encoder, getBase64Decoder } from '@solana/codecs-strings';
+import { getBase58Encoder, getBase64Decoder } from '@solana/codecs';
 import { Nonce } from '@solana/transactions';
 
 import { createNonceInvalidationPromiseFactory } from '../transaction-confirmation-strategy-nonce';

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -1,5 +1,6 @@
 export * from '@solana/accounts';
 export * from '@solana/addresses';
+export * from '@solana/codecs';
 export * from '@solana/functional';
 export * from '@solana/instructions';
 export * from '@solana/keys';

--- a/packages/library/src/transaction-confirmation-strategy-nonce.ts
+++ b/packages/library/src/transaction-confirmation-strategy-nonce.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { getBase58Decoder, getBase64Encoder } from '@solana/codecs-strings';
+import { getBase58Decoder, getBase64Encoder } from '@solana/codecs';
 import type { AccountNotificationsApi, GetAccountInfoApi } from '@solana/rpc-core';
 import type { Rpc, RpcSubscriptions } from '@solana/rpc-transport';
 import { Base64EncodedDataResponse, Commitment } from '@solana/rpc-types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1011,9 +1011,9 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
-      '@solana/codecs-strings':
+      '@solana/codecs':
         specifier: workspace:*
-        version: link:../codecs-strings
+        version: link:../codecs
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional


### PR DESCRIPTION
This PR adds the new `@solana/codecs` umbrella package to the main `@solana/web3.js` library.

Codecs are a core component of the new Web3.js and are already being fully imported by the current dependencies of the main library. For instance, `@solana/transactions` — which is re-exported by the main library — uses them all.

Therefore, it makes sense to also export them from the main library so end-users can easily leverage them in their own applications.
