### PR TITLE
A typetest for coded errors

### DIFF
--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -66,6 +66,7 @@
         "node": ">=17.4"
     },
     "devDependencies": {
+        "@solana/addresses": "workspace:*",
         "@solana/eslint-config-solana": "^1.0.2",
         "@swc/jest": "^0.2.29",
         "@types/jest": "^29.5.11",

--- a/packages/errors/src/__typetests__/error-typetest.ts
+++ b/packages/errors/src/__typetests__/error-typetest.ts
@@ -1,0 +1,46 @@
+import { address } from '@solana/addresses';
+
+import * as SolanaErrorCodeModule from '../codes';
+import { SolanaErrorCode } from '../codes';
+import { SolanaErrorContext } from '../context';
+import { isSolanaError, SolanaError } from '../error';
+
+const { SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE, SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES } =
+    SolanaErrorCodeModule;
+
+// If this line raises a type error, you might have forgotten to add a new error to the
+// `SolanaErrorCode` union in `src/codes.ts`.
+Object.values(SolanaErrorCodeModule) satisfies SolanaErrorCode[];
+
+const transactionMissingSignaturesError = new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
+    addresses: [address('123'), '456'],
+});
+
+transactionMissingSignaturesError.context.__code satisfies typeof SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES;
+// @ts-expect-error Wrong error code.
+transactionMissingSignaturesError.context.__code satisfies typeof SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE;
+
+transactionMissingSignaturesError.context satisfies SolanaErrorContext[typeof SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES];
+// @ts-expect-error Non existent context property.
+transactionMissingSignaturesError.context.feePayer;
+
+new SolanaError(SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE);
+// @ts-expect-error Missing context property (`addresses`)
+new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES);
+
+const unknownError = null as unknown as SolanaError;
+if (unknownError.context.__code === SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES) {
+    unknownError.context satisfies SolanaErrorContext[typeof SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES];
+    // @ts-expect-error Context belongs to another error code
+    unknownError.context satisfies SolanaErrorContext[typeof SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE];
+}
+
+const e = null as unknown;
+if (isSolanaError(e)) {
+    e.context satisfies Readonly<{ __code: SolanaErrorCode }>;
+}
+if (isSolanaError(e, SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES)) {
+    e.context satisfies SolanaErrorContext[typeof SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES];
+    // @ts-expect-error Context belongs to another error code
+    e.context satisfies SolanaErrorContext[typeof SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,6 +749,9 @@ importers:
 
   packages/errors:
     devDependencies:
+      '@solana/addresses':
+        specifier: workspace:*
+        version: link:../addresses
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
         version: 1.0.2(@typescript-eslint/eslint-plugin@6.13.2)(@typescript-eslint/parser@6.8.0)(eslint-plugin-jest@27.4.2)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-simple-import-sort@10.0.0)(eslint-plugin-sort-keys-fix@1.1.2)(eslint@8.51.0)(typescript@5.2.2)


### PR DESCRIPTION
# Summary

This typetest really drives home how to use `SolanaError` and `isSolanaError()` in practice. Watch how you can refine errors by code, and how the type of the context materiailzes with it.

# Test Plan

```shell
cd packages/errors/
pnpm turbo test:typecheck
```
