### PR TITLE
Export the async decodeTransaction function from library

### DIFF
--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -10,6 +10,7 @@ export * from '@solana/rpc-types';
 export * from '@solana/signers';
 export * from '@solana/transactions';
 export * from './airdrop';
+export * from './decode-transaction';
 export * from './rpc';
 export * from './rpc-transport';
 export * from './rpc-websocket-transport';


### PR DESCRIPTION
It turns out this function is less helpful when it's not exported from the package! 