### PR TITLE
nit: Add comment specifying encoding of addresses

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -944,7 +944,7 @@ export type SimulateTransactionConfig = {
   replaceRecentBlockhash?: boolean;
   /** Optional parameter used to set the commitment level when selecting the latest block */
   commitment?: Commitment;
-  /** Optional parameter used to specify a list of account addresses to return post simulation state for */
+  /** Optional parameter used to specify a list of account addresses (in bs58) to return post simulation state for */
   accounts?: {
     encoding: 'base64';
     addresses: string[];

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -944,7 +944,7 @@ export type SimulateTransactionConfig = {
   replaceRecentBlockhash?: boolean;
   /** Optional parameter used to set the commitment level when selecting the latest block */
   commitment?: Commitment;
-  /** Optional parameter used to specify a list of account addresses (in bs58) to return post simulation state for */
+  /** Optional parameter used to specify a list of base58-encoded account addresses to return post simulation state for */
   accounts?: {
     encoding: 'base64';
     addresses: string[];

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -946,6 +946,7 @@ export type SimulateTransactionConfig = {
   commitment?: Commitment;
   /** Optional parameter used to specify a list of base58-encoded account addresses to return post simulation state for */
   accounts?: {
+    /** The encoding of the returned account's data */
     encoding: 'base64';
     addresses: string[];
   };


### PR DESCRIPTION
Caused some initial confusion for me when using this type, as it wasn't directly obvious to me that the returned data is encoded in base64, not that the addresses themselves are meant to be in base64 (they're meant to be in base58 as usual).  Not sure if this is just me being a doofus, but either way specifying the encoding in a comment can't hurt.