### PR TITLE
refactor(experimental): graphql: refactor entrypoint to fix caching

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -869,26 +869,28 @@ describe('account', () => {
             expect.assertions(2);
             const source = `
                 query testQuery {
-                    account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
-                        address
-                        ... on MintAccount {
-                            mintAuthority {
-                                address
-                                lamports
-                            }
-                        }
+                    account1: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                        lamports
+                    }
+                    account2: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                        lamports
+                    }
+                    account3: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                        lamports
                     }
                 }
             `;
             const result = await rpcGraphQL.query(source);
             expect(result).toMatchObject({
                 data: {
-                    account: {
-                        address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
-                        mintAuthority: {
-                            address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
-                            lamports: expect.any(BigInt),
-                        },
+                    account1: {
+                        lamports: expect.any(BigInt),
+                    },
+                    account2: {
+                        lamports: expect.any(BigInt),
+                    },
+                    account3: {
+                        lamports: expect.any(BigInt),
                     },
                 },
             });

--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -784,7 +784,7 @@ describe('account', () => {
     describe('when querying only an address', () => {
         describe('in the first level', () => {
             it('will not call the RPC for only an address', async () => {
-                expect.assertions(2);
+                expect.assertions(1);
                 const source = `
                 query testQuery {
                     account(address: "2JPQuT3dHtPjrdcbUQyrrT4XYRYaWpWfmAJ54SUapg6n") {
@@ -792,20 +792,13 @@ describe('account', () => {
                     }
                 }
             `;
-                const result = await rpcGraphQL.query(source);
-                expect(result).toMatchObject({
-                    data: {
-                        account: {
-                            address: '2JPQuT3dHtPjrdcbUQyrrT4XYRYaWpWfmAJ54SUapg6n',
-                        },
-                    },
-                });
+                await rpcGraphQL.query(source);
                 expect(fetchMock).not.toHaveBeenCalled();
             });
         });
         describe('in the second level', () => {
             it('will not call the RPC for only an address', async () => {
-                expect.assertions(2);
+                expect.assertions(1);
                 const source = `
                 query testQuery {
                     account(address: "CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN") {
@@ -816,23 +809,13 @@ describe('account', () => {
                     }
                 }
             `;
-                const result = await rpcGraphQL.query(source);
-                expect(result).toMatchObject({
-                    data: {
-                        account: {
-                            address: 'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN',
-                            ownerProgram: {
-                                address: 'Stake11111111111111111111111111111111111111',
-                            },
-                        },
-                    },
-                });
+                await rpcGraphQL.query(source);
                 expect(fetchMock).toHaveBeenCalledTimes(1);
             });
         });
         describe('in the third level', () => {
             it('will not call the RPC for only an address', async () => {
-                expect.assertions(2);
+                expect.assertions(1);
                 const source = `
                 query testQuery {
                     account(address: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
@@ -846,27 +829,14 @@ describe('account', () => {
                     }
                 }
             `;
-                const result = await rpcGraphQL.query(source);
-                expect(result).toMatchObject({
-                    data: {
-                        account: {
-                            address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
-                            ownerProgram: {
-                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-                                ownerProgram: {
-                                    address: 'BPFLoader2111111111111111111111111111111111',
-                                },
-                            },
-                        },
-                    },
-                });
+                await rpcGraphQL.query(source);
                 expect(fetchMock).toHaveBeenCalledTimes(2);
             });
         });
     });
     describe('cache tests', () => {
         it('coalesces multiple requests for the same account into one', async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const source = `
                 query testQuery {
                     account1: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
@@ -880,21 +850,22 @@ describe('account', () => {
                     }
                 }
             `;
-            const result = await rpcGraphQL.query(source);
-            expect(result).toMatchObject({
-                data: {
-                    account1: {
-                        lamports: expect.any(BigInt),
-                    },
-                    account2: {
-                        lamports: expect.any(BigInt),
-                    },
-                    account3: {
-                        lamports: expect.any(BigInt),
-                    },
-                },
-            });
+            await rpcGraphQL.query(source);
             expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+        it('cache resets on new tick', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                        lamports
+                    }
+                }
+            `;
+            // Call the query twice
+            await rpcGraphQL.query(source);
+            await rpcGraphQL.query(source);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -306,7 +306,37 @@ describe('block', () => {
         it.todo('can query a block with transactions as JSON parsed with specific instructions');
     });
     describe('cache tests', () => {
-        // Not required yet since blocks are not supported as nested queries.
-        it.todo('coalesces multiple requests for the same block into one');
+        it('coalesces multiple requests for the same block into one', async () => {
+            expect.assertions(2);
+            fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockNone)));
+            const source = /* GraphQL */ `
+                query testQuery($slot: BigInt!) {
+                    block1: block(slot: $slot) {
+                        blockhash
+                    }
+                    block2: block(slot: $slot) {
+                        blockhash
+                    }
+                    block3: block(slot: $slot) {
+                        blockhash
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { slot: defaultSlot });
+            expect(result).toMatchObject({
+                data: {
+                    block1: {
+                        blockhash: expect.any(String),
+                    },
+                    block2: {
+                        blockhash: expect.any(String),
+                    },
+                    block3: {
+                        blockhash: expect.any(String),
+                    },
+                },
+            });
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -657,7 +657,7 @@ describe('programAccounts', () => {
     });
     describe('cache tests', () => {
         it('coalesces multiple requests for the same program into one', async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const source = /* GraphQL */ `
                 query testQuery {
                     programAccounts1: programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
@@ -671,15 +671,23 @@ describe('programAccounts', () => {
                     }
                 }
             `;
-            const result = await rpcGraphQL.query(source);
-            expect(result).toMatchObject({
-                data: {
-                    programAccounts1: expect.arrayContaining([{ lamports: expect.any(BigInt) }]),
-                    programAccounts2: expect.arrayContaining([{ lamports: expect.any(BigInt) }]),
-                    programAccounts3: expect.arrayContaining([{ lamports: expect.any(BigInt) }]),
-                },
-            });
+            await rpcGraphQL.query(source);
             expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+        it('cache resets on new tick', async () => {
+            expect.assertions(1);
+            await jest.runAllTimersAsync();
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                        lamports
+                    }
+                }
+            `;
+            // Call the query twice
+            await rpcGraphQL.query(source);
+            await rpcGraphQL.query(source);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -656,7 +656,30 @@ describe('programAccounts', () => {
         });
     });
     describe('cache tests', () => {
-        // Not required yet since program accounts are not supported as nested queries.
-        it.todo('coalesces multiple requests for the same program into one');
+        it('coalesces multiple requests for the same program into one', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts1: programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                        lamports
+                    }
+                    programAccounts2: programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                        lamports
+                    }
+                    programAccounts3: programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                        lamports
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source);
+            expect(result).toMatchObject({
+                data: {
+                    programAccounts1: expect.arrayContaining([{ lamports: expect.any(BigInt) }]),
+                    programAccounts2: expect.arrayContaining([{ lamports: expect.any(BigInt) }]),
+                    programAccounts3: expect.arrayContaining([{ lamports: expect.any(BigInt) }]),
+                },
+            });
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -719,7 +719,43 @@ describe('transaction', () => {
         });
     });
     describe('cache tests', () => {
-        // Not required yet since transactions are not supported as nested queries.
-        it.todo('coalesces multiple requests for the same transaction into one');
+        it('coalesces multiple requests for the same transaction into one', async () => {
+            expect.assertions(2);
+            fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionVote)));
+            const source = /* GraphQL */ `
+                query testQuery {
+                    transaction1: transaction(
+                        signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                    ) {
+                        slot
+                    }
+                    transaction2: transaction(
+                        signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                    ) {
+                        slot
+                    }
+                    transaction3: transaction(
+                        signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                    ) {
+                        slot
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source);
+            expect(result).toMatchObject({
+                data: {
+                    transaction1: {
+                        slot: expect.any(BigInt),
+                    },
+                    transaction2: {
+                        slot: expect.any(BigInt),
+                    },
+                    transaction3: {
+                        slot: expect.any(BigInt),
+                    },
+                },
+            });
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/rpc-graphql/src/context.ts
+++ b/packages/rpc-graphql/src/context.ts
@@ -11,7 +11,6 @@ export type Rpc = Parameters<typeof createRpcGraphQL>[0];
 
 export interface RpcGraphQLContext {
     loaders: RpcGraphQLLoaders;
-    rpc: Rpc;
 }
 
 export function createSolanaGraphQLContext(rpc: Rpc): RpcGraphQLContext {
@@ -22,6 +21,5 @@ export function createSolanaGraphQLContext(rpc: Rpc): RpcGraphQLContext {
             programAccounts: createProgramAccountsLoader(rpc),
             transaction: createTransactionLoader(rpc),
         },
-        rpc,
     };
 }

--- a/packages/rpc-graphql/src/index.ts
+++ b/packages/rpc-graphql/src/index.ts
@@ -17,13 +17,13 @@ export interface RpcGraphQL {
 }
 
 export function createRpcGraphQL(rpc: Rpc<RpcMethods>): RpcGraphQL {
-    const contextValue = createSolanaGraphQLContext(rpc);
     const schema = makeExecutableSchema({
         resolvers: createSolanaGraphQLResolvers(),
         typeDefs: createSolanaGraphQLTypeDefs(),
     });
     return {
         async query(source, variableValues?) {
+            const contextValue = createSolanaGraphQLContext(rpc);
             return graphql({
                 contextValue,
                 schema,


### PR DESCRIPTION
This PR fixes the caching problem reported on the Playground's repository at
<https://github.com/solana-labs/solana-graphql-playground/issues/19>.

It refactors the entrypoint to create the instance of the loaders/resolvers at
the time of querying, meaning each query gets a fresh cache.
