### PR TITLE
refactor(experimental): add multiple instructions to transactions helpers

### DIFF
--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -30,7 +30,7 @@ const transferTransaction = pipe(
     createTransaction({ version: 0 }),
     tx => setTransactionFeePayer(myAddress, tx),
     tx => setTransactionLifetimeUsingBlockhash(latestBlockhash, tx),
-    tx => appendTransactionInstruction(createTransferInstruction(myAddress, toAddress, amountInLamports), tx)
+    tx => appendTransactionInstruction(createTransferInstruction(myAddress, toAddress, amountInLamports), tx),
 );
 ```
 
@@ -144,7 +144,7 @@ const nonce =
 
 const durableNonceTransaction = setTransactionLifetimeUsingDurableNonce(
     { nonce, nonceAccountAddress, nonceAuthorityAddress },
-    tx
+    tx,
 );
 ```
 
@@ -210,13 +210,17 @@ const memoTransaction = appendTransactionInstruction(
         data: new TextEncoder().encode('Hello world!'),
         programAddress: address('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
     },
-    tx
+    tx,
 );
 ```
+
+If you'd like to add multiple instructions to a transaction at once, you may use the `appendTransactionInstructions` function instead which accepts an array of instructions.
 
 #### `prependTransactionInstruction()`
 
 Given an instruction, this method will return a new transaction with that instruction having been added to the beginning of the list of existing instructions.
+
+If you'd like to prepend multiple instructions to a transaction at once, you may use the `prependTransactionInstructions` function instead which accepts an array of instructions.
 
 See [`appendTransactionInstruction()`](#appendtransactioninstruction) for an example of how to use this function.
 

--- a/packages/transactions/src/__tests__/instructions-test.ts
+++ b/packages/transactions/src/__tests__/instructions-test.ts
@@ -3,7 +3,12 @@ import 'test-matchers/toBeFrozenObject';
 import { Address } from '@solana/addresses';
 import { IInstruction } from '@solana/instructions';
 
-import { appendTransactionInstruction, prependTransactionInstruction } from '../instructions';
+import {
+    appendTransactionInstruction,
+    appendTransactionInstructions,
+    prependTransactionInstruction,
+    prependTransactionInstructions,
+} from '../instructions';
 import { ITransactionWithSignatures } from '../signatures';
 import { BaseTransaction } from '../types';
 
@@ -11,10 +16,13 @@ const PROGRAM_A =
     'AALQD2dt1k43Acrkp4SvdhZaN4S115Ff2Bi7rHPti3sL' as Address<'AALQD2dt1k43Acrkp4SvdhZaN4S115Ff2Bi7rHPti3sL'>;
 const PROGRAM_B =
     'DNAbkMkoMLRXF7wuLCrTzouMyzi25krr3B94yW87VvxU' as Address<'DNAbkMkoMLRXF7wuLCrTzouMyzi25krr3B94yW87VvxU'>;
+const PROGRAM_C =
+    '6Bkt4j67rxzFF6s9DaMRyfitftRrGxe4oYHPRHuFChzi' as Address<'6Bkt4j67rxzFF6s9DaMRyfitftRrGxe4oYHPRHuFChzi'>;
 
 describe('Transaction instruction helpers', () => {
     let baseTx: BaseTransaction;
     let exampleInstruction: IInstruction<string>;
+    let secondExampleInstruction: IInstruction<string>;
     beforeEach(() => {
         baseTx = {
             instructions: [
@@ -26,6 +34,9 @@ describe('Transaction instruction helpers', () => {
         };
         exampleInstruction = {
             programAddress: PROGRAM_B,
+        };
+        secondExampleInstruction = {
+            programAddress: PROGRAM_C,
         };
     });
     describe('appendTransactionInstruction', () => {
@@ -41,7 +52,7 @@ describe('Transaction instruction helpers', () => {
                     signatures: {},
                 };
             });
-            it('clears the signatures when the fee payer is different than the current one', () => {
+            it('clears the transaction signatures', () => {
                 expect(appendTransactionInstruction(exampleInstruction, txWithSignatures)).not.toHaveProperty(
                     'signatures',
                 );
@@ -49,6 +60,40 @@ describe('Transaction instruction helpers', () => {
         });
         it('freezes the object', () => {
             const txWithAddedInstruction = appendTransactionInstruction(exampleInstruction, baseTx);
+            expect(txWithAddedInstruction).toBeFrozenObject();
+        });
+    });
+    describe('appendTransactionInstructions', () => {
+        it('adds the instructions to the end of the list', () => {
+            const txWithAddedInstructions = appendTransactionInstructions(
+                [exampleInstruction, secondExampleInstruction],
+                baseTx,
+            );
+            expect(txWithAddedInstructions.instructions).toMatchObject([
+                ...baseTx.instructions,
+                exampleInstruction,
+                secondExampleInstruction,
+            ]);
+        });
+        describe('given a transaction with signatures', () => {
+            let txWithSignatures: BaseTransaction & ITransactionWithSignatures;
+            beforeEach(() => {
+                txWithSignatures = {
+                    ...baseTx,
+                    signatures: {},
+                };
+            });
+            it('clears the transaction signatures', () => {
+                expect(
+                    appendTransactionInstructions([exampleInstruction, secondExampleInstruction], txWithSignatures),
+                ).not.toHaveProperty('signatures');
+            });
+        });
+        it('freezes the object', () => {
+            const txWithAddedInstruction = appendTransactionInstructions(
+                [exampleInstruction, secondExampleInstruction],
+                baseTx,
+            );
             expect(txWithAddedInstruction).toBeFrozenObject();
         });
     });
@@ -65,7 +110,7 @@ describe('Transaction instruction helpers', () => {
                     signatures: {},
                 };
             });
-            it('clears the signatures when the fee payer is different than the current one', () => {
+            it('clears the transaction signatures', () => {
                 expect(prependTransactionInstruction(exampleInstruction, txWithSignatures)).not.toHaveProperty(
                     'signatures',
                 );
@@ -73,6 +118,40 @@ describe('Transaction instruction helpers', () => {
         });
         it('freezes the object', () => {
             const txWithAddedInstruction = prependTransactionInstruction(exampleInstruction, baseTx);
+            expect(txWithAddedInstruction).toBeFrozenObject();
+        });
+    });
+    describe('prependTransactionInstructions', () => {
+        it('adds the instructions to the beginning of the list', () => {
+            const txWithAddedInstruction = prependTransactionInstructions(
+                [exampleInstruction, secondExampleInstruction],
+                baseTx,
+            );
+            expect(txWithAddedInstruction.instructions).toMatchObject([
+                exampleInstruction,
+                secondExampleInstruction,
+                ...baseTx.instructions,
+            ]);
+        });
+        describe('given a transaction with signatures', () => {
+            let txWithSignatures: BaseTransaction & ITransactionWithSignatures;
+            beforeEach(() => {
+                txWithSignatures = {
+                    ...baseTx,
+                    signatures: {},
+                };
+            });
+            it('clears the transaction signatures', () => {
+                expect(
+                    prependTransactionInstructions([exampleInstruction, secondExampleInstruction], txWithSignatures),
+                ).not.toHaveProperty('signatures');
+            });
+        });
+        it('freezes the object', () => {
+            const txWithAddedInstruction = prependTransactionInstructions(
+                [exampleInstruction, secondExampleInstruction],
+                baseTx,
+            );
             expect(txWithAddedInstruction).toBeFrozenObject();
         });
     });

--- a/packages/transactions/src/instructions.ts
+++ b/packages/transactions/src/instructions.ts
@@ -6,9 +6,16 @@ export function appendTransactionInstruction<TTransaction extends BaseTransactio
     instruction: TTransaction['instructions'][number],
     transaction: TTransaction | (TTransaction & ITransactionWithSignatures),
 ): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
+    return appendTransactionInstructions([instruction], transaction);
+}
+
+export function appendTransactionInstructions<TTransaction extends BaseTransaction>(
+    instructions: ReadonlyArray<TTransaction['instructions'][number]>,
+    transaction: TTransaction | (TTransaction & ITransactionWithSignatures),
+): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
     const out = {
         ...getUnsignedTransaction(transaction),
-        instructions: [...transaction.instructions, instruction],
+        instructions: [...transaction.instructions, ...instructions],
     };
     Object.freeze(out);
     return out;
@@ -18,9 +25,16 @@ export function prependTransactionInstruction<TTransaction extends BaseTransacti
     instruction: TTransaction['instructions'][number],
     transaction: TTransaction | (TTransaction & ITransactionWithSignatures),
 ): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
+    return prependTransactionInstructions([instruction], transaction);
+}
+
+export function prependTransactionInstructions<TTransaction extends BaseTransaction>(
+    instructions: ReadonlyArray<TTransaction['instructions'][number]>,
+    transaction: TTransaction | (TTransaction & ITransactionWithSignatures),
+): TTransaction | Omit<TTransaction, keyof ITransactionWithSignatures> {
     const out = {
         ...getUnsignedTransaction(transaction),
-        instructions: [instruction, ...transaction.instructions],
+        instructions: [...instructions, ...transaction.instructions],
     };
     Object.freeze(out);
     return out;


### PR DESCRIPTION
This PR adds the following two helper functions enabling users to add multiple instructions to their transaction within a single function call:
- `appendTransactionInstructions`
- `prependTransactionInstructions`

Additionally, it refactors the `appendTransactionInstruction` and `prependTransactionInstruction` functions such that they now delegate to their respective plural helper by passing an array with a single element.

Tests added.
README updated.
Fixes #2108.