### PR TITLE
refactor(experimental): decouple @solana/accounts from @solana/rpc-core

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -65,7 +65,6 @@
         "@solana/addresses": "workspace:*",
         "@solana/codecs-core": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
-        "@solana/rpc-core": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
     "devDependencies": {

--- a/packages/accounts/src/__tests__/__setup__.ts
+++ b/packages/accounts/src/__tests__/__setup__.ts
@@ -1,22 +1,20 @@
 import type { Address } from '@solana/addresses';
 import type { Decoder } from '@solana/codecs-core';
-import type { GetAccountInfoApi, GetMultipleAccountsApi } from '@solana/rpc-core';
+import type { PendingRpcRequest, Rpc, RpcResponse } from '@solana/rpc-types';
+
 import type {
     AccountInfoBase,
     AccountInfoWithBase58Bytes,
     AccountInfoWithBase58EncodedData,
     AccountInfoWithBase64EncodedData,
-} from '@solana/rpc-core/dist/types/rpc-methods/common';
-import type { PendingRpcRequest, Rpc, RpcResponse, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
+    GetAccountInfoApi,
+    GetMultipleAccountsApi,
+    JsonParsedDataResponse,
+} from '../rpc-api';
 
 export type Base64RpcAccount = AccountInfoBase & AccountInfoWithBase64EncodedData;
 export type Base58RpcAccount = AccountInfoBase & (AccountInfoWithBase58Bytes | AccountInfoWithBase58EncodedData);
-export type JsonParsedRpcAccount = AccountInfoBase & Readonly<{ data: JsonParsedData<unknown> }>;
-export type JsonParsedData<TData> = Readonly<{
-    program: string;
-    parsed: { info: TData; type: string };
-    space: U64UnsafeBeyond2Pow53Minus1;
-}>;
+export type JsonParsedRpcAccount = AccountInfoBase & { readonly data: JsonParsedDataResponse<unknown> };
 
 export function getMockRpc(
     accounts: Record<Address, Base64RpcAccount | JsonParsedRpcAccount>,

--- a/packages/accounts/src/__typetests__/fetch-account-typetest.ts
+++ b/packages/accounts/src/__typetests__/fetch-account-typetest.ts
@@ -1,5 +1,4 @@
-import { Address } from '@solana/addresses';
-import type { GetAccountInfoApi, GetMultipleAccountsApi } from '@solana/rpc-core';
+import type { Address } from '@solana/addresses';
 import type { Rpc } from '@solana/rpc-types';
 
 import {
@@ -8,7 +7,8 @@ import {
     fetchJsonParsedAccount,
     fetchJsonParsedAccounts,
 } from '../fetch-account';
-import { MaybeAccount, MaybeEncodedAccount } from '../maybe-account';
+import type { MaybeAccount, MaybeEncodedAccount } from '../maybe-account';
+import type { GetAccountInfoApi, GetMultipleAccountsApi } from '../rpc-api';
 
 const rpc = {} as Rpc<GetAccountInfoApi & GetMultipleAccountsApi>;
 const address = '1111' as Address<'1111'>;

--- a/packages/accounts/src/fetch-account.ts
+++ b/packages/accounts/src/fetch-account.ts
@@ -1,9 +1,9 @@
 import type { Address } from '@solana/addresses';
-import type { GetAccountInfoApi, GetMultipleAccountsApi } from '@solana/rpc-core';
 import type { Commitment, Rpc, Slot } from '@solana/rpc-types';
 
 import type { MaybeAccount, MaybeEncodedAccount } from './maybe-account';
 import { parseBase64RpcAccount, parseJsonRpcAccount } from './parse-account';
+import type { GetAccountInfoApi, GetMultipleAccountsApi } from './rpc-api';
 
 /** Optional configuration for fetching a singular account. */
 export type FetchAccountConfig = {

--- a/packages/accounts/src/parse-account.ts
+++ b/packages/accounts/src/parse-account.ts
@@ -1,14 +1,15 @@
 import type { Address } from '@solana/addresses';
 import { getBase58Encoder, getBase64Encoder } from '@solana/codecs-strings';
+
+import type { Account, BaseAccount, EncodedAccount } from './account';
+import { MaybeAccount, MaybeEncodedAccount } from './maybe-account';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58Bytes,
     AccountInfoWithBase58EncodedData,
     AccountInfoWithBase64EncodedData,
-} from '@solana/rpc-core/dist/types/rpc-methods/common';
-
-import type { Account, BaseAccount, EncodedAccount } from './account';
-import { MaybeAccount, MaybeEncodedAccount } from './maybe-account';
+    JsonParsedDataResponse,
+} from './rpc-api';
 
 type Base64EncodedRpcAccount = AccountInfoBase & AccountInfoWithBase64EncodedData;
 
@@ -50,8 +51,7 @@ export function parseBase58RpcAccount<TAddress extends string = string>(
     return Object.freeze({ ...parseBaseAccount(rpcAccount), address, data, exists: true });
 }
 
-type JsonParsedRpcAccount = AccountInfoBase & { readonly data: JsonParsedData<unknown> };
-type JsonParsedData<TData> = { readonly parsed: { readonly info: TData } };
+type JsonParsedRpcAccount = AccountInfoBase & { readonly data: JsonParsedDataResponse<unknown> };
 
 /** Parse an account object received from a json-parsed RPC call into an Account or MaybeAccount type. */
 export function parseJsonRpcAccount<TData extends object, TAddress extends string = string>(

--- a/packages/accounts/src/rpc-api/common.ts
+++ b/packages/accounts/src/rpc-api/common.ts
@@ -1,0 +1,61 @@
+import { Address } from '@solana/addresses';
+import type {
+    Base58EncodedBytes,
+    Base58EncodedDataResponse,
+    Base64EncodedDataResponse,
+    Base64EncodedZStdCompressedDataResponse,
+    LamportsUnsafeBeyond2Pow53Minus1,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
+
+export type DataSlice = Readonly<{
+    offset: number;
+    length: number;
+}>;
+
+export type AccountInfoBase = Readonly<{
+    /** indicates if the account contains a program (and is strictly read-only) */
+    executable: boolean;
+    /** number of lamports assigned to this account */
+    lamports: LamportsUnsafeBeyond2Pow53Minus1;
+    /** pubkey of the program this account has been assigned to */
+    owner: Address;
+    /** the epoch at which this account will next owe rent */
+    rentEpoch: U64UnsafeBeyond2Pow53Minus1;
+}>;
+
+/** @deprecated */
+export type AccountInfoWithBase58Bytes = Readonly<{
+    data: Base58EncodedBytes;
+}>;
+
+/** @deprecated */
+export type AccountInfoWithBase58EncodedData = Readonly<{
+    data: Base58EncodedDataResponse;
+}>;
+
+export type AccountInfoWithBase64EncodedData = Readonly<{
+    data: Base64EncodedDataResponse;
+}>;
+
+export type AccountInfoWithBase64EncodedZStdCompressedData = Readonly<{
+    data: Base64EncodedZStdCompressedDataResponse;
+}>;
+
+export type AccountInfoWithJsonData = Readonly<{
+    data:
+        | JsonParsedDataResponse
+        // If `jsonParsed` encoding is requested but a parser cannot be found for the given
+        // account the `data` field falls back to `base64`.
+        | Base64EncodedDataResponse;
+}>;
+
+export type JsonParsedDataResponse<TData = object> = Readonly<{
+    // Name of the program that owns this account.
+    program: string;
+    parsed: {
+        info?: TData;
+        type: string;
+    };
+    space: U64UnsafeBeyond2Pow53Minus1;
+}>;

--- a/packages/accounts/src/rpc-api/getAccountInfo.ts
+++ b/packages/accounts/src/rpc-api/getAccountInfo.ts
@@ -1,0 +1,71 @@
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot } from '@solana/rpc-types';
+
+import {
+    AccountInfoBase,
+    AccountInfoWithBase58Bytes,
+    AccountInfoWithBase58EncodedData,
+    AccountInfoWithBase64EncodedData,
+    AccountInfoWithBase64EncodedZStdCompressedData,
+    AccountInfoWithJsonData,
+    DataSlice,
+} from './common';
+
+type GetAccountInfoApiResponseBase = RpcResponse<AccountInfoBase | null>;
+
+type NestInRpcResponseOrNull<T> = Readonly<{
+    value: T | null;
+}>;
+
+type GetAccountInfoApiCommonConfig = Readonly<{
+    // Defaults to `finalized`
+    commitment?: Commitment;
+    // The minimum slot that the request can be evaluated at
+    minContextSlot?: Slot;
+}>;
+
+type GetAccountInfoApiSliceableCommonConfig = Readonly<{
+    // Limit the returned account data using the provided "offset: <usize>" and "length: <usize>" fields.
+    dataSlice?: DataSlice;
+}>;
+
+export interface GetAccountInfoApi extends IRpcApiMethods {
+    /**
+     * Returns all information associated with the account of provided public key
+     */
+    getAccountInfo(
+        address: Address,
+        config: GetAccountInfoApiCommonConfig &
+            GetAccountInfoApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base64';
+            }>,
+    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase64EncodedData>;
+    getAccountInfo(
+        address: Address,
+        config: GetAccountInfoApiCommonConfig &
+            GetAccountInfoApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base64+zstd';
+            }>,
+    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase64EncodedZStdCompressedData>;
+    getAccountInfo(
+        address: Address,
+        config: GetAccountInfoApiCommonConfig &
+            Readonly<{
+                encoding: 'jsonParsed';
+            }>,
+    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithJsonData>;
+    getAccountInfo(
+        address: Address,
+        config: GetAccountInfoApiCommonConfig &
+            GetAccountInfoApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base58';
+            }>,
+    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase58EncodedData>;
+    getAccountInfo(
+        address: Address,
+        config?: GetAccountInfoApiCommonConfig,
+    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase58Bytes>;
+}

--- a/packages/accounts/src/rpc-api/getMultipleAccounts.ts
+++ b/packages/accounts/src/rpc-api/getMultipleAccounts.ts
@@ -1,0 +1,71 @@
+import type { Address } from '@solana/addresses';
+import type { Commitment, IRpcApiMethods, RpcResponse, Slot } from '@solana/rpc-types';
+
+import {
+    AccountInfoBase,
+    AccountInfoWithBase58EncodedData,
+    AccountInfoWithBase64EncodedData,
+    AccountInfoWithBase64EncodedZStdCompressedData,
+    AccountInfoWithJsonData,
+    DataSlice,
+} from './common';
+
+type GetMultipleAccountsApiResponseBase = AccountInfoBase | null;
+
+type GetMultipleAccountsApiCommonConfig = Readonly<{
+    /** Defaults to `finalized` */
+    commitment?: Commitment;
+    /** The minimum slot that the request can be evaluated at */
+    minContextSlot?: Slot;
+}>;
+
+type GetMultipleAccountsApiSliceableCommonConfig = Readonly<{
+    /** Limit the returned account data */
+    dataSlice?: DataSlice;
+}>;
+
+export interface GetMultipleAccountsApi extends IRpcApiMethods {
+    /**
+     * Returns the account information for a list of Pubkeys.
+     */
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Address[],
+        config: GetMultipleAccountsApiCommonConfig &
+            GetMultipleAccountsApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base64';
+            }>,
+    ): RpcResponse<(GetMultipleAccountsApiResponseBase & (AccountInfoWithBase64EncodedData | null))[]>;
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Address[],
+        config: GetMultipleAccountsApiCommonConfig &
+            GetMultipleAccountsApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base64+zstd';
+            }>,
+    ): RpcResponse<(GetMultipleAccountsApiResponseBase & (AccountInfoWithBase64EncodedZStdCompressedData | null))[]>;
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Address[],
+        config: GetMultipleAccountsApiCommonConfig &
+            Readonly<{
+                encoding: 'jsonParsed';
+            }>,
+    ): RpcResponse<(GetMultipleAccountsApiResponseBase & (AccountInfoWithJsonData | null))[]>;
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Address[],
+        config: GetMultipleAccountsApiCommonConfig &
+            GetMultipleAccountsApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base58';
+            }>,
+    ): RpcResponse<(GetMultipleAccountsApiResponseBase & (AccountInfoWithBase58EncodedData | null))[]>;
+    getMultipleAccounts(
+        /** An array of up to 100 Pubkeys to query */
+        addresses: Address[],
+        config?: GetMultipleAccountsApiCommonConfig,
+    ): RpcResponse<(GetMultipleAccountsApiResponseBase & (AccountInfoWithBase64EncodedData | null))[]>;
+}

--- a/packages/accounts/src/rpc-api/index.ts
+++ b/packages/accounts/src/rpc-api/index.ts
@@ -1,0 +1,3 @@
+export * from './common';
+export * from './getAccountInfo';
+export * from './getMultipleAccounts';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,9 +43,6 @@ importers:
       '@solana/codecs-strings':
         specifier: workspace:*
         version: link:../codecs-strings
-      '@solana/rpc-core':
-        specifier: workspace:*
-        version: link:../rpc-core
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types


### PR DESCRIPTION
This PR removes the `@solana/rpc-core` dependency from `@solana/accounts` which avoids ending up with unused nested dependencies such as `@solana/transactions` when we only need the `GetAccountInfoApi` and `GetMultipleAccountsApi` types.

It does this by simply duplicating the types locally in the `@solana/accounts` package.