### PR TITLE
refactor(experimental): graphql: add `loadMany` to loaders

### DIFF
--- a/packages/rpc-graphql/src/loaders/account.ts
+++ b/packages/rpc-graphql/src/loaders/account.ts
@@ -31,16 +31,14 @@ async function loadAccount(
 
 function createAccountBatchLoadFn(rpc: Rpc<GetAccountInfoApi>) {
     const resolveAccountUsingRpc = loadAccount.bind(null, rpc);
-    return async (accountQueryArgs: readonly AccountLoaderArgs[]) => {
-        return await Promise.all(
-            accountQueryArgs.map(async args => await resolveAccountUsingRpc(applyDefaultArgs(args))),
-        );
-    };
+    return async (accountQueryArgs: readonly AccountLoaderArgs[]) =>
+        Promise.all(accountQueryArgs.map(async args => resolveAccountUsingRpc(applyDefaultArgs(args))));
 }
 
 export function createAccountLoader(rpc: Rpc<GetAccountInfoApi>): AccountLoader {
     const loader = new DataLoader(createAccountBatchLoadFn(rpc), { cacheKeyFn });
     return {
         load: async args => loader.load(applyDefaultArgs(args)),
+        loadMany: async args => loader.loadMany(args.map(applyDefaultArgs)),
     };
 }

--- a/packages/rpc-graphql/src/loaders/block.ts
+++ b/packages/rpc-graphql/src/loaders/block.ts
@@ -34,14 +34,14 @@ async function loadBlock(rpc: Rpc<GetBlockApi>, { slot, ...config }: BlockLoader
 
 function createBlockBatchLoadFn(rpc: Rpc<GetBlockApi>) {
     const resolveBlockUsingRpc = loadBlock.bind(null, rpc);
-    return async (blockQueryArgs: readonly BlockLoaderArgs[]) => {
-        return await Promise.all(blockQueryArgs.map(async args => await resolveBlockUsingRpc(applyDefaultArgs(args))));
-    };
+    return async (blockQueryArgs: readonly BlockLoaderArgs[]) =>
+        Promise.all(blockQueryArgs.map(async args => resolveBlockUsingRpc(applyDefaultArgs(args))));
 }
 
 export function createBlockLoader(rpc: Rpc<GetBlockApi>): BlockLoader {
     const loader = new DataLoader(createBlockBatchLoadFn(rpc), { cacheKeyFn });
     return {
         load: async args => loader.load(applyDefaultArgs(args)),
+        loadMany: async args => loader.loadMany(args.map(applyDefaultArgs)),
     };
 }

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -7,7 +7,8 @@ import type { Commitment, Slot } from '@solana/rpc-types';
 import stringify from 'json-stable-stringify';
 
 export type LoadFn<TArgs, T> = (args: TArgs) => Promise<T>;
-export type Loader<TArgs, T> = { load: LoadFn<TArgs, T> };
+export type LoadManyFn<TArgs, T> = (args: TArgs[]) => Promise<(T | Error)[]>;
+export type Loader<TArgs, T> = { load: LoadFn<TArgs, T>; loadMany: LoadManyFn<TArgs, T> };
 
 // FIX ME: https://github.com/microsoft/TypeScript/issues/43187
 // export type AccountLoaderArgs = { address: Parameters<GetAccountInfoApi['getAccountInfo']>[0] } & Parameters<

--- a/packages/rpc-graphql/src/loaders/program-accounts.ts
+++ b/packages/rpc-graphql/src/loaders/program-accounts.ts
@@ -37,16 +37,14 @@ async function loadProgramAccounts(
 
 function createProgramAccountsBatchLoadFn(rpc: Rpc<GetProgramAccountsApi>) {
     const resolveProgramAccountsUsingRpc = loadProgramAccounts.bind(null, rpc);
-    return async (programAccountsQueryArgs: readonly ProgramAccountsLoaderArgs[]) => {
-        return await Promise.all(
-            programAccountsQueryArgs.map(async args => await resolveProgramAccountsUsingRpc(applyDefaultArgs(args))),
-        );
-    };
+    return async (programAccountsQueryArgs: readonly ProgramAccountsLoaderArgs[]) =>
+        Promise.all(programAccountsQueryArgs.map(async args => resolveProgramAccountsUsingRpc(applyDefaultArgs(args))));
 }
 
 export function createProgramAccountsLoader(rpc: Rpc<GetProgramAccountsApi>): ProgramAccountsLoader {
     const loader = new DataLoader(createProgramAccountsBatchLoadFn(rpc), { cacheKeyFn });
     return {
         load: async args => loader.load(applyDefaultArgs(args)),
+        loadMany: async args => loader.loadMany(args.map(applyDefaultArgs)),
     };
 }

--- a/packages/rpc-graphql/src/loaders/transaction.ts
+++ b/packages/rpc-graphql/src/loaders/transaction.ts
@@ -31,16 +31,14 @@ async function loadTransaction(
 
 function createTransactionBatchLoadFn(rpc: Rpc<GetTransactionApi>) {
     const resolveTransactionUsingRpc = loadTransaction.bind(null, rpc);
-    return async (transactionQueryArgs: readonly TransactionLoaderArgs[]) => {
-        return await Promise.all(
-            transactionQueryArgs.map(async args => await resolveTransactionUsingRpc(applyDefaultArgs(args))),
-        );
-    };
+    return async (transactionQueryArgs: readonly TransactionLoaderArgs[]) =>
+        Promise.all(transactionQueryArgs.map(async args => resolveTransactionUsingRpc(applyDefaultArgs(args))));
 }
 
 export function createTransactionLoader(rpc: Rpc<GetTransactionApi>): TransactionLoader {
     const loader = new DataLoader(createTransactionBatchLoadFn(rpc), { cacheKeyFn });
     return {
         load: async args => loader.load(applyDefaultArgs(args)),
+        loadMany: async args => loader.loadMany(args.map(applyDefaultArgs)),
     };
 }


### PR DESCRIPTION
Add a `loadMany` function to the `Loader` interface, in order to set the stage
for future resolvers to be able to combine multiple fetches into one query
result.
