### PR TITLE
remove broken 2.0.0-development dependency

### DIFF
--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -62,7 +62,7 @@
         "maintained node versions"
     ],
     "devDependencies": {
-        "@solana/codecs-core": "workspace:2.0.0-development",
+        "@solana/codecs-core": "workspace:*",
         "@solana/eslint-config-solana": "^1.0.2",
         "@swc/jest": "^0.2.29",
         "@types/jest": "^29.5.11",
@@ -94,6 +94,6 @@
         ]
     },
     "dependencies": {
-        "@solana/codecs-strings": "workspace:2.0.0-development"
+        "@solana/codecs-strings": "workspace:*"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1879,11 +1879,11 @@ importers:
   packages/rpc-types:
     dependencies:
       '@solana/codecs-strings':
-        specifier: workspace:2.0.0-development
+        specifier: workspace:*
         version: link:../codecs-strings
     devDependencies:
       '@solana/codecs-core':
-        specifier: workspace:2.0.0-development
+        specifier: workspace:*
         version: link:../codecs-core
       '@solana/eslint-config-solana':
         specifier: ^1.0.2


### PR DESCRIPTION
Some idiot (me) added a `workspace:2.0.0-development` dependency and broke installing all the things

```
$ npm install @solana/web3.js@2.0.0-experimental.4c9a8b8
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @solana/codecs-strings@2.0.0-development.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```

This PR fixes it! 