### PR TITLE
SyntaxError due to unsupported ||= operator in @solana/web3.js/lib/index.cjs.js

### DIFF
--- a/packages/addresses/src/program-derived-address.ts
+++ b/packages/addresses/src/program-derived-address.ts
@@ -88,7 +88,7 @@ async function createProgramDerivedAddress({ programAddress, seeds }: ProgramDer
     }
     let textEncoder: TextEncoder;
     const seedBytes = seeds.reduce((acc, seed, ii) => {
-        const bytes = typeof seed === 'string' ? (textEncoder ||= new TextEncoder()).encode(seed) : seed;
+        const bytes = typeof seed === 'string' ? (textEncoder = textEncoder || new TextEncoder()).encode(seed) : seed;
         if (bytes.byteLength > MAX_SEED_LENGTH) {
             // TODO: Coded error.
             throw new Error(`The seed at index ${ii} exceeds the maximum length of 32 bytes`);

--- a/packages/codecs-strings/src/utf8.ts
+++ b/packages/codecs-strings/src/utf8.ts
@@ -14,9 +14,9 @@ import { removeNullCharacters } from './null-characters';
 export const getUtf8Encoder = (): VariableSizeEncoder<string> => {
     let textEncoder: TextEncoder;
     return createEncoder({
-        getSizeFromValue: value => (textEncoder ||= new TextEncoder()).encode(value).length,
+        getSizeFromValue: value => (textEncoder =textEncoder || new TextEncoder()).encode(value).length,
         write: (value: string, bytes, offset) => {
-            const bytesToAdd = (textEncoder ||= new TextEncoder()).encode(value);
+            const bytesToAdd = (textEncoder =textEncoder || new TextEncoder()).encode(value);
             bytes.set(bytesToAdd, offset);
             return offset + bytesToAdd.length;
         },
@@ -28,7 +28,7 @@ export const getUtf8Decoder = (): VariableSizeDecoder<string> => {
     let textDecoder: TextDecoder;
     return createDecoder({
         read(bytes, offset) {
-            const value = (textDecoder ||= new TextDecoder()).decode(bytes.slice(offset));
+            const value = (textDecoder = textDecoder || new TextDecoder()).decode(bytes.slice(offset));
             return [removeNullCharacters(value), bytes.length];
         },
     });

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -6022,7 +6022,9 @@ export class Connection {
     }
     const stateChangeCallbacks = (this._subscriptionStateChangeCallbacksByHash[
       hash
-    ] ||= new Set());
+    ] = this._subscriptionStateChangeCallbacksByHash[
+      hash
+    ] || new Set());
     stateChangeCallbacks.add(callback);
     return () => {
       stateChangeCallbacks.delete(callback);

--- a/packages/library-legacy/src/message/compiled-keys.ts
+++ b/packages/library-legacy/src/message/compiled-keys.ts
@@ -49,8 +49,8 @@ export class CompiledKeys {
       getOrInsertDefault(ix.programId).isInvoked = true;
       for (const accountMeta of ix.keys) {
         const keyMeta = getOrInsertDefault(accountMeta.pubkey);
-        keyMeta.isSigner ||= accountMeta.isSigner;
-        keyMeta.isWritable ||= accountMeta.isWritable;
+        keyMeta.isSigner = keyMeta.isSigner || accountMeta.isSigner;
+        keyMeta.isWritable = keyMeta.isWriteable || accountMeta.isWritable;
       }
     }
 

--- a/packages/library-legacy/src/transaction/legacy.ts
+++ b/packages/library-legacy/src/transaction/legacy.ts
@@ -782,11 +782,11 @@ export class Transaction {
     for (const {signature, publicKey} of this.signatures) {
       if (signature === null) {
         if (requireAllSignatures) {
-          (errors.missing ||= []).push(publicKey);
+          (errors.missing = errors.missing || []).push(publicKey);
         }
       } else {
         if (!verify(signature, message, publicKey.toBytes())) {
-          (errors.invalid ||= []).push(publicKey);
+          (errors.invalid = errors.invalid || []).push(publicKey);
         }
       }
     }

--- a/packages/library/src/__tests__/rpc-websocket-autopinger-test.ts
+++ b/packages/library/src/__tests__/rpc-websocket-autopinger-test.ts
@@ -21,7 +21,7 @@ describe('getWebSocketTransportWithAutoping', () => {
             async *[Symbol.asyncIterator]() {
                 try {
                     while (true) {
-                        yield (resultPromise ||= new Promise((resolve, reject) => {
+                        yield (resultPromise = resultPromise || new Promise((resolve, reject) => {
                             killConnection = () => {
                                 reject('error');
                             };

--- a/packages/library/src/rpc-subscription-coalescer.ts
+++ b/packages/library/src/rpc-subscription-coalescer.ts
@@ -96,7 +96,7 @@ export function getRpcSubscriptionsWithSubscriptionCoalescing<TRpcSubscriptionsM
                         return {
                             ...iterable,
                             async *[Symbol.asyncIterator]() {
-                                abortPromise ||= abortSignal.aborted
+                                abortPromise = abortPromise || abortSignal.aborted
                                     ? Promise.reject(EXPLICIT_ABORT_TOKEN)
                                     : new Promise<never>((_, reject) => {
                                           abortSignal.addEventListener('abort', () => {

--- a/packages/transactions/src/accounts.ts
+++ b/packages/transactions/src/accounts.ts
@@ -106,7 +106,7 @@ export function getAddressMapFromInstructions(feePayer: Address, instructions: r
                                     // Consider using the new LOOKUP_TABLE if its address is different...
                                     entry.lookupTableAddress !== accountMeta.lookupTableAddress &&
                                     // ...and sorts before the existing one.
-                                    (addressComparator ||= getAddressComparator())(
+                                    (addressComparator = addressComparator || getAddressComparator())(
                                         accountMeta.lookupTableAddress,
                                         entry.lookupTableAddress,
                                     ) < 0;
@@ -225,7 +225,7 @@ export function getOrderedAccountsFromAddressMap(addressMap: AddressMap): Ordere
                 return leftIsWritable ? -1 : 1;
             }
             // STEP 3: Sort by address.
-            addressComparator ||= getAddressComparator();
+            addressComparator = addressComparator || getAddressComparator();
             if (
                 leftEntry[TYPE] === AddressMapEntryType.LOOKUP_TABLE &&
                 rightEntry[TYPE] === AddressMapEntryType.LOOKUP_TABLE &&

--- a/packages/transactions/src/compile-address-table-lookups.ts
+++ b/packages/transactions/src/compile-address-table-lookups.ts
@@ -15,7 +15,7 @@ export function getCompiledAddressTableLookups(orderedAccounts: OrderedAccounts)
         if (!('lookupTableAddress' in account)) {
             continue;
         }
-        const entry = (index[account.lookupTableAddress] ||= {
+        const entry = (index[account.lookupTableAddress] = index[account.lookupTableAddress] || {
             readableIndices: [],
             writableIndices: [],
         });

--- a/packages/webcrypto-ed25519-polyfill/src/index.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/index.ts
@@ -14,15 +14,15 @@ if (__NODEJS__) {
      * Node only sets the `crypto` global variable when run with `--experimental-global-webcrypto`.
      * Let's set it unconditionally here.
      */
-    globalThis.crypto ||= cryptoImpl;
+    globalThis.crypto = globalThis.crypto || cryptoImpl;
 }
 
 if (!__BROWSER__ || globalThis.isSecureContext) {
     /**
      * Create `crypto.subtle` if it doesn't exist.
      */
-    const originalCryptoObject = (globalThis.crypto ||= {} as Crypto);
-    const originalSubtleCrypto = ((originalCryptoObject as Crypto & { subtle: SubtleCrypto }).subtle ||=
+    const originalCryptoObject = (globalThis.crypto = globalThis.crypto || {} as Crypto);
+    const originalSubtleCrypto = ((originalCryptoObject as Crypto & { subtle: SubtleCrypto }).subtle = { subtle: SubtleCrypto }).subtle ||
         {} as SubtleCrypto);
 
     /**

--- a/packages/webcrypto-ed25519-polyfill/src/secrets.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/secrets.ts
@@ -73,7 +73,7 @@ function createKeyPairFromBytes(
     keyUsages: readonly KeyUsage[],
 ): CryptoKeyPair {
     const keyPair = createKeyPair_INTERNAL_ONLY_DO_NOT_EXPORT(extractable, keyUsages);
-    const cache = (storageKeyBySecretKey_INTERNAL_ONLY_DO_NOT_EXPORT ||= new WeakMap());
+    const cache = (storageKeyBySecretKey_INTERNAL_ONLY_DO_NOT_EXPORT = storageKeyBySecretKey_INTERNAL_ONLY_DO_NOT_EXPORT || new WeakMap());
     cache.set(keyPair.privateKey, bytes);
     cache.set(keyPair.publicKey, bytes);
     return keyPair;
@@ -122,7 +122,7 @@ function getSecretKeyBytes_INTERNAL_ONLY_DO_NOT_EXPORT(key: CryptoKey): Uint8Arr
 
 async function getPublicKeyBytes(key: CryptoKey): Promise<Uint8Array> {
     // Try to find the key in the public key store first
-    const publicKeyStore = (publicKeyBytesStore ||= new WeakMap());
+    const publicKeyStore = (publicKeyBytesStore = publicKeyBytesStore || new WeakMap());
     const fromPublicStore = publicKeyStore.get(key);
     if (fromPublicStore) return fromPublicStore;
 
@@ -221,7 +221,7 @@ export function importKeyPolyfill(
             usages: Object.freeze(keyUsages.filter(usage => usage === 'verify')) as KeyUsage[],
         } as CryptoKey;
 
-        const cache = (publicKeyBytesStore ||= new WeakMap());
+        const cache = (publicKeyBytesStore =publicKeyBytesStore || new WeakMap());
         cache.set(publicKey, bytes);
 
         return publicKey;
@@ -250,7 +250,7 @@ export function importKeyPolyfill(
             usages: Object.freeze(keyUsages.filter(usage => usage === 'sign')) as KeyUsage[],
         } as CryptoKey;
 
-        const cache = (storageKeyBySecretKey_INTERNAL_ONLY_DO_NOT_EXPORT ||= new WeakMap());
+        const cache = (storageKeyBySecretKey_INTERNAL_ONLY_DO_NOT_EXPORT = storageKeyBySecretKey_INTERNAL_ONLY_DO_NOT_EXPORT || new WeakMap());
         cache.set(privateKey, secretKeyBytes);
 
         return privateKey;


### PR DESCRIPTION
I discovered a bug in the @solana/web3.js library related to the use of the logical OR assignment (||=) operator in the @solana/web3.js/lib/index.cjs.js file. 

The logical OR assignment (||=) operator is not supported in certain environments, leading to a SyntaxError. The suggested fix is to replace the ||= operator with the equivalent logical OR (||) and assignment (=) syntax, as shown below: 
Before: 
operator1 ||= operator2; 
After:
operator1 = operator1 || operator2;