### PR TITLE
refactor(experimental): graphql: transaction makeover

### DIFF
--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -14,8 +14,6 @@ import {
     createLocalhostSolanaRpc,
     mockBlockAccounts,
     mockBlockFull,
-    mockBlockFullBase58,
-    mockBlockFullBase64,
     mockBlockNone,
     mockBlockSignatures,
     mockRpcResponse,
@@ -242,64 +240,8 @@ describe('block', () => {
         });
     });
     describe('block with full transaction details', () => {
-        it('can query a block with base58 encoded transactions', async () => {
-            expect.assertions(1);
-            fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockFullBase58)));
-            const source = /* GraphQL */ `
-                query testQuery($slot: Slot!) {
-                    block(slot: $slot, encoding: BASE_58) {
-                        ... on BlockWithFull {
-                            transactions {
-                                ... on TransactionBase58 {
-                                    data
-                                }
-                            }
-                        }
-                    }
-                }
-            `;
-            const result = await rpcGraphQL.query(source, { slot: defaultSlot });
-            expect(result).toMatchObject({
-                data: {
-                    block: {
-                        transactions: expect.arrayContaining([
-                            {
-                                data: expect.any(String),
-                            },
-                        ]),
-                    },
-                },
-            });
-        });
-        it('can query a block with base64 encoded transactions', async () => {
-            expect.assertions(1);
-            fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockBlockFullBase64)));
-            const source = /* GraphQL */ `
-                query testQuery($slot: Slot!) {
-                    block(slot: $slot, encoding: BASE_64) {
-                        ... on BlockWithFull {
-                            transactions {
-                                ... on TransactionBase64 {
-                                    data
-                                }
-                            }
-                        }
-                    }
-                }
-            `;
-            const result = await rpcGraphQL.query(source, { slot: defaultSlot });
-            expect(result).toMatchObject({
-                data: {
-                    block: {
-                        transactions: expect.arrayContaining([
-                            {
-                                data: expect.any(String),
-                            },
-                        ]),
-                    },
-                },
-            });
-        });
+        it.todo('can query a block with base58 encoded transactions');
+        it.todo('can query a block with base64 encoded transactions');
         it.todo('can query a block with transactions as JSON parsed');
         it.todo('can query a block with transactions as JSON parsed with specific instructions');
     });

--- a/packages/rpc-graphql/src/loaders/__tests__/transaction-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/transaction-loader-test.ts
@@ -26,7 +26,7 @@ describe('account loader', () => {
         };
         rpcGraphQL = createRpcGraphQL(rpc);
     });
-    describe('cache tests', () => {
+    describe('cached responses', () => {
         it('coalesces multiple requests for the same transaction into one', async () => {
             expect.assertions(1);
             const source = /* GraphQL */ `
@@ -64,6 +64,445 @@ describe('account loader', () => {
             await Promise.resolve();
             jest.runAllTimers();
             expect(rpc.getTransaction).toHaveBeenCalledTimes(2);
+        });
+    });
+    describe('batch loading', () => {
+        describe('request partitioning', () => {
+            it('coalesces multiple requests for the same transaction but different fields into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction1: transaction(signature: $signature) {
+                            blockTime
+                        }
+                        transaction2: transaction(signature: $signature) {
+                            slot
+                        }
+                        transaction3: transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    ... on SplTokenInitializeMintInstruction {
+                                        decimals
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, {
+                    signature:
+                        '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
+            it('coalesces multiple requests for the same transaction but one with specified `confirmed` commitment into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction1: transaction(signature: $signature) {
+                            blockTime
+                        }
+                        transaction2: transaction(signature: $signature, commitment: CONFIRMED) {
+                            blockTime
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, {
+                    signature:
+                        '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+            });
+            it('will not coalesce multiple requests for the same transaction but with different commitments into one request', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction1: transaction(signature: $signature) {
+                            blockTime
+                        }
+                        transaction2: transaction(signature: $signature, commitment: CONFIRMED) {
+                            blockTime
+                        }
+                        transaction3: transaction(signature: $signature, commitment: FINALIZED) {
+                            blockTime
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, {
+                    signature:
+                        '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(2);
+                expect(rpc.getTransaction).toHaveBeenCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+                expect(rpc.getTransaction).toHaveBeenCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'finalized',
+                        encoding: 'base64', // GraphQL client prefers `base64`
+                    },
+                );
+            });
+        });
+        describe('encoding requests', () => {
+            it('does not use `jsonParsed` if no parsed type is queried', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            blockTime
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64',
+                    },
+                );
+            });
+            it('uses only `base58` if one data field is requested with `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            data(encoding: BASE_58)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base58',
+                    },
+                );
+            });
+            it('uses only `base64` if one data field is requested with `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            data(encoding: BASE_64)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64',
+                    },
+                );
+            });
+            it('only uses `jsonParsed` if a parsed type is queried, but data is not', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            message {
+                                instructions {
+                                    ... on SplTokenInitializeMintInstruction {
+                                        decimals
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
+            it('does not call the loader twice for other base fields and `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            blockTime
+                            data(encoding: BASE_58)
+                            slot
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base58',
+                    },
+                );
+            });
+            it('does not call the loader twice for other base fields and `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            blockTime
+                            data(encoding: BASE_64)
+                            slot
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64',
+                    },
+                );
+            });
+            it('does not call the loader twice for other base fields and inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            message {
+                                instructions {
+                                    ... on SplTokenInitializeMintInstruction {
+                                        decimals
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
+            it('will not make multiple calls for more than one inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            message {
+                                instructions {
+                                    ... on SplTokenInitializeMintInstruction {
+                                        decimals
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                    ... on SplTokenInitializeAccountInstruction {
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                    ... on SplTokenInitializeMultisigInstruction {
+                                        multisig {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+                expect(rpc.getTransaction).toHaveBeenLastCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
+            it('uses `jsonParsed` and the requested data encoding if a parsed type is queried alongside encoded data', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            data(encoding: BASE_64)
+                            message {
+                                instructions {
+                                    ... on SplTokenInitializeMintInstruction {
+                                        decimals
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(2);
+                expect(rpc.getTransaction).toHaveBeenCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64',
+                    },
+                );
+                expect(rpc.getTransaction).toHaveBeenCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
+            it('uses only the number of requests for the number of different encodings requested', async () => {
+                expect.assertions(4);
+                const source = /* GraphQL */ `
+                    query testQuery {
+                        transaction(
+                            signature: "67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk"
+                        ) {
+                            dataBase58_1: data(encoding: BASE_58)
+                            dataBase58_2: data(encoding: BASE_58)
+                            dataBase58_3: data(encoding: BASE_58)
+                            dataBase64_1: data(encoding: BASE_64)
+                            dataBase64_2: data(encoding: BASE_64)
+                            dataBase64_3: data(encoding: BASE_64)
+                            message {
+                                instructions {
+                                    ... on SplTokenInitializeMintInstruction {
+                                        decimals
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source);
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getTransaction).toHaveBeenCalledTimes(3);
+                expect(rpc.getTransaction).toHaveBeenCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base58',
+                    },
+                );
+                expect(rpc.getTransaction).toHaveBeenCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'base64',
+                    },
+                );
+                expect(rpc.getTransaction).toHaveBeenCalledWith(
+                    '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    },
+                );
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -54,15 +54,11 @@ export type ProgramAccountsLoaderArgs = { programAddress: Address } & ProgramAcc
 export type ProgramAccountsLoaderValue = ReturnType<GetProgramAccountsApi['getProgramAccounts']>;
 export type ProgramAccountsLoader = Loader<ProgramAccountsLoaderArgs, ProgramAccountsLoaderValue>;
 
-// FIX ME: https://github.com/microsoft/TypeScript/issues/43187
-// export type TransactionLoaderArgs = { signature: Parameters<GetTransactionApi['getTransaction']>[0] } & Parameters<
-//     GetTransactionApi['getTransaction']
-// >[1];
-export type TransactionLoaderArgs = {
-    commitment?: Commitment;
+export type TransactionLoaderArgsBase = {
+    commitment?: Omit<Commitment, 'processed'>;
     encoding?: 'base58' | 'base64' | 'json' | 'jsonParsed';
-    signature: Signature;
 };
+export type TransactionLoaderArgs = { signature: Signature } & TransactionLoaderArgsBase;
 export type TransactionLoaderValue = ReturnType<GetTransactionApi['getTransaction']> | null;
 export type TransactionLoader = Loader<TransactionLoaderArgs, TransactionLoaderValue>;
 

--- a/packages/rpc-graphql/src/loaders/transaction.ts
+++ b/packages/rpc-graphql/src/loaders/transaction.ts
@@ -1,19 +1,14 @@
 import type { GetTransactionApi, Rpc } from '@solana/rpc';
 import DataLoader from 'dataloader';
 
-import { cacheKeyFn, TransactionLoader, TransactionLoaderArgs, TransactionLoaderValue } from './loader';
-
-function applyDefaultArgs({
-    commitment,
-    encoding = 'jsonParsed',
-    signature,
-}: TransactionLoaderArgs): TransactionLoaderArgs {
-    return {
-        commitment,
-        encoding,
-        signature,
-    };
-}
+import { buildCoalescedFetchesByArgsHash, ToFetchMap } from './coalescer';
+import {
+    cacheKeyFn,
+    TransactionLoader,
+    TransactionLoaderArgs,
+    TransactionLoaderArgsBase,
+    TransactionLoaderValue,
+} from './loader';
 
 async function loadTransaction(
     rpc: Rpc<GetTransactionApi>,
@@ -31,14 +26,62 @@ async function loadTransaction(
 
 function createTransactionBatchLoadFn(rpc: Rpc<GetTransactionApi>) {
     const resolveTransactionUsingRpc = loadTransaction.bind(null, rpc);
-    return async (transactionQueryArgs: readonly TransactionLoaderArgs[]) =>
-        Promise.all(transactionQueryArgs.map(async args => resolveTransactionUsingRpc(applyDefaultArgs(args))));
+    return async (
+        transactionQueryArgs: readonly TransactionLoaderArgs[],
+    ): ReturnType<TransactionLoader['loadMany']> => {
+        /**
+         * Gather all the transactions that need to be fetched, grouped by signature.
+         */
+        const transactionsToFetch: ToFetchMap<TransactionLoaderArgsBase, TransactionLoaderValue> = {};
+        try {
+            return Promise.all(transactionQueryArgs.map(
+                ({ signature, ...args }) =>
+                    new Promise((resolve, reject) => {
+                        const transactionRecords = (transactionsToFetch[signature] ||= []);
+                        // Apply the default commitment level.
+                        if (!args.commitment) {
+                            args.commitment = 'confirmed';
+                        }
+                        transactionRecords.push({ args, promiseCallback: { reject, resolve } });
+                    }),
+            )) as ReturnType<TransactionLoader['loadMany']>;
+        } finally {
+            /**
+             * Group together transactions that are fetched with identical args.
+             */
+            const transactionFetchesByArgsHash = buildCoalescedFetchesByArgsHash(transactionsToFetch, {
+                criteria: (args: TransactionLoaderArgsBase) => args.encoding === undefined,
+                defaults: (args: TransactionLoaderArgsBase) => ({ ...args, encoding: 'base64' }),
+                hashOmit: ['encoding'],
+            });
+
+            /**
+             * For each set of transactions related to some common args, fetch them in the fewest number
+             * of network requests.
+             */
+            Object.values(transactionFetchesByArgsHash).map(({ args, fetches: transactionCallbacks }) => {
+                return Object.entries(transactionCallbacks).map(([signature, { callbacks }]) => {
+                    return Array.from({ length: 1 }, async () => {
+                        try {
+                            const result = await resolveTransactionUsingRpc({
+                                signature,
+                                ...args,
+                            } as TransactionLoaderArgs);
+                            callbacks.forEach(c => c.resolve(result));
+                        } catch (e) {
+                            callbacks.forEach(c => c.reject(e));
+                        }
+                    });
+                });
+            });
+        }
+    };
 }
 
 export function createTransactionLoader(rpc: Rpc<GetTransactionApi>): TransactionLoader {
     const loader = new DataLoader(createTransactionBatchLoadFn(rpc), { cacheKeyFn });
     return {
-        load: async args => loader.load(applyDefaultArgs(args)),
-        loadMany: async args => loader.loadMany(args.map(applyDefaultArgs)),
+        load: async args => loader.load(args),
+        loadMany: async args => loader.loadMany(args),
     };
 }

--- a/packages/rpc-graphql/src/resolvers/__tests__/transaction-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/transaction-resolver-test.ts
@@ -1,0 +1,165 @@
+import type {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
+
+import { createRpcGraphQL, RpcGraphQL } from '../../index';
+
+describe('transaction resolver', () => {
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi>;
+    let rpcGraphQL: RpcGraphQL;
+    // Not actually used. Just needed for proper query parsing.
+    const signature = '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk';
+    beforeEach(() => {
+        jest.useFakeTimers();
+        rpc = {
+            getAccountInfo: jest.fn(),
+            getBlock: jest.fn(),
+            getMultipleAccounts: jest.fn(),
+            getProgramAccounts: jest.fn(),
+            getTransaction: jest.fn(),
+        };
+        rpcGraphQL = createRpcGraphQL(rpc);
+    });
+    describe('fragment spreads', () => {
+        it('will resolve fields from fragment spreads', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery($signature: Signature!) {
+                    transaction(signature: $signature) {
+                        ...GetBlockTime
+                    }
+                }
+                fragment GetBlockTime on Transaction {
+                    blockTime
+                }
+            `;
+            rpcGraphQL.query(source, { signature });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+            expect(rpc.getTransaction).toHaveBeenLastCalledWith(signature, {
+                commitment: 'confirmed',
+                encoding: 'base64',
+            });
+        });
+        it('will resolve fields from multiple fragment spreads', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery($signature: Signature!) {
+                    transaction(signature: $signature) {
+                        ...GetBlockTime
+                        ...GetDataBase64
+                    }
+                }
+                fragment GetBlockTime on Transaction {
+                    blockTime
+                }
+                fragment GetDataBase64 on Transaction {
+                    data(encoding: BASE_64)
+                }
+            `;
+            rpcGraphQL.query(source, { signature });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+            expect(rpc.getTransaction).toHaveBeenLastCalledWith(signature, {
+                commitment: 'confirmed',
+                encoding: 'base64',
+            });
+        });
+        it('will resolve fragment spreads with `jsonParsed` when `jsonParsed` fields are requested', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery($signature: Signature!) {
+                    transaction(signature: $signature) {
+                        message {
+                            instructions {
+                                ...GetGenericInstructionData
+                            }
+                        }
+                    }
+                }
+                fragment GetGenericInstructionData on TransactionInstruction {
+                    ... on GenericInstruction {
+                        data
+                    }
+                }
+            `;
+            rpcGraphQL.query(source, { signature });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+            expect(rpc.getTransaction).toHaveBeenLastCalledWith(signature, {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+            });
+        });
+        it('will resolve fragment spreads with `jsonParsed` and the proper encoding when data and `jsonParsed` fields are requested', async () => {
+            expect.assertions(3);
+            const source = /* GraphQL */ `
+                query testQuery($signature: Signature!) {
+                    transaction(signature: $signature) {
+                        ...GetDataAndGenericInstructionData
+                    }
+                }
+                fragment GetDataAndGenericInstructionData on Transaction {
+                    transactionData: data(encoding: BASE_58)
+                    message {
+                        instructions {
+                            ... on GenericInstruction {
+                                data
+                            }
+                        }
+                    }
+                }
+            `;
+            rpcGraphQL.query(source, { signature });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getTransaction).toHaveBeenCalledTimes(2);
+            expect(rpc.getTransaction).toHaveBeenCalledWith(signature, {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+            });
+            expect(rpc.getTransaction).toHaveBeenCalledWith(signature, {
+                commitment: 'confirmed',
+                encoding: 'base58',
+            });
+        });
+        it('will resolve fragment spreads with only the proper encoding not `jsonParsed` when no `jsonParsed` fields are requested', async () => {
+            expect.assertions(3);
+            const source = /* GraphQL */ `
+                query testQuery($signature: Signature!) {
+                    transaction(signature: $signature) {
+                        ...GetTransactionData
+                    }
+                }
+                fragment GetTransactionData on Transaction {
+                    transactionData: data(encoding: BASE_58)
+                }
+            `;
+            rpcGraphQL.query(source, { signature });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+            expect(rpc.getTransaction).toHaveBeenLastCalledWith(signature, {
+                commitment: 'confirmed',
+                encoding: 'base58',
+            });
+            expect(rpc.getTransaction).not.toHaveBeenCalledWith(signature, {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+            });
+        });
+    });
+});

--- a/packages/rpc-graphql/src/resolvers/block.ts
+++ b/packages/rpc-graphql/src/resolvers/block.ts
@@ -2,9 +2,62 @@ import type { Slot } from '@solana/rpc-types';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { RpcGraphQLContext } from '../context';
-import { BlockLoaderArgs } from '../loaders';
+import { BlockLoaderArgs, TransactionLoaderArgs } from '../loaders';
 import { onlyFieldsRequested } from './resolve-info';
-import { transformLoadedTransaction } from './transaction';
+
+// ====================================
+// Removed in next commit
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformParsedInstruction(parsedInstruction: any) {
+    if ('parsed' in parsedInstruction) {
+        if (typeof parsedInstruction.parsed === 'string' && parsedInstruction.program === 'spl-memo') {
+            const { parsed: memo, program: programName, programId } = parsedInstruction;
+            const instructionType = 'memo';
+            return { instructionType, memo, programId, programName };
+        }
+        const {
+            parsed: { info: data, type: instructionType },
+            program: programName,
+            programId,
+        } = parsedInstruction;
+        return { instructionType, programId, programName, ...data };
+    } else {
+        return parsedInstruction;
+    }
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformParsedTransaction(parsedTransaction: any) {
+    const transactionData = parsedTransaction.transaction;
+    const transactionMeta = parsedTransaction.meta;
+    transactionData.message.instructions = transactionData.message.instructions.map(transformParsedInstruction);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    transactionMeta.innerInstructions = transactionMeta.innerInstructions.map((innerInstruction: any) => {
+        innerInstruction.instructions = innerInstruction.instructions.map(transformParsedInstruction);
+        return innerInstruction;
+    });
+    return [transactionData, transactionMeta];
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function transformLoadedTransaction({
+    encoding = 'jsonParsed',
+    transaction,
+}: {
+    encoding: TransactionLoaderArgs['encoding'];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    transaction: any;
+}) {
+    const [transactionData, transactionMeta] = Array.isArray(transaction.transaction)
+        ? // The requested encoding is base58 or base64.
+          [transaction.transaction[0], transaction.meta]
+        : // The transaction was either partially parsed or
+          // fully JSON-parsed, which will be sorted later.
+          transformParsedTransaction(transaction);
+    transaction.data = transactionData;
+    transaction.encoding = encoding;
+    transaction.meta = transactionMeta;
+    return transaction;
+}
+// ====================================
 
 export function transformLoadedBlock({
     block,

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -1,9 +1,11 @@
 import { resolveAccount } from './account';
+import { InstructionResult } from './transaction';
 
 export const instructionResolvers = {
     AdvanceNonceAccountInstruction: {
         nonceAccount: resolveAccount('nonceAccount'),
         nonceAuthority: resolveAccount('nonceAuthority'),
+        recentBlockhashesSysvar: resolveAccount('recentBlockhashesSysvar'),
     },
     AllocateInstruction: {
         account: resolveAccount('account'),
@@ -40,9 +42,11 @@ export const instructionResolvers = {
     BpfUpgradeableLoaderDeployWithMaxDataLenInstruction: {
         authority: resolveAccount('authority'),
         bufferAccount: resolveAccount('bufferAccount'),
+        clockSysvar: resolveAccount('clockSysvar'),
         payerAccount: resolveAccount('payerAccount'),
         programAccount: resolveAccount('programAccount'),
         programDataAccount: resolveAccount('programDataAccount'),
+        rentSysvar: resolveAccount('rentSysvar'),
     },
     BpfUpgradeableLoaderExtendProgramInstruction: {
         payerAccount: resolveAccount('payerAccount'),
@@ -66,8 +70,10 @@ export const instructionResolvers = {
     BpfUpgradeableLoaderUpgradeInstruction: {
         authority: resolveAccount('authority'),
         bufferAccount: resolveAccount('bufferAccount'),
+        clockSysvar: resolveAccount('clockSysvar'),
         programAccount: resolveAccount('programAccount'),
         programDataAccount: resolveAccount('programDataAccount'),
+        rentSysvar: resolveAccount('rentSysvar'),
     },
     BpfUpgradeableLoaderWriteInstruction: {
         account: resolveAccount('account'),
@@ -111,6 +117,8 @@ export const instructionResolvers = {
     InitializeNonceAccountInstruction: {
         nonceAccount: resolveAccount('nonceAccount'),
         nonceAuthority: resolveAccount('nonceAuthority'),
+        recentBlockhashesSysvar: resolveAccount('recentBlockhashesSysvar'),
+        rentSysvar: resolveAccount('rentSysvar'),
     },
     Lockup: {
         custodian: resolveAccount('custodian'),
@@ -187,6 +195,7 @@ export const instructionResolvers = {
         account: resolveAccount('account'),
         mint: resolveAccount('mint'),
         owner: resolveAccount('owner'),
+        rentSysvar: resolveAccount('rentSysvar'),
     },
     SplTokenInitializeAccount3Instruction: {
         account: resolveAccount('account'),
@@ -197,6 +206,7 @@ export const instructionResolvers = {
         account: resolveAccount('account'),
         mint: resolveAccount('mint'),
         owner: resolveAccount('owner'),
+        rentSysvar: resolveAccount('rentSysvar'),
     },
     SplTokenInitializeMint2Instruction: {
         freezeAuthority: resolveAccount('freezeAuthority'),
@@ -211,12 +221,14 @@ export const instructionResolvers = {
         freezeAuthority: resolveAccount('freezeAuthority'),
         mint: resolveAccount('mint'),
         mintAuthority: resolveAccount('mintAuthority'),
+        rentSysvar: resolveAccount('rentSysvar'),
     },
     SplTokenInitializeMultisig2Instruction: {
         multisig: resolveAccount('multisig'),
     },
     SplTokenInitializeMultisigInstruction: {
         multisig: resolveAccount('multisig'),
+        rentSysvar: resolveAccount('rentSysvar'),
     },
     SplTokenMintToCheckedInstruction: {
         account: resolveAccount('account'),
@@ -269,6 +281,7 @@ export const instructionResolvers = {
     },
     StakeAuthorizeCheckedInstruction: {
         authority: resolveAccount('authority'),
+        clockSysvar: resolveAccount('clockSysvar'),
         custodian: resolveAccount('custodian'),
         newAuthority: resolveAccount('newAuthority'),
         stakeAccount: resolveAccount('stakeAccount'),
@@ -276,12 +289,14 @@ export const instructionResolvers = {
     StakeAuthorizeCheckedWithSeedInstruction: {
         authorityBase: resolveAccount('authorityBase'),
         authorityOwner: resolveAccount('authorityOwner'),
+        clockSysvar: resolveAccount('clockSysvar'),
         custodian: resolveAccount('custodian'),
         newAuthorized: resolveAccount('newAuthorized'),
         stakeAccount: resolveAccount('stakeAccount'),
     },
     StakeAuthorizeInstruction: {
         authority: resolveAccount('authority'),
+        clockSysvar: resolveAccount('clockSysvar'),
         custodian: resolveAccount('custodian'),
         newAuthority: resolveAccount('newAuthority'),
         stakeAccount: resolveAccount('stakeAccount'),
@@ -289,6 +304,7 @@ export const instructionResolvers = {
     StakeAuthorizeWithSeedInstruction: {
         authorityBase: resolveAccount('authorityBase'),
         authorityOwner: resolveAccount('authorityOwner'),
+        clockSysvar: resolveAccount('clockSysvar'),
         custodian: resolveAccount('custodian'),
         newAuthorized: resolveAccount('newAuthorized'),
         stakeAccount: resolveAccount('stakeAccount'),
@@ -299,20 +315,28 @@ export const instructionResolvers = {
         voteAccount: resolveAccount('voteAccount'),
     },
     StakeDeactivateInstruction: {
+        clockSysvar: resolveAccount('clockSysvar'),
         stakeAccount: resolveAccount('stakeAccount'),
         stakeAuthority: resolveAccount('stakeAuthority'),
     },
     StakeDelegateStakeInstruction: {
+        clockSysvar: resolveAccount('clockSysvar'),
         stakeAccount: resolveAccount('stakeAccount'),
         stakeAuthority: resolveAccount('stakeAuthority'),
         stakeConfigAccount: resolveAccount('stakeConfigAccount'),
+        stakeHistorySysvar: resolveAccount('stakeHistorySysvar'),
         voteAccount: resolveAccount('voteAccount'),
+    },
+    StakeInitializeCheckedInstruction: {
+        rentSysvar: resolveAccount('rentSysvar'),
+        stakeAccount: resolveAccount('stakeAccount'),
     },
     StakeInitializeCheckedInstructionDataAuthorized: {
         staker: resolveAccount('staker'),
         withdrawer: resolveAccount('withdrawer'),
     },
     StakeInitializeInstruction: {
+        rentSysvar: resolveAccount('rentSysvar'),
         stakeAccount: resolveAccount('stakeAccount'),
     },
     StakeInitializeInstructionDataAuthorized: {
@@ -320,9 +344,11 @@ export const instructionResolvers = {
         withdrawer: resolveAccount('withdrawer'),
     },
     StakeMergeInstruction: {
+        clockSysvar: resolveAccount('clockSysvar'),
         destination: resolveAccount('destination'),
         source: resolveAccount('source'),
         stakeAuthority: resolveAccount('stakeAuthority'),
+        stakeHistorySysvar: resolveAccount('stakeHistorySysvar'),
     },
     StakeRedelegateInstruction: {
         newStakeAccount: resolveAccount('newStakeAccount'),
@@ -345,287 +371,289 @@ export const instructionResolvers = {
         stakeAuthority: resolveAccount('stakeAuthority'),
     },
     StakeWithdrawInstruction: {
+        clockSysvar: resolveAccount('clockSysvar'),
         destination: resolveAccount('destination'),
         stakeAccount: resolveAccount('stakeAccount'),
         withdrawAuthority: resolveAccount('withdrawAuthority'),
     },
     TransactionInstruction: {
-        __resolveType(instruction: { programName: string; instructionType: string }) {
-            if (instruction.programName) {
-                if (instruction.programName === 'address-lookup-table') {
-                    if (instruction.instructionType === 'createLookupTable') {
+        __resolveType(instructionResult: InstructionResult) {
+            const { jsonParsedConfigs } = instructionResult;
+            if (jsonParsedConfigs) {
+                if (jsonParsedConfigs.programName === 'address-lookup-table') {
+                    if (jsonParsedConfigs.instructionType === 'createLookupTable') {
                         return 'CreateLookupTableInstruction';
                     }
-                    if (instruction.instructionType === 'freezeLookupTable') {
+                    if (jsonParsedConfigs.instructionType === 'freezeLookupTable') {
                         return 'FreezeLookupTableInstruction';
                     }
-                    if (instruction.instructionType === 'extendLookupTable') {
+                    if (jsonParsedConfigs.instructionType === 'extendLookupTable') {
                         return 'ExtendLookupTableInstruction';
                     }
-                    if (instruction.instructionType === 'deactivateLookupTable') {
+                    if (jsonParsedConfigs.instructionType === 'deactivateLookupTable') {
                         return 'DeactivateLookupTableInstruction';
                     }
-                    if (instruction.instructionType === 'closeLookupTable') {
+                    if (jsonParsedConfigs.instructionType === 'closeLookupTable') {
                         return 'CloseLookupTableInstruction';
                     }
                 }
-                if (instruction.programName === 'bpf-loader') {
-                    if (instruction.instructionType === 'write') {
+                if (jsonParsedConfigs.programName === 'bpf-loader') {
+                    if (jsonParsedConfigs.instructionType === 'write') {
                         return 'BpfLoaderWriteInstruction';
                     }
-                    if (instruction.instructionType === 'finalize') {
+                    if (jsonParsedConfigs.instructionType === 'finalize') {
                         return 'BpfLoaderFinalizeInstruction';
                     }
                 }
-                if (instruction.programName === 'bpf-upgradeable-loader') {
-                    if (instruction.instructionType === 'initializeBuffer') {
+                if (jsonParsedConfigs.programName === 'bpf-upgradeable-loader') {
+                    if (jsonParsedConfigs.instructionType === 'initializeBuffer') {
                         return 'BpfUpgradeableLoaderInitializeBufferInstruction';
                     }
-                    if (instruction.instructionType === 'write') {
+                    if (jsonParsedConfigs.instructionType === 'write') {
                         return 'BpfUpgradeableLoaderWriteInstruction';
                     }
-                    if (instruction.instructionType === 'deployWithMaxDataLen') {
+                    if (jsonParsedConfigs.instructionType === 'deployWithMaxDataLen') {
                         return 'BpfUpgradeableLoaderDeployWithMaxDataLenInstruction';
                     }
-                    if (instruction.instructionType === 'upgrade') {
+                    if (jsonParsedConfigs.instructionType === 'upgrade') {
                         return 'BpfUpgradeableLoaderUpgradeInstruction';
                     }
-                    if (instruction.instructionType === 'setAuthority') {
+                    if (jsonParsedConfigs.instructionType === 'setAuthority') {
                         return 'BpfUpgradeableLoaderSetAuthorityInstruction';
                     }
-                    if (instruction.instructionType === 'setAuthorityChecked') {
+                    if (jsonParsedConfigs.instructionType === 'setAuthorityChecked') {
                         return 'BpfUpgradeableLoaderSetAuthorityCheckedInstruction';
                     }
-                    if (instruction.instructionType === 'close') {
+                    if (jsonParsedConfigs.instructionType === 'close') {
                         return 'BpfUpgradeableLoaderCloseInstruction';
                     }
-                    if (instruction.instructionType === 'extendProgram') {
+                    if (jsonParsedConfigs.instructionType === 'extendProgram') {
                         return 'BpfUpgradeableLoaderExtendProgramInstruction';
                     }
                 }
-                if (instruction.programName === 'spl-associated-token-account') {
-                    if (instruction.instructionType === 'create') {
+                if (jsonParsedConfigs.programName === 'spl-associated-token-account') {
+                    if (jsonParsedConfigs.instructionType === 'create') {
                         return 'SplAssociatedTokenCreateInstruction';
                     }
-                    if (instruction.instructionType === 'createIdempotent') {
+                    if (jsonParsedConfigs.instructionType === 'createIdempotent') {
                         return 'SplAssociatedTokenCreateIdempotentInstruction';
                     }
-                    if (instruction.instructionType === 'recoverNested') {
+                    if (jsonParsedConfigs.instructionType === 'recoverNested') {
                         return 'SplAssociatedTokenRecoverNestedInstruction';
                     }
                 }
-                if (instruction.programName === 'spl-memo') {
+                if (jsonParsedConfigs.programName === 'spl-memo') {
                     return 'SplMemoInstruction';
                 }
-                if (instruction.programName === 'spl-token') {
-                    if (instruction.instructionType === 'initializeMint') {
+                if (jsonParsedConfigs.programName === 'spl-token') {
+                    if (jsonParsedConfigs.instructionType === 'initializeMint') {
                         return 'SplTokenInitializeMintInstruction';
                     }
-                    if (instruction.instructionType === 'initializeMint2') {
+                    if (jsonParsedConfigs.instructionType === 'initializeMint2') {
                         return 'SplTokenInitializeMint2Instruction';
                     }
-                    if (instruction.instructionType === 'initializeAccount') {
+                    if (jsonParsedConfigs.instructionType === 'initializeAccount') {
                         return 'SplTokenInitializeAccountInstruction';
                     }
-                    if (instruction.instructionType === 'initializeAccount2') {
+                    if (jsonParsedConfigs.instructionType === 'initializeAccount2') {
                         return 'SplTokenInitializeAccount2Instruction';
                     }
-                    if (instruction.instructionType === 'initializeAccount3') {
+                    if (jsonParsedConfigs.instructionType === 'initializeAccount3') {
                         return 'SplTokenInitializeAccount3Instruction';
                     }
-                    if (instruction.instructionType === 'initializeMultisig') {
+                    if (jsonParsedConfigs.instructionType === 'initializeMultisig') {
                         return 'SplTokenInitializeMultisigInstruction';
                     }
-                    if (instruction.instructionType === 'initializeMultisig2') {
+                    if (jsonParsedConfigs.instructionType === 'initializeMultisig2') {
                         return 'SplTokenInitializeMultisig2Instruction';
                     }
-                    if (instruction.instructionType === 'transfer') {
+                    if (jsonParsedConfigs.instructionType === 'transfer') {
                         return 'SplTokenTransferInstruction';
                     }
-                    if (instruction.instructionType === 'approve') {
+                    if (jsonParsedConfigs.instructionType === 'approve') {
                         return 'SplTokenApproveInstruction';
                     }
-                    if (instruction.instructionType === 'revoke') {
+                    if (jsonParsedConfigs.instructionType === 'revoke') {
                         return 'SplTokenRevokeInstruction';
                     }
-                    if (instruction.instructionType === 'setAuthority') {
+                    if (jsonParsedConfigs.instructionType === 'setAuthority') {
                         return 'SplTokenSetAuthorityInstruction';
                     }
-                    if (instruction.instructionType === 'mintTo') {
+                    if (jsonParsedConfigs.instructionType === 'mintTo') {
                         return 'SplTokenMintToInstruction';
                     }
-                    if (instruction.instructionType === 'burn') {
+                    if (jsonParsedConfigs.instructionType === 'burn') {
                         return 'SplTokenBurnInstruction';
                     }
-                    if (instruction.instructionType === 'closeAccount') {
+                    if (jsonParsedConfigs.instructionType === 'closeAccount') {
                         return 'SplTokenCloseAccountInstruction';
                     }
-                    if (instruction.instructionType === 'freezeAccount') {
+                    if (jsonParsedConfigs.instructionType === 'freezeAccount') {
                         return 'SplTokenFreezeAccountInstruction';
                     }
-                    if (instruction.instructionType === 'thawAccount') {
+                    if (jsonParsedConfigs.instructionType === 'thawAccount') {
                         return 'SplTokenThawAccountInstruction';
                     }
-                    if (instruction.instructionType === 'transferChecked') {
+                    if (jsonParsedConfigs.instructionType === 'transferChecked') {
                         return 'SplTokenTransferCheckedInstruction';
                     }
-                    if (instruction.instructionType === 'approveChecked') {
+                    if (jsonParsedConfigs.instructionType === 'approveChecked') {
                         return 'SplTokenApproveCheckedInstruction';
                     }
-                    if (instruction.instructionType === 'mintToChecked') {
+                    if (jsonParsedConfigs.instructionType === 'mintToChecked') {
                         return 'SplTokenMintToCheckedInstruction';
                     }
-                    if (instruction.instructionType === 'burnChecked') {
+                    if (jsonParsedConfigs.instructionType === 'burnChecked') {
                         return 'SplTokenBurnCheckedInstruction';
                     }
-                    if (instruction.instructionType === 'syncNative') {
+                    if (jsonParsedConfigs.instructionType === 'syncNative') {
                         return 'SplTokenSyncNativeInstruction';
                     }
-                    if (instruction.instructionType === 'getAccountDataSize') {
+                    if (jsonParsedConfigs.instructionType === 'getAccountDataSize') {
                         return 'SplTokenGetAccountDataSizeInstruction';
                     }
-                    if (instruction.instructionType === 'initializeImmutableOwner') {
+                    if (jsonParsedConfigs.instructionType === 'initializeImmutableOwner') {
                         return 'SplTokenInitializeImmutableOwnerInstruction';
                     }
-                    if (instruction.instructionType === 'amountToUiAmount') {
+                    if (jsonParsedConfigs.instructionType === 'amountToUiAmount') {
                         return 'SplTokenAmountToUiAmountInstruction';
                     }
-                    if (instruction.instructionType === 'uiAmountToAmount') {
+                    if (jsonParsedConfigs.instructionType === 'uiAmountToAmount') {
                         return 'SplTokenUiAmountToAmountInstruction';
                     }
-                    if (instruction.instructionType === 'initializeMintCloseAuthority') {
+                    if (jsonParsedConfigs.instructionType === 'initializeMintCloseAuthority') {
                         return 'SplTokenInitializeMintCloseAuthorityInstruction';
                     }
                 }
-                if (instruction.programName === 'stake') {
-                    if (instruction.instructionType === 'initialize') {
+                if (jsonParsedConfigs.programName === 'stake') {
+                    if (jsonParsedConfigs.instructionType === 'initialize') {
                         return 'StakeInitializeInstruction';
                     }
-                    if (instruction.instructionType === 'authorize') {
+                    if (jsonParsedConfigs.instructionType === 'authorize') {
                         return 'StakeAuthorizeInstruction';
                     }
-                    if (instruction.instructionType === 'delegate') {
+                    if (jsonParsedConfigs.instructionType === 'delegate') {
                         return 'StakeDelegateStakeInstruction';
                     }
-                    if (instruction.instructionType === 'split') {
+                    if (jsonParsedConfigs.instructionType === 'split') {
                         return 'StakeSplitInstruction';
                     }
-                    if (instruction.instructionType === 'withdraw') {
+                    if (jsonParsedConfigs.instructionType === 'withdraw') {
                         return 'StakeWithdrawInstruction';
                     }
-                    if (instruction.instructionType === 'deactivate') {
+                    if (jsonParsedConfigs.instructionType === 'deactivate') {
                         return 'StakeDeactivateInstruction';
                     }
-                    if (instruction.instructionType === 'setLockup') {
+                    if (jsonParsedConfigs.instructionType === 'setLockup') {
                         return 'StakeSetLockupInstruction';
                     }
-                    if (instruction.instructionType === 'merge') {
+                    if (jsonParsedConfigs.instructionType === 'merge') {
                         return 'StakeMergeInstruction';
                     }
-                    if (instruction.instructionType === 'authorizeWithSeed') {
+                    if (jsonParsedConfigs.instructionType === 'authorizeWithSeed') {
                         return 'StakeAuthorizeWithSeedInstruction';
                     }
-                    if (instruction.instructionType === 'initializeChecked') {
+                    if (jsonParsedConfigs.instructionType === 'initializeChecked') {
                         return 'StakeInitializeCheckedInstruction';
                     }
-                    if (instruction.instructionType === 'authorizeChecked') {
+                    if (jsonParsedConfigs.instructionType === 'authorizeChecked') {
                         return 'StakeAuthorizeCheckedInstruction';
                     }
-                    if (instruction.instructionType === 'authorizeCheckedWithSeed') {
+                    if (jsonParsedConfigs.instructionType === 'authorizeCheckedWithSeed') {
                         return 'StakeAuthorizeCheckedWithSeedInstruction';
                     }
-                    if (instruction.instructionType === 'setLockupChecked') {
+                    if (jsonParsedConfigs.instructionType === 'setLockupChecked') {
                         return 'StakeSetLockupCheckedInstruction';
                     }
-                    if (instruction.instructionType === 'deactivateDelinquent') {
+                    if (jsonParsedConfigs.instructionType === 'deactivateDelinquent') {
                         return 'StakeDeactivateDelinquentInstruction';
                     }
-                    if (instruction.instructionType === 'redelegate') {
+                    if (jsonParsedConfigs.instructionType === 'redelegate') {
                         return 'StakeRedelegateInstruction';
                     }
                 }
-                if (instruction.programName === 'system') {
-                    if (instruction.instructionType === 'createAccount') {
+                if (jsonParsedConfigs.programName === 'system') {
+                    if (jsonParsedConfigs.instructionType === 'createAccount') {
                         return 'CreateAccountInstruction';
                     }
-                    if (instruction.instructionType === 'assign') {
+                    if (jsonParsedConfigs.instructionType === 'assign') {
                         return 'AssignInstruction';
                     }
-                    if (instruction.instructionType === 'transfer') {
+                    if (jsonParsedConfigs.instructionType === 'transfer') {
                         return 'TransferInstruction';
                     }
-                    if (instruction.instructionType === 'createAccountWithSeed') {
+                    if (jsonParsedConfigs.instructionType === 'createAccountWithSeed') {
                         return 'CreateAccountWithSeedInstruction';
                     }
-                    if (instruction.instructionType === 'advanceNonceAccount') {
+                    if (jsonParsedConfigs.instructionType === 'advanceNonceAccount') {
                         return 'AdvanceNonceAccountInstruction';
                     }
-                    if (instruction.instructionType === 'withdrawNonceAccount') {
+                    if (jsonParsedConfigs.instructionType === 'withdrawNonceAccount') {
                         return 'WithdrawNonceAccountInstruction';
                     }
-                    if (instruction.instructionType === 'initializeNonceAccount') {
+                    if (jsonParsedConfigs.instructionType === 'initializeNonceAccount') {
                         return 'InitializeNonceAccountInstruction';
                     }
-                    if (instruction.instructionType === 'authorizeNonceAccount') {
+                    if (jsonParsedConfigs.instructionType === 'authorizeNonceAccount') {
                         return 'AuthorizeNonceAccountInstruction';
                     }
-                    if (instruction.instructionType === 'upgradeNonceAccount') {
+                    if (jsonParsedConfigs.instructionType === 'upgradeNonceAccount') {
                         return 'UpgradeNonceAccountInstruction';
                     }
-                    if (instruction.instructionType === 'allocate') {
+                    if (jsonParsedConfigs.instructionType === 'allocate') {
                         return 'AllocateInstruction';
                     }
-                    if (instruction.instructionType === 'allocateWithSeed') {
+                    if (jsonParsedConfigs.instructionType === 'allocateWithSeed') {
                         return 'AllocateWithSeedInstruction';
                     }
-                    if (instruction.instructionType === 'assignWithSeed') {
+                    if (jsonParsedConfigs.instructionType === 'assignWithSeed') {
                         return 'AssignWithSeedInstruction';
                     }
-                    if (instruction.instructionType === 'transferWithSeed') {
+                    if (jsonParsedConfigs.instructionType === 'transferWithSeed') {
                         return 'TransferWithSeedInstruction';
                     }
                 }
-                if (instruction.programName === 'vote') {
-                    if (instruction.instructionType === 'initialize') {
+                if (jsonParsedConfigs.programName === 'vote') {
+                    if (jsonParsedConfigs.instructionType === 'initialize') {
                         return 'VoteInitializeAccountInstruction';
                     }
-                    if (instruction.instructionType === 'authorize') {
+                    if (jsonParsedConfigs.instructionType === 'authorize') {
                         return 'VoteAuthorizeInstruction';
                     }
-                    if (instruction.instructionType === 'authorizeWithSeed') {
+                    if (jsonParsedConfigs.instructionType === 'authorizeWithSeed') {
                         return 'VoteAuthorizeWithSeedInstruction';
                     }
-                    if (instruction.instructionType === 'authorizeCheckedWithSeed') {
+                    if (jsonParsedConfigs.instructionType === 'authorizeCheckedWithSeed') {
                         return 'VoteAuthorizeCheckedWithSeedInstruction';
                     }
-                    if (instruction.instructionType === 'vote') {
+                    if (jsonParsedConfigs.instructionType === 'vote') {
                         return 'VoteVoteInstruction';
                     }
-                    if (instruction.instructionType === 'updatevotestate') {
+                    if (jsonParsedConfigs.instructionType === 'updatevotestate') {
                         return 'VoteUpdateVoteStateInstruction';
                     }
-                    if (instruction.instructionType === 'updatevotestateswitch') {
+                    if (jsonParsedConfigs.instructionType === 'updatevotestateswitch') {
                         return 'VoteUpdateVoteStateSwitchInstruction';
                     }
-                    if (instruction.instructionType === 'compactupdatevotestate') {
+                    if (jsonParsedConfigs.instructionType === 'compactupdatevotestate') {
                         return 'VoteCompactUpdateVoteStateInstruction';
                     }
-                    if (instruction.instructionType === 'compactupdatevotestateswitch') {
+                    if (jsonParsedConfigs.instructionType === 'compactupdatevotestateswitch') {
                         return 'VoteCompactUpdateVoteStateSwitchInstruction';
                     }
-                    if (instruction.instructionType === 'withdraw') {
+                    if (jsonParsedConfigs.instructionType === 'withdraw') {
                         return 'VoteWithdrawInstruction';
                     }
-                    if (instruction.instructionType === 'updateValidatorIdentity') {
+                    if (jsonParsedConfigs.instructionType === 'updateValidatorIdentity') {
                         return 'VoteUpdateValidatorIdentityInstruction';
                     }
-                    if (instruction.instructionType === 'updateCommission') {
+                    if (jsonParsedConfigs.instructionType === 'updateCommission') {
                         return 'VoteUpdateCommissionInstruction';
                     }
-                    if (instruction.instructionType === 'voteSwitch') {
+                    if (jsonParsedConfigs.instructionType === 'voteSwitch') {
                         return 'VoteVoteSwitchInstruction';
                     }
-                    if (instruction.instructionType === 'authorizeChecked') {
+                    if (jsonParsedConfigs.instructionType === 'authorizeChecked') {
                         return 'VoteAuthorizeCheckedInstruction';
                     }
                 }
@@ -648,21 +676,25 @@ export const instructionResolvers = {
     },
     VoteAuthorizeCheckedInstruction: {
         authority: resolveAccount('authority'),
+        clockSysvar: resolveAccount('clockSysvar'),
         newAuthority: resolveAccount('newAuthority'),
         voteAccount: resolveAccount('voteAccount'),
     },
     VoteAuthorizeCheckedWithSeedInstruction: {
         authorityOwner: resolveAccount('authorityOwner'),
+        clockSysvar: resolveAccount('clockSysvar'),
         newAuthority: resolveAccount('newAuthority'),
         voteAccount: resolveAccount('voteAccount'),
     },
     VoteAuthorizeInstruction: {
         authority: resolveAccount('authority'),
+        clockSysvar: resolveAccount('clockSysvar'),
         newAuthority: resolveAccount('newAuthority'),
         voteAccount: resolveAccount('voteAccount'),
     },
     VoteAuthorizeWithSeedInstruction: {
         authorityOwner: resolveAccount('authorityOwner'),
+        clockSysvar: resolveAccount('clockSysvar'),
         newAuthority: resolveAccount('newAuthority'),
         voteAccount: resolveAccount('voteAccount'),
     },
@@ -677,7 +709,10 @@ export const instructionResolvers = {
     VoteInitializeAccountInstruction: {
         authorizedVoter: resolveAccount('authorizedVoter'),
         authorizedWithdrawer: resolveAccount('authorizedWithdrawer'),
+        clockSysvar: resolveAccount('clockSysvar'),
         node: resolveAccount('node'),
+
+        rentSysvar: resolveAccount('rentSysvar'),
         voteAccount: resolveAccount('voteAccount'),
     },
     VoteUpdateCommissionInstruction: {
@@ -686,6 +721,7 @@ export const instructionResolvers = {
     },
     VoteUpdateValidatorIdentityInstruction: {
         newValidatorIdentity: resolveAccount('newValidatorIdentity'),
+
         voteAccount: resolveAccount('voteAccount'),
         withdrawAuthority: resolveAccount('withdrawAuthority'),
     },
@@ -698,10 +734,14 @@ export const instructionResolvers = {
         voteAuthority: resolveAccount('voteAuthority'),
     },
     VoteVoteInstruction: {
+        clockSysvar: resolveAccount('clockSysvar'),
+        slotHashesSysvar: resolveAccount('slotHashesSysvar'),
         voteAccount: resolveAccount('voteAccount'),
         voteAuthority: resolveAccount('voteAuthority'),
     },
     VoteVoteSwitchInstruction: {
+        clockSysvar: resolveAccount('clockSysvar'),
+        slotHashesSysvar: resolveAccount('slotHashesSysvar'),
         voteAccount: resolveAccount('voteAccount'),
         voteAuthority: resolveAccount('voteAuthority'),
     },
@@ -713,5 +753,7 @@ export const instructionResolvers = {
         destination: resolveAccount('destination'),
         nonceAccount: resolveAccount('nonceAccount'),
         nonceAuthority: resolveAccount('nonceAuthority'),
+        recentBlockhashesSysvar: resolveAccount('recentBlockhashesSysvar'),
+        rentSysvar: resolveAccount('rentSysvar'),
     },
 };

--- a/packages/rpc-graphql/src/resolvers/resolve-info/index.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/index.ts
@@ -1,3 +1,4 @@
 export * from './account';
 export * from './program-accounts';
+export * from './transaction';
 export * from './visitor';

--- a/packages/rpc-graphql/src/resolvers/resolve-info/transaction.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/transaction.ts
@@ -1,0 +1,81 @@
+import { Signature } from '@solana/keys';
+import { Commitment, Slot } from '@solana/rpc-types';
+import { ArgumentNode, GraphQLResolveInfo } from 'graphql';
+
+import { TransactionLoaderArgs } from '../../loaders';
+import { injectableRootVisitor } from './visitor';
+
+function findArgumentNodeByName(argumentNodes: readonly ArgumentNode[], name: string): ArgumentNode | undefined {
+    return argumentNodes.find(argumentNode => argumentNode.name.value === name);
+}
+
+export function parseTransactionEncodingArgument(
+    argumentNodes: readonly ArgumentNode[],
+    variableValues: {
+        [variable: string]: unknown;
+    },
+): TransactionLoaderArgs['encoding'] | undefined {
+    const argumentNode = findArgumentNodeByName(argumentNodes, 'encoding');
+    if (argumentNode) {
+        if (argumentNode.value.kind === 'EnumValue') {
+            if (argumentNode.value.value === 'BASE_58') {
+                return 'base58';
+            }
+            if (argumentNode.value.value === 'BASE_64') {
+                return 'base64';
+            }
+        }
+        if (argumentNode.value.kind === 'Variable') {
+            return variableValues[argumentNode.value.name.value] as TransactionLoaderArgs['encoding'];
+        }
+    } else {
+        return undefined;
+    }
+}
+
+/**
+ * Build a set of transaction loader args by inspecting which fields have
+ * been requested in the query (ie. `data` or inline fragments).
+ */
+export function buildTransactionLoaderArgSetFromResolveInfo(
+    args: {
+        commitment?: Omit<Commitment, 'processed'>;
+        minContextSlot?: Slot;
+        signature: Signature;
+    },
+    info: GraphQLResolveInfo,
+): TransactionLoaderArgs[] {
+    const argSet: TransactionLoaderArgs[] = [args];
+
+    function buildArgSetWithVisitor(root: Parameters<typeof injectableRootVisitor>[1]) {
+        injectableRootVisitor(info, root, {
+            fieldNodeOperation(info, node) {
+                if (node.name.value === 'message' || node.name.value === 'meta') {
+                    argSet.push({ ...args, encoding: 'jsonParsed' });
+                } else if (node.name.value === 'data') {
+                    // At least `encoding` is required on the `data` field.
+                    if (node.arguments) {
+                        const { variableValues } = info;
+                        const encoding: TransactionLoaderArgs['encoding'] = parseTransactionEncodingArgument(
+                            node.arguments,
+                            variableValues,
+                        );
+                        argSet.push({ ...args, encoding });
+                    }
+                }
+            },
+            fragmentSpreadNodeOperation(_info, fragment) {
+                buildArgSetWithVisitor(fragment);
+            },
+            inlineFragmentNodeOperation(_info, _node) {
+                // Transaction schema doesn't support inline fragments at the
+                // root level.
+                return;
+            },
+        });
+    }
+
+    buildArgSetWithVisitor(null);
+
+    return argSet;
+}

--- a/packages/rpc-graphql/src/resolvers/types.ts
+++ b/packages/rpc-graphql/src/resolvers/types.ts
@@ -54,6 +54,10 @@ export const typeTypeResolvers = {
         FINALIZED: 'finalized',
         PROCESSED: 'processed',
     },
+    CommitmentWithoutProcessed: {
+        CONFIRMED: 'confirmed',
+        FINALIZED: 'finalized',
+    },
     Signature: stringScalarAlias,
     Slot: bigIntScalarAlias,
     TokenBalance: {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -115,12 +115,12 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         authority: Account
         bufferAccount: Account
-        clockSysvar: Address
+        clockSysvar: Account
         maxDataLen: BigInt
         payerAccount: Account
         programAccount: Account
         programDataAccount: Account
-        rentSysvar: Address
+        rentSysvar: Account
     }
 
     """
@@ -130,10 +130,10 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         authority: Account
         bufferAccount: Account
-        clockSysvar: Address
+        clockSysvar: Account
         programAccount: Account
         programDataAccount: Account
-        rentSysvar: Address
+        rentSysvar: Account
         spillAccount: Account
     }
 
@@ -186,7 +186,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     type SplAssociatedTokenCreateInstruction implements TransactionInstruction {
         programId: Address
         account: Account
-        mint: Address
+        mint: Account
         source: Account
         systemProgram: Account
         tokenProgram: Account
@@ -199,7 +199,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     type SplAssociatedTokenCreateIdempotentInstruction implements TransactionInstruction {
         programId: Address
         account: Account
-        mint: Address
+        mint: Account
         source: Account
         systemProgram: Account
         tokenProgram: Account
@@ -237,7 +237,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         freezeAuthority: Account
         mint: Account
         mintAuthority: Account
-        rentSysvar: Address
+        rentSysvar: Account
     }
 
     """
@@ -259,7 +259,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         account: Account
         mint: Account
         owner: Account
-        rentSysvar: Address
+        rentSysvar: Account
     }
 
     """
@@ -270,7 +270,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         account: Account
         mint: Account
         owner: Account
-        rentSysvar: Address
+        rentSysvar: Account
     }
 
     """
@@ -290,7 +290,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         m: BigInt # FIXME:*
         multisig: Account
-        rentSysvar: Address
+        rentSysvar: Account
         signers: [Address]
     }
 
@@ -545,7 +545,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         authorized: StakeInitializeInstructionDataAuthorized
         lockup: Lockup
-        rentSysvar: Address
+        rentSysvar: Account
         stakeAccount: Account
     }
 
@@ -556,7 +556,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         authority: Account
         authorityType: String
-        clockSysvar: Address
+        clockSysvar: Account
         custodian: Account
         newAuthority: Account
         stakeAccount: Account
@@ -567,11 +567,11 @@ export const instructionTypeDefs = /* GraphQL */ `
     """
     type StakeDelegateStakeInstruction implements TransactionInstruction {
         programId: Address
-        clockSysvar: Address
+        clockSysvar: Account
         stakeAccount: Account
         stakeAuthority: Account
         stakeConfigAccount: Account
-        stakeHistorySysvar: Address
+        stakeHistorySysvar: Account
         voteAccount: Account
     }
 
@@ -591,7 +591,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     """
     type StakeWithdrawInstruction implements TransactionInstruction {
         programId: Address
-        clockSysvar: Address
+        clockSysvar: Account
         destination: Account
         lamports: BigInt
         stakeAccount: Account
@@ -603,7 +603,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     """
     type StakeDeactivateInstruction implements TransactionInstruction {
         programId: Address
-        clockSysvar: Address
+        clockSysvar: Account
         stakeAccount: Account
         stakeAuthority: Account
     }
@@ -623,11 +623,11 @@ export const instructionTypeDefs = /* GraphQL */ `
     """
     type StakeMergeInstruction implements TransactionInstruction {
         programId: Address
-        clockSysvar: Address
+        clockSysvar: Account
         destination: Account
         source: Account
         stakeAuthority: Account
-        stakeHistorySysvar: Address
+        stakeHistorySysvar: Account
     }
 
     """
@@ -639,7 +639,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         authorityOwner: Account
         authoritySeed: String
         authorityType: String
-        clockSysvar: Address
+        clockSysvar: Account
         custodian: Account
         newAuthorized: Account
         stakeAccount: Account
@@ -656,7 +656,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         authorized: StakeInitializeCheckedInstructionDataAuthorized
         lockup: Lockup
-        rentSysvar: Address
+        rentSysvar: Account
         stakeAccount: Account
     }
 
@@ -667,7 +667,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         authority: Account
         authorityType: String
-        clockSysvar: Address
+        clockSysvar: Account
         custodian: Account
         newAuthority: Account
         stakeAccount: Account
@@ -682,7 +682,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         authorityOwner: Account
         authoritySeed: String
         authorityType: String
-        clockSysvar: Address
+        clockSysvar: Account
         custodian: Account
         newAuthorized: Account
         stakeAccount: Account
@@ -770,7 +770,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         nonceAccount: Account
         nonceAuthority: Account
-        recentBlockhashesSysvar: Address
+        recentBlockhashesSysvar: Account
     }
 
     """
@@ -782,8 +782,8 @@ export const instructionTypeDefs = /* GraphQL */ `
         lamports: BigInt
         nonceAccount: Account
         nonceAuthority: Account
-        recentBlockhashesSysvar: Address
-        rentSysvar: Address
+        recentBlockhashesSysvar: Account
+        rentSysvar: Account
     }
 
     """
@@ -793,8 +793,8 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         nonceAccount: Account
         nonceAuthority: Account
-        recentBlockhashesSysvar: Address
-        rentSysvar: Address
+        recentBlockhashesSysvar: Account
+        rentSysvar: Account
     }
 
     """
@@ -868,10 +868,10 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         authorizedVoter: Account
         authorizedWithdrawer: Account
-        clockSysvar: Address
+        clockSysvar: Account
         commission: BigInt # FIXME:*
         node: Account
-        rentSysvar: Address
+        rentSysvar: Account
         voteAccount: Account
     }
 
@@ -882,7 +882,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         authority: Account
         authorityType: String
-        clockSysvar: Address
+        clockSysvar: Account
         newAuthority: Account
         voteAccount: Account
     }
@@ -896,7 +896,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         authorityOwner: Account
         authoritySeed: String
         authorityType: String
-        clockSysvar: Address
+        clockSysvar: Account
         newAuthority: Account
         voteAccount: Account
     }
@@ -910,7 +910,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         authorityOwner: Account
         authoritySeed: String
         authorityType: String
-        clockSysvar: Address
+        clockSysvar: Account
         newAuthority: Account
         voteAccount: Account
     }
@@ -926,8 +926,8 @@ export const instructionTypeDefs = /* GraphQL */ `
     """
     type VoteVoteInstruction implements TransactionInstruction {
         programId: Address
-        clockSysvar: Address
-        slotHashesSysvar: Address
+        clockSysvar: Account
+        slotHashesSysvar: Account
         vote: Vote
         voteAccount: Account
         voteAuthority: Account
@@ -1024,9 +1024,9 @@ export const instructionTypeDefs = /* GraphQL */ `
     """
     type VoteVoteSwitchInstruction implements TransactionInstruction {
         programId: Address
-        clockSysvar: Address
+        clockSysvar: Account
         hash: String
-        slotHashesSysvar: Address
+        slotHashesSysvar: Account
         vote: Vote
         voteAccount: Account
         voteAuthority: Account
@@ -1039,7 +1039,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         authority: Account
         authorityType: String
-        clockSysvar: Address
+        clockSysvar: Account
         newAuthority: Account
         voteAccount: Account
     }

--- a/packages/rpc-graphql/src/schema/root.ts
+++ b/packages/rpc-graphql/src/schema/root.ts
@@ -13,7 +13,7 @@ export const rootTypeDefs = /* GraphQL */ `
             filters: [ProgramAccountsFilter]
             minContextSlot: Slot
         ): [Account]
-        transaction(signature: Signature!, commitment: Commitment, encoding: TransactionEncoding): Transaction
+        transaction(signature: Signature!, commitment: CommitmentWithoutProcessed): Transaction
     }
 
     schema {

--- a/packages/rpc-graphql/src/schema/transaction.ts
+++ b/packages/rpc-graphql/src/schema/transaction.ts
@@ -62,49 +62,15 @@ export const transactionTypeDefs = /* GraphQL */ `
     }
 
     """
-    Transaction interface
+    A Solana transaction
     """
-    interface Transaction {
+    type Transaction {
         blockTime: BigInt
-        meta: TransactionMeta
-        slot: BigInt
-        version: String
-    }
-
-    """
-    A transaction with base58 encoded data
-    """
-    type TransactionBase58 implements Transaction {
-        blockTime: BigInt
-        data: Base58EncodedBytes
-        meta: TransactionMeta
-        slot: BigInt
-        version: String
-    }
-
-    """
-    A transaction with base64 encoded data
-    """
-    type TransactionBase64 implements Transaction {
-        blockTime: BigInt
-        data: Base64EncodedBytes
-        meta: TransactionMeta
-        slot: BigInt
-        version: String
-    }
-
-    """
-    A transaction with JSON encoded data
-    """
-    type TransactionDataParsed {
+        data(encoding: TransactionEncoding!): String
         message: TransactionMessage
-        signatures: [String]
-    }
-    type TransactionParsed implements Transaction {
-        blockTime: BigInt
-        data: TransactionDataParsed
         meta: TransactionMeta
-        slot: BigInt
+        signatures: [Signature]
+        slot: Slot
         version: String
     }
 `;

--- a/packages/rpc-graphql/src/schema/types.ts
+++ b/packages/rpc-graphql/src/schema/types.ts
@@ -28,6 +28,11 @@ export const typeTypeDefs = /* GraphQL */ `
         PROCESSED
     }
 
+    enum CommitmentWithoutProcessed {
+        CONFIRMED
+        FINALIZED
+    }
+
     input DataSlice {
         offset: Int!
         length: Int!


### PR DESCRIPTION
Similar to the previous commit, adding a request coalescer for transactions.
However, here the schema is also modified to be much simpler, allowing for
`data` field queries directly - similar to accounts - and shedding any
unnecessary object structure from the RPC default.
