### PR TITLE
Fix TypeScript index signature

### DIFF
--- a/packages/codecs-data-structures/src/scalar-enum.ts
+++ b/packages/codecs-data-structures/src/scalar-enum.ts
@@ -23,6 +23,8 @@ import {
     NumberEncoder,
 } from '@solana/codecs-numbers';
 
+type ScalarEnumKeyType = number | string;
+
 /**
  * Defines a scalar enum as a type from its constructor.
  *
@@ -32,7 +34,7 @@ import {
  * type DirectionType = ScalarEnum<Direction>;
  * ```
  */
-export type ScalarEnum<T> = ({ [key: number | string]: string | number | T } | number | T) & NonNullable<unknown>;
+export type ScalarEnum<T> = ({ [key in ScalarEnumKeyType as string]: string | number | T } | number | T) & NonNullable<unknown>;
 
 /** Defines the config for scalar enum codecs. */
 export type ScalarEnumCodecConfig<TDiscriminator extends NumberCodec | NumberEncoder | NumberDecoder> = {


### PR DESCRIPTION
# Summary

Fixing an issue related to **ScalarEnum** type definition not complying with the TypeScript signature parameter types (cannot be union types).

# Heads up
This is my very first attempt to contribute to this project and I might not be entirely up to speed with the project's conventions. In the case I have missed anything, first I am sorry, and second let me know so I have a chance to fix it. Thank you.

# Details
When including @solana-web3.js inside a TypeScript project an error is raised against `type ScalarEnum<T>` more specifically it's signature parameter type is using a type union. 

The specific error is: `An index signature parameter type cannot be a union type. Consider using a mapped object type instead.` and can be reproduced quite easily by just including the dependency inside a TypeScript 4+ project.

## Mitigation
Separating the type union and discriminating the key as being in the union's types while casting it to a constant string should eliminate the issue.
