### PR TITLE
refactor(experimental): graphql: block makeover

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1655,39 +1655,6 @@ export const mockBlockFull = {
     ],
 };
 
-export const mockBlockAccounts = {
-    blockHeight: 257317189,
-    blockTime: 1699618066,
-    blockhash: 'bFotro8geZ9HJbE3SUJ77yQuCaECpRidocDapgM2BNW',
-    parentSlot: 257317188,
-    previousBlockhash: '3Z3gk6nNq8qRq6JnV8o9Xh7s7P8Q4qY4v9dZ5XnJzGtM',
-    rewards: mockRewards,
-    transactions: [
-        {
-            meta: {
-                fee: 5000,
-                postBalances: [1000000000000000, 1],
-                postTokenBalances: [],
-                preBalances: [1000000000000000, 1],
-                preTokenBalances: [],
-                status: {
-                    Ok: null,
-                },
-            },
-            transaction: {
-                accountKeys: [
-                    '2gZDNztVterZb7aSMifCRd4V15YY8a9QcBBQ3ARTDe95',
-                    'GGLDv8wTrSNuEq1pBhUfDFYEKFXDsvFU7YHkMj7a1EyK',
-                ],
-                signatures: [
-                    '41TfwbZi3WV5NJ7BY42r9sSkCUNfA7ab3j744DXR2wxZG9FyfctAoMYVYpQDj4je3xo89W7cvqGMzAq1nxd8R4xx',
-                    '2FaeinN3wGnytjrEZkP1KULaF24jrTHbD52TYowyErEfuhvavwRcLensJyiRicqEPKEaiBCzxn1BpR5Yi8BCYrhK',
-                ],
-            },
-        },
-    ],
-};
-
 export const mockBlockSignatures = {
     blockHeight: 257317189,
     blockTime: 1699618066,
@@ -1698,36 +1665,5 @@ export const mockBlockSignatures = {
     signatures: [
         '3mjQHJqKBrWe2LnUYsx3a7Vr68qQHCW1ru2m2ycuiFfcihcpXdQ7KqKrjqKyQkmN5jjcvMeBvJDsSTiaXzoSWXSF',
         '2Tfh6G4R9cxdtFDbCvnNR9QKjJX8o19ux4WwYiZsx9xRcAKKmZg88BqgQRJf2mrZBj1PuTPVCspWTDqqaNZAdsPJ',
-    ],
-};
-
-export const mockBlockNone = {
-    blockHeight: 257317189,
-    blockTime: 1699618066,
-    blockhash: 'bFotro8geZ9HJbE3SUJ77yQuCaECpRidocDapgM2BNW',
-    parentSlot: 257317188,
-    previousBlockhash: '3Z3gk6nNq8qRq6JnV8o9Xh7s7P8Q4qY4v9dZ5XnJzGtM',
-    rewards: [
-        {
-            commission: 0.1,
-            lamports: 50000,
-            postBalance: 1000000000000000,
-            pubkey: 'DdNzYKnkq7PqCRX4kncvwVYNZE7dZ9xdCz6yMekqjWH4',
-            rewardType: 'stake',
-        },
-        {
-            commission: 0.1,
-            lamports: 50000,
-            postBalance: 1000000000000000,
-            pubkey: 'DdNzYKnkq7PqCRX4kncvwVYNZE7dZ9xdCz6yMekqjWH4',
-            rewardType: 'stake',
-        },
-        {
-            commission: 0.1,
-            lamports: 50000,
-            postBalance: 1000000000000000,
-            pubkey: 'DdNzYKnkq7PqCRX4kncvwVYNZE7dZ9xdCz6yMekqjWH4',
-            rewardType: 'stake',
-        },
     ],
 };

--- a/packages/rpc-graphql/src/loaders/__tests__/block-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/block-loader-test.ts
@@ -27,7 +27,7 @@ describe('account loader', () => {
         };
         rpcGraphQL = createRpcGraphQL(rpc);
     });
-    describe('cache tests', () => {
+    describe('cached responses', () => {
         it('coalesces multiple requests for the same block into one', async () => {
             expect.assertions(1);
             const source = /* GraphQL */ `
@@ -66,6 +66,452 @@ describe('account loader', () => {
             await Promise.resolve();
             jest.runAllTimers();
             expect(rpc.getBlock).toHaveBeenCalledTimes(2);
+        });
+    });
+    describe('batch loading', () => {
+        describe('request partitioning', () => {
+            it('coalesces multiple requests for the same block but different fields into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block1: block(slot: $slot) {
+                            blockhash
+                        }
+                        block2: block(slot: $slot) {
+                            blockTime
+                        }
+                        block3: block(slot: $slot) {
+                            previousBlockhash
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'none',
+                });
+            });
+            it('coalesces multiple requests for the same block but one with specified `confirmed` commitment into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block1: block(slot: $slot) {
+                            blockhash
+                        }
+                        block2: block(slot: $slot, commitment: CONFIRMED) {
+                            blockhash
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'none',
+                });
+            });
+            it('will not coalesce multiple requests for the same block but with different commitments into one request', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block1: block(slot: $slot) {
+                            blockhash
+                        }
+                        block2: block(slot: $slot, commitment: CONFIRMED) {
+                            blockhash
+                        }
+                        block3: block(slot: $slot, commitment: FINALIZED) {
+                            blockhash
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(2);
+                expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                    commitment: 'confirmed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'none',
+                });
+                expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                    commitment: 'finalized',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'none',
+                });
+            });
+        });
+        describe('encoding requests', () => {
+            it('does not use `jsonParsed` if no parsed type is queried', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            blockhash
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'none',
+                });
+            });
+            it('uses only `base58` if one data field is requested with `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            transactions {
+                                data(encoding: BASE_58)
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+            });
+            it('uses only `base64` if one data field is requested with `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            transactions {
+                                data(encoding: BASE_64)
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+            });
+            it('only uses `jsonParsed` if a parsed type is queried, but data is not', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            transactions {
+                                message {
+                                    recentBlockhash
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+            });
+            it('does not call the loader twice for other base fields and `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            blockhash
+                            transactions {
+                                data(encoding: BASE_58)
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+            });
+            it('does not call the loader twice for other base fields and `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            blockhash
+                            transactions {
+                                data(encoding: BASE_64)
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+            });
+            it('does not call the loader twice for other base fields and inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            transactions {
+                                message {
+                                    recentBlockhash
+                                    instructions {
+                                        ... on GenericInstruction {
+                                            programId
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+            });
+            it('will not make multiple calls for more than one inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            transactions {
+                                message {
+                                    recentBlockhash
+                                    instructions {
+                                        ... on GenericInstruction {
+                                            programId
+                                        }
+                                        ... on CreateLookupTableInstruction {
+                                            programId
+                                        }
+                                        ... on CloseLookupTableInstruction {
+                                            programId
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+            });
+            it('uses `jsonParsed` and the requested data encoding if a parsed type is queried alongside encoded data', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            transactions {
+                                data(encoding: BASE_64)
+                                message {
+                                    recentBlockhash
+                                    instructions {
+                                        ... on GenericInstruction {
+                                            programId
+                                        }
+                                        ... on CreateLookupTableInstruction {
+                                            programId
+                                        }
+                                        ... on CloseLookupTableInstruction {
+                                            programId
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(2);
+                expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+                expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+            });
+            it('uses only the number of requests for the number of different encodings requested', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            transactions {
+                                dataBase58: data(encoding: BASE_58)
+                                dataBase64: data(encoding: BASE_64)
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(2);
+                expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+                expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+            });
+        });
+        describe('signatures-only requests', () => {
+            it('uses only `signatures` if the `signatures` field is requested', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            signatures
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'signatures',
+                });
+            });
+            it('uses only `signatures` if the `signatures` field is requested with other fields', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            blockhash
+                            blockTime
+                            signatures
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+                expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                    commitment: 'confirmed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'signatures',
+                });
+            });
+            it('will call once for `signatures` as well as once per encoding', async () => {
+                expect.assertions(4);
+                const source = /* GraphQL */ `
+                    query testQuery($slot: Slot!) {
+                        block(slot: $slot) {
+                            blockhash
+                            blockTime
+                            signatures
+                            transactions {
+                                dataBase58: data(encoding: BASE_58)
+                                dataBase64: data(encoding: BASE_64)
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { slot });
+                // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+                await Promise.resolve();
+                jest.runAllTimers();
+                expect(rpc.getBlock).toHaveBeenCalledTimes(3);
+                expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+                expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                });
+                expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                    commitment: 'confirmed',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'signatures',
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/loaders/block.ts
+++ b/packages/rpc-graphql/src/loaders/block.ts
@@ -1,25 +1,8 @@
 import type { GetBlockApi, Rpc } from '@solana/rpc';
 import DataLoader from 'dataloader';
 
-import { BlockLoader, BlockLoaderArgs, BlockLoaderValue, cacheKeyFn } from './loader';
-
-function applyDefaultArgs({
-    slot,
-    commitment,
-    encoding = 'jsonParsed',
-    maxSupportedTransactionVersion = 0,
-    rewards,
-    transactionDetails = 'full',
-}: BlockLoaderArgs): BlockLoaderArgs {
-    return {
-        commitment,
-        encoding,
-        maxSupportedTransactionVersion,
-        rewards,
-        slot,
-        transactionDetails,
-    };
-}
+import { buildCoalescedFetchesByArgsHash, ToFetchMap } from './coalescer';
+import { BlockLoader, BlockLoaderArgs, BlockLoaderArgsBase, BlockLoaderValue, cacheKeyFn } from './loader';
 
 async function loadBlock(rpc: Rpc<GetBlockApi>, { slot, ...config }: BlockLoaderArgs): Promise<BlockLoaderValue> {
     // @ts-expect-error FIX ME: https://github.com/microsoft/TypeScript/issues/43187
@@ -34,14 +17,64 @@ async function loadBlock(rpc: Rpc<GetBlockApi>, { slot, ...config }: BlockLoader
 
 function createBlockBatchLoadFn(rpc: Rpc<GetBlockApi>) {
     const resolveBlockUsingRpc = loadBlock.bind(null, rpc);
-    return async (blockQueryArgs: readonly BlockLoaderArgs[]) =>
-        Promise.all(blockQueryArgs.map(async args => resolveBlockUsingRpc(applyDefaultArgs(args))));
+    return async (blockQueryArgs: readonly BlockLoaderArgs[]): ReturnType<BlockLoader['loadMany']> => {
+        /**
+         * Gather all the blocks that need to be fetched, grouped by slot.
+         */
+        const blocksToFetch: ToFetchMap<BlockLoaderArgsBase, BlockLoaderValue> = {};
+        try {
+            return Promise.all(blockQueryArgs.map(
+                ({ slot, ...args }) =>
+                    new Promise((resolve, reject) => {
+                        const blockRecords = (blocksToFetch[slot.toString()] ||= []);
+                        // Apply the default commitment level.
+                        if (!args.commitment) {
+                            args.commitment = 'confirmed';
+                        }
+                        blockRecords.push({ args, promiseCallback: { reject, resolve } });
+                    }),
+            )) as ReturnType<BlockLoader['loadMany']>;
+        } finally {
+            /**
+             * Group together blocks that are fetched with identical args.
+             */
+            const blockFetchesByArgsHash = buildCoalescedFetchesByArgsHash(blocksToFetch, {
+                criteria: (args: BlockLoaderArgsBase) =>
+                    args.encoding === undefined && args.transactionDetails !== 'signatures',
+                defaults: (args: BlockLoaderArgsBase) => ({
+                    ...args,
+                    transactionDetails: 'none' as BlockLoaderArgsBase['transactionDetails'],
+                }),
+                hashOmit: ['encoding', 'transactionDetails'],
+            });
+
+            /**
+             * For each set of blocks related to some common args, fetch them in the fewest number
+             * of network requests.
+             */
+            Object.values(blockFetchesByArgsHash).map(({ args, fetches: blockCallbacks }) => {
+                return Object.entries(blockCallbacks).map(([slot, { callbacks }]) => {
+                    return Array.from({ length: 1 }, async () => {
+                        try {
+                            const result = await resolveBlockUsingRpc({
+                                slot: BigInt(slot),
+                                ...args,
+                            });
+                            callbacks.forEach(c => c.resolve(result));
+                        } catch (e) {
+                            callbacks.forEach(c => c.reject(e));
+                        }
+                    });
+                });
+            });
+        }
+    };
 }
 
 export function createBlockLoader(rpc: Rpc<GetBlockApi>): BlockLoader {
     const loader = new DataLoader(createBlockBatchLoadFn(rpc), { cacheKeyFn });
     return {
-        load: async args => loader.load(applyDefaultArgs(args)),
-        loadMany: async args => loader.loadMany(args.map(applyDefaultArgs)),
+        load: async args => loader.load({ ...args, maxSupportedTransactionVersion: 0 }),
+        loadMany: async args => loader.loadMany(args.map(a => ({ ...a, maxSupportedTransactionVersion: 0 }))),
     };
 }

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -26,16 +26,14 @@ export type AccountLoaderArgs = { address: Address } & AccountLoaderArgsBase;
 export type AccountLoaderValue = ReturnType<GetAccountInfoApi['getAccountInfo']>['value'] | null;
 export type AccountLoader = Loader<AccountLoaderArgs, AccountLoaderValue>;
 
-// FIX ME: https://github.com/microsoft/TypeScript/issues/43187
-// export type BlockLoaderArgs = { slot: Parameters<GetBlockApi['getBlock']>[0] } & Parameters<GetBlockApi['getBlock']>[1];
-export type BlockLoaderArgs = {
+export type BlockLoaderArgsBase = {
     commitment?: Omit<Commitment, 'processed'>;
     encoding?: 'base58' | 'base64' | 'json' | 'jsonParsed';
     maxSupportedTransactionVersion?: 0 | 'legacy';
     rewards?: boolean;
-    slot: Slot;
     transactionDetails?: 'accounts' | 'full' | 'none' | 'signatures';
 };
+export type BlockLoaderArgs = { slot: Slot } & BlockLoaderArgsBase;
 export type BlockLoaderValue = ReturnType<GetBlockApi['getBlock']> | null;
 export type BlockLoader = Loader<BlockLoaderArgs, BlockLoaderValue>;
 

--- a/packages/rpc-graphql/src/resolvers/__tests__/block-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/block-resolver-test.ts
@@ -1,0 +1,185 @@
+import type {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
+import type { Slot } from '@solana/rpc-types';
+
+import { createRpcGraphQL, RpcGraphQL } from '../../index';
+
+describe('block resolver', () => {
+    let rpc: Rpc<GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi>;
+    let rpcGraphQL: RpcGraphQL;
+    // Random slot for testing.
+    // Not actually used. Just needed for proper query parsing.
+    const slot = 511226n as Slot;
+    beforeEach(() => {
+        jest.useFakeTimers();
+        rpc = {
+            getAccountInfo: jest.fn(),
+            getBlock: jest.fn(),
+            getMultipleAccounts: jest.fn(),
+            getProgramAccounts: jest.fn(),
+            getTransaction: jest.fn(),
+        };
+        rpcGraphQL = createRpcGraphQL(rpc);
+    });
+    describe('fragment spreads', () => {
+        it('will resolve fields from fragment spreads', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery($slot: Slot!) {
+                    block(slot: $slot) {
+                        ...GetBlockhash
+                    }
+                }
+                fragment GetBlockhash on Block {
+                    blockhash
+                }
+            `;
+            rpcGraphQL.query(source, { slot });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+            expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                commitment: 'confirmed',
+                maxSupportedTransactionVersion: 0,
+                transactionDetails: 'none',
+            });
+        });
+        it('will resolve fields from multiple fragment spreads', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery($slot: Slot!) {
+                    block(slot: $slot) {
+                        ...GetBlockhash
+                        ...GetParentSlot
+                    }
+                }
+                fragment GetBlockhash on Block {
+                    blockhash
+                }
+                fragment GetParentSlot on Block {
+                    parentSlot
+                }
+            `;
+            rpcGraphQL.query(source, { slot });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+            expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                commitment: 'confirmed',
+                maxSupportedTransactionVersion: 0,
+                transactionDetails: 'none',
+            });
+        });
+        it('will resolve fragment spreads with `jsonParsed` when `jsonParsed` fields are requested', async () => {
+            expect.assertions(2);
+            const source = /* GraphQL */ `
+                query testQuery($slot: Slot!) {
+                    block(slot: $slot) {
+                        transactions {
+                            message {
+                                instructions {
+                                    ...GetGenericInstructionData
+                                }
+                            }
+                        }
+                    }
+                }
+                fragment GetGenericInstructionData on TransactionInstruction {
+                    ... on GenericInstruction {
+                        data
+                    }
+                }
+            `;
+            rpcGraphQL.query(source, { slot });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+            expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+                maxSupportedTransactionVersion: 0,
+                transactionDetails: 'full',
+            });
+        });
+        it('will resolve fragment spreads with `jsonParsed` and the proper encoding when data and `jsonParsed` fields are requested', async () => {
+            expect.assertions(3);
+            const source = /* GraphQL */ `
+                query testQuery($slot: Slot!) {
+                    block(slot: $slot) {
+                        transactions {
+                            ...GetDataAndGenericInstructionData
+                        }
+                    }
+                }
+                fragment GetDataAndGenericInstructionData on Transaction {
+                    transactionData: data(encoding: BASE_58)
+                    message {
+                        instructions {
+                            ... on GenericInstruction {
+                                data
+                            }
+                        }
+                    }
+                }
+            `;
+            rpcGraphQL.query(source, { slot });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getBlock).toHaveBeenCalledTimes(2);
+            expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+                maxSupportedTransactionVersion: 0,
+                transactionDetails: 'full',
+            });
+            expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
+                commitment: 'confirmed',
+                encoding: 'base58',
+                maxSupportedTransactionVersion: 0,
+                transactionDetails: 'full',
+            });
+        });
+        it('will resolve fragment spreads with only the proper encoding not `jsonParsed` when no `jsonParsed` fields are requested', async () => {
+            expect.assertions(3);
+            const source = /* GraphQL */ `
+                query testQuery($slot: Slot!) {
+                    block(slot: $slot) {
+                        transactions {
+                            ...GetTransactionData
+                        }
+                    }
+                }
+                fragment GetTransactionData on Transaction {
+                    transactionData: data(encoding: BASE_58)
+                }
+            `;
+            rpcGraphQL.query(source, { slot });
+            // FIXME: Prefer async version of this timer runner. See https://github.com/jestjs/jest/issues/14549
+            await Promise.resolve();
+            jest.runAllTimers();
+            expect(rpc.getBlock).toHaveBeenCalledTimes(1);
+            expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
+                commitment: 'confirmed',
+                encoding: 'base58',
+                maxSupportedTransactionVersion: 0,
+                transactionDetails: 'full',
+            });
+            expect(rpc.getBlock).not.toHaveBeenCalledWith(slot, {
+                commitment: 'confirmed',
+                encoding: 'jsonParsed',
+                maxSupportedTransactionVersion: 0,
+                transactionDetails: 'full',
+            });
+        });
+    });
+});

--- a/packages/rpc-graphql/src/resolvers/resolve-info/block.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/block.ts
@@ -1,0 +1,45 @@
+import { Commitment, Slot } from '@solana/rpc-types';
+import { GraphQLResolveInfo } from 'graphql';
+
+import { BlockLoaderArgs } from '../../loaders';
+import { buildTransactionArgSetWithVisitor } from './transaction';
+import { injectableRootVisitor } from './visitor';
+
+/**
+ * Build a set of block loader args by inspecting which fields have
+ * been requested in the query (ie. `data` or inline fragments).
+ */
+export function buildBlockLoaderArgSetFromResolveInfo(
+    args: {
+        commitment?: Omit<Commitment, 'processed'>;
+        minContextSlot?: Slot;
+        slot: Slot;
+    },
+    info: GraphQLResolveInfo,
+): BlockLoaderArgs[] {
+    const argSet: BlockLoaderArgs[] = [args];
+
+    function buildArgSetWithVisitor(root: Parameters<typeof injectableRootVisitor>[1]) {
+        injectableRootVisitor(info, root, {
+            fieldNodeOperation(info, node) {
+                if (node.name.value === 'signatures') {
+                    argSet.push({ ...args, transactionDetails: 'signatures' });
+                } else if (node.name.value === 'transactions') {
+                    argSet.push(...buildTransactionArgSetWithVisitor({ ...args, transactionDetails: 'full' }, info));
+                }
+            },
+            fragmentSpreadNodeOperation(_info, fragment) {
+                buildArgSetWithVisitor(fragment);
+            },
+            inlineFragmentNodeOperation(_info, _node) {
+                // Block schema doesn't support inline fragments at the
+                // root level.
+                return;
+            },
+        });
+    }
+
+    buildArgSetWithVisitor(null);
+
+    return argSet;
+}

--- a/packages/rpc-graphql/src/resolvers/resolve-info/index.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/index.ts
@@ -1,4 +1,5 @@
 export * from './account';
+export * from './block';
 export * from './program-accounts';
 export * from './transaction';
 export * from './visitor';

--- a/packages/rpc-graphql/src/resolvers/types.ts
+++ b/packages/rpc-graphql/src/resolvers/types.ts
@@ -43,12 +43,6 @@ export const typeTypeResolvers = {
     Base64EncodedBytes: stringScalarAlias,
     Base64ZstdEncodedBytes: stringScalarAlias,
     BigInt: bigIntScalarAlias,
-    BlockTransactionDetails: {
-        ACCOUNTS: 'accounts',
-        FULL: 'full',
-        NONE: 'none',
-        SIGNATURES: 'signatures',
-    },
     Commitment: {
         CONFIRMED: 'confirmed',
         FINALIZED: 'finalized',
@@ -67,10 +61,5 @@ export const typeTypeResolvers = {
     TransactionEncoding: {
         BASE_58: 'base58',
         BASE_64: 'base64',
-        PARSED: 'jsonParsed',
-    },
-    TransactionVersion: {
-        LEGACY: 'legacy',
-        ZERO: 0,
     },
 };

--- a/packages/rpc-graphql/src/schema/block.ts
+++ b/packages/rpc-graphql/src/schema/block.ts
@@ -1,90 +1,15 @@
 export const blockTypeDefs = /* GraphQL */ `
-    type TransactionMetaForAccounts {
-        err: String
-        fee: BigInt
-        postBalances: [BigInt]
-        postTokenBalances: [TokenBalance]
-        preBalances: [BigInt]
-        preTokenBalances: [TokenBalance]
-        status: TransactionStatus
-    }
-
-    type TransactionDataForAccounts {
-        accountKeys: [Address]
-        signatures: [String]
-    }
-
-    type BlockTransactionAccounts {
-        meta: TransactionMetaForAccounts
-        data: TransactionDataForAccounts
-        version: String
-    }
-
     """
-    Block interface
+    A Solana block
     """
-    interface Block {
+    type Block {
         blockhash: String
         blockHeight: BigInt
         blockTime: BigInt
-        parentSlot: BigInt
+        parentSlot: Slot
         previousBlockhash: String
         rewards: [Reward]
-        transactionDetails: String
-    }
-
-    """
-    A block with account transaction details
-    """
-    type BlockWithAccounts implements Block {
-        blockhash: String
-        blockHeight: BigInt
-        blockTime: BigInt
-        parentSlot: BigInt
-        previousBlockhash: String
-        rewards: [Reward]
-        transactions: [BlockTransactionAccounts]
-        transactionDetails: String
-    }
-
-    """
-    A block with full transaction details
-    """
-    type BlockWithFull implements Block {
-        blockhash: String
-        blockHeight: BigInt
-        blockTime: BigInt
-        parentSlot: BigInt
-        previousBlockhash: String
-        rewards: [Reward]
+        signatures: [Signature]
         transactions: [Transaction]
-        transactionDetails: String
-    }
-
-    """
-    A block with no transaction details
-    """
-    type BlockWithNone implements Block {
-        blockhash: String
-        blockHeight: BigInt
-        blockTime: BigInt
-        parentSlot: BigInt
-        previousBlockhash: String
-        rewards: [Reward]
-        transactionDetails: String
-    }
-
-    """
-    A block with signature transaction details
-    """
-    type BlockWithSignatures implements Block {
-        blockhash: String
-        blockHeight: BigInt
-        blockTime: BigInt
-        parentSlot: BigInt
-        previousBlockhash: String
-        rewards: [Reward]
-        signatures: [String]
-        transactionDetails: String
     }
 `;

--- a/packages/rpc-graphql/src/schema/root.ts
+++ b/packages/rpc-graphql/src/schema/root.ts
@@ -1,12 +1,7 @@
 export const rootTypeDefs = /* GraphQL */ `
     type Query {
         account(address: Address!, commitment: Commitment, minContextSlot: Slot): Account
-        block(
-            slot: Slot!
-            commitment: Commitment
-            encoding: TransactionEncoding
-            transactionDetails: BlockTransactionDetails
-        ): Block
+        block(slot: Slot!, commitment: CommitmentWithoutProcessed): Block
         programAccounts(
             programAddress: Address!
             commitment: Commitment

--- a/packages/rpc-graphql/src/schema/types.ts
+++ b/packages/rpc-graphql/src/schema/types.ts
@@ -15,13 +15,6 @@ export const typeTypeDefs = /* GraphQL */ `
 
     scalar BigInt
 
-    enum BlockTransactionDetails {
-        ACCOUNTS
-        FULL
-        NONE
-        SIGNATURES
-    }
-
     enum Commitment {
         CONFIRMED
         FINALIZED
@@ -80,11 +73,5 @@ export const typeTypeDefs = /* GraphQL */ `
     enum TransactionEncoding {
         BASE_58
         BASE_64
-        PARSED
-    }
-
-    enum TransactionVersion {
-        LEGACY
-        ZERO
     }
 `;


### PR DESCRIPTION
This commit updates the `block` schema to leverage the new transaction schema
laid out in the previous commit. It also adds the necessary request coalescer,
resolve info, and more to the block schema.
