### PR TITLE
fix: change request retry output log to an error log

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -1634,7 +1634,7 @@ function createRpcClient(
         if (too_many_requests_retries === 0) {
           break;
         }
-        console.log(
+        console.error(
           `Server responded with ${res.status} ${res.statusText}.  Retrying after ${waitTime}ms delay...`,
         );
         await sleep(waitTime);


### PR DESCRIPTION
When rate limiting errors are hit in the legacy library, an error message is logged via `console.log` rather than `console.error`. This means that this error message gets logged to `stdout` for node apps.. which is very annoying when writing node scripts.