### PR TITLE
refactor(experimental): add `ClusterUrl` types

### DIFF
--- a/packages/rpc-types/src/cluster-url.ts
+++ b/packages/rpc-types/src/cluster-url.ts
@@ -1,0 +1,14 @@
+export type MainnetUrl = string & { '~cluster': 'mainnet' };
+export type DevnetUrl = string & { '~cluster': 'devnet' };
+export type TestnetUrl = string & { '~cluster': 'testnet' };
+export type ClusterUrl = string | MainnetUrl | DevnetUrl | TestnetUrl;
+
+export function mainnet(putativeString: string): MainnetUrl {
+    return putativeString as MainnetUrl;
+}
+export function devnet(putativeString: string): DevnetUrl {
+    return putativeString as DevnetUrl;
+}
+export function testnet(putativeString: string): TestnetUrl {
+    return putativeString as TestnetUrl;
+}

--- a/packages/rpc-types/src/index.ts
+++ b/packages/rpc-types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './blockhash';
+export * from './cluster-url';
 export * from './commitment';
 export * from './encoded-bytes';
 export * from './lamports';


### PR DESCRIPTION
As per @lorisleiva's suggestion, here's some types for cluster URLs!
Straight from [this comment](https://github.com/solana-labs/solana-web3.js/pull/2053#issuecomment-1916636042)