### PR TITLE
refactor(experimental): add `info` field to JSON parsed types

### DIFF
--- a/packages/rpc-parsed-types/src/__typetests__/address-lookup-table-accounts-test.ts
+++ b/packages/rpc-parsed-types/src/__typetests__/address-lookup-table-accounts-test.ts
@@ -4,14 +4,16 @@ import { StringifiedBigInt } from '@solana/rpc-types';
 import { JsonParsedAddressLookupTableAccount } from '../address-lookup-table-accounts';
 
 const account = {
-    addresses: [
-        'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address,
-        'FWscgV4VDSsMxkQg7jZ4HksqjLyadJS5RiCnAVZv2se9' as Address,
-    ],
-    authority: '4msgK65vdz5ADUAB3eTQGpF388NuQUAoknLxutUQJd5B' as Address,
-    deactivationSlot: '204699277' as StringifiedBigInt,
-    lastExtendedSlot: '204699234' as StringifiedBigInt,
-    lastExtendedSlotStartIndex: 20,
+    info: {
+        addresses: [
+            'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address,
+            'FWscgV4VDSsMxkQg7jZ4HksqjLyadJS5RiCnAVZv2se9' as Address,
+        ],
+        authority: '4msgK65vdz5ADUAB3eTQGpF388NuQUAoknLxutUQJd5B' as Address,
+        deactivationSlot: '204699277' as StringifiedBigInt,
+        lastExtendedSlot: '204699234' as StringifiedBigInt,
+        lastExtendedSlotStartIndex: 20,
+    },
 };
 
 account satisfies JsonParsedAddressLookupTableAccount;

--- a/packages/rpc-parsed-types/src/__typetests__/nonce-accounts-test.ts
+++ b/packages/rpc-parsed-types/src/__typetests__/nonce-accounts-test.ts
@@ -5,10 +5,12 @@ import { JsonParsedNonceAccount } from '../nonce-accounts';
 
 {
     const account = {
-        authority: '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe' as Address,
-        blockhash: 'TcVy2wVcs7WqWVopv8LAJBHQfqVYZrm8UDqjDvBFQt8' as Blockhash,
-        feeCalculator: {
-            lamportsPerSignature: '5000' as StringifiedBigInt,
+        info: {
+            authority: '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe' as Address,
+            blockhash: 'TcVy2wVcs7WqWVopv8LAJBHQfqVYZrm8UDqjDvBFQt8' as Blockhash,
+            feeCalculator: {
+                lamportsPerSignature: '5000' as StringifiedBigInt,
+            },
         },
     };
     account satisfies JsonParsedNonceAccount;

--- a/packages/rpc-parsed-types/src/__typetests__/vote-accounts-test.ts
+++ b/packages/rpc-parsed-types/src/__typetests__/vote-accounts-test.ts
@@ -4,43 +4,45 @@ import { Epoch, Slot, StringifiedBigInt, UnixTimestamp } from '@solana/rpc-types
 import { JsonParsedVoteAccount } from '../vote-accounts';
 
 const account = {
-    authorizedVoters: [
-        {
-            authorizedVoter: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr' as Address,
-            epoch: 529n as Epoch,
+    info: {
+        authorizedVoters: [
+            {
+                authorizedVoter: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr' as Address,
+                epoch: 529n as Epoch,
+            },
+        ],
+        authorizedWithdrawer: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr' as Address,
+        commission: 50,
+        epochCredits: [
+            {
+                credits: '68697256' as StringifiedBigInt,
+                epoch: 466n as Epoch,
+                previousCredits: '68325825' as StringifiedBigInt,
+            },
+            {
+                credits: '69068118' as StringifiedBigInt,
+                epoch: 467n as Epoch,
+                previousCredits: '68697256' as StringifiedBigInt,
+            },
+        ],
+        lastTimestamp: {
+            slot: 228884530n as Slot,
+            timestamp: 1689090220 as UnixTimestamp,
         },
-    ],
-    authorizedWithdrawer: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr' as Address,
-    commission: 50,
-    epochCredits: [
-        {
-            credits: '68697256' as StringifiedBigInt,
-            epoch: 466n as Epoch,
-            previousCredits: '68325825' as StringifiedBigInt,
-        },
-        {
-            credits: '69068118' as StringifiedBigInt,
-            epoch: 467n as Epoch,
-            previousCredits: '68697256' as StringifiedBigInt,
-        },
-    ],
-    lastTimestamp: {
-        slot: 228884530n as Slot,
-        timestamp: 1689090220 as UnixTimestamp,
+        nodePubkey: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr' as Address,
+        priorVoters: [],
+        rootSlot: 228884499n as Slot,
+        votes: [
+            {
+                confirmationCount: 31,
+                slot: 228884500n as Slot,
+            },
+            {
+                confirmationCount: 30,
+                slot: 228884501n as Slot,
+            },
+        ],
     },
-    nodePubkey: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr' as Address,
-    priorVoters: [],
-    rootSlot: 228884499n as Slot,
-    votes: [
-        {
-            confirmationCount: 31,
-            slot: 228884500n as Slot,
-        },
-        {
-            confirmationCount: 30,
-            slot: 228884501n as Slot,
-        },
-    ],
 };
 
 account satisfies JsonParsedVoteAccount;

--- a/packages/rpc-parsed-types/src/address-lookup-table-accounts.ts
+++ b/packages/rpc-parsed-types/src/address-lookup-table-accounts.ts
@@ -1,7 +1,9 @@
 import type { Address } from '@solana/addresses';
 import type { StringifiedBigInt } from '@solana/rpc-types';
 
-export type JsonParsedAddressLookupTableAccount = Readonly<{
+import { RpcParsedInfo } from './rpc-parsed-type';
+
+export type JsonParsedAddressLookupTableAccount = RpcParsedInfo<{
     addresses: readonly Address[];
     authority?: Address;
     deactivationSlot: StringifiedBigInt;

--- a/packages/rpc-parsed-types/src/nonce-accounts.ts
+++ b/packages/rpc-parsed-types/src/nonce-accounts.ts
@@ -1,7 +1,9 @@
 import { Address } from '@solana/addresses';
 import type { Blockhash, StringifiedBigInt } from '@solana/rpc-types';
 
-export type JsonParsedNonceAccount = Readonly<{
+import { RpcParsedInfo } from './rpc-parsed-type';
+
+export type JsonParsedNonceAccount = RpcParsedInfo<{
     authority: Address;
     blockhash: Blockhash;
     feeCalculator: Readonly<{

--- a/packages/rpc-parsed-types/src/rpc-parsed-type.ts
+++ b/packages/rpc-parsed-types/src/rpc-parsed-type.ts
@@ -2,3 +2,7 @@ export type RpcParsedType<TType extends string, TInfo> = Readonly<{
     info: TInfo;
     type: TType;
 }>;
+
+export type RpcParsedInfo<TInfo> = Readonly<{
+    info: TInfo;
+}>;

--- a/packages/rpc-parsed-types/src/vote-accounts.ts
+++ b/packages/rpc-parsed-types/src/vote-accounts.ts
@@ -1,7 +1,9 @@
 import { Address } from '@solana/addresses';
 import { Epoch, Slot, StringifiedBigInt, UnixTimestamp } from '@solana/rpc-types';
 
-export type JsonParsedVoteAccount = Readonly<{
+import { RpcParsedInfo } from './rpc-parsed-type';
+
+export type JsonParsedVoteAccount = RpcParsedInfo<{
     authorizedVoters: Readonly<{
         authorizedVoter: Address;
         epoch: Epoch;


### PR DESCRIPTION
Some of the programs that own JSON parseable accounts, such as token, have accounts with multiple types. They have both `info` and `type` fields, and we have these typed so that you can discriminate using the `type` field.

But some other programs, such as vote and address lookup tables, have only one type of account. They don't have a `type` field but do have the `info` field, with the same shape for all their accounts.

Since I didn't need to discriminate them, I exported these types without the`info` field too. This PR changes this so that their type includes the `info` field, with all their properties nested inside it.

I found that it's annoying to use these as-is because you end up with some types having an `info` field containing their properties, and others not. But if the data comes from `getAccountInfo` etc, that `info` field is always there, so it makes sense for the types to always include it too. This reduces special cases in code using these types.