### PR TITLE
refactor(experimental): move RpcResponse and typed bigints to rpc-types

### DIFF
--- a/packages/accounts/src/__tests__/__setup__.ts
+++ b/packages/accounts/src/__tests__/__setup__.ts
@@ -6,10 +6,8 @@ import type {
     AccountInfoWithBase58Bytes,
     AccountInfoWithBase58EncodedData,
     AccountInfoWithBase64EncodedData,
-    RpcResponse,
-    U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-core/dist/types/rpc-methods/common';
-import type { PendingRpcRequest, Rpc } from '@solana/rpc-types';
+import type { PendingRpcRequest, Rpc, RpcResponse, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 export type Base64RpcAccount = AccountInfoBase & AccountInfoWithBase64EncodedData;
 export type Base58RpcAccount = AccountInfoBase & (AccountInfoWithBase58Bytes | AccountInfoWithBase58EncodedData);

--- a/packages/accounts/src/fetch-account.ts
+++ b/packages/accounts/src/fetch-account.ts
@@ -1,8 +1,6 @@
 import type { Address } from '@solana/addresses';
-import type { Slot } from '@solana/rpc-core/dist/types/rpc-methods/common';
-import type { GetAccountInfoApi } from '@solana/rpc-core/dist/types/rpc-methods/getAccountInfo';
-import type { GetMultipleAccountsApi } from '@solana/rpc-core/dist/types/rpc-methods/getMultipleAccounts';
-import type { Commitment, Rpc } from '@solana/rpc-types';
+import type { GetAccountInfoApi, GetMultipleAccountsApi } from '@solana/rpc-core';
+import type { Commitment, Rpc, Slot } from '@solana/rpc-types';
 
 import type { MaybeAccount, MaybeEncodedAccount } from './maybe-account';
 import { parseBase64RpcAccount, parseJsonRpcAccount } from './parse-account';

--- a/packages/library/src/transaction-confirmation.ts
+++ b/packages/library/src/transaction-confirmation.ts
@@ -4,10 +4,9 @@ import type {
     GetEpochInfoApi,
     GetSignatureStatusesApi,
     SignatureNotificationsApi,
-    Slot,
     SlotNotificationsApi,
 } from '@solana/rpc-core';
-import type { Rpc, RpcSubscriptions } from '@solana/rpc-types';
+import type { Rpc, RpcSubscriptions, Slot } from '@solana/rpc-types';
 import {
     getSignatureFromTransaction,
     IDurableNonceTransaction,

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-block-type-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-block-type-test.ts
@@ -1,18 +1,19 @@
 import { Address } from '@solana/addresses';
-import type { Rpc } from '@solana/rpc-types';
 import type {
     Base58EncodedBytes,
     Base58EncodedDataResponse,
     Base64EncodedDataResponse,
     Blockhash,
     LamportsUnsafeBeyond2Pow53Minus1,
+    Rpc,
+    U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-types';
 import { TransactionVersion } from '@solana/transactions';
 
 import { TransactionError } from '../../transaction-error';
-import { GetBlockApi } from '..';
-import { TokenBalance, U64UnsafeBeyond2Pow53Minus1 } from '../common';
+import { TokenBalance } from '../common';
 import { Reward, TransactionStatus } from '../common-transactions';
+import { GetBlockApi } from '../getBlock';
 
 function assertNotAProperty<T extends object, TPropName extends string>(
     _: { [Prop in keyof T]: Prop extends TPropName ? never : T[Prop] },

--- a/packages/rpc-core/src/rpc-methods/common-transactions.ts
+++ b/packages/rpc-core/src/rpc-methods/common-transactions.ts
@@ -5,11 +5,12 @@ import {
     Base64EncodedDataResponse,
     Blockhash,
     LamportsUnsafeBeyond2Pow53Minus1,
+    U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-types';
 import { TransactionVersion } from '@solana/transactions';
 
 import { TransactionError } from '../transaction-error';
-import { SignedLamportsAsI64Unsafe, TokenBalance, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import { SignedLamportsAsI64Unsafe, TokenBalance } from './common';
 
 type AddressTableLookup = Readonly<{
     /** public key for an address lookup table account. */

--- a/packages/rpc-core/src/rpc-methods/common.ts
+++ b/packages/rpc-core/src/rpc-methods/common.ts
@@ -4,8 +4,10 @@ import type {
     Base58EncodedDataResponse,
     Base64EncodedDataResponse,
     Base64EncodedZStdCompressedDataResponse,
+    LamportsUnsafeBeyond2Pow53Minus1,
+    TokenAmount,
+    U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-types';
-import { LamportsUnsafeBeyond2Pow53Minus1, TokenAmount } from '@solana/rpc-types';
 
 export type DataSlice = Readonly<{
     offset: number;
@@ -18,13 +20,6 @@ export type DataSlice = Readonly<{
 //
 // Spefically being used to denote micro-lamports, which are 0.000001 lamports.
 export type MicroLamportsUnsafeBeyond2Pow53Minus1 = bigint & { readonly __brand: unique symbol };
-
-export type Slot = U64UnsafeBeyond2Pow53Minus1;
-
-// FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
-// truncated or rounded because of a downcast to JavaScript `number` between your calling code and
-// the JSON-RPC transport.
-export type U64UnsafeBeyond2Pow53Minus1 = bigint;
 
 // FIXME(solana-labs/solana/issues/30341) Beware that any value outside of range
 // +/- 9007199254740991 may be truncated or rounded because of a downcast to JavaScript `number`
@@ -39,13 +34,6 @@ export type SignedLamportsAsI64Unsafe = bigint;
 // can be truncated or rounded because of a downcast to JavaScript `number` between your calling
 // code and the JSON-RPC transport.
 export type F64UnsafeSeeDocumentation = number;
-
-export type RpcResponse<TValue> = Readonly<{
-    context: Readonly<{
-        slot: Slot;
-    }>;
-    value: TValue;
-}>;
 
 export type AccountInfoBase = Readonly<{
     /** indicates if the account contains a program (and is strictly read-only) */

--- a/packages/rpc-core/src/rpc-methods/getAccountInfo.ts
+++ b/packages/rpc-core/src/rpc-methods/getAccountInfo.ts
@@ -1,6 +1,5 @@
 import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot } from '@solana/rpc-types';
 
 import {
     AccountInfoBase,
@@ -10,8 +9,6 @@ import {
     AccountInfoWithBase64EncodedZStdCompressedData,
     AccountInfoWithJsonData,
     DataSlice,
-    RpcResponse,
-    Slot,
 } from './common';
 
 type GetAccountInfoApiResponseBase = RpcResponse<AccountInfoBase | null>;

--- a/packages/rpc-core/src/rpc-methods/getBalance.ts
+++ b/packages/rpc-core/src/rpc-methods/getBalance.ts
@@ -1,8 +1,11 @@
 import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
-
-import { RpcResponse, Slot } from './common';
+import type {
+    Commitment,
+    IRpcApiMethods,
+    LamportsUnsafeBeyond2Pow53Minus1,
+    RpcResponse,
+    Slot,
+} from '@solana/rpc-types';
 
 type GetBalanceApiResponse = RpcResponse<LamportsUnsafeBeyond2Pow53Minus1>;
 

--- a/packages/rpc-core/src/rpc-methods/getBlock.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlock.ts
@@ -1,8 +1,14 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import type { Base58EncodedBytes, Blockhash, Commitment, UnixTimestamp } from '@solana/rpc-types';
+import type {
+    Base58EncodedBytes,
+    Blockhash,
+    Commitment,
+    IRpcApiMethods,
+    Slot,
+    U64UnsafeBeyond2Pow53Minus1,
+    UnixTimestamp,
+} from '@solana/rpc-types';
 import { TransactionVersion } from '@solana/transactions';
 
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 import {
     Reward,
     TransactionForAccounts,

--- a/packages/rpc-core/src/rpc-methods/getBlockCommitment.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockCommitment.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { IRpcApiMethods, LamportsUnsafeBeyond2Pow53Minus1, Slot } from '@solana/rpc-types';
 
 type GetBlockCommitmentApiResponse = Readonly<{
     commitment: LamportsUnsafeBeyond2Pow53Minus1[] | null;

--- a/packages/rpc-core/src/rpc-methods/getBlockHeight.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockHeight.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type { Commitment, IRpcApiMethods, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetBlockHeightApiResponse = U64UnsafeBeyond2Pow53Minus1;
 

--- a/packages/rpc-core/src/rpc-methods/getBlockProduction.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockProduction.ts
@@ -1,8 +1,5 @@
 import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type NumberOfLeaderSlots = U64UnsafeBeyond2Pow53Minus1;
 type NumberOfBlocksProduced = U64UnsafeBeyond2Pow53Minus1;

--- a/packages/rpc-core/src/rpc-methods/getBlockTime.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockTime.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { UnixTimestamp } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { IRpcApiMethods, Slot, UnixTimestamp } from '@solana/rpc-types';
 
 /** Estimated production time, as Unix timestamp (seconds since the Unix epoch) */
 type GetBlockTimeApiResponse = UnixTimestamp;

--- a/packages/rpc-core/src/rpc-methods/getBlocks.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlocks.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 type GetBlocksApiResponse = Slot[];
 

--- a/packages/rpc-core/src/rpc-methods/getBlocksWithLimit.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlocksWithLimit.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 type GetBlocksWithLimitApiResponse = Slot[];
 

--- a/packages/rpc-core/src/rpc-methods/getEpochInfo.ts
+++ b/packages/rpc-core/src/rpc-methods/getEpochInfo.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type { Commitment, IRpcApiMethods, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetEpochInfoApiResponse = Readonly<{
     /** the current slot */

--- a/packages/rpc-core/src/rpc-methods/getEpochSchedule.ts
+++ b/packages/rpc-core/src/rpc-methods/getEpochSchedule.ts
@@ -1,6 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-
-import { U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type { IRpcApiMethods, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetEpochScheduleApiResponse = Readonly<{
     /** the maximum number of slots in each epoch */

--- a/packages/rpc-core/src/rpc-methods/getFeeForMessage.ts
+++ b/packages/rpc-core/src/rpc-methods/getFeeForMessage.ts
@@ -1,8 +1,5 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 import { SerializedMessageBytesBase64 } from '@solana/transactions';
-
-import { RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 /** Fee corresponding to the message at the specified blockhash */
 type GetFeeForMessageApiResponse = RpcResponse<U64UnsafeBeyond2Pow53Minus1 | null>;

--- a/packages/rpc-core/src/rpc-methods/getFirstAvailableBlock.ts
+++ b/packages/rpc-core/src/rpc-methods/getFirstAvailableBlock.ts
@@ -1,6 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 type GetFirstAvailableBlockApiResponse = Slot;
 

--- a/packages/rpc-core/src/rpc-methods/getGenesisHash.ts
+++ b/packages/rpc-core/src/rpc-methods/getGenesisHash.ts
@@ -1,5 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import type { Blockhash } from '@solana/rpc-types';
+import type { Blockhash, IRpcApiMethods } from '@solana/rpc-types';
 
 type GetGenesisHashApiResponse = Blockhash;
 

--- a/packages/rpc-core/src/rpc-methods/getHighestSnapshotSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getHighestSnapshotSlot.ts
@@ -1,6 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 type GetHighestSnapshotSlotApiResponse = Readonly<{
     full: Slot;

--- a/packages/rpc-core/src/rpc-methods/getIdentity.ts
+++ b/packages/rpc-core/src/rpc-methods/getIdentity.ts
@@ -1,4 +1,4 @@
-import { Address } from '@solana/addresses';
+import type { Address } from '@solana/addresses';
 import type { IRpcApiMethods } from '@solana/rpc-types';
 
 type GetIdentityApiResponse = Readonly<{

--- a/packages/rpc-core/src/rpc-methods/getInflationGovernor.ts
+++ b/packages/rpc-core/src/rpc-methods/getInflationGovernor.ts
@@ -1,5 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Commitment, IRpcApiMethods } from '@solana/rpc-types';
 
 import { F64UnsafeSeeDocumentation } from './common';
 

--- a/packages/rpc-core/src/rpc-methods/getInflationRate.ts
+++ b/packages/rpc-core/src/rpc-methods/getInflationRate.ts
@@ -1,6 +1,6 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
+import type { IRpcApiMethods, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
-import { F64UnsafeSeeDocumentation, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import { F64UnsafeSeeDocumentation } from './common';
 
 type GetInflationRateApiResponse = Readonly<{
     /** Epoch for which these values are valid */

--- a/packages/rpc-core/src/rpc-methods/getInflationReward.ts
+++ b/packages/rpc-core/src/rpc-methods/getInflationReward.ts
@@ -1,8 +1,11 @@
 import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
-
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type {
+    Commitment,
+    IRpcApiMethods,
+    LamportsUnsafeBeyond2Pow53Minus1,
+    Slot,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
 
 type GetInflationRewardApiResponse = Readonly<{
     // Reward amount in lamports

--- a/packages/rpc-core/src/rpc-methods/getLargestAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getLargestAccounts.ts
@@ -1,8 +1,5 @@
 import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
-
-import { RpcResponse } from './common';
+import type { Commitment, IRpcApiMethods, LamportsUnsafeBeyond2Pow53Minus1, RpcResponse } from '@solana/rpc-types';
 
 type GetLargestAccountsResponseItem = Readonly<{
     /** Base-58 encoded address of the account */

--- a/packages/rpc-core/src/rpc-methods/getLatestBlockhash.ts
+++ b/packages/rpc-core/src/rpc-methods/getLatestBlockhash.ts
@@ -1,7 +1,11 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import type { Blockhash, Commitment } from '@solana/rpc-types';
-
-import { RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type {
+    Blockhash,
+    Commitment,
+    IRpcApiMethods,
+    RpcResponse,
+    Slot,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
 
 type GetLatestBlockhashApiResponse = RpcResponse<{
     /** a Hash as base-58 encoded string */

--- a/packages/rpc-core/src/rpc-methods/getLeaderSchedule.ts
+++ b/packages/rpc-core/src/rpc-methods/getLeaderSchedule.ts
@@ -1,8 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 /**
  * This return type is a dictionary of validator identities, as base-58 encoded

--- a/packages/rpc-core/src/rpc-methods/getMaxRetransmitSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getMaxRetransmitSlot.ts
@@ -1,6 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 type GetMaxRetransmitSlotApiResponse = Slot;
 

--- a/packages/rpc-core/src/rpc-methods/getMaxShredInsertSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getMaxShredInsertSlot.ts
@@ -1,6 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 type GetMaxShredInsertSlotApiResponse = Slot;
 

--- a/packages/rpc-core/src/rpc-methods/getMinimumBalanceForRentExemption.ts
+++ b/packages/rpc-core/src/rpc-methods/getMinimumBalanceForRentExemption.ts
@@ -1,7 +1,9 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
-
-import { U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type {
+    Commitment,
+    IRpcApiMethods,
+    LamportsUnsafeBeyond2Pow53Minus1,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
 
 type GetMinimumBalanceForRentExemptionApiResponse = LamportsUnsafeBeyond2Pow53Minus1;
 

--- a/packages/rpc-core/src/rpc-methods/getMultipleAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getMultipleAccounts.ts
@@ -1,6 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot } from '@solana/rpc-types';
 
 import {
     AccountInfoBase,
@@ -9,8 +8,6 @@ import {
     AccountInfoWithBase64EncodedZStdCompressedData,
     AccountInfoWithJsonData,
     DataSlice,
-    RpcResponse,
-    Slot,
 } from './common';
 
 type GetMultipleAccountsApiResponseBase = AccountInfoBase | null;

--- a/packages/rpc-core/src/rpc-methods/getProgramAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getProgramAccounts.ts
@@ -1,6 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot } from '@solana/rpc-types';
 
 import {
     AccountInfoBase,
@@ -13,8 +12,6 @@ import {
     DataSlice,
     GetProgramAccountsDatasizeFilter,
     GetProgramAccountsMemcmpFilter,
-    RpcResponse,
-    Slot,
 } from './common';
 
 type GetProgramAccountsApiCommonConfig = Readonly<{

--- a/packages/rpc-core/src/rpc-methods/getRecentPerformanceSamples.ts
+++ b/packages/rpc-core/src/rpc-methods/getRecentPerformanceSamples.ts
@@ -1,6 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type { IRpcApiMethods, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type PerformanceSample = Readonly<{
     /** Slot in which sample was taken at */

--- a/packages/rpc-core/src/rpc-methods/getRecentPrioritizationFees.ts
+++ b/packages/rpc-core/src/rpc-methods/getRecentPrioritizationFees.ts
@@ -1,7 +1,7 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
+import type { Address } from '@solana/addresses';
+import type { IRpcApiMethods, Slot } from '@solana/rpc-types';
 
-import { MicroLamportsUnsafeBeyond2Pow53Minus1, Slot } from './common';
+import { MicroLamportsUnsafeBeyond2Pow53Minus1 } from './common';
 
 type GetRecentPrioritizationFeesApiResponse = Readonly<{
     /**

--- a/packages/rpc-core/src/rpc-methods/getSignatureStatuses.ts
+++ b/packages/rpc-core/src/rpc-methods/getSignatureStatuses.ts
@@ -1,9 +1,7 @@
-import { Signature } from '@solana/keys';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Signature } from '@solana/keys';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import { TransactionError } from '../transaction-error';
-import { RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
 
 /** @deprecated */
 type TransactionStatusOk = Readonly<{

--- a/packages/rpc-core/src/rpc-methods/getSignaturesForAddress.ts
+++ b/packages/rpc-core/src/rpc-methods/getSignaturesForAddress.ts
@@ -1,10 +1,8 @@
-import { Address } from '@solana/addresses';
-import { Signature } from '@solana/keys';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, UnixTimestamp } from '@solana/rpc-types';
+import type { Address } from '@solana/addresses';
+import type { Signature } from '@solana/keys';
+import type { Commitment, IRpcApiMethods, Slot, UnixTimestamp } from '@solana/rpc-types';
 
 import { TransactionError } from '../transaction-error';
-import { Slot } from './common';
 
 type GetSignaturesForAddressTransaction = Readonly<{
     /** transaction signature as base-58 encoded string */

--- a/packages/rpc-core/src/rpc-methods/getSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/getSlot.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 type GetSlotApiResponse = Slot;
 

--- a/packages/rpc-core/src/rpc-methods/getSlotLeader.ts
+++ b/packages/rpc-core/src/rpc-methods/getSlotLeader.ts
@@ -1,8 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 export interface GetSlotLeaderApi extends IRpcApiMethods {
     /**

--- a/packages/rpc-core/src/rpc-methods/getSlotLeaders.ts
+++ b/packages/rpc-core/src/rpc-methods/getSlotLeaders.ts
@@ -1,7 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { Address } from '@solana/addresses';
+import type { IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 /** array of Node identity public keys as base-58 encoded strings */
 type GetSlotLeadersApiResponse = Address[];

--- a/packages/rpc-core/src/rpc-methods/getStakeActivation.ts
+++ b/packages/rpc-core/src/rpc-methods/getStakeActivation.ts
@@ -1,8 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetStakeActivationApiResponse = Readonly<{
     /** Stake active during the epoch */

--- a/packages/rpc-core/src/rpc-methods/getStakeMinimumDelegation.ts
+++ b/packages/rpc-core/src/rpc-methods/getStakeMinimumDelegation.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
-
-import { RpcResponse } from './common';
+import type { Commitment, IRpcApiMethods, LamportsUnsafeBeyond2Pow53Minus1, RpcResponse } from '@solana/rpc-types';
 
 type GetStakeMinimumDelegationApiResponse = RpcResponse<LamportsUnsafeBeyond2Pow53Minus1>;
 

--- a/packages/rpc-core/src/rpc-methods/getSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getSupply.ts
@@ -1,8 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
-
-import { RpcResponse } from './common';
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, LamportsUnsafeBeyond2Pow53Minus1, RpcResponse } from '@solana/rpc-types';
 
 type GetSupplyConfig = Readonly<{
     commitment?: Commitment;

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountBalance.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountBalance.ts
@@ -1,8 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, TokenAmount } from '@solana/rpc-types';
-
-import { RpcResponse } from './common';
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, RpcResponse, TokenAmount } from '@solana/rpc-types';
 
 type GetTokenAccountBalanceApiResponse = RpcResponse<TokenAmount>;
 

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountsByDelegate.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountsByDelegate.ts
@@ -1,7 +1,6 @@
-import { Address } from '@solana/addresses';
+import type { Address } from '@solana/addresses';
 import type { JsonParsedTokenAccount } from '@solana/rpc-parsed-types';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import {
     AccountInfoBase,
@@ -11,9 +10,6 @@ import {
     AccountInfoWithBase64EncodedZStdCompressedData,
     AccountInfoWithPubkey,
     DataSlice,
-    RpcResponse,
-    Slot,
-    U64UnsafeBeyond2Pow53Minus1,
 } from './common';
 
 type TokenAccountInfoWithJsonData = Readonly<{

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountsByOwner.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountsByOwner.ts
@@ -1,7 +1,6 @@
-import { Address } from '@solana/addresses';
+import type { Address } from '@solana/addresses';
 import type { JsonParsedTokenAccount } from '@solana/rpc-parsed-types';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import {
     AccountInfoBase,
@@ -11,9 +10,6 @@ import {
     AccountInfoWithBase64EncodedZStdCompressedData,
     AccountInfoWithPubkey,
     DataSlice,
-    RpcResponse,
-    Slot,
-    U64UnsafeBeyond2Pow53Minus1,
 } from './common';
 
 type TokenAccountInfoWithJsonData = Readonly<{

--- a/packages/rpc-core/src/rpc-methods/getTokenLargestAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenLargestAccounts.ts
@@ -1,8 +1,5 @@
 import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, TokenAmount } from '@solana/rpc-types';
-
-import { RpcResponse } from './common';
+import type { Commitment, IRpcApiMethods, RpcResponse, TokenAmount } from '@solana/rpc-types';
 
 type GetTokenLargestAccountsApiResponse = RpcResponse<TokenAmount & { address: Address }[]>;
 

--- a/packages/rpc-core/src/rpc-methods/getTokenSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenSupply.ts
@@ -1,8 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, TokenAmount } from '@solana/rpc-types';
-
-import { RpcResponse } from './common';
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, RpcResponse, TokenAmount } from '@solana/rpc-types';
 
 type GetTokenSupplyApiResponse = RpcResponse<TokenAmount>;
 

--- a/packages/rpc-core/src/rpc-methods/getTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/getTransaction.ts
@@ -8,12 +8,14 @@ import {
     Blockhash,
     Commitment,
     LamportsUnsafeBeyond2Pow53Minus1,
+    Slot,
+    U64UnsafeBeyond2Pow53Minus1,
     UnixTimestamp,
 } from '@solana/rpc-types';
 import { TransactionVersion } from '@solana/transactions';
 
 import { TransactionError } from '../transaction-error';
-import { Slot, TokenBalance, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import { TokenBalance } from './common';
 import { Reward, TransactionStatus } from './common-transactions';
 
 type ReturnData = {

--- a/packages/rpc-core/src/rpc-methods/getTransactionCount.ts
+++ b/packages/rpc-core/src/rpc-methods/getTransactionCount.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type { Commitment, IRpcApiMethods, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetTransactionCountApiResponse = U64UnsafeBeyond2Pow53Minus1;
 

--- a/packages/rpc-core/src/rpc-methods/getVoteAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getVoteAccounts.ts
@@ -1,8 +1,5 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from './common';
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type Epoch = U64UnsafeBeyond2Pow53Minus1;
 type Credits = U64UnsafeBeyond2Pow53Minus1;

--- a/packages/rpc-core/src/rpc-methods/index.ts
+++ b/packages/rpc-core/src/rpc-methods/index.ts
@@ -176,4 +176,4 @@ export type {
     SimulateTransactionApi,
 };
 
-export type { DataSlice, GetProgramAccountsDatasizeFilter, GetProgramAccountsMemcmpFilter, Slot } from './common';
+export type { DataSlice, GetProgramAccountsDatasizeFilter, GetProgramAccountsMemcmpFilter } from './common';

--- a/packages/rpc-core/src/rpc-methods/isBlockhashValid.ts
+++ b/packages/rpc-core/src/rpc-methods/isBlockhashValid.ts
@@ -1,7 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import type { Blockhash, Commitment } from '@solana/rpc-types';
-
-import { RpcResponse, Slot } from './common';
+import type { Blockhash, Commitment, IRpcApiMethods, RpcResponse, Slot } from '@solana/rpc-types';
 
 type IsBlockhashValidApiResponse = RpcResponse<boolean>;
 

--- a/packages/rpc-core/src/rpc-methods/minimumLedgerSlot.ts
+++ b/packages/rpc-core/src/rpc-methods/minimumLedgerSlot.ts
@@ -1,6 +1,4 @@
-import type { IRpcApiMethods } from '@solana/rpc-types';
-
-import { Slot } from './common';
+import type { IRpcApiMethods, Slot } from '@solana/rpc-types';
 
 type MinimumLedgerSlotApiResponse = Slot;
 

--- a/packages/rpc-core/src/rpc-methods/requestAirdrop.ts
+++ b/packages/rpc-core/src/rpc-methods/requestAirdrop.ts
@@ -1,7 +1,6 @@
-import { Address } from '@solana/addresses';
-import { Signature } from '@solana/keys';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
+import type { Address } from '@solana/addresses';
+import type { Signature } from '@solana/keys';
+import type { Commitment, IRpcApiMethods, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type RequestAirdropConfig = Readonly<{
     commitment?: Commitment;

--- a/packages/rpc-core/src/rpc-methods/sendTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/sendTransaction.ts
@@ -1,9 +1,6 @@
-import { Signature } from '@solana/keys';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
-import { Base64EncodedWireTransaction } from '@solana/transactions';
-
-import { Slot } from './common';
+import type { Signature } from '@solana/keys';
+import type { Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
+import type { Base64EncodedWireTransaction } from '@solana/transactions';
 
 type SendTransactionConfig = Readonly<{
     skipPreflight?: boolean;

--- a/packages/rpc-core/src/rpc-methods/simulateTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/simulateTransaction.ts
@@ -1,7 +1,14 @@
-import { Address } from '@solana/addresses';
-import type { IRpcApiMethods } from '@solana/rpc-types';
-import { Base58EncodedBytes, Base64EncodedDataResponse, Commitment } from '@solana/rpc-types';
-import { Base64EncodedWireTransaction } from '@solana/transactions';
+import type { Address } from '@solana/addresses';
+import type {
+    Base58EncodedBytes,
+    Base64EncodedDataResponse,
+    Commitment,
+    IRpcApiMethods,
+    RpcResponse,
+    Slot,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
+import type { Base64EncodedWireTransaction } from '@solana/transactions';
 
 import { TransactionError } from '../transaction-error';
 import {
@@ -9,9 +16,6 @@ import {
     AccountInfoWithBase64EncodedData,
     AccountInfoWithBase64EncodedZStdCompressedData,
     AccountInfoWithJsonData,
-    RpcResponse,
-    Slot,
-    U64UnsafeBeyond2Pow53Minus1,
 } from './common';
 
 type SimulateTransactionConfigBase = Readonly<{

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/account-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/account-notifications-type-test.ts
@@ -1,16 +1,18 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import { Address } from '@solana/addresses';
-import type { PendingRpcSubscription, RpcSubscriptions } from '@solana/rpc-types';
 import type {
     Base58EncodedBytes,
     Base58EncodedDataResponse,
     Base64EncodedDataResponse,
     Base64EncodedZStdCompressedDataResponse,
     LamportsUnsafeBeyond2Pow53Minus1,
+    PendingRpcSubscription,
+    RpcResponse,
+    RpcSubscriptions,
+    U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-types';
 
-import { RpcResponse, U64UnsafeBeyond2Pow53Minus1 } from '../../rpc-methods/common';
 import { AccountNotificationsApi } from '../account-notifications';
 
 async () => {

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/block-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/block-notifications-type-test.ts
@@ -1,16 +1,19 @@
 import { Address } from '@solana/addresses';
-import type { PendingRpcSubscription, RpcSubscriptions } from '@solana/rpc-types';
 import type {
     Base58EncodedBytes,
     Base58EncodedDataResponse,
     Base64EncodedDataResponse,
     Blockhash,
     LamportsUnsafeBeyond2Pow53Minus1,
+    PendingRpcSubscription,
+    RpcResponse,
+    RpcSubscriptions,
+    Slot,
+    U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-types';
 import { TransactionVersion } from '@solana/transactions';
 
-import { RpcResponse, Slot } from '../../rpc-methods/common';
-import { TokenBalance, U64UnsafeBeyond2Pow53Minus1 } from '../../rpc-methods/common';
+import { TokenBalance } from '../../rpc-methods/common';
 import { Reward, TransactionStatus } from '../../rpc-methods/common-transactions';
 import { TransactionError } from '../../transaction-error';
 import { SolanaRpcSubscriptions } from '../index';

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/logs-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/logs-notifications-type-test.ts
@@ -2,9 +2,8 @@
 
 import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
-import type { PendingRpcSubscription, RpcSubscriptions } from '@solana/rpc-types';
+import type { PendingRpcSubscription, RpcResponse, RpcSubscriptions } from '@solana/rpc-types';
 
-import { RpcResponse } from '../../rpc-methods/common';
 import { TransactionError } from '../../transaction-error';
 import { LogsNotificationsApi } from '../logs-notifications';
 

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/program-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/program-notifications-type-test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import { Address } from '@solana/addresses';
-import type { PendingRpcSubscription, RpcSubscriptions } from '@solana/rpc-types';
 import type {
     Base58EncodedBytes,
     Base58EncodedDataResponse,
@@ -9,9 +8,12 @@ import type {
     Base64EncodedDataResponse,
     Base64EncodedZStdCompressedDataResponse,
     LamportsUnsafeBeyond2Pow53Minus1,
+    PendingRpcSubscription,
+    RpcResponse,
+    RpcSubscriptions,
+    U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-types';
 
-import { RpcResponse, U64UnsafeBeyond2Pow53Minus1 } from '../../rpc-methods/common';
 import { ProgramNotificationsApi } from '../program-notifications';
 
 async () => {

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/root-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/root-notifications-type-test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import type { PendingRpcSubscription, RpcSubscriptions } from '@solana/rpc-types';
+import type { PendingRpcSubscription, RpcSubscriptions, Slot } from '@solana/rpc-types';
 
-import { Slot } from '../../rpc-methods/common';
 import { RootNotificationsApi } from '../root-notifications';
 
 async () => {

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/signature-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/signature-notifications-type-test.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import { Signature } from '@solana/keys';
-import type { PendingRpcSubscription, RpcSubscriptions } from '@solana/rpc-types';
+import type { PendingRpcSubscription, RpcResponse, RpcSubscriptions } from '@solana/rpc-types';
 
-import { RpcResponse } from '../../rpc-methods/common';
 import { TransactionError } from '../../transaction-error';
 import { SignatureNotificationsApi } from '../signature-notifications';
 

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/slot-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/slot-notifications-type-test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import type { RpcSubscriptions } from '@solana/rpc-types';
+import type { RpcSubscriptions, Slot } from '@solana/rpc-types';
 
-import { Slot } from '../../rpc-methods/common';
 import { SolanaRpcSubscriptions } from '../index';
 
 async () => {

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/slots-updates-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/slots-updates-notifications-type-test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import type { PendingRpcSubscription, RpcSubscriptions } from '@solana/rpc-types';
+import type { PendingRpcSubscription, RpcSubscriptions, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from '../../rpc-methods/common';
 import { SlotsUpdatesNotificationsApi } from '../slots-updates-notifications';
 
 async () => {

--- a/packages/rpc-core/src/rpc-subscriptions/__typetests__/vote-notifications-type-test.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/__typetests__/vote-notifications-type-test.ts
@@ -2,10 +2,8 @@
 
 import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
-import type { PendingRpcSubscription, RpcSubscriptions } from '@solana/rpc-types';
-import type { Blockhash, UnixTimestamp } from '@solana/rpc-types';
+import type { Blockhash, PendingRpcSubscription, RpcSubscriptions, Slot, UnixTimestamp } from '@solana/rpc-types';
 
-import { Slot } from '../../rpc-methods/common';
 import { VoteNotificationsApi } from '../vote-notifications';
 
 async () => {

--- a/packages/rpc-core/src/rpc-subscriptions/account-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/account-notifications.ts
@@ -1,6 +1,5 @@
 import { Address } from '@solana/addresses';
-import type { IRpcApiSubscriptions } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Commitment, IRpcApiSubscriptions, RpcResponse } from '@solana/rpc-types';
 
 import {
     AccountInfoBase,
@@ -9,7 +8,6 @@ import {
     AccountInfoWithBase64EncodedData,
     AccountInfoWithBase64EncodedZStdCompressedData,
     AccountInfoWithJsonData,
-    RpcResponse,
 } from '../rpc-methods/common';
 
 type AccountNotificationsApiCommonConfig = Readonly<{

--- a/packages/rpc-core/src/rpc-subscriptions/block-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/block-notifications.ts
@@ -1,8 +1,15 @@
-import type { IRpcApiSubscriptions } from '@solana/rpc-types';
-import type { Base58EncodedBytes, Blockhash, Commitment, UnixTimestamp } from '@solana/rpc-types';
+import type {
+    Base58EncodedBytes,
+    Blockhash,
+    Commitment,
+    IRpcApiSubscriptions,
+    RpcResponse,
+    Slot,
+    U64UnsafeBeyond2Pow53Minus1,
+    UnixTimestamp,
+} from '@solana/rpc-types';
 import { TransactionVersion } from '@solana/transactions';
 
-import { RpcResponse, Slot, U64UnsafeBeyond2Pow53Minus1 } from '../rpc-methods/common';
 import {
     Reward,
     TransactionForAccounts,

--- a/packages/rpc-core/src/rpc-subscriptions/logs-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/logs-notifications.ts
@@ -1,9 +1,7 @@
 import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
-import type { IRpcApiSubscriptions } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Commitment, IRpcApiSubscriptions, RpcResponse } from '@solana/rpc-types';
 
-import { RpcResponse } from '../rpc-methods/common';
 import { TransactionError } from '../transaction-error';
 
 type LogsNotificationsApiNotification = RpcResponse<

--- a/packages/rpc-core/src/rpc-subscriptions/program-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/program-notifications.ts
@@ -1,6 +1,12 @@
 import { Address } from '@solana/addresses';
-import type { IRpcApiSubscriptions } from '@solana/rpc-types';
-import { Base58EncodedBytes, Base64EncodedBytes, Commitment } from '@solana/rpc-types';
+import type {
+    Base58EncodedBytes,
+    Base64EncodedBytes,
+    Commitment,
+    IRpcApiSubscriptions,
+    RpcResponse,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
 
 import {
     AccountInfoBase,
@@ -9,8 +15,6 @@ import {
     AccountInfoWithBase64EncodedData,
     AccountInfoWithBase64EncodedZStdCompressedData,
     AccountInfoWithJsonData,
-    RpcResponse,
-    U64UnsafeBeyond2Pow53Minus1,
 } from '../rpc-methods/common';
 
 type ProgramNotificationsMemcmpFilterBase58 = Readonly<{

--- a/packages/rpc-core/src/rpc-subscriptions/root-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/root-notifications.ts
@@ -1,6 +1,4 @@
-import type { IRpcApiSubscriptions } from '@solana/rpc-types';
-
-import { Slot } from '../rpc-methods/common';
+import type { IRpcApiSubscriptions, Slot } from '@solana/rpc-types';
 
 type RootNotificationsApiNotification = Slot;
 

--- a/packages/rpc-core/src/rpc-subscriptions/signature-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/signature-notifications.ts
@@ -1,8 +1,6 @@
 import { Signature } from '@solana/keys';
-import type { IRpcApiSubscriptions } from '@solana/rpc-types';
-import { Commitment } from '@solana/rpc-types';
+import type { Commitment, IRpcApiSubscriptions, RpcResponse } from '@solana/rpc-types';
 
-import { RpcResponse } from '../rpc-methods/common';
 import { TransactionError } from '../transaction-error';
 
 type SignatureNotificationsApiNotificationReceived = RpcResponse<Readonly<string>>;

--- a/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/slot-notifications.ts
@@ -1,6 +1,4 @@
-import type { IRpcApiSubscriptions } from '@solana/rpc-types';
-
-import { Slot } from '../rpc-methods/common';
+import type { IRpcApiSubscriptions, Slot } from '@solana/rpc-types';
 
 type SlotNotificationsApiNotification = Readonly<{
     parent: Slot;

--- a/packages/rpc-core/src/rpc-subscriptions/slots-updates-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/slots-updates-notifications.ts
@@ -1,4 +1,4 @@
-import { Slot, U64UnsafeBeyond2Pow53Minus1 } from '../rpc-methods/common';
+import type { Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type SlotsUpdatesNotificationsApiNotificationBase = Readonly<{
     slot: Slot;

--- a/packages/rpc-core/src/rpc-subscriptions/vote-notifications.ts
+++ b/packages/rpc-core/src/rpc-subscriptions/vote-notifications.ts
@@ -1,8 +1,6 @@
 import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
-import type { Blockhash, UnixTimestamp } from '@solana/rpc-types';
-
-import { Slot } from '../rpc-methods/common';
+import type { Blockhash, Slot, UnixTimestamp } from '@solana/rpc-types';
 
 type VoteNotificationsApiNotification = Readonly<{
     hash: Blockhash;

--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -4,10 +4,9 @@ import {
     GetBlockApi,
     GetProgramAccountsApi,
     GetTransactionApi,
-    type Slot,
 } from '@solana/rpc-core';
 import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
-import type { Rpc } from '@solana/rpc-types';
+import type { Rpc, Slot } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
 import { createRpcGraphQL, RpcGraphQL } from '../rpc';

--- a/packages/rpc-graphql/src/loaders/account.ts
+++ b/packages/rpc-graphql/src/loaders/account.ts
@@ -1,5 +1,6 @@
-import { Address } from '@solana/addresses';
-import { DataSlice, Slot } from '@solana/rpc-core';
+import type { Address } from '@solana/addresses';
+import type { DataSlice } from '@solana/rpc-core';
+import type { Slot } from '@solana/rpc-types';
 import DataLoader from 'dataloader';
 import { GraphQLResolveInfo } from 'graphql';
 

--- a/packages/rpc-graphql/src/loaders/block.ts
+++ b/packages/rpc-graphql/src/loaders/block.ts
@@ -1,5 +1,4 @@
-import { Slot } from '@solana/rpc-core';
-import { Commitment } from '@solana/rpc-types';
+import type { Commitment, Slot } from '@solana/rpc-types';
 import DataLoader from 'dataloader';
 import { GraphQLResolveInfo } from 'graphql';
 

--- a/packages/rpc-graphql/src/loaders/program-accounts.ts
+++ b/packages/rpc-graphql/src/loaders/program-accounts.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Address } from '@solana/addresses';
-import { DataSlice, GetProgramAccountsDatasizeFilter, GetProgramAccountsMemcmpFilter, Slot } from '@solana/rpc-core';
-import { Commitment } from '@solana/rpc-types';
+import type { Address } from '@solana/addresses';
+import type { DataSlice, GetProgramAccountsDatasizeFilter, GetProgramAccountsMemcmpFilter } from '@solana/rpc-core';
+import type { Commitment, Slot } from '@solana/rpc-types';
 import DataLoader from 'dataloader';
 import { GraphQLResolveInfo } from 'graphql';
 

--- a/packages/rpc-graphql/src/resolvers/block.ts
+++ b/packages/rpc-graphql/src/resolvers/block.ts
@@ -1,4 +1,4 @@
-import type { Slot } from '@solana/rpc-core';
+import type { Slot } from '@solana/rpc-types';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { RpcGraphQLContext } from '../context';

--- a/packages/rpc-types/src/index.ts
+++ b/packages/rpc-types/src/index.ts
@@ -6,12 +6,5 @@ export * from './rpc-api';
 export * from './stringified-bigint';
 export * from './stringified-number';
 export * from './token-amount';
+export * from './typed-numbers';
 export * from './unix-timestamp';
-
-// FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
-// truncated or rounded because of a downcast to JavaScript `number` between your calling code and
-// the JSON-RPC transport.
-export type U64UnsafeBeyond2Pow53Minus1 = bigint;
-
-export type Slot = U64UnsafeBeyond2Pow53Minus1;
-export type Epoch = U64UnsafeBeyond2Pow53Minus1;

--- a/packages/rpc-types/src/rpc-api.ts
+++ b/packages/rpc-types/src/rpc-api.ts
@@ -1,4 +1,5 @@
-import { Overloads } from './overloads';
+import type { Overloads } from './overloads';
+import type { Slot } from './typed-numbers';
 
 /**
  * Public RPC API.
@@ -95,6 +96,14 @@ type PendingRpcSubscriptionBuilder<TSubscriptionMethodImplementations> = UnionTo
         >;
     }>
 >;
+
+/**
+ * Rpc Response helper.
+ */
+export type RpcResponse<TValue> = Readonly<{
+    context: Readonly<{ slot: Slot }>;
+    value: TValue;
+}>;
 
 /**
  * Utility types that do terrible, awful things.

--- a/packages/rpc-types/src/typed-numbers.ts
+++ b/packages/rpc-types/src/typed-numbers.ts
@@ -1,0 +1,9 @@
+/**
+ * FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
+ * truncated or rounded because of a downcast to JavaScript `number` between your calling code and
+ * the JSON-RPC transport.
+ */
+export type U64UnsafeBeyond2Pow53Minus1 = bigint;
+
+export type Slot = U64UnsafeBeyond2Pow53Minus1;
+export type Epoch = U64UnsafeBeyond2Pow53Minus1;


### PR DESCRIPTION
This PR moves the `RpcResponse` helper type from `@solana/rpc-core` to `@solana/rpc-types` since it is a very common helper to use when designing RPC methods.

Additionally, it removes the `Slot` and `U64UnsafeBeyond2Pow53Minus1` types from `@solana/rpc-core` since they have already been moved to `@solana/rpc-types`. Most of the changes on this PR are import updates such that these types are imported from `rpc-types` instead of `rpc-core`.