### PR TITLE
refactor(experimental): graphql: fix `blockTime` in transaction schema

### DIFF
--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -109,7 +109,7 @@ describe('block', () => {
             expect(result).toMatchObject({
                 data: {
                     block: {
-                        blockTime: expect.any(Number),
+                        blockTime: expect.any(BigInt),
                     },
                 },
             });

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -42,12 +42,13 @@ describe('transaction', () => {
     });
 
     describe('basic queries', () => {
-        it("can query a transaction's slot", async () => {
+        it('can query a transaction', async () => {
             expect.assertions(1);
             fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionVote)));
             const source = /* GraphQL */ `
                 query testQuery {
                     transaction(signature: "${defaultTransactionSignature}") {
+                        blockTime
                         slot
                     }
                 }
@@ -56,6 +57,7 @@ describe('transaction', () => {
             expect(result).toMatchObject({
                 data: {
                     transaction: {
+                        blockTime: expect.any(BigInt),
                         slot: expect.any(BigInt),
                     },
                 },

--- a/packages/rpc-graphql/src/schema/block.ts
+++ b/packages/rpc-graphql/src/schema/block.ts
@@ -26,7 +26,7 @@ export const blockTypeDefs = /* GraphQL */ `
     interface Block {
         blockhash: String
         blockHeight: BigInt
-        blockTime: Int
+        blockTime: BigInt
         parentSlot: BigInt
         previousBlockhash: String
         rewards: [Reward]
@@ -39,7 +39,7 @@ export const blockTypeDefs = /* GraphQL */ `
     type BlockWithAccounts implements Block {
         blockhash: String
         blockHeight: BigInt
-        blockTime: Int
+        blockTime: BigInt
         parentSlot: BigInt
         previousBlockhash: String
         rewards: [Reward]
@@ -53,7 +53,7 @@ export const blockTypeDefs = /* GraphQL */ `
     type BlockWithFull implements Block {
         blockhash: String
         blockHeight: BigInt
-        blockTime: Int
+        blockTime: BigInt
         parentSlot: BigInt
         previousBlockhash: String
         rewards: [Reward]
@@ -67,7 +67,7 @@ export const blockTypeDefs = /* GraphQL */ `
     type BlockWithNone implements Block {
         blockhash: String
         blockHeight: BigInt
-        blockTime: Int
+        blockTime: BigInt
         parentSlot: BigInt
         previousBlockhash: String
         rewards: [Reward]
@@ -80,7 +80,7 @@ export const blockTypeDefs = /* GraphQL */ `
     type BlockWithSignatures implements Block {
         blockhash: String
         blockHeight: BigInt
-        blockTime: Int
+        blockTime: BigInt
         parentSlot: BigInt
         previousBlockhash: String
         rewards: [Reward]

--- a/packages/rpc-graphql/src/schema/transaction.ts
+++ b/packages/rpc-graphql/src/schema/transaction.ts
@@ -65,7 +65,7 @@ export const transactionTypeDefs = /* GraphQL */ `
     Transaction interface
     """
     interface Transaction {
-        blockTime: String
+        blockTime: BigInt
         meta: TransactionMeta
         slot: BigInt
         version: String
@@ -75,7 +75,7 @@ export const transactionTypeDefs = /* GraphQL */ `
     A transaction with base58 encoded data
     """
     type TransactionBase58 implements Transaction {
-        blockTime: String
+        blockTime: BigInt
         data: Base58EncodedBytes
         meta: TransactionMeta
         slot: BigInt
@@ -86,7 +86,7 @@ export const transactionTypeDefs = /* GraphQL */ `
     A transaction with base64 encoded data
     """
     type TransactionBase64 implements Transaction {
-        blockTime: String
+        blockTime: BigInt
         data: Base64EncodedBytes
         meta: TransactionMeta
         slot: BigInt
@@ -101,7 +101,7 @@ export const transactionTypeDefs = /* GraphQL */ `
         signatures: [String]
     }
     type TransactionParsed implements Transaction {
-        blockTime: String
+        blockTime: BigInt
         data: TransactionDataParsed
         meta: TransactionMeta
         slot: BigInt


### PR DESCRIPTION
In the Solana monorepo, a [`UnixTimestamp`](https://github.com/solana-labs/solana/blob/098076f5cab81a54335330993842fc0831e1ca65/sdk/program/src/clock.rs#L173) is of type `i64`. Therefore, timestamps should be `BigInt`.

Closes #2061
