### PR TITLE
refactor(experimental): graphql: program accounts makeover

### DIFF
--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -85,25 +85,20 @@ describe('programAccounts', () => {
         });
     });
     describe('account data queries', () => {
+        // See scripts/fixtures/gpa2-1.json, scripts/fixtures/gpa2-2.json,
+        const programAddress = 'AmtpVzo6H6qQCP9dH9wfu5hfa8kKaAFpTJ4aamPYR6V6';
         it("can get program accounts' data as base58", async () => {
             expect.assertions(1);
-            // See scripts/fixtures/gpa2-1.json, scripts/fixtures/gpa2-2.json,
-            const variableValues = {
-                commitment: 'CONFIRMED',
-                encoding: 'BASE_58',
-                programAddress: 'AmtpVzo6H6qQCP9dH9wfu5hfa8kKaAFpTJ4aamPYR6V6',
-            };
             const source = /* GraphQL */ `
-                query testQuery($programAddress: Address!, $commitment: Commitment, $encoding: AccountEncoding!) {
-                    # TODO: Program accounts needs refactor
-                    programAccounts(programAddress: $programAddress, commitment: $commitment, encoding: $encoding) {
+                query testQuery($programAddress: Address!) {
+                    programAccounts(programAddress: $programAddress) {
                         address
                         executable
-                        data(encoding: $encoding)
+                        data(encoding: BASE_58)
                     }
                 }
             `;
-            const result = await rpcGraphQL.query(source, variableValues);
+            const result = await rpcGraphQL.query(source, { programAddress });
             expect(result).toMatchObject({
                 data: {
                     programAccounts: expect.arrayContaining([
@@ -123,23 +118,16 @@ describe('programAccounts', () => {
         });
         it("can get program accounts' data as base64", async () => {
             expect.assertions(1);
-            // See scripts/fixtures/gpa2-1.json, scripts/fixtures/gpa2-2.json,
-            const variableValues = {
-                commitment: 'CONFIRMED',
-                encoding: 'BASE_64',
-                programAddress: 'AmtpVzo6H6qQCP9dH9wfu5hfa8kKaAFpTJ4aamPYR6V6',
-            };
             const source = /* GraphQL */ `
-                query testQuery($programAddress: Address!, $commitment: Commitment, $encoding: AccountEncoding!) {
-                    # TODO: Program accounts needs refactor
-                    programAccounts(programAddress: $programAddress, commitment: $commitment, encoding: $encoding) {
+                query testQuery($programAddress: Address!) {
+                    programAccounts(programAddress: $programAddress) {
                         address
                         executable
-                        data(encoding: $encoding)
+                        data(encoding: BASE_64)
                     }
                 }
             `;
-            const result = await rpcGraphQL.query(source, variableValues);
+            const result = await rpcGraphQL.query(source, { programAddress });
             expect(result).toMatchObject({
                 data: {
                     programAccounts: expect.arrayContaining([
@@ -159,23 +147,16 @@ describe('programAccounts', () => {
         });
         it("can get program accounts' data as base64+zstd", async () => {
             expect.assertions(1);
-            // See scripts/fixtures/gpa2-1.json, scripts/fixtures/gpa2-2.json,
-            const variableValues = {
-                commitment: 'CONFIRMED',
-                encoding: 'BASE_64_ZSTD',
-                programAddress: 'AmtpVzo6H6qQCP9dH9wfu5hfa8kKaAFpTJ4aamPYR6V6',
-            };
             const source = /* GraphQL */ `
-                query testQuery($programAddress: Address!, $commitment: Commitment, $encoding: AccountEncoding!) {
-                    # TODO: Program accounts needs refactor
-                    programAccounts(programAddress: $programAddress, commitment: $commitment, encoding: $encoding) {
+                query testQuery($programAddress: Address!) {
+                    programAccounts(programAddress: $programAddress) {
                         address
                         executable
-                        data(encoding: $encoding)
+                        data(encoding: BASE_64_ZSTD)
                     }
                 }
             `;
-            const result = await rpcGraphQL.query(source, variableValues);
+            const result = await rpcGraphQL.query(source, { programAddress });
             expect(result).toMatchObject({
                 data: {
                     programAccounts: expect.arrayContaining([
@@ -580,13 +561,7 @@ describe('programAccounts', () => {
                         $dataSlice: DataSlice
                         $encoding: AccountEncoding!
                     ) {
-                        # TODO: Program accounts needs refactor
-                        programAccounts(
-                            programAddress: $programAddress
-                            commitment: $commitment
-                            dataSlice: $dataSlice
-                            encoding: $encoding
-                        ) {
+                        programAccounts(programAddress: $programAddress, commitment: $commitment) {
                             data(encoding: $encoding, dataSlice: $dataSlice)
                         }
                     }
@@ -623,13 +598,7 @@ describe('programAccounts', () => {
                         $dataSlice: DataSlice
                         $encoding: AccountEncoding!
                     ) {
-                        # TODO: Program accounts needs refactor
-                        programAccounts(
-                            programAddress: $programAddress
-                            commitment: $commitment
-                            dataSlice: $dataSlice
-                            encoding: $encoding
-                        ) {
+                        programAccounts(programAddress: $programAddress, commitment: $commitment) {
                             data(dataSlice: $dataSlice, encoding: $encoding)
                         }
                     }

--- a/packages/rpc-graphql/src/context.ts
+++ b/packages/rpc-graphql/src/context.ts
@@ -40,7 +40,7 @@ export function createSolanaGraphQLContext(
         loaders: {
             account: createAccountLoader(rpc, config),
             block: createBlockLoader(rpc),
-            programAccounts: createProgramAccountsLoader(rpc),
+            programAccounts: createProgramAccountsLoader(rpc, config),
             transaction: createTransactionLoader(rpc),
         },
     };

--- a/packages/rpc-graphql/src/loaders/__tests__/program-accounts-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/program-accounts-loader-test.ts
@@ -26,7 +26,7 @@ describe('account loader', () => {
         };
         rpcGraphQL = createRpcGraphQL(rpc);
     });
-    describe('cache tests', () => {
+    describe('cached responses', () => {
         it('coalesces multiple requests for the same program into one', async () => {
             expect.assertions(1);
             const source = /* GraphQL */ `
@@ -65,6 +65,611 @@ describe('account loader', () => {
             await Promise.resolve();
             jest.runAllTimers();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
+        });
+    });
+    describe('batch loading', () => {
+        describe('request partitioning', () => {
+            it('coalesces multiple requests for the same program but different fields into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        programAccounts1: programAccounts(programAddress: $address) {
+                            lamports
+                        }
+                        programAccounts2: programAccounts(programAddress: $address) {
+                            space
+                        }
+                        programAccounts3: programAccounts(programAddress: $address) {
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { address: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj' });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
+            it('coalesces multiple requests for the same program but one with specified `confirmed` commitment into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        programAccounts1: programAccounts(programAddress: $address) {
+                            lamports
+                        }
+                        programAccounts2: programAccounts(programAddress: $address, commitment: CONFIRMED) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { address: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj' });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+            });
+            it('will not coalesce multiple requests for the same program but with different commitments into one request', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        programAccounts1: programAccounts(programAddress: $address) {
+                            lamports
+                        }
+                        programAccounts2: programAccounts(programAddress: $address, commitment: CONFIRMED) {
+                            lamports
+                        }
+                        programAccounts3: programAccounts(programAddress: $address, commitment: FINALIZED) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { address: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj' });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'finalized',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+            });
+        });
+        describe('encoding requests', () => {
+            it('does not use `jsonParsed` if no parsed type is queried', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64',
+                    },
+                );
+            });
+            it('uses only `base58` if one data field is requested with `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            data(encoding: BASE_58)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base58',
+                    },
+                );
+            });
+            it('uses only `base64` if one data field is requested with `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            data(encoding: BASE_64)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64',
+                    },
+                );
+            });
+            it('uses only `base64+zstd` if one data field is requested with `base64+zstd` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            data(encoding: BASE_64_ZSTD)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64+zstd',
+                    },
+                );
+            });
+            it('only uses `jsonParsed` if a parsed type is queried, but data is not', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
+            it('does not call the loader twice for other base fields and `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            data(encoding: BASE_58)
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base58',
+                    },
+                );
+            });
+            it('does not call the loader twice for other base fields and `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            data(encoding: BASE_64)
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64',
+                    },
+                );
+            });
+            it('does not call the loader twice for other base fields and `base64+zstd` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            data(encoding: BASE_64_ZSTD)
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64+zstd',
+                    },
+                );
+            });
+            it('does not call the loader twice for other base fields and inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            lamports
+                            space
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
+            it('will not make multiple calls for more than one inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            ... on MintAccount {
+                                supply
+                            }
+                            ... on TokenAccount {
+                                lamports
+                            }
+                            ... on NonceAccount {
+                                blockhash
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
+            it('uses `jsonParsed` and the requested data encoding if a parsed type is queried alongside encoded data', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            data(encoding: BASE_64)
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('uses only the number of requests for the number of different encodings requested', async () => {
+                expect.assertions(5);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            dataBase58_1: data(encoding: BASE_58)
+                            dataBase58_2: data(encoding: BASE_58)
+                            dataBase58_3: data(encoding: BASE_58)
+                            dataBase64_1: data(encoding: BASE_64)
+                            dataBase64_2: data(encoding: BASE_64)
+                            dataBase64_3: data(encoding: BASE_64)
+                            dataBase64Zstd_1: data(encoding: BASE_64_ZSTD)
+                            dataBase64Zstd_2: data(encoding: BASE_64_ZSTD)
+                            dataBase64Zstd_3: data(encoding: BASE_64_ZSTD)
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(4);
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    encoding: 'base64+zstd',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+        });
+        describe('data slice requests', () => {
+            it('does not call the loader twice for data slice and other fields', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 10, offset: 0 },
+                        encoding: 'base64',
+                    },
+                );
+            });
+            it('coalesces a data with no data slice and data with data slice within byte limit to the same request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            dataWithNoSlice: data(encoding: BASE_64)
+                            dataWithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
+                    'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                    },
+                );
+            });
+            it('coalesces non-sliced and sliced data requests across encodings', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            dataBase58WithNoSlice: data(encoding: BASE_58)
+                            dataBase58WithSlice: data(encoding: BASE_58, dataSlice: { length: 10, offset: 0 })
+                            dataBase64WithNoSlice: data(encoding: BASE_64)
+                            dataBase64WithSlice: data(encoding: BASE_64, dataSlice: { length: 20, offset: 4 })
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    encoding: 'base58', // No `dataSlice` arg since one field asked for the whole data
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                });
+            });
+            it('always uses separate requests for `base64+zstd` no matter the data slice', async () => {
+                expect.assertions(4);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            dataBase64ZstdWithNoSlice: data(encoding: BASE_64_ZSTD)
+                            dataBase64ZstdWithSlice1: data(
+                                encoding: BASE_64_ZSTD
+                                dataSlice: { length: 16, offset: 4 }
+                            )
+                            dataBase64ZstdWithSlice2: data(
+                                encoding: BASE_64_ZSTD
+                                dataSlice: { length: 40, offset: 12 }
+                            )
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(3);
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    encoding: 'base64+zstd',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    dataSlice: { length: 16, offset: 4 },
+                    encoding: 'base64+zstd',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    dataSlice: { length: 40, offset: 12 },
+                    encoding: 'base64+zstd',
+                });
+            });
+            it('coalesces multiple data slice requests within byte limit to the same request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            dataSlice1: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            dataSlice2: data(encoding: BASE_64, dataSlice: { length: 16, offset: 2 })
+                            dataSlice3: data(encoding: BASE_64, dataSlice: { length: 20, offset: 6 })
+                            dataSlice4: data(encoding: BASE_64, dataSlice: { length: 10, offset: 10 })
+                            dataSlice5: data(encoding: BASE_64, dataSlice: { length: 10, offset: 30 })
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    dataSlice: { length: 40, offset: 0 }, // Coalesced into one slice
+                    encoding: 'base64',
+                });
+            });
+            it('splits multiple data slice requests beyond byte limit into two requests', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            dataSlice1: data(encoding: BASE_64, dataSlice: { length: 4, offset: 0 })
+                            dataSlice2: data(encoding: BASE_64, dataSlice: { length: 4, offset: 2000 })
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    dataSlice: { length: 4, offset: 0 },
+                    encoding: 'base64',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    dataSlice: { length: 4, offset: 2000 },
+                    encoding: 'base64',
+                });
+            });
+            it('honors the byte limit across encodings', async () => {
+                expect.assertions(5);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        programAccounts(programAddress: "DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj") {
+                            dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { length: 4, offset: 0 })
+                            dataBase58BeyondByteLimit: data(encoding: BASE_58, dataSlice: { length: 4, offset: 2000 })
+                            dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { length: 4, offset: 0 })
+                            dataBase64BeyondByteLimit: data(encoding: BASE_64, dataSlice: { length: 4, offset: 2000 })
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(4);
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    dataSlice: { length: 4, offset: 0 },
+                    encoding: 'base58',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    dataSlice: { length: 4, offset: 2000 },
+                    encoding: 'base58',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    dataSlice: { length: 4, offset: 0 },
+                    encoding: 'base64',
+                });
+                expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
+                    commitment: 'confirmed',
+                    dataSlice: { length: 4, offset: 2000 },
+                    encoding: 'base64',
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/loaders/account.ts
+++ b/packages/rpc-graphql/src/loaders/account.ts
@@ -3,12 +3,12 @@ import { getBase58Codec, getBase64Codec } from '@solana/codecs-strings';
 import type { GetAccountInfoApi, GetMultipleAccountsApi, Rpc } from '@solana/rpc';
 import DataLoader from 'dataloader';
 
+import { buildCoalescedFetchesByArgsHashWithDataSlice, ToFetchMap } from './coalescer';
 import {
     AccountLoader,
     AccountLoaderArgs,
     AccountLoaderArgsBase,
     AccountLoaderValue,
-    BatchLoadPromiseCallback,
     cacheKeyFn,
     MultipleAccountsLoaderArgs,
 } from './loader';
@@ -21,13 +21,7 @@ type Config = {
 type Encoding = 'base58' | 'base64' | 'base64+zstd';
 type DataSlice = { length: number; offset: number };
 
-type AccountBatchLoadPromiseCallback = BatchLoadPromiseCallback<AccountLoaderValue>;
-type AccountBatchLoadCallbackItem = {
-    callback: AccountBatchLoadPromiseCallback;
-    dataSlice?: DataSlice | null;
-};
-
-function getCodec(encoding: Omit<Encoding, 'base64+zstd'>) {
+function getCodec(encoding: Encoding) {
     switch (encoding) {
         case 'base58':
             return getBase58Codec();
@@ -36,7 +30,7 @@ function getCodec(encoding: Omit<Encoding, 'base64+zstd'>) {
     }
 }
 
-function sliceData(
+export function sliceData(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     account: any,
     dataSlice?: DataSlice | null,
@@ -96,17 +90,6 @@ async function loadMultipleAccounts(
         .then(res => res.value);
 }
 
-const hashOmit = (args: AccountLoaderArgsBase, omit: (keyof AccountLoaderArgsBase)[]) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const argsObj: any = {};
-    for (const [key, value] of Object.entries(args)) {
-        if (!omit.includes(key as keyof AccountLoaderArgsBase)) {
-            argsObj[key] = value;
-        }
-    }
-    return cacheKeyFn(argsObj);
-};
-
 function createAccountBatchLoadFn(rpc: Rpc<GetAccountInfoApi & GetMultipleAccountsApi>, config: Config) {
     const resolveAccountUsingRpc = loadAccount.bind(null, rpc);
     const resolveMultipleAccountsUsingRpc = loadMultipleAccounts.bind(null, rpc);
@@ -114,12 +97,7 @@ function createAccountBatchLoadFn(rpc: Rpc<GetAccountInfoApi & GetMultipleAccoun
         /**
          * Gather all the accounts that need to be fetched, grouped by address.
          */
-        const accountsToFetch: {
-            [address: string]: Readonly<{
-                args: AccountLoaderArgsBase;
-                promiseCallback: AccountBatchLoadPromiseCallback;
-            }>[];
-        } = {};
+        const accountsToFetch: ToFetchMap<AccountLoaderArgsBase, AccountLoaderValue> = {};
         try {
             return Promise.all(
                 accountQueryArgs.map(
@@ -140,150 +118,16 @@ function createAccountBatchLoadFn(rpc: Rpc<GetAccountInfoApi & GetMultipleAccoun
             /**
              * Group together accounts that are fetched with identical args.
              */
-            const accountFetchesByArgsHash: {
-                [argsHash: string]: {
-                    args: AccountLoaderArgsBase;
-                    addresses: {
-                        [address: string]: {
-                            callbacks: AccountBatchLoadCallbackItem[];
-                        };
-                    };
-                };
-            } = {};
-
-            // Keep track of any fetches that don't specify an encoding, to be
-            // wrapped into another fetch that does.
-            const orphanedFetches: typeof accountsToFetch = {};
-
-            Object.entries(accountsToFetch).forEach(([address, toFetch]) => {
-                toFetch.forEach(({ args, promiseCallback }) => {
-                    // As per the schema, `encoding` can only be provided if a
-                    // `data` field is present, and the argument is required.
-                    // So we can assume if no encoding is provided, this
-                    // particular fetch is not concerned with data. We can
-                    // combine it with some other fetch.
-                    if (!args.encoding) {
-                        const toFetch = (orphanedFetches[address] ||= []);
-                        toFetch.push({ args, promiseCallback });
-                        return;
-                    }
-                    // As per the schema, `dataSlice` cannot be provided without
-                    // encoding.
-                    // Don't try to combine fetches with `base64+zstd` encoding.
-                    if (args.encoding != 'base64+zstd' && args.dataSlice) {
-                        // If the fetch arg set has `dataSlice` provided, try
-                        // to combine it with another request.
-                        const r = args.dataSlice;
-                        for (const { addresses: fetchAddresses, args: fetchArgs } of Object.values(
-                            accountFetchesByArgsHash,
-                        )) {
-                            /**
-                             * Add a callback to the list of callbacks for the current address,
-                             * possibly updating the `dataSlice` argument used for the entire
-                             * fetch.
-                             */
-                            const addCallbackWithDataSlice = (updateDataSlice?: DataSlice) => {
-                                const { callbacks: promiseCallbacksForAddress } = (fetchAddresses[address] ||= {
-                                    callbacks: [],
-                                });
-                                promiseCallbacksForAddress.push({
-                                    callback: promiseCallback,
-                                    dataSlice: args.dataSlice ?? null,
-                                });
-                                if (fetchArgs.dataSlice && updateDataSlice) {
-                                    fetchArgs.dataSlice = updateDataSlice;
-                                }
-                            };
-
-                            // Check if the two arg sets are a match without the `dataSlice`
-                            // argument.
-                            if (hashOmit(args, ['dataSlice']) === hashOmit(fetchArgs, ['dataSlice'])) {
-                                if (fetchArgs.dataSlice) {
-                                    // The arg sets match, and the fetch arg set has a `dataSlice`
-                                    // argument. Try to merge the two account fetches.
-                                    const g = fetchArgs.dataSlice;
-                                    if (
-                                        r.offset <= g.offset &&
-                                        g.offset - r.offset + r.length <= maxDataSliceByteRange
-                                    ) {
-                                        const length = Math.max(r.length, g.offset + g.length - r.offset);
-                                        const offset = r.offset;
-                                        addCallbackWithDataSlice({ length, offset });
-                                        return;
-                                    }
-                                    if (
-                                        r.offset >= g.offset &&
-                                        r.offset - g.offset + g.length <= maxDataSliceByteRange
-                                    ) {
-                                        const length = Math.max(g.length, r.offset + r.length - g.offset);
-                                        const offset = g.offset;
-                                        addCallbackWithDataSlice({ length, offset });
-                                        return;
-                                    }
-                                } else {
-                                    // The arg sets match, and the fetch arg set has no `dataSlice`
-                                    // argument. Merge the two account fetches.
-                                    const { length, offset } = r;
-                                    addCallbackWithDataSlice({ length, offset });
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                    // Either the fetch arg set has no `dataSlice` argument, or
-                    // it couldn't be combined with another fetch, likely due to
-                    // the wasted byte limitation.
-                    // Add the fetch to the list as a new fetch.
-                    const argsHash = hashOmit(args, []);
-                    const accountFetches = (accountFetchesByArgsHash[argsHash] ||= {
-                        addresses: {},
-                        args,
-                    });
-                    const { callbacks: promiseCallbacksForAddress } = (accountFetches.addresses[address] ||= {
-                        callbacks: [],
-                    });
-                    promiseCallbacksForAddress.push({ callback: promiseCallback, dataSlice: args.dataSlice ?? null });
-                });
-            });
-
-            // Place the orphans
-            Object.entries(orphanedFetches).forEach(([address, toFetch]) => {
-                toFetch.forEach(({ args: orphanedArgs, promiseCallback: orphanPromiseCallback }) => {
-                    if (Object.keys(accountFetchesByArgsHash).length !== 0) {
-                        for (const { addresses, args } of Object.values(accountFetchesByArgsHash)) {
-                            // Check if the two arg sets are a match without
-                            // `encoding` and `dataSlice` arguments.
-                            if (
-                                hashOmit(orphanedArgs, ['encoding', 'dataSlice']) ===
-                                hashOmit(args, ['encoding', 'dataSlice'])
-                            ) {
-                                const { callbacks: promiseCallbacksForAddress } = (addresses[address] ||= {
-                                    callbacks: [],
-                                });
-                                promiseCallbacksForAddress.push({ callback: orphanPromiseCallback });
-                                return;
-                            }
-                        }
-                    }
-                    // Create a new fetch. Prefer `base64` encoding.
-                    const args: AccountLoaderArgsBase = { ...orphanedArgs, encoding: 'base64' };
-                    const argsHash = hashOmit(args, []);
-                    const accountFetches = (accountFetchesByArgsHash[argsHash] ||= {
-                        addresses: {},
-                        args,
-                    });
-                    const { callbacks: promiseCallbacksForAddress } = (accountFetches.addresses[address] ||= {
-                        callbacks: [],
-                    });
-                    promiseCallbacksForAddress.push({ callback: orphanPromiseCallback });
-                });
-            });
+            const accountFetchesByArgsHash = buildCoalescedFetchesByArgsHashWithDataSlice(
+                accountsToFetch,
+                maxDataSliceByteRange,
+            );
 
             /**
              * For each set of accounts related to some common args, fetch them in the fewest number
              * of network requests.
              */
-            Object.values(accountFetchesByArgsHash).map(({ args, addresses: addressCallbacks }) => {
+            Object.values(accountFetchesByArgsHash).map(({ args, fetches: addressCallbacks }) => {
                 const addresses = Object.keys(addressCallbacks) as Address[];
                 if (addresses.length === 1) {
                     const address = addresses[0];

--- a/packages/rpc-graphql/src/loaders/coalescer.ts
+++ b/packages/rpc-graphql/src/loaders/coalescer.ts
@@ -1,0 +1,175 @@
+import { DataSlice } from '@solana/rpc-types';
+
+import { BatchLoadPromiseCallback, cacheKeyFn } from './loader';
+
+type Encoding = 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
+
+export type Fetch<TArgs extends { encoding?: Encoding }, TValue> = Readonly<{
+    args: TArgs;
+    promiseCallback: BatchLoadPromiseCallback<TValue>;
+}>;
+export type ToFetchMap<TArgs extends { encoding?: Encoding }, TValue> = {
+    [key: string]: Fetch<TArgs, TValue>[];
+};
+export type FetchesByArgsHash<TArgs extends { encoding?: Encoding }, TValue> = {
+    [argsHash: string]: {
+        args: TArgs;
+        fetches: {
+            [key: string]: {
+                callbacks: BatchLoadPromiseCallback<TValue>[];
+            };
+        };
+    };
+};
+export type FetchesByArgsHashWithDataSlice<TArgs extends { dataSlice?: DataSlice; encoding?: Encoding }, TValue> = {
+    [argsHash: string]: {
+        args: TArgs;
+        fetches: {
+            [key: string]: {
+                callbacks: {
+                    callback: BatchLoadPromiseCallback<TValue>;
+                    dataSlice?: DataSlice | null;
+                }[];
+            };
+        };
+    };
+};
+
+const hashOmit = <TArgs extends object>(args: TArgs, omit: (keyof TArgs)[]) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const argsObj: any = {};
+    for (const [key, value] of Object.entries(args)) {
+        if (!omit.includes(key as keyof TArgs)) {
+            argsObj[key] = value;
+        }
+    }
+    return cacheKeyFn(argsObj);
+};
+
+export function buildCoalescedFetchesByArgsHashWithDataSlice<
+    TArgs extends { dataSlice?: DataSlice; encoding?: Encoding },
+    TValue,
+>(toFetchMap: ToFetchMap<TArgs, TValue>, maxDataSliceByteRange: number): FetchesByArgsHashWithDataSlice<TArgs, TValue> {
+    const fetchesByArgsHash: FetchesByArgsHashWithDataSlice<TArgs, TValue> = {};
+
+    // Keep track of any fetches that don't specify an encoding, to be
+    // wrapped into another fetch that does.
+    const orphanedFetches: typeof toFetchMap = {};
+
+    Object.entries(toFetchMap).forEach(([address, toFetch]) => {
+        toFetch.forEach(({ args, promiseCallback }) => {
+            // As per the schema, `encoding` can only be provided if a
+            // `data` field is present, and the argument is required.
+            // So we can assume if no encoding is provided, this
+            // particular fetch is not concerned with data. We can
+            // combine it with some other fetch.
+            if (!args.encoding) {
+                const toFetch = (orphanedFetches[address] ||= []);
+                toFetch.push({ args, promiseCallback });
+                return;
+            }
+            // As per the schema, `dataSlice` cannot be provided without
+            // encoding.
+            // Don't try to combine fetches with `base64+zstd` encoding.
+            if (args.encoding != 'base64+zstd' && args.dataSlice) {
+                // If the fetch arg set has `dataSlice` provided, try
+                // to combine it with another request.
+                const r = args.dataSlice;
+                for (const { fetches: fetchAddresses, args: fetchArgs } of Object.values(fetchesByArgsHash)) {
+                    /**
+                     * Add a callback to the list of callbacks for the current address,
+                     * possibly updating the `dataSlice` argument used for the entire
+                     * fetch.
+                     */
+                    const addCallbackWithDataSlice = (updateDataSlice?: DataSlice) => {
+                        const { callbacks: promiseCallbacksForAddress } = (fetchAddresses[address] ||= {
+                            callbacks: [],
+                        });
+                        promiseCallbacksForAddress.push({
+                            callback: promiseCallback,
+                            dataSlice: args.dataSlice ?? null,
+                        });
+                        if (fetchArgs.dataSlice && updateDataSlice) {
+                            fetchArgs.dataSlice = updateDataSlice;
+                        }
+                    };
+
+                    // Check if the two arg sets are a match without the `dataSlice`
+                    // argument.
+                    if (hashOmit(args, ['dataSlice']) === hashOmit(fetchArgs, ['dataSlice'])) {
+                        if (fetchArgs.dataSlice) {
+                            // The arg sets match, and the fetch arg set has a `dataSlice`
+                            // argument. Try to merge the two account fetches.
+                            const g = fetchArgs.dataSlice;
+                            if (r.offset <= g.offset && g.offset - r.offset + r.length <= maxDataSliceByteRange) {
+                                const length = Math.max(r.length, g.offset + g.length - r.offset);
+                                const offset = r.offset;
+                                addCallbackWithDataSlice({ length, offset });
+                                return;
+                            }
+                            if (r.offset >= g.offset && r.offset - g.offset + g.length <= maxDataSliceByteRange) {
+                                const length = Math.max(g.length, r.offset + r.length - g.offset);
+                                const offset = g.offset;
+                                addCallbackWithDataSlice({ length, offset });
+                                return;
+                            }
+                        } else {
+                            // The arg sets match, and the fetch arg set has no `dataSlice`
+                            // argument. Merge the two account fetches.
+                            const { length, offset } = r;
+                            addCallbackWithDataSlice({ length, offset });
+                            return;
+                        }
+                    }
+                }
+            }
+            // Either the fetch arg set has no `dataSlice` argument, or
+            // it couldn't be combined with another fetch, likely due to
+            // the wasted byte limitation.
+            // Add the fetch to the list as a new fetch.
+            const argsHash = hashOmit(args, []);
+            const accountFetches = (fetchesByArgsHash[argsHash] ||= {
+                args,
+                fetches: {},
+            });
+            const { callbacks: promiseCallbacksForAddress } = (accountFetches.fetches[address] ||= {
+                callbacks: [],
+            });
+            promiseCallbacksForAddress.push({ callback: promiseCallback, dataSlice: args.dataSlice ?? null });
+        });
+    });
+
+    // Place the orphans
+    Object.entries(orphanedFetches).forEach(([address, toFetch]) => {
+        toFetch.forEach(({ args: orphanedArgs, promiseCallback: orphanPromiseCallback }) => {
+            if (Object.keys(fetchesByArgsHash).length !== 0) {
+                for (const { fetches, args } of Object.values(fetchesByArgsHash)) {
+                    // Check if the two arg sets are a match without
+                    // `encoding` and `dataSlice` arguments.
+                    if (
+                        hashOmit(orphanedArgs, ['encoding', 'dataSlice']) === hashOmit(args, ['encoding', 'dataSlice'])
+                    ) {
+                        const { callbacks: promiseCallbacksForAddress } = (fetches[address] ||= {
+                            callbacks: [],
+                        });
+                        promiseCallbacksForAddress.push({ callback: orphanPromiseCallback });
+                        return;
+                    }
+                }
+            }
+            // Create a new fetch. Prefer `base64` encoding.
+            const args: TArgs = { ...orphanedArgs, encoding: 'base64' };
+            const argsHash = hashOmit(args, []);
+            const accountFetches = (fetchesByArgsHash[argsHash] ||= {
+                args,
+                fetches: {},
+            });
+            const { callbacks: promiseCallbacksForAddress } = (accountFetches.fetches[address] ||= {
+                callbacks: [],
+            });
+            promiseCallbacksForAddress.push({ callback: orphanPromiseCallback });
+        });
+    });
+
+    return fetchesByArgsHash;
+}

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -43,19 +43,15 @@ export type MultipleAccountsLoaderArgs = { addresses: Address[] } & AccountLoade
 export type MultipleAccountsLoaderValue = AccountLoaderValue[];
 export type MultipleAccountsLoader = Loader<MultipleAccountsLoaderArgs, MultipleAccountsLoaderValue>;
 
-// FIX ME: https://github.com/solana-labs/solana-web3.js/pull/2052
-// export type ProgramAccountsLoaderArgs = {
-//     programAddress: Parameters<GetProgramAccountsApi['getProgramAccounts']>[0];
-// } & Parameters<GetProgramAccountsApi['getProgramAccounts']>[1];
-export type ProgramAccountsLoaderArgs = {
+export type ProgramAccountsLoaderArgsBase = {
     commitment?: Commitment;
     dataSlice?: { offset: number; length: number };
     encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
     filters?: readonly { memcmp: { offset: number; bytes: string } }[];
     minContextSlot?: Slot;
-    programAddress: Address;
 };
-export type ProgramAccountsLoaderValue = ReturnType<GetProgramAccountsApi['getProgramAccounts']> | null;
+export type ProgramAccountsLoaderArgs = { programAddress: Address } & ProgramAccountsLoaderArgsBase;
+export type ProgramAccountsLoaderValue = ReturnType<GetProgramAccountsApi['getProgramAccounts']>;
 export type ProgramAccountsLoader = Loader<ProgramAccountsLoaderArgs, ProgramAccountsLoaderValue>;
 
 // FIX ME: https://github.com/microsoft/TypeScript/issues/43187

--- a/packages/rpc-graphql/src/loaders/program-accounts.ts
+++ b/packages/rpc-graphql/src/loaders/program-accounts.ts
@@ -1,24 +1,18 @@
 import type { GetProgramAccountsApi, Rpc } from '@solana/rpc';
 import DataLoader from 'dataloader';
 
-import { cacheKeyFn, ProgramAccountsLoader, ProgramAccountsLoaderArgs, ProgramAccountsLoaderValue } from './loader';
+import { sliceData } from './account';
+import { buildCoalescedFetchesByArgsHashWithDataSlice, ToFetchMap } from './coalescer';
+import {
+    cacheKeyFn,
+    ProgramAccountsLoader,
+    ProgramAccountsLoaderArgs,
+    ProgramAccountsLoaderArgsBase,
+    ProgramAccountsLoaderValue,
+} from './loader';
 
-function applyDefaultArgs({
-    commitment,
-    dataSlice,
-    encoding = 'jsonParsed',
-    filters,
-    minContextSlot,
-    programAddress,
-}: ProgramAccountsLoaderArgs): ProgramAccountsLoaderArgs {
-    return {
-        commitment,
-        dataSlice,
-        encoding,
-        filters,
-        minContextSlot,
-        programAddress,
-    };
+type Config = {
+    maxDataSliceByteRange: number;
 }
 
 async function loadProgramAccounts(
@@ -35,16 +29,68 @@ async function loadProgramAccounts(
         .send();
 }
 
-function createProgramAccountsBatchLoadFn(rpc: Rpc<GetProgramAccountsApi>) {
+function createProgramAccountsBatchLoadFn(rpc: Rpc<GetProgramAccountsApi>, config: Config) {
     const resolveProgramAccountsUsingRpc = loadProgramAccounts.bind(null, rpc);
-    return async (programAccountsQueryArgs: readonly ProgramAccountsLoaderArgs[]) =>
-        Promise.all(programAccountsQueryArgs.map(async args => resolveProgramAccountsUsingRpc(applyDefaultArgs(args))));
+    return async (
+        accountQueryArgs: readonly ProgramAccountsLoaderArgs[],
+    ): ReturnType<ProgramAccountsLoader['loadMany']> => {
+        /**
+         * Gather all the program-accounts that need to be fetched, grouped by
+         * program address.
+         */
+        const programAccountsToFetch: ToFetchMap<ProgramAccountsLoaderArgsBase, ProgramAccountsLoaderValue> = {};
+        try {
+            return Promise.all(accountQueryArgs.map(
+                ({ programAddress, ...args }) =>
+                    new Promise((resolve, reject) => {
+                        const accountRecords = (programAccountsToFetch[programAddress] ||= []);
+                        // Apply the default commitment level.
+                        if (!args.commitment) {
+                            args.commitment = 'confirmed';
+                        }
+                        accountRecords.push({ args, promiseCallback: { reject, resolve } });
+                    }),
+            )) as ReturnType<ProgramAccountsLoader['loadMany']>;
+        } finally {
+            const { maxDataSliceByteRange } = config;
+
+            /**
+             * Group together program-accounts that are fetched with identical args.
+             */
+            const programAccountsFetchesByArgsHash =
+                buildCoalescedFetchesByArgsHashWithDataSlice(programAccountsToFetch, maxDataSliceByteRange);
+
+            /**
+             * For each set of program-accounts related to some common args, fetch them in the fewest
+             * number of network requests.
+             */
+            Object.values(programAccountsFetchesByArgsHash).map(({ args, fetches: programAddressCallbacks }) => {
+                return Object.entries(programAddressCallbacks).map(([programAddress, { callbacks }]) => {
+                    return Array.from({ length: 1 }, async () => {
+                        try {
+                            const result = await resolveProgramAccountsUsingRpc({
+                                programAddress,
+                                ...args,
+                            } as ProgramAccountsLoaderArgs);
+                            callbacks.forEach(({ callback, dataSlice }) => {
+                                callback.resolve(sliceData(result, dataSlice, args.dataSlice));
+                            });
+                        } catch (e) {
+                            callbacks.forEach(({ callback }) => {
+                                callback.reject(e);
+                            });
+                        }
+                    });
+                });
+            });
+        }
+    };
 }
 
-export function createProgramAccountsLoader(rpc: Rpc<GetProgramAccountsApi>): ProgramAccountsLoader {
-    const loader = new DataLoader(createProgramAccountsBatchLoadFn(rpc), { cacheKeyFn });
+export function createProgramAccountsLoader(rpc: Rpc<GetProgramAccountsApi>, config: Config): ProgramAccountsLoader {
+    const loader = new DataLoader(createProgramAccountsBatchLoadFn(rpc, config), { cacheKeyFn });
     return {
-        load: async args => loader.load(applyDefaultArgs(args)),
-        loadMany: async args => loader.loadMany(args.map(applyDefaultArgs)),
+        load: async args => loader.load(args),
+        loadMany: async args => loader.loadMany(args),
     };
 }

--- a/packages/rpc-graphql/src/resolvers/__tests__/program-accounts-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/program-accounts-resolver-test.ts
@@ -1,0 +1,235 @@
+import type {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
+
+import { createRpcGraphQL, RpcGraphQL } from '../../index';
+
+describe('program accounts resolver', () => {
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi>;
+    let rpcGraphQL: RpcGraphQL;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        rpc = {
+            getAccountInfo: jest.fn(),
+            getBlock: jest.fn(),
+            getMultipleAccounts: jest.fn(),
+            getProgramAccounts: jest.fn(),
+            getTransaction: jest.fn(),
+        };
+        rpcGraphQL = createRpcGraphQL(rpc);
+    });
+    describe('inline fragments', () => {
+        it('will resolve inline fragments with `jsonParsed` when `jsonParsed` fields are requested', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts(programAddress: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        ... on MintAccount {
+                            supply
+                        }
+                    }
+                }
+            `;
+            rpcGraphQL.query(source);
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+            expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+            });
+        });
+        it('will resolve inline fragments with `jsonParsed` and the proper encoding when data and `jsonParsed` fields are requested', async () => {
+            expect.assertions(3);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts(programAddress: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        ... on MintAccount {
+                            data(encoding: BASE_58)
+                            supply
+                        }
+                    }
+                }
+            `;
+            rpcGraphQL.query(source);
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
+            expect(rpc.getProgramAccounts).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+            });
+            expect(rpc.getProgramAccounts).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'base58',
+            });
+        });
+        it('will resolve inline fragments with only the proper encoding not `jsonParsed` when no `jsonParsed` fields are requested', async () => {
+            expect.assertions(3);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts(programAddress: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        ... on MintAccount {
+                            data(encoding: BASE_58)
+                            lamports
+                            space
+                        }
+                    }
+                }
+            `;
+            rpcGraphQL.query(source);
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+            expect(rpc.getProgramAccounts).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'base58',
+            });
+            expect(rpc.getProgramAccounts).not.toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+            });
+        });
+    });
+    describe('fragment spreads', () => {
+        it('will resolve fields from fragment spreads', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts(programAddress: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        ...GetLamports
+                    }
+                }
+                fragment GetLamports on Account {
+                    lamports
+                }
+            `;
+            rpcGraphQL.query(source);
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+            expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'base64',
+            });
+        });
+        it('will resolve fields from multiple fragment spreads', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts(programAddress: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        ...GetLamports
+                        ...GetDataBase64
+                    }
+                }
+                fragment GetLamports on Account {
+                    lamports
+                }
+                fragment GetDataBase64 on Account {
+                    data(encoding: BASE_64_ZSTD)
+                }
+            `;
+            rpcGraphQL.query(source);
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+            expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'base64+zstd',
+            });
+        });
+        it('will resolve fragment spreads with `jsonParsed` when `jsonParsed` fields are requested', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts(programAddress: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        ...GetLamportsAndSupplyFromMintAccount
+                    }
+                }
+                fragment GetLamportsAndSupplyFromMintAccount on Account {
+                    ... on MintAccount {
+                        lamports
+                        supply
+                    }
+                }
+            `;
+            rpcGraphQL.query(source);
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+            expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+            });
+        });
+        it('will resolve fragment spreads with `jsonParsed` and the proper encoding when data and `jsonParsed` fields are requested', async () => {
+            expect.assertions(3);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts(programAddress: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        ...GetDataAndSupplyFromMintAccount
+                    }
+                }
+                fragment GetDataAndSupplyFromMintAccount on Account {
+                    ... on MintAccount {
+                        data(encoding: BASE_58)
+                        supply
+                    }
+                }
+            `;
+            rpcGraphQL.query(source);
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
+            expect(rpc.getProgramAccounts).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+            });
+            expect(rpc.getProgramAccounts).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'base58',
+            });
+        });
+        it('will resolve fragment spreads with only the proper encoding not `jsonParsed` when no `jsonParsed` fields are requested', async () => {
+            expect.assertions(3);
+            const source = /* GraphQL */ `
+                query testQuery {
+                    programAccounts(programAddress: "AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca") {
+                        ...GetLamportsAndDataFromMintAccount
+                    }
+                }
+                fragment GetLamportsAndDataFromMintAccount on Account {
+                    ... on MintAccount {
+                        lamports
+                        data(encoding: BASE_64_ZSTD)
+                    }
+                }
+            `;
+            rpcGraphQL.query(source);
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
+            expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'base64+zstd',
+            });
+            expect(rpc.getProgramAccounts).not.toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+            });
+        });
+    });
+});

--- a/packages/rpc-graphql/src/resolvers/resolve-info/index.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/index.ts
@@ -1,2 +1,3 @@
 export * from './account';
+export * from './program-accounts';
 export * from './visitor';

--- a/packages/rpc-graphql/src/resolvers/resolve-info/program-accounts.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/program-accounts.ts
@@ -1,0 +1,22 @@
+import { Address } from '@solana/addresses';
+import { Commitment, Slot } from '@solana/rpc-types';
+import { GraphQLResolveInfo } from 'graphql';
+
+import { ProgramAccountsLoaderArgs } from '../../loaders';
+import { buildAccountArgSetWithVisitor } from './account';
+
+/**
+ * Build a set of account loader args by inspecting which fields have
+ * been requested in the query (ie. `data` or inline fragments).
+ */
+export function buildProgramAccountsLoaderArgSetFromResolveInfo(
+    args: {
+        commitment?: Commitment;
+        filters?: readonly { memcmp: { offset: number; bytes: string } }[];
+        minContextSlot?: Slot;
+        programAddress: Address;
+    },
+    info: GraphQLResolveInfo,
+): ProgramAccountsLoaderArgs[] {
+    return buildAccountArgSetWithVisitor(args, info);
+}

--- a/packages/rpc-graphql/src/schema/root.ts
+++ b/packages/rpc-graphql/src/schema/root.ts
@@ -10,8 +10,6 @@ export const rootTypeDefs = /* GraphQL */ `
         programAccounts(
             programAddress: Address!
             commitment: Commitment
-            dataSlice: DataSlice
-            encoding: AccountEncoding
             filters: [ProgramAccountsFilter]
             minContextSlot: Slot
         ): [Account]


### PR DESCRIPTION
Continue in the spirit of the previous commit, this time adding a request
coalescer to the `programAccounts` query, allowing for similar optimizations to
`account`, despite there being no batch RPC method for `getProgramAccounts`.
