### PR TITLE
refactor(experimental): graphql: expand on batch loader for accounts

### DIFF
--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -64,6 +64,7 @@
     ],
     "dependencies": {
         "@graphql-tools/schema": "^10.0.0",
+        "@solana/codecs-strings": "workspace:*",
         "dataloader": "^2.2.2",
         "graphql": "^16.8.0",
         "json-stable-stringify": "^1.1.0"

--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -1,4 +1,11 @@
-import { GetAccountInfoApi, GetBlockApi, GetProgramAccountsApi, GetTransactionApi, Rpc } from '@solana/rpc';
+import {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
 import type { Slot } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
@@ -15,7 +22,7 @@ import {
 } from './__setup__';
 
 describe('block', () => {
-    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>;
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi>;
     let rpcGraphQL: RpcGraphQL;
 
     // Random slot for testing.

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -1,11 +1,18 @@
-import { GetAccountInfoApi, GetBlockApi, GetProgramAccountsApi, GetTransactionApi, Rpc } from '@solana/rpc';
+import {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
 import fetchMock from 'jest-fetch-mock-fork';
 
 import { createRpcGraphQL, RpcGraphQL } from '../index';
 import { createLocalhostSolanaRpc } from './__setup__';
 
 describe('programAccounts', () => {
-    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>;
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi>;
     let rpcGraphQL: RpcGraphQL;
     beforeEach(() => {
         fetchMock.resetMocks();
@@ -589,7 +596,7 @@ describe('programAccounts', () => {
                     data: {
                         programAccounts: expect.arrayContaining([
                             {
-                                data: 'E8f4pET',
+                                data: 'E8f4pET', // As tested on local RPC
                             },
                         ]),
                     },
@@ -632,7 +639,7 @@ describe('programAccounts', () => {
                     data: {
                         programAccounts: expect.arrayContaining([
                             {
-                                data: 'dGVzdCA=',
+                                data: 'dGVzdCA=', // As tested on local RPC
                             },
                         ]),
                     },

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1,5 +1,12 @@
 import { Signature } from '@solana/keys';
-import { GetAccountInfoApi, GetBlockApi, GetProgramAccountsApi, GetTransactionApi, Rpc } from '@solana/rpc';
+import {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
 import fetchMock from 'jest-fetch-mock-fork';
 
 import { createRpcGraphQL, RpcGraphQL } from '../index';
@@ -17,7 +24,7 @@ import {
 } from './__setup__';
 
 describe('transaction', () => {
-    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi>;
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi>;
     let rpcGraphQL: RpcGraphQL;
 
     // Random signature for testing.

--- a/packages/rpc-graphql/src/context.ts
+++ b/packages/rpc-graphql/src/context.ts
@@ -1,4 +1,12 @@
-import type { createRpcGraphQL } from './index';
+import type {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
+
 import {
     createAccountLoader,
     createBlockLoader,
@@ -7,16 +15,30 @@ import {
     RpcGraphQLLoaders,
 } from './loaders';
 
-export type Rpc = Parameters<typeof createRpcGraphQL>[0];
+type Config = {
+    /**
+     * Maximum number of acceptable bytes to waste before splitting two
+     * `dataSlice` requests into two requests.
+     */
+    maxDataSliceByteRange: number;
+    /**
+     * Maximum number of accounts to fetch in a single batch.
+     * See https://docs.solana.com/api/http#getmultipleaccounts.
+     */
+    maxMultipleAccountsBatchSize: number;
+};
 
 export interface RpcGraphQLContext {
     loaders: RpcGraphQLLoaders;
 }
 
-export function createSolanaGraphQLContext(rpc: Rpc): RpcGraphQLContext {
+export function createSolanaGraphQLContext(
+    rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi>,
+    config: Config,
+): RpcGraphQLContext {
     return {
         loaders: {
-            account: createAccountLoader(rpc),
+            account: createAccountLoader(rpc, config),
             block: createBlockLoader(rpc),
             programAccounts: createProgramAccountsLoader(rpc),
             transaction: createTransactionLoader(rpc),

--- a/packages/rpc-graphql/src/loaders/__tests__/account-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/account-loader-test.ts
@@ -10,7 +10,13 @@ import type {
 import { createRpcGraphQL, RpcGraphQL } from '../../index';
 
 describe('account loader', () => {
-    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi>;
+    let rpc: {
+        getAccountInfo: jest.MockedFunction<Rpc<GetAccountInfoApi>['getAccountInfo']>;
+        getBlock: jest.MockedFunction<Rpc<GetBlockApi>['getBlock']>;
+        getMultipleAccounts: jest.MockedFunction<Rpc<GetMultipleAccountsApi>['getMultipleAccounts']>;
+        getProgramAccounts: jest.MockedFunction<Rpc<GetProgramAccountsApi>['getProgramAccounts']>;
+        getTransaction: jest.MockedFunction<Rpc<GetTransactionApi>['getTransaction']>;
+    };
     let rpcGraphQL: RpcGraphQL;
     // Random address for testing.
     // Not actually used. Just needed for proper query parsing.
@@ -24,7 +30,11 @@ describe('account loader', () => {
             getProgramAccounts: jest.fn(),
             getTransaction: jest.fn(),
         };
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createRpcGraphQL(
+            rpc as unknown as Rpc<
+                GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi
+            >,
+        );
     });
     describe('cached responses', () => {
         it('coalesces multiple requests for the same account into one', async () => {
@@ -64,6 +74,1528 @@ describe('account loader', () => {
             await Promise.resolve();
             jest.runAllTimers();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
+        });
+    });
+    describe('batch loading', () => {
+        describe('request partitioning', () => {
+            it('coalesces multiple requests for the same account but different fields into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account1: account(address: $address) {
+                            lamports
+                        }
+                        account2: account(address: $address) {
+                            space
+                        }
+                        account3: account(address: $address) {
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('coalesces multiple requests for the same account but one with specified `confirmed` commitment into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account1: account(address: $address) {
+                            lamports
+                        }
+                        account2: account(address: $address, commitment: CONFIRMED) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+            it('will not coalesce multiple requests for the same account but with different commitments into one request', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account1: account(address: $address) {
+                            lamports
+                        }
+                        account2: account(address: $address, commitment: CONFIRMED) {
+                            lamports
+                        }
+                        account3: account(address: $address, commitment: FINALIZED) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
+                expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+                expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'finalized',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+            it('coalesces multiple requests for multiple accounts into one `getMultipleAccounts` request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account1: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            lamports
+                        }
+                        account2: account(address: "E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr") {
+                            lamports
+                        }
+                        account3: account(address: "8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M") {
+                            lamports
+                        }
+                        account4: account(address: "BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx") {
+                            lamports
+                        }
+                        account5: account(address: "68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC") {
+                            lamports
+                        }
+                        account6: account(address: "FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa") {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
+                    [
+                        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        'E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr',
+                        '8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M',
+                        'BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx',
+                        '68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC',
+                        'FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa',
+                    ],
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+            });
+            it('coalesces multiple requests for multiple accounts into one `getMultipleAccounts` request, coalescing `confirmed` commitments', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account1: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            lamports
+                        }
+                        account1Confirmed: account(
+                            address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account2: account(address: "E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr") {
+                            lamports
+                        }
+                        account2Confirmed: account(
+                            address: "E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account3: account(address: "8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M") {
+                            lamports
+                        }
+                        account3Confirmed: account(
+                            address: "8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account4: account(address: "BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx") {
+                            lamports
+                        }
+                        account4Confirmed: account(
+                            address: "BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account5: account(address: "68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC") {
+                            lamports
+                        }
+                        account5Confirmed: account(
+                            address: "68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account6: account(address: "FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa") {
+                            lamports
+                        }
+                        account6Confirmed: account(
+                            address: "FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
+                    [
+                        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        'E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr',
+                        '8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M',
+                        'BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx',
+                        '68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC',
+                        'FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa',
+                    ],
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+            });
+            it('will not coalesce multiple requests for multiple accounts into one `getMultipleAccounts` request when different commitments are requested', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account1: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            lamports
+                        }
+                        account1Confirmed: account(
+                            address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account1Finalized: account(
+                            address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr"
+                            commitment: FINALIZED
+                        ) {
+                            lamports
+                        }
+                        account2: account(address: "E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr") {
+                            lamports
+                        }
+                        account2Confirmed: account(
+                            address: "E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account2Finalized: account(
+                            address: "E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr"
+                            commitment: FINALIZED
+                        ) {
+                            lamports
+                        }
+                        account3: account(address: "8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M") {
+                            lamports
+                        }
+                        account3Confirmed: account(
+                            address: "8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account3Finalized: account(
+                            address: "8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M"
+                            commitment: FINALIZED
+                        ) {
+                            lamports
+                        }
+                        account4: account(address: "BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx") {
+                            lamports
+                        }
+                        account4Confirmed: account(
+                            address: "BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account4Finalized: account(
+                            address: "BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx"
+                            commitment: FINALIZED
+                        ) {
+                            lamports
+                        }
+                        account5: account(address: "68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC") {
+                            lamports
+                        }
+                        account5Confirmed: account(
+                            address: "68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account5Finalized: account(
+                            address: "68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC"
+                            commitment: FINALIZED
+                        ) {
+                            lamports
+                        }
+                        account6: account(address: "FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa") {
+                            lamports
+                        }
+                        account6Confirmed: account(
+                            address: "FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa"
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        account6Finalized: account(
+                            address: "FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa"
+                            commitment: FINALIZED
+                        ) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                    [
+                        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        'E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr',
+                        '8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M',
+                        'BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx',
+                        '68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC',
+                        'FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa',
+                    ],
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                    [
+                        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        'E3gxDM5HFkRALNTiWkdi9CNnXpCyTRuHz1fijP9EZbqr',
+                        '8mU8aurnEhNooLD7gRbY3jhtjWHsYpBEcFL1Dut3wu8M',
+                        'BXiu8QD4YiJ9QhMhijgDrdZh6buNe1Axtz5JG71fuDBx',
+                        '68xCDFqAHkce2tRMCTg8NMYDP9UHyMzSGsJQcHwto7aC',
+                        'FAMce8gx9Kt6CiE1AE7at6P15myQyQFqQr9fXoZbfJSa',
+                    ],
+                    {
+                        commitment: 'finalized',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+            });
+            it('coalesces multi-layered multiple requests into `getMultipleAccounts` requests', async () => {
+                expect.assertions(7);
+
+                // Set up mocks
+                type MockDataOwner = { data: [string, string]; owner: string };
+                const getAccountInfoMockResponseValue = ({ data, owner }: MockDataOwner) =>
+                    ({
+                        data,
+                        owner,
+                    }) as unknown as ReturnType<GetAccountInfoApi['getAccountInfo']>;
+                const getMultipleAccountsMockResponse = (accounts: MockDataOwner[]) =>
+                    ({
+                        context: {
+                            slot: 0n,
+                        },
+                        value: accounts.map(({ data, owner }) => getAccountInfoMockResponseValue({ data, owner })),
+                    }) as unknown as ReturnType<GetMultipleAccountsApi['getMultipleAccounts']>;
+
+                // First we should see `getMultipleAccounts` used for the first two layers
+                rpc.getMultipleAccounts
+                    .mockImplementationOnce(() => ({
+                        send: async () =>
+                            getMultipleAccountsMockResponse([
+                                {
+                                    data: ['AA', 'base64'],
+                                    owner: '11111111111111111111111111111111',
+                                },
+                                {
+                                    data: ['AA', 'base64'],
+                                    owner: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                },
+                                {
+                                    data: ['AA', 'base64'],
+                                    owner: 'Stake11111111111111111111111111111111111111',
+                                },
+                                {
+                                    data: ['AA', 'base64'],
+                                    owner: 'Vote111111111111111111111111111111111111111',
+                                },
+                            ]),
+                    }))
+                    .mockImplementationOnce(() => ({
+                        send: async () =>
+                            getMultipleAccountsMockResponse([
+                                {
+                                    data: ['AA', 'base64'],
+                                    owner: 'NativeLoader1111111111111111111111111111111',
+                                },
+                                {
+                                    data: ['AA', 'base64'],
+                                    owner: 'BPFLoader2111111111111111111111111111111111',
+                                },
+                                {
+                                    data: ['AA', 'base64'],
+                                    owner: 'NativeLoader1111111111111111111111111111111',
+                                },
+                            ]),
+                    }));
+
+                // Then we should see `getAccountInfo` used for the single
+                // account in the last layer
+                rpc.getAccountInfo.mockReturnValue({
+                    send: jest.fn().mockReturnValueOnce({
+                        context: {
+                            slot: 0,
+                        },
+                        value: getAccountInfoMockResponseValue({
+                            data: ['AA', 'base64'],
+                            owner: 'NativeLoader1111111111111111111111111111111',
+                        }),
+                    }),
+                });
+
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        # Nonce account (see scripts/fixtures/nonce-account.json)
+                        account1: account(address: "AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU") {
+                            lamports
+                            ownerProgram {
+                                lamports
+                            }
+                        }
+                        # Mint account (see scripts/fixtures/spl-token-mint-account.json)
+                        account2: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            lamports
+                            ownerProgram {
+                                lamports
+                                ownerProgram {
+                                    lamports
+                                }
+                            }
+                        }
+                        # Stake account (see scripts/fixtures/stake-account.json)
+                        account3: account(address: "CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN") {
+                            lamports
+                        }
+                        # Vote account (see scripts/fixtures/vote-account.json)
+                        account4: account(address: "4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp") {
+                            lamports
+                            ownerProgram {
+                                space
+                            }
+                        }
+                    }
+                `;
+
+                rpcGraphQL.query(source);
+
+                // Evaluate layer 1
+                await jest.advanceTimersToNextTimerAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
+                    [
+                        'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
+                        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN',
+                        '4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp',
+                    ],
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+                rpc.getMultipleAccounts.mockClear();
+
+                // Evaluate layer 2
+                await jest.advanceTimersToNextTimerAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
+                    [
+                        '11111111111111111111111111111111',
+                        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                        'Vote111111111111111111111111111111111111111',
+                    ],
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+                rpc.getMultipleAccounts.mockClear();
+
+                // Evaluate layer 3
+                await jest.advanceTimersToNextTimerAsync();
+                jest.runAllTimers();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(0);
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('BPFLoader2111111111111111111111111111111111', {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+            it('breaks multiple account requests into multiple `getMultipleAccounts` requests if the batch limit is exceeded', async () => {
+                expect.assertions(3);
+
+                rpcGraphQL = createRpcGraphQL(
+                    rpc as unknown as Rpc<
+                        GetAccountInfoApi &
+                            GetBlockApi &
+                            GetMultipleAccountsApi &
+                            GetProgramAccountsApi &
+                            GetTransactionApi
+                    >,
+                    { maxMultipleAccountsBatchSize: 3 },
+                );
+
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        # Nonce account (see scripts/fixtures/nonce-account.json)
+                        account1: account(address: "AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU") {
+                            lamports
+                        }
+                        # Mint account (see scripts/fixtures/spl-token-mint-account.json)
+                        account2: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            lamports
+                        }
+                        # Stake account (see scripts/fixtures/stake-account.json)
+                        account3: account(address: "CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN") {
+                            lamports
+                        }
+                        # Vote account (see scripts/fixtures/vote-account.json)
+                        account4: account(address: "4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp") {
+                            lamports
+                        }
+                    }
+                `;
+
+                rpcGraphQL.query(source);
+
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                    [
+                        'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
+                        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN',
+                    ],
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(['4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp'], {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+        });
+        describe('encoding requests', () => {
+            it('does not use `jsonParsed` if no parsed type is queried', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+            });
+            it('uses only `base58` if one data field is requested with `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            data(encoding: BASE_58)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                });
+            });
+            it('uses only `base64` if one data field is requested with `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            data(encoding: BASE_64)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+            });
+            it('uses only `base64+zstd` if one data field is requested with `base64+zstd` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            data(encoding: BASE_64_ZSTD)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base64+zstd',
+                });
+            });
+            it('only uses `jsonParsed` if a parsed type is queried, but data is not', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('does not call the loader twice for other base fields and `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            data(encoding: BASE_58)
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                });
+            });
+            it('does not call the loader twice for other base fields and `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            data(encoding: BASE_64)
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+            });
+            it('does not call the loader twice for other base fields and `base64+zstd` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            data(encoding: BASE_64_ZSTD)
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base64+zstd',
+                });
+            });
+            it('does not call the loader twice for other base fields and inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            lamports
+                            space
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('will not make multiple calls for more than one inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            ... on MintAccount {
+                                supply
+                            }
+                            ... on TokenAccount {
+                                lamports
+                            }
+                            ... on NonceAccount {
+                                blockhash
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('uses `jsonParsed` and the requested data encoding if a parsed type is queried alongside encoded data', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            data(encoding: BASE_64)
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
+                expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+                expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('uses only the number of requests for the number of different encodings requested', async () => {
+                expect.assertions(4);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                            dataBase58_1: data(encoding: BASE_58)
+                            dataBase58_2: data(encoding: BASE_58)
+                            dataBase58_3: data(encoding: BASE_58)
+                            dataBase64_1: data(encoding: BASE_64)
+                            dataBase64_2: data(encoding: BASE_64)
+                            dataBase64_3: data(encoding: BASE_64)
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getAccountInfo).toHaveBeenCalledTimes(3);
+                expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                });
+                expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+                expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+        });
+        describe('data slice requests', () => {
+            describe('single account queries', () => {
+                it('does not call the loader twice for data slice and other fields', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                lamports
+                                space
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                    expect(rpc.getAccountInfo).toHaveBeenLastCalledWith(
+                        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 10, offset: 0 },
+                            encoding: 'base64',
+                        },
+                    );
+                });
+                it('coalesces a data with no data slice and data with data slice within byte limit to the same request', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataWithNoSlice: data(encoding: BASE_64)
+                                dataWithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                    expect(rpc.getAccountInfo).toHaveBeenLastCalledWith(
+                        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        {
+                            commitment: 'confirmed',
+                            encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                        },
+                    );
+                });
+                it('coalesces non-sliced and sliced data requests across encodings', async () => {
+                    expect.assertions(3);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataBase58WithNoSlice: data(encoding: BASE_58)
+                                dataBase58WithSlice: data(encoding: BASE_58, dataSlice: { length: 10, offset: 0 })
+                                dataBase64WithNoSlice: data(encoding: BASE_64)
+                                dataBase64WithSlice: data(encoding: BASE_64, dataSlice: { length: 20, offset: 4 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        encoding: 'base58', // No `dataSlice` arg since one field asked for the whole data
+                    });
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                    });
+                });
+                it('always uses separate requests for `base64+zstd` no matter the data slice', async () => {
+                    expect.assertions(4);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataBase64ZstdWithNoSlice: data(encoding: BASE_64_ZSTD)
+                                dataBase64ZstdWithSlice1: data(
+                                    encoding: BASE_64_ZSTD
+                                    dataSlice: { length: 16, offset: 4 }
+                                )
+                                dataBase64ZstdWithSlice2: data(
+                                    encoding: BASE_64_ZSTD
+                                    dataSlice: { length: 40, offset: 12 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getAccountInfo).toHaveBeenCalledTimes(3);
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        encoding: 'base64+zstd',
+                    });
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 16, offset: 4 },
+                        encoding: 'base64+zstd',
+                    });
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 40, offset: 12 },
+                        encoding: 'base64+zstd',
+                    });
+                });
+                it('coalesces multiple data slice requests within byte limit to the same request', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { length: 16, offset: 2 })
+                                dataSlice3: data(encoding: BASE_64, dataSlice: { length: 20, offset: 6 })
+                                dataSlice4: data(encoding: BASE_64, dataSlice: { length: 10, offset: 10 })
+                                dataSlice5: data(encoding: BASE_64, dataSlice: { length: 10, offset: 30 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 40, offset: 0 }, // Coalesced into one slice
+                        encoding: 'base64',
+                    });
+                });
+                it('splits multiple data slice requests beyond byte limit into two requests', async () => {
+                    expect.assertions(3);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { length: 4, offset: 0 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { length: 4, offset: 2000 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base64',
+                    });
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 2000 },
+                        encoding: 'base64',
+                    });
+                });
+                it('honors the byte limit across encodings', async () => {
+                    expect.assertions(5);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { length: 4, offset: 0 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { length: 4, offset: 2000 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { length: 4, offset: 0 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { length: 4, offset: 2000 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getAccountInfo).toHaveBeenCalledTimes(4);
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base58',
+                    });
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 2000 },
+                        encoding: 'base58',
+                    });
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base64',
+                    });
+                    expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 2000 },
+                        encoding: 'base64',
+                    });
+                });
+            });
+            describe('multiple account queries', () => {
+                it('does not call the loader twice for data slice and other fields', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            accountA: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                lamports
+                                space
+                            }
+                            accountB: account(address: "2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb") {
+                                data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                lamports
+                                space
+                            }
+                            accountC: account(address: "4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u") {
+                                data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                lamports
+                                space
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                    expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 10, offset: 0 },
+                            encoding: 'base64',
+                        },
+                    );
+                });
+                it('coalesces a data with no data slice and data with data slice within byte limit to the same request', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            accountA: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataWithNoSlice: data(encoding: BASE_64)
+                                dataWithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                            accountB: account(address: "2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb") {
+                                dataWithNoSlice: data(encoding: BASE_64)
+                                dataWithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                            accountC: account(address: "4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u") {
+                                dataWithNoSlice: data(encoding: BASE_64)
+                                dataWithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                    expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                        },
+                    );
+                });
+                it('coalesces non-sliced and sliced data requests across encodings', async () => {
+                    expect.assertions(3);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            accountA: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataBase58WithNoSlice: data(encoding: BASE_58)
+                                dataBase58WithSlice: data(encoding: BASE_58, dataSlice: { length: 10, offset: 0 })
+                                dataBase64WithNoSlice: data(encoding: BASE_64)
+                                dataBase64WithSlice: data(encoding: BASE_64, dataSlice: { length: 12, offset: 4 })
+                            }
+                            accountB: account(address: "2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb") {
+                                dataBase58WithNoSlice: data(encoding: BASE_58)
+                                dataBase58WithSlice: data(encoding: BASE_58, dataSlice: { length: 14, offset: 4 })
+                                dataBase64WithNoSlice: data(encoding: BASE_64)
+                                dataBase64WithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                            accountC: account(address: "4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u") {
+                                dataBase58WithNoSlice: data(encoding: BASE_58)
+                                dataBase58WithSlice: data(encoding: BASE_58, dataSlice: { length: 10, offset: 50 })
+                                dataBase64WithNoSlice: data(encoding: BASE_64)
+                                dataBase64WithSlice: data(encoding: BASE_64, dataSlice: { length: 100, offset: 0 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            encoding: 'base58', // No `dataSlice` arg since one field asked for the whole data
+                        },
+                    );
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                        },
+                    );
+                });
+                it('coalesces multiple data slice requests within byte limit to the same request', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            accountA: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 10 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2, length: 16 })
+                                dataSlice3: data(encoding: BASE_64, dataSlice: { offset: 6, length: 20 })
+                                dataSlice4: data(encoding: BASE_64, dataSlice: { offset: 10, length: 10 })
+                                dataSlice5: data(encoding: BASE_64, dataSlice: { offset: 30, length: 10 })
+                            }
+                            accountB: account(address: "2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 10 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2, length: 16 })
+                                dataSlice3: data(encoding: BASE_64, dataSlice: { offset: 6, length: 20 })
+                                dataSlice4: data(encoding: BASE_64, dataSlice: { offset: 10, length: 10 })
+                                dataSlice5: data(encoding: BASE_64, dataSlice: { offset: 30, length: 10 })
+                            }
+                            accountC: account(address: "4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 10 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2, length: 16 })
+                                dataSlice3: data(encoding: BASE_64, dataSlice: { offset: 6, length: 20 })
+                                dataSlice4: data(encoding: BASE_64, dataSlice: { offset: 10, length: 10 })
+                                dataSlice5: data(encoding: BASE_64, dataSlice: { offset: 30, length: 10 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 40, offset: 0 }, // Coalesced into one slice
+                            encoding: 'base64',
+                        },
+                    );
+                });
+                it('splits multiple data slice requests beyond the default byte limit into two requests', async () => {
+                    expect.assertions(3);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            accountA: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2000, length: 4 })
+                            }
+                            accountB: account(address: "2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2000, length: 4 })
+                            }
+                            accountC: account(address: "4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2000, length: 4 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: 0 },
+                            encoding: 'base64',
+                        },
+                    );
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: 2000 },
+                            encoding: 'base64',
+                        },
+                    );
+                });
+                it('splits multiple data slice requests beyond a provided byte limit into two requests', async () => {
+                    expect.assertions(3);
+                    const maxDataSliceByteRange = 100;
+                    rpcGraphQL = createRpcGraphQL(
+                        rpc as unknown as Rpc<
+                            GetAccountInfoApi &
+                                GetBlockApi &
+                                GetMultipleAccountsApi &
+                                GetProgramAccountsApi &
+                                GetTransactionApi
+                        >,
+                        {
+                            maxDataSliceByteRange,
+                        },
+                    );
+                    const source = /* GraphQL */ `
+                        query testQuery($maxDataSliceByteRange: Int!) {
+                            accountA: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                            accountB: account(address: "2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                            accountC: account(address: "4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u") {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { maxDataSliceByteRange });
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: 0 },
+                            encoding: 'base64',
+                        },
+                    );
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: maxDataSliceByteRange },
+                            encoding: 'base64',
+                        },
+                    );
+                });
+                it('honors the default byte limit across encodings', async () => {
+                    expect.assertions(5);
+                    const source = /* GraphQL */ `
+                        query testQuery {
+                            accountA: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                            }
+                            accountB: account(address: "2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb") {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                            }
+                            accountC: account(address: "4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u") {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source);
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(4);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: 0 },
+                            encoding: 'base58',
+                        },
+                    );
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: 2000 },
+                            encoding: 'base58',
+                        },
+                    );
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: 0 },
+                            encoding: 'base64',
+                        },
+                    );
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: 2000 },
+                            encoding: 'base64',
+                        },
+                    );
+                });
+                it('honors a provided byte limit across encodings', async () => {
+                    expect.assertions(5);
+                    const maxDataSliceByteRange = 100;
+                    rpcGraphQL = createRpcGraphQL(
+                        rpc as unknown as Rpc<
+                            GetAccountInfoApi &
+                                GetBlockApi &
+                                GetMultipleAccountsApi &
+                                GetProgramAccountsApi &
+                                GetTransactionApi
+                        >,
+                        {
+                            maxDataSliceByteRange,
+                        },
+                    );
+                    const source = /* GraphQL */ `
+                        query testQuery($maxDataSliceByteRange: Int!) {
+                            accountA: account(address: "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr") {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                            accountB: account(address: "2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb") {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                            accountC: account(address: "4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u") {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { maxDataSliceByteRange });
+                    // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                    await Promise.resolve();
+                    jest.runAllTimers();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(4);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: 0 },
+                            encoding: 'base58',
+                        },
+                    );
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: maxDataSliceByteRange },
+                            encoding: 'base58',
+                        },
+                    );
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: 0 },
+                            encoding: 'base64',
+                        },
+                    );
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+                        [
+                            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            '2KAARoNUYTddAChEdWb21bdKH6dWu51AAPFjSjRmzsbb',
+                            '4rFV8bvFpacLkvxTFuVN4pqe5s7CTyEkmYvPpu45779u',
+                        ],
+                        {
+                            commitment: 'confirmed',
+                            dataSlice: { length: 4, offset: maxDataSliceByteRange },
+                            encoding: 'base64',
+                        },
+                    );
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/loaders/account.ts
+++ b/packages/rpc-graphql/src/loaders/account.ts
@@ -1,44 +1,344 @@
-import type { GetAccountInfoApi, Rpc } from '@solana/rpc';
+import { Address } from '@solana/addresses';
+import { getBase58Codec, getBase64Codec } from '@solana/codecs-strings';
+import type { GetAccountInfoApi, GetMultipleAccountsApi, Rpc } from '@solana/rpc';
 import DataLoader from 'dataloader';
 
-import { AccountLoader, AccountLoaderArgs, AccountLoaderValue, cacheKeyFn } from './loader';
+import {
+    AccountLoader,
+    AccountLoaderArgs,
+    AccountLoaderArgsBase,
+    AccountLoaderValue,
+    BatchLoadPromiseCallback,
+    cacheKeyFn,
+    MultipleAccountsLoaderArgs,
+} from './loader';
 
-function applyDefaultArgs({
-    address,
-    commitment,
-    dataSlice,
-    encoding = 'base64', // Fixed by batch loader
-    minContextSlot,
-}: AccountLoaderArgs): AccountLoaderArgs {
-    return {
-        address,
-        commitment,
-        dataSlice,
-        encoding,
-        minContextSlot,
-    };
+type Config = {
+    maxDataSliceByteRange: number;
+    maxMultipleAccountsBatchSize: number;
+};
+
+type Encoding = 'base58' | 'base64' | 'base64+zstd';
+type DataSlice = { length: number; offset: number };
+
+type AccountBatchLoadPromiseCallback = BatchLoadPromiseCallback<AccountLoaderValue>;
+type AccountBatchLoadCallbackItem = {
+    callback: AccountBatchLoadPromiseCallback;
+    dataSlice?: DataSlice | null;
+};
+
+function getCodec(encoding: Omit<Encoding, 'base64+zstd'>) {
+    switch (encoding) {
+        case 'base58':
+            return getBase58Codec();
+        default:
+            return getBase64Codec();
+    }
 }
 
-async function loadAccount(
-    rpc: Rpc<GetAccountInfoApi>,
-    { address, ...config }: AccountLoaderArgs,
-): Promise<AccountLoaderValue> {
+function sliceData(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    account: any,
+    dataSlice?: DataSlice | null,
+    masterDataSlice?: DataSlice,
+) {
+    if (dataSlice) {
+        const masterOffset = masterDataSlice ? masterDataSlice.offset : 0;
+
+        const slicedData = (data: string, encoding: Encoding): string => {
+            if (encoding === 'base64+zstd') {
+                // Don't slice `base64+zstd` encoding.
+                return data;
+            }
+            const { offset, length } = dataSlice;
+            const trueOffset = offset - masterOffset;
+            const codec = getCodec(encoding);
+            return codec.decode(codec.encode(data).slice(trueOffset, trueOffset + length));
+        };
+
+        if (Array.isArray(account.data)) {
+            const [data, encoding] = account.data;
+            return {
+                ...account,
+                data: [slicedData(data, encoding), encoding],
+            };
+        } else if (typeof account.data === 'string') {
+            const data = account.data;
+            return {
+                ...account,
+                data: slicedData(data, 'base58'),
+            };
+        }
+    }
+    return account;
+}
+
+/**
+ * Load an account using the RPC's `getAccountInfo` method.
+ */
+async function loadAccount(rpc: Rpc<GetAccountInfoApi>, { address, ...config }: AccountLoaderArgs) {
     return await rpc
         .getAccountInfo(address, config)
         .send()
         .then(res => res.value);
 }
 
-function createAccountBatchLoadFn(rpc: Rpc<GetAccountInfoApi>) {
-    const resolveAccountUsingRpc = loadAccount.bind(null, rpc);
-    return async (accountQueryArgs: readonly AccountLoaderArgs[]) =>
-        Promise.all(accountQueryArgs.map(async args => resolveAccountUsingRpc(applyDefaultArgs(args))));
+/**
+ * Load multiple accounts using the RPC's `getMultipleAccounts` method.
+ */
+async function loadMultipleAccounts(
+    rpc: Rpc<GetMultipleAccountsApi>,
+    { addresses, ...config }: MultipleAccountsLoaderArgs,
+) {
+    return await rpc
+        .getMultipleAccounts(addresses, config)
+        .send()
+        .then(res => res.value);
 }
 
-export function createAccountLoader(rpc: Rpc<GetAccountInfoApi>): AccountLoader {
-    const loader = new DataLoader(createAccountBatchLoadFn(rpc), { cacheKeyFn });
+const hashOmit = (args: AccountLoaderArgsBase, omit: (keyof AccountLoaderArgsBase)[]) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const argsObj: any = {};
+    for (const [key, value] of Object.entries(args)) {
+        if (!omit.includes(key as keyof AccountLoaderArgsBase)) {
+            argsObj[key] = value;
+        }
+    }
+    return cacheKeyFn(argsObj);
+};
+
+function createAccountBatchLoadFn(rpc: Rpc<GetAccountInfoApi & GetMultipleAccountsApi>, config: Config) {
+    const resolveAccountUsingRpc = loadAccount.bind(null, rpc);
+    const resolveMultipleAccountsUsingRpc = loadMultipleAccounts.bind(null, rpc);
+    return async (accountQueryArgs: readonly AccountLoaderArgs[]): ReturnType<AccountLoader['loadMany']> => {
+        /**
+         * Gather all the accounts that need to be fetched, grouped by address.
+         */
+        const accountsToFetch: {
+            [address: string]: Readonly<{
+                args: AccountLoaderArgsBase;
+                promiseCallback: AccountBatchLoadPromiseCallback;
+            }>[];
+        } = {};
+        try {
+            return Promise.all(
+                accountQueryArgs.map(
+                    ({ address, ...args }) =>
+                        new Promise((resolve, reject) => {
+                            const accountRecords = (accountsToFetch[address] ||= []);
+                            // Apply the default commitment level.
+                            if (!args.commitment) {
+                                args.commitment = 'confirmed';
+                            }
+                            accountRecords.push({ args, promiseCallback: { reject, resolve } });
+                        }),
+                ),
+            ) as ReturnType<AccountLoader['loadMany']>;
+        } finally {
+            const { maxDataSliceByteRange, maxMultipleAccountsBatchSize } = config;
+
+            /**
+             * Group together accounts that are fetched with identical args.
+             */
+            const accountFetchesByArgsHash: {
+                [argsHash: string]: {
+                    args: AccountLoaderArgsBase;
+                    addresses: {
+                        [address: string]: {
+                            callbacks: AccountBatchLoadCallbackItem[];
+                        };
+                    };
+                };
+            } = {};
+
+            // Keep track of any fetches that don't specify an encoding, to be
+            // wrapped into another fetch that does.
+            const orphanedFetches: typeof accountsToFetch = {};
+
+            Object.entries(accountsToFetch).forEach(([address, toFetch]) => {
+                toFetch.forEach(({ args, promiseCallback }) => {
+                    // As per the schema, `encoding` can only be provided if a
+                    // `data` field is present, and the argument is required.
+                    // So we can assume if no encoding is provided, this
+                    // particular fetch is not concerned with data. We can
+                    // combine it with some other fetch.
+                    if (!args.encoding) {
+                        const toFetch = (orphanedFetches[address] ||= []);
+                        toFetch.push({ args, promiseCallback });
+                        return;
+                    }
+                    // As per the schema, `dataSlice` cannot be provided without
+                    // encoding.
+                    // Don't try to combine fetches with `base64+zstd` encoding.
+                    if (args.encoding != 'base64+zstd' && args.dataSlice) {
+                        // If the fetch arg set has `dataSlice` provided, try
+                        // to combine it with another request.
+                        const r = args.dataSlice;
+                        for (const { addresses: fetchAddresses, args: fetchArgs } of Object.values(
+                            accountFetchesByArgsHash,
+                        )) {
+                            /**
+                             * Add a callback to the list of callbacks for the current address,
+                             * possibly updating the `dataSlice` argument used for the entire
+                             * fetch.
+                             */
+                            const addCallbackWithDataSlice = (updateDataSlice?: DataSlice) => {
+                                const { callbacks: promiseCallbacksForAddress } = (fetchAddresses[address] ||= {
+                                    callbacks: [],
+                                });
+                                promiseCallbacksForAddress.push({
+                                    callback: promiseCallback,
+                                    dataSlice: args.dataSlice ?? null,
+                                });
+                                if (fetchArgs.dataSlice && updateDataSlice) {
+                                    fetchArgs.dataSlice = updateDataSlice;
+                                }
+                            };
+
+                            // Check if the two arg sets are a match without the `dataSlice`
+                            // argument.
+                            if (hashOmit(args, ['dataSlice']) === hashOmit(fetchArgs, ['dataSlice'])) {
+                                if (fetchArgs.dataSlice) {
+                                    // The arg sets match, and the fetch arg set has a `dataSlice`
+                                    // argument. Try to merge the two account fetches.
+                                    const g = fetchArgs.dataSlice;
+                                    if (
+                                        r.offset <= g.offset &&
+                                        g.offset - r.offset + r.length <= maxDataSliceByteRange
+                                    ) {
+                                        const length = Math.max(r.length, g.offset + g.length - r.offset);
+                                        const offset = r.offset;
+                                        addCallbackWithDataSlice({ length, offset });
+                                        return;
+                                    }
+                                    if (
+                                        r.offset >= g.offset &&
+                                        r.offset - g.offset + g.length <= maxDataSliceByteRange
+                                    ) {
+                                        const length = Math.max(g.length, r.offset + r.length - g.offset);
+                                        const offset = g.offset;
+                                        addCallbackWithDataSlice({ length, offset });
+                                        return;
+                                    }
+                                } else {
+                                    // The arg sets match, and the fetch arg set has no `dataSlice`
+                                    // argument. Merge the two account fetches.
+                                    const { length, offset } = r;
+                                    addCallbackWithDataSlice({ length, offset });
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                    // Either the fetch arg set has no `dataSlice` argument, or
+                    // it couldn't be combined with another fetch, likely due to
+                    // the wasted byte limitation.
+                    // Add the fetch to the list as a new fetch.
+                    const argsHash = hashOmit(args, []);
+                    const accountFetches = (accountFetchesByArgsHash[argsHash] ||= {
+                        addresses: {},
+                        args,
+                    });
+                    const { callbacks: promiseCallbacksForAddress } = (accountFetches.addresses[address] ||= {
+                        callbacks: [],
+                    });
+                    promiseCallbacksForAddress.push({ callback: promiseCallback, dataSlice: args.dataSlice ?? null });
+                });
+            });
+
+            // Place the orphans
+            Object.entries(orphanedFetches).forEach(([address, toFetch]) => {
+                toFetch.forEach(({ args: orphanedArgs, promiseCallback: orphanPromiseCallback }) => {
+                    if (Object.keys(accountFetchesByArgsHash).length !== 0) {
+                        for (const { addresses, args } of Object.values(accountFetchesByArgsHash)) {
+                            // Check if the two arg sets are a match without
+                            // `encoding` and `dataSlice` arguments.
+                            if (
+                                hashOmit(orphanedArgs, ['encoding', 'dataSlice']) ===
+                                hashOmit(args, ['encoding', 'dataSlice'])
+                            ) {
+                                const { callbacks: promiseCallbacksForAddress } = (addresses[address] ||= {
+                                    callbacks: [],
+                                });
+                                promiseCallbacksForAddress.push({ callback: orphanPromiseCallback });
+                                return;
+                            }
+                        }
+                    }
+                    // Create a new fetch. Prefer `base64` encoding.
+                    const args: AccountLoaderArgsBase = { ...orphanedArgs, encoding: 'base64' };
+                    const argsHash = hashOmit(args, []);
+                    const accountFetches = (accountFetchesByArgsHash[argsHash] ||= {
+                        addresses: {},
+                        args,
+                    });
+                    const { callbacks: promiseCallbacksForAddress } = (accountFetches.addresses[address] ||= {
+                        callbacks: [],
+                    });
+                    promiseCallbacksForAddress.push({ callback: orphanPromiseCallback });
+                });
+            });
+
+            /**
+             * For each set of accounts related to some common args, fetch them in the fewest number
+             * of network requests.
+             */
+            Object.values(accountFetchesByArgsHash).map(({ args, addresses: addressCallbacks }) => {
+                const addresses = Object.keys(addressCallbacks) as Address[];
+                if (addresses.length === 1) {
+                    const address = addresses[0];
+                    return Array.from({ length: 1 }, async () => {
+                        try {
+                            const result = await resolveAccountUsingRpc({ address, ...args });
+                            addressCallbacks[address].callbacks.forEach(({ callback, dataSlice }) => {
+                                callback.resolve(sliceData(result, dataSlice, args.dataSlice));
+                            });
+                        } catch (e) {
+                            addressCallbacks[address].callbacks.forEach(({ callback }) => {
+                                callback.reject(e);
+                            });
+                        }
+                    });
+                } else {
+                    return Array.from(
+                        { length: Math.ceil(addresses.length / maxMultipleAccountsBatchSize) },
+                        async (_, ii) => {
+                            const startIndex = ii * maxMultipleAccountsBatchSize;
+                            const endIndex = startIndex + maxMultipleAccountsBatchSize;
+                            const chunk = addresses.slice(startIndex, endIndex);
+                            try {
+                                const results = await resolveMultipleAccountsUsingRpc({
+                                    addresses: chunk,
+                                    ...args,
+                                });
+                                chunk.forEach((address, ii) => {
+                                    const result = results[ii];
+                                    addressCallbacks[address].callbacks.forEach(({ callback, dataSlice }) => {
+                                        callback.resolve(sliceData(result, dataSlice, args.dataSlice));
+                                    });
+                                });
+                            } catch (e) {
+                                chunk.forEach(address => {
+                                    addressCallbacks[address].callbacks.forEach(({ callback }) => {
+                                        callback.reject(e);
+                                    });
+                                });
+                            }
+                        },
+                    );
+                }
+            });
+        }
+    };
+}
+
+export function createAccountLoader(
+    rpc: Rpc<GetAccountInfoApi & GetMultipleAccountsApi>,
+    config: Config,
+): AccountLoader {
+    const loader = new DataLoader(createAccountBatchLoadFn(rpc, config), { cacheKeyFn });
     return {
-        load: async args => loader.load(applyDefaultArgs(args)),
-        loadMany: async args => loader.loadMany(args.map(applyDefaultArgs)),
+        load: async args => loader.load(args),
+        loadMany: async args => loader.loadMany(args),
     };
 }

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -6,21 +6,23 @@ import type { Commitment, Slot } from '@solana/rpc-types';
 // @ts-ignore
 import stringify from 'json-stable-stringify';
 
+export type BatchLoadPromiseCallback<T> = Readonly<{
+    resolve: (value: T) => void;
+    reject: (reason?: unknown) => void;
+}>;
+
+// Loader base types
 export type LoadFn<TArgs, T> = (args: TArgs) => Promise<T>;
 export type LoadManyFn<TArgs, T> = (args: TArgs[]) => Promise<(T | Error)[]>;
 export type Loader<TArgs, T> = { load: LoadFn<TArgs, T>; loadMany: LoadManyFn<TArgs, T> };
 
-// FIX ME: https://github.com/microsoft/TypeScript/issues/43187
-// export type AccountLoaderArgs = { address: Parameters<GetAccountInfoApi['getAccountInfo']>[0] } & Parameters<
-//     GetAccountInfoApi['getAccountInfo']
-// >[1];
-export type AccountLoaderArgs = {
-    address: Address;
+export type AccountLoaderArgsBase = {
     commitment?: Commitment;
     dataSlice?: { offset: number; length: number };
     encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
     minContextSlot?: Slot;
 };
+export type AccountLoaderArgs = { address: Address } & AccountLoaderArgsBase;
 export type AccountLoaderValue = ReturnType<GetAccountInfoApi['getAccountInfo']>['value'] | null;
 export type AccountLoader = Loader<AccountLoaderArgs, AccountLoaderValue>;
 
@@ -37,7 +39,11 @@ export type BlockLoaderArgs = {
 export type BlockLoaderValue = ReturnType<GetBlockApi['getBlock']> | null;
 export type BlockLoader = Loader<BlockLoaderArgs, BlockLoaderValue>;
 
-// FIX ME: https://github.com/microsoft/TypeScript/issues/43187
+export type MultipleAccountsLoaderArgs = { addresses: Address[] } & AccountLoaderArgsBase;
+export type MultipleAccountsLoaderValue = AccountLoaderValue[];
+export type MultipleAccountsLoader = Loader<MultipleAccountsLoaderArgs, MultipleAccountsLoaderValue>;
+
+// FIX ME: https://github.com/solana-labs/solana-web3.js/pull/2052
 // export type ProgramAccountsLoaderArgs = {
 //     programAddress: Parameters<GetProgramAccountsApi['getProgramAccounts']>[0];
 // } & Parameters<GetProgramAccountsApi['getProgramAccounts']>[1];

--- a/packages/rpc-graphql/src/resolvers/__tests__/account-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/account-resolver-test.ts
@@ -243,8 +243,9 @@ describe('account resolver', () => {
             // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
             await Promise.resolve();
             jest.runAllTimers();
-            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2); // Fixed with batch loader
+            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'jsonParsed',
             });
         });
@@ -264,11 +265,13 @@ describe('account resolver', () => {
             // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
             await Promise.resolve();
             jest.runAllTimers();
-            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(3); // Fixed with batch loader
+            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
             expect(rpc.getAccountInfo).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'jsonParsed',
             });
             expect(rpc.getAccountInfo).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'base58',
             });
         });
@@ -289,11 +292,13 @@ describe('account resolver', () => {
             // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
             await Promise.resolve();
             jest.runAllTimers();
-            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2); // Fixed with batch loader
+            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'base58',
             });
             expect(rpc.getAccountInfo).not.toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'jsonParsed',
             });
         });
@@ -317,6 +322,7 @@ describe('account resolver', () => {
             jest.runAllTimers();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'base64',
             });
         });
@@ -340,8 +346,9 @@ describe('account resolver', () => {
             // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
             await Promise.resolve();
             jest.runAllTimers();
-            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2); // Fixed with batch loader
+            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'base64+zstd',
             });
         });
@@ -364,8 +371,9 @@ describe('account resolver', () => {
             // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
             await Promise.resolve();
             jest.runAllTimers();
-            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2); // Fixed with batch loader
+            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'jsonParsed',
             });
         });
@@ -388,11 +396,13 @@ describe('account resolver', () => {
             // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
             await Promise.resolve();
             jest.runAllTimers();
-            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(3); // Fixed with batch loader
+            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
             expect(rpc.getAccountInfo).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'jsonParsed',
             });
             expect(rpc.getAccountInfo).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'base58',
             });
         });
@@ -415,11 +425,13 @@ describe('account resolver', () => {
             // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
             await Promise.resolve();
             jest.runAllTimers();
-            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2); // Fixed with batch loader
+            expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'base64+zstd',
             });
             expect(rpc.getAccountInfo).not.toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
                 encoding: 'jsonParsed',
             });
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1831,6 +1831,9 @@ importers:
       '@graphql-tools/schema':
         specifier: ^10.0.0
         version: 10.0.0(graphql@16.8.1)
+      '@solana/codecs-strings':
+        specifier: workspace:*
+        version: link:../codecs-strings
       dataloader:
         specifier: ^2.2.2
         version: 2.2.2


### PR DESCRIPTION
So.... this batch loader works great!

However, my tests are super flaky with the timer manipulation.
Every 5-6 attempts, they all pass, but the other times I get a few failures.
It's always the same tests that fail, and they seem to be 1 less `fetchMock`
invocation than expected.
I think I'm missing something.