### PR TITLE
Export @solana/rpc-parsed-types from the main library

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -72,6 +72,7 @@
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
         "@solana/rpc-core": "workspace:*",
+        "@solana/rpc-parsed-types": "workspace:*",
         "@solana/rpc-transport": "workspace:*",
         "@solana/rpc-types": "workspace:*",
         "@solana/transactions": "workspace:*",

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -3,6 +3,7 @@ export * from '@solana/addresses';
 export * from '@solana/functional';
 export * from '@solana/instructions';
 export * from '@solana/keys';
+export * from '@solana/rpc-parsed-types';
 export * from '@solana/rpc-types';
 export * from '@solana/transactions';
 export * from './airdrop';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,6 +962,9 @@ importers:
       '@solana/rpc-core':
         specifier: workspace:*
         version: link:../rpc-core
+      '@solana/rpc-parsed-types':
+        specifier: workspace:*
+        version: link:../rpc-parsed-types
       '@solana/rpc-transport':
         specifier: workspace:*
         version: link:../rpc-transport


### PR DESCRIPTION
Since these are intended to be used with `accounts` or `rpc-core` account fetching, I think it makes sense to export them from the main package too.
