### PR TITLE
Convert two errors in `@solana/transactions` to the new coded error system

### DIFF
--- a/packages/errors/src/__tests__/error-test.ts
+++ b/packages/errors/src/__tests__/error-test.ts
@@ -7,8 +7,8 @@ describe('SolanaError', () => {
     let error123: SolanaError;
     beforeEach(() => {
         error123 = new SolanaError(
-            123,
             // @ts-expect-error Mock error codes don't conform to `SolanaErrorCode`
+            123,
             { foo: 'bar' },
         );
     });
@@ -29,10 +29,8 @@ describe('SolanaError', () => {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 await import('../error');
-            const error456 = new SolanaErrorModule.SolanaError(
-                // @ts-expect-error Mock error codes don't conform to `SolanaErrorCode`
-                456,
-            );
+            // @ts-expect-error Mock error codes don't conform to `SolanaErrorCode`
+            const error456 = new SolanaErrorModule.SolanaError(456);
             expect(error456).toHaveProperty('message', 'o no');
         });
     });
@@ -41,10 +39,8 @@ describe('SolanaError', () => {
 describe('isSolanaError()', () => {
     let error123: SolanaError;
     beforeEach(() => {
-        error123 = new SolanaError(
-            // @ts-expect-error Mock error codes don't conform to `SolanaErrorCode`
-            123,
-        );
+        // @ts-expect-error Mock error codes don't conform to `SolanaErrorCode`
+        error123 = new SolanaError(123);
     });
     it('returns `true` for an instance of `SolanaError`', () => {
         expect(isSolanaError(error123)).toBe(true);

--- a/packages/errors/src/__tests__/message-formatter-test.ts
+++ b/packages/errors/src/__tests__/message-formatter-test.ts
@@ -30,6 +30,7 @@ describe('getErrorMessage', () => {
         it('renders static error messages', () => {
             const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
             messagesSpy.mockReturnValue({
+                // @ts-expect-error Mock error config doesn't conform to exported config.
                 123: 'static error message',
             });
             const message = getErrorMessage(
@@ -41,6 +42,7 @@ describe('getErrorMessage', () => {
         it('interpolates variables into a error message format string', () => {
             const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
             messagesSpy.mockReturnValue({
+                // @ts-expect-error Mock error config doesn't conform to exported config.
                 123: "Something $severity happened: '$foo'. How $severity!",
             });
             const message = getErrorMessage(

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -1,4 +1,15 @@
 /**
+ * To add a new error, follow the instructions at
+ * https://github.com/solana-labs/solana-web3.js/tree/master/packages/error#adding-a-new-error
+ *
+ * WARNING:
+ *   - Don't remove error codes
+ *   - Don't change or reorder error codes.
+ */
+export const SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES = 1 as const;
+export const SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE = 2 as const;
+
+/**
  * A union of every Solana error code
  *
  * You might be wondering why this is not a TypeScript enum or const enum.
@@ -13,4 +24,6 @@
  * actually used. Unfortunately exporting ambient (const) enums from a library like `@solana/errors`
  * is not safe, for a variety of reasons covered here: https://stackoverflow.com/a/28818850
  */
-export type SolanaErrorCode = never;
+export type SolanaErrorCode =
+    | typeof SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES
+    | typeof SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE;

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -1,4 +1,4 @@
-import { SolanaErrorCode } from './codes';
+import { SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, SolanaErrorCode } from './codes';
 
 export type DefaultUnspecifiedErrorContextToUndefined<T> = {
     [P in SolanaErrorCode]: P extends keyof T ? T[P] : undefined;
@@ -11,4 +11,8 @@ export type DefaultUnspecifiedErrorContextToUndefined<T> = {
  * WARNING:
  *   - Don't change or remove members of an error's context.
  */
-export type SolanaErrorContext = DefaultUnspecifiedErrorContextToUndefined<Record<string, never>>;
+export type SolanaErrorContext = DefaultUnspecifiedErrorContextToUndefined<{
+    [SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES]: {
+        addresses: string[];
+    };
+}>;

--- a/packages/errors/src/error.ts
+++ b/packages/errors/src/error.ts
@@ -33,8 +33,6 @@ export class SolanaError<TErrorCode extends SolanaErrorCode = SolanaErrorCode> e
         super(message);
         this.context = {
             __code: code,
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-expect-error
             ...context,
         } as SolanaErrorCodedContext[TErrorCode];
         // This is necessary so that `isSolanaError()` can identify a `SolanaError` without having

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -1,4 +1,8 @@
-import { SolanaErrorCode } from './codes';
+import {
+    SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES,
+    SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE,
+    SolanaErrorCode,
+} from './codes';
 
 /**
  * To add a new error, follow the instructions at
@@ -11,4 +15,9 @@ export const SolanaErrorMessages: Readonly<{
     // This type makes this data structure exhaustive with respect to `SolanaErrorCode`.
     // TypeScript will fail to build this project if add an error code without a message.
     [P in SolanaErrorCode]: string;
-}> = {};
+}> = {
+    [SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES]: 'Transaction is missing signatures for addresses: $addresses',
+    [SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE]:
+        "Could not determine this transaction's signature. Make sure that the transaction has " +
+        'been signed by its fee payer.',
+};

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -68,6 +68,7 @@
         "@solana/accounts": "workspace:*",
         "@solana/addresses": "workspace:*",
         "@solana/codecs": "workspace:*",
+        "@solana/errors": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",

--- a/packages/library/src/__tests__/transaction-confirmation-test.ts
+++ b/packages/library/src/__tests__/transaction-confirmation-test.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import { SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE, SolanaError } from '@solana/errors';
 import { AccountRole, ReadonlySignerAccount, WritableAccount } from '@solana/instructions';
 import { Signature, SignatureBytes } from '@solana/keys';
 import type { Blockhash } from '@solana/rpc-types';
@@ -143,8 +144,7 @@ describe('waitForDurableNonceTransactionConfirmation', () => {
             transaction: transactionWithoutFeePayerSignature,
         });
         await expect(commitmentPromise).rejects.toThrow(
-            "Could not determine this transaction's signature. Make sure that the transaction " +
-                'has been signed by its fee payer.',
+            new SolanaError(SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE),
         );
     });
     it('resolves when the signature confirmation promise resolves despite the block height exceedence promise having thrown', async () => {
@@ -260,8 +260,7 @@ describe('waitForRecentTransactionConfirmation', () => {
             transaction: transactionWithoutFeePayerSignature,
         });
         await expect(commitmentPromise).rejects.toThrow(
-            "Could not determine this transaction's signature. Make sure that the transaction " +
-                'has been signed by its fee payer.',
+            new SolanaError(SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE),
         );
     });
     it('resolves when the signature confirmation promise resolves despite the block height exceedence promise having thrown', async () => {

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -66,6 +66,7 @@
     },
     "dependencies": {
         "@solana/addresses": "workspace:*",
+        "@solana/errors": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
         "@solana/transactions": "workspace:*"

--- a/packages/signers/src/__tests__/sign-transaction-test.ts
+++ b/packages/signers/src/__tests__/sign-transaction-test.ts
@@ -1,6 +1,7 @@
 import 'test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
+import { SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, SolanaError } from '@solana/errors';
 import { CompilableTransaction, IFullySignedTransaction, ITransactionWithSignatures } from '@solana/transactions';
 
 import {
@@ -331,7 +332,11 @@ describe('signTransactionWithSigners', () => {
 
         // Then we expect an error letting us know the transaction is not fully signed.
         // This is because sending signers are ignored by signTransactionWithSigners.
-        await expect(promise).rejects.toThrow('Transaction is missing signatures for addresses: 2222');
+        await expect(promise).rejects.toThrow(
+            new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
+                addresses: ['2222' as Address],
+            }),
+        );
     });
 
     it('can be cancelled using an AbortSignal', async () => {

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -67,6 +67,7 @@
         "@solana/codecs-data-structures": "workspace:*",
         "@solana/codecs-numbers": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
+        "@solana/errors": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/keys": "workspace:*"
     },

--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -7,6 +7,11 @@ import {
     getAddressEncoder,
     getAddressFromPublicKey,
 } from '@solana/addresses';
+import {
+    SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES,
+    SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE,
+    SolanaError,
+} from '@solana/errors';
 import { AccountRole } from '@solana/instructions';
 import { SignatureBytes, signBytes } from '@solana/keys';
 import type { Blockhash } from '@solana/rpc-types';
@@ -47,10 +52,7 @@ describe('getSignatureFromTransaction', () => {
         };
         expect(() => {
             getSignatureFromTransaction(transactionWithoutFeePayerSignature);
-        }).toThrow(
-            "Could not determine this transaction's signature. Make sure that the transaction " +
-                'has been signed by its fee payer.',
-        );
+        }).toThrow(new SolanaError(SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE));
     });
 });
 
@@ -279,7 +281,9 @@ describe('signTransaction', () => {
         expect.assertions(1);
         const signedTransactionPromise = signTransaction([mockKeyPairA], MOCK_TRANSACTION);
         await expect(signedTransactionPromise).rejects.toThrow(
-            `Transaction is missing signatures for addresses: ${mockPublicKeyAddressB}`,
+            new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
+                addresses: [mockPublicKeyAddressB],
+            }),
         );
     });
     it('returns a transaction object having multiple signatures', async () => {
@@ -368,7 +372,9 @@ describe('assertTransactionIsFullySigned', () => {
         };
 
         expect(() => assertTransactionIsFullySigned(transaction)).toThrow(
-            'Transaction is missing signatures for addresses: A',
+            new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
+                addresses: [mockPublicKeyAddressA],
+            }),
         );
     });
 
@@ -387,7 +393,9 @@ describe('assertTransactionIsFullySigned', () => {
         };
 
         expect(() => assertTransactionIsFullySigned(transaction)).toThrow(
-            'Transaction is missing signatures for addresses: A, B',
+            new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
+                addresses: [mockPublicKeyAddressA, mockPublicKeyAddressB],
+            }),
         );
     });
 
@@ -413,7 +421,9 @@ describe('assertTransactionIsFullySigned', () => {
         };
 
         expect(() => assertTransactionIsFullySigned(transaction)).toThrow(
-            'Transaction is missing signatures for addresses: B',
+            new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
+                addresses: [mockPublicKeyAddressB],
+            }),
         );
     });
 
@@ -439,7 +449,9 @@ describe('assertTransactionIsFullySigned', () => {
         };
 
         expect(() => assertTransactionIsFullySigned(transaction)).toThrow(
-            'Transaction is missing signatures for addresses: B',
+            new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
+                addresses: [mockPublicKeyAddressB],
+            }),
         );
     });
 
@@ -475,7 +487,9 @@ describe('assertTransactionIsFullySigned', () => {
         };
 
         expect(() => assertTransactionIsFullySigned(transaction)).toThrow(
-            'Transaction is missing signatures for addresses: C',
+            new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
+                addresses: [mockPublicKeyAddressC],
+            }),
         );
     });
 

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -1,6 +1,11 @@
 import { Address, getAddressFromPublicKey } from '@solana/addresses';
 import { Decoder } from '@solana/codecs-core';
 import { getBase58Decoder } from '@solana/codecs-strings';
+import {
+    SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES,
+    SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE,
+    SolanaError,
+} from '@solana/errors';
 import { isSignerRole } from '@solana/instructions';
 import { Signature, SignatureBytes, signBytes } from '@solana/keys';
 
@@ -25,11 +30,7 @@ export function getSignatureFromTransaction(
 
     const signatureBytes = transaction.signatures[transaction.feePayer];
     if (!signatureBytes) {
-        // TODO: Coded error.
-        throw new Error(
-            "Could not determine this transaction's signature. Make sure that the transaction " +
-                'has been signed by its fee payer.',
-        );
+        throw new SolanaError(SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE);
     }
     const transactionSignature = base58Decoder.decode(signatureBytes);
     return transactionSignature as Signature;
@@ -85,7 +86,8 @@ export function assertTransactionIsFullySigned<TTransaction extends CompilableTr
     });
 
     if (missingSigs.length > 0) {
-        // TODO coded error
-        throw new Error('Transaction is missing signatures for addresses: ' + missingSigs.join(', '));
+        throw new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
+            addresses: missingSigs,
+        });
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1074,6 +1074,9 @@ importers:
       '@solana/codecs':
         specifier: workspace:*
         version: link:../codecs
+      '@solana/errors':
+        specifier: workspace:*
+        version: link:../errors
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional
@@ -2018,6 +2021,9 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/errors':
+        specifier: workspace:*
+        version: link:../errors
       '@solana/instructions':
         specifier: workspace:*
         version: link:../instructions
@@ -2225,6 +2231,9 @@ importers:
       '@solana/codecs-strings':
         specifier: workspace:*
         version: link:../codecs-strings
+      '@solana/errors':
+        specifier: workspace:*
+        version: link:../errors
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional


### PR DESCRIPTION
# Summary

In this PR we make first use of the new `SolanaError` class to convert two regular errors into coded errors.

# Test Plan

```shell
cd packages/transactions/
pnpm turbo test:unit:browser
pnpm turbo test:unit:node
```
