### PR TITLE
Export RpcParsedType from rpc-parsed-types package

### DIFF
--- a/packages/rpc-parsed-types/src/index.ts
+++ b/packages/rpc-parsed-types/src/index.ts
@@ -2,6 +2,7 @@ export * from './address-lookup-table-accounts';
 export * from './bpf-upgradeable-loader-accounts';
 export * from './config-accounts';
 export * from './nonce-accounts';
+export * from './rpc-parsed-type';
 export * from './stake-accounts';
 export * from './sysvar-accounts';
 export * from './token-accounts';


### PR DESCRIPTION
This PR exports the `RpcParsedType` that is used for the tagged union when there are multiple JSON parsed accounts for the same program

Exporting this makes it easy for a caller to create a conditional type to define each individual subtype that it needs, without us exporting them all
