### PR TITLE
refactor(experimental): store fee payer Signers in transactions

### DIFF
--- a/packages/signers/src/__tests__/account-signer-meta-test.ts
+++ b/packages/signers/src/__tests__/account-signer-meta-test.ts
@@ -1,6 +1,8 @@
 import { Address } from '@solana/addresses';
+import { createTransaction } from '@solana/transactions';
 
 import { getSignersFromInstruction, getSignersFromTransaction } from '../account-signer-meta';
+import { setTransactionFeePayerSigner } from '../fee-payer-signer';
 import {
     createMockInstructionWithSigners,
     createMockTransactionModifyingSigner,
@@ -53,6 +55,19 @@ describe('getSignersFromTransaction', () => {
         expect(extractedSigners).toHaveLength(2);
         expect(extractedSigners[0]).toBe(signerA);
         expect(extractedSigners[1]).toBe(signerB);
+    });
+
+    it('extracts the fee payer signer of the provided transaction', () => {
+        // Given a transaction with a signer fee payer.
+        const feePayerSigner = createMockTransactionPartialSigner('1111' as Address);
+        const transaction = setTransactionFeePayerSigner(feePayerSigner, createTransaction({ version: 0 }));
+
+        // When we extract the signers from the transaction.
+        const extractedSigners = getSignersFromTransaction(transaction);
+
+        // Then we expect the extracted signers to contain the fee payer signer.
+        expect(extractedSigners).toHaveLength(1);
+        expect(extractedSigners[0]).toBe(feePayerSigner);
     });
 
     it('removes duplicated signers', () => {

--- a/packages/signers/src/__tests__/fee-payer-signer-test.ts
+++ b/packages/signers/src/__tests__/fee-payer-signer-test.ts
@@ -1,0 +1,107 @@
+import 'test-matchers/toBeFrozenObject';
+
+import { Address } from '@solana/addresses';
+import { BaseTransaction, ITransactionWithFeePayer, ITransactionWithSignatures } from '@solana/transactions';
+
+import { ITransactionWithFeePayerSigner, setTransactionFeePayerSigner } from '../fee-payer-signer';
+import { TransactionSigner } from '../transaction-signer';
+import { createMockTransactionPartialSigner } from './__setup__';
+
+describe('setTransactionFeePayerSigner', () => {
+    let feePayerSignerA: TransactionSigner;
+    let feePayerSignerB: TransactionSigner;
+    let baseTx: BaseTransaction;
+    beforeEach(() => {
+        baseTx = { instructions: [], version: 0 };
+        feePayerSignerA = createMockTransactionPartialSigner('1111' as Address);
+        feePayerSignerB = createMockTransactionPartialSigner('2222' as Address);
+    });
+    it('sets the fee payer signer on the transaction', () => {
+        const txWithFeePayerA = setTransactionFeePayerSigner(feePayerSignerA, baseTx);
+        expect(txWithFeePayerA).toHaveProperty('feePayer', feePayerSignerA.address);
+        expect(txWithFeePayerA).toHaveProperty('feePayerSigner', feePayerSignerA);
+    });
+    describe('given a transaction with a fee payer signer already set', () => {
+        let txWithFeePayerA: BaseTransaction & ITransactionWithFeePayerSigner;
+        beforeEach(() => {
+            txWithFeePayerA = {
+                ...baseTx,
+                feePayer: feePayerSignerA.address,
+                feePayerSigner: feePayerSignerA,
+            };
+        });
+        it('sets the new fee payer on the transaction when it differs from the existing one', () => {
+            const txWithFeePayerB = setTransactionFeePayerSigner(feePayerSignerB, txWithFeePayerA);
+            expect(txWithFeePayerB).toHaveProperty('feePayer', feePayerSignerB.address);
+            expect(txWithFeePayerB).toHaveProperty('feePayerSigner', feePayerSignerB);
+        });
+        it('returns the original transaction when trying to set the same fee payer again', () => {
+            const txWithSameFeePayer = setTransactionFeePayerSigner(feePayerSignerA, txWithFeePayerA);
+            expect(txWithFeePayerA).toBe(txWithSameFeePayer);
+        });
+        describe('given that transaction also has signatures', () => {
+            let txWithFeePayerAndSignatures: BaseTransaction & ITransactionWithFeePayer & ITransactionWithSignatures;
+            beforeEach(() => {
+                txWithFeePayerAndSignatures = {
+                    ...txWithFeePayerA,
+                    signatures: {},
+                };
+            });
+            it('does not clear the signatures when the fee payer is the same as the current one', () => {
+                expect(setTransactionFeePayerSigner(feePayerSignerA, txWithFeePayerAndSignatures)).toHaveProperty(
+                    'signatures',
+                    txWithFeePayerAndSignatures.signatures,
+                );
+            });
+            it('clears the signatures when the fee payer is different than the current one', () => {
+                expect(setTransactionFeePayerSigner(feePayerSignerB, txWithFeePayerAndSignatures)).not.toHaveProperty(
+                    'signatures',
+                );
+            });
+        });
+    });
+    describe('given a transaction with a non-signer fee payer already set', () => {
+        let txWithFeePayerA: BaseTransaction & ITransactionWithFeePayer;
+        beforeEach(() => {
+            txWithFeePayerA = {
+                ...baseTx,
+                feePayer: feePayerSignerA.address,
+            };
+        });
+        it('sets the new fee payer on the transaction when it differs from the existing one', () => {
+            const txWithFeePayerB = setTransactionFeePayerSigner(feePayerSignerB, txWithFeePayerA);
+            expect(txWithFeePayerB).toHaveProperty('feePayer', feePayerSignerB.address);
+            expect(txWithFeePayerB).toHaveProperty('feePayerSigner', feePayerSignerB);
+        });
+        it('returns a new transaction instance when setting the same fee payer but as a signer this time', () => {
+            const txWithSameFeePayer = setTransactionFeePayerSigner(feePayerSignerA, txWithFeePayerA);
+            expect(txWithSameFeePayer).toHaveProperty('feePayer', feePayerSignerA.address);
+            expect(txWithSameFeePayer).toHaveProperty('feePayerSigner', feePayerSignerA);
+            expect(txWithFeePayerA).not.toBe(txWithSameFeePayer);
+        });
+        describe('given that transaction also has signatures', () => {
+            let txWithFeePayerAndSignatures: BaseTransaction & ITransactionWithFeePayer & ITransactionWithSignatures;
+            beforeEach(() => {
+                txWithFeePayerAndSignatures = {
+                    ...txWithFeePayerA,
+                    signatures: {},
+                };
+            });
+            it('does not clear the signatures when the fee payer is the same as the current one', () => {
+                expect(setTransactionFeePayerSigner(feePayerSignerA, txWithFeePayerAndSignatures)).toHaveProperty(
+                    'signatures',
+                    txWithFeePayerAndSignatures.signatures,
+                );
+            });
+            it('clears the signatures when the fee payer is different than the current one', () => {
+                expect(setTransactionFeePayerSigner(feePayerSignerB, txWithFeePayerAndSignatures)).not.toHaveProperty(
+                    'signatures',
+                );
+            });
+        });
+    });
+    it('freezes the object', () => {
+        const txWithFeePayer = setTransactionFeePayerSigner(feePayerSignerA, baseTx);
+        expect(txWithFeePayer).toBeFrozenObject();
+    });
+});

--- a/packages/signers/src/account-signer-meta.ts
+++ b/packages/signers/src/account-signer-meta.ts
@@ -7,13 +7,13 @@ import { TransactionSigner } from './transaction-signer';
 /** An extension of the IAccountMeta type that keeps track of its transaction signer. */
 export interface IAccountSignerMeta<
     TAddress extends string = string,
-    TSigner extends TransactionSigner = TransactionSigner,
+    TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
 > extends IAccountMeta<TAddress> {
     readonly role: AccountRole.READONLY_SIGNER | AccountRole.WRITABLE_SIGNER;
     readonly signer: TSigner;
 }
 
-type IAccountMetaWithWithSigner<TSigner extends TransactionSigner = TransactionSigner> =
+type IAccountMetaWithSigner<TSigner extends TransactionSigner = TransactionSigner> =
     | IAccountMeta
     | IAccountLookupMeta
     | IAccountSignerMeta<string, TSigner>;
@@ -21,17 +21,17 @@ type IAccountMetaWithWithSigner<TSigner extends TransactionSigner = TransactionS
 /** A variation of the instruction type that allows IAccountSignerMeta in its account metas. */
 export type IInstructionWithSigners<
     TSigner extends TransactionSigner = TransactionSigner,
-    TAccounts extends readonly IAccountMetaWithWithSigner<TSigner>[] = readonly IAccountMetaWithWithSigner<TSigner>[],
+    TAccounts extends readonly IAccountMetaWithSigner<TSigner>[] = readonly IAccountMetaWithSigner<TSigner>[],
 > = Pick<IInstruction<string, TAccounts>, 'accounts'>;
 
 /** A variation of the transaction type that allows IAccountSignerMeta in its account metas. */
 export type ITransactionWithSigners<
     TSigner extends TransactionSigner = TransactionSigner,
-    TAccounts extends readonly IAccountMetaWithWithSigner<TSigner>[] = readonly IAccountMetaWithWithSigner<TSigner>[],
+    TAccounts extends readonly IAccountMetaWithSigner<TSigner>[] = readonly IAccountMetaWithSigner<TSigner>[],
 > = Pick<
     BaseTransaction<TransactionVersion, IInstruction & IInstructionWithSigners<TSigner, TAccounts>>,
     'instructions'
->;
+> & { feePayerSigner?: TSigner };
 
 /** Extract all signers from an instruction that may contain IAccountSignerMeta accounts. */
 export function getSignersFromInstruction<TSigner extends TransactionSigner = TransactionSigner>(
@@ -47,5 +47,8 @@ export function getSignersFromTransaction<
     TSigner extends TransactionSigner = TransactionSigner,
     TTransaction extends ITransactionWithSigners<TSigner> = ITransactionWithSigners<TSigner>,
 >(transaction: TTransaction): readonly TSigner[] {
-    return deduplicateSigners(transaction.instructions.flatMap(getSignersFromInstruction));
+    return deduplicateSigners([
+        ...(transaction.feePayerSigner ? [transaction.feePayerSigner] : []),
+        ...transaction.instructions.flatMap(getSignersFromInstruction),
+    ]);
 }

--- a/packages/signers/src/fee-payer-signer.ts
+++ b/packages/signers/src/fee-payer-signer.ts
@@ -1,0 +1,52 @@
+import { Address } from '@solana/addresses';
+import {
+    BaseTransaction,
+    getUnsignedTransaction,
+    ITransactionWithFeePayer,
+    ITransactionWithSignatures,
+} from '@solana/transactions';
+
+import { TransactionSigner } from './transaction-signer';
+
+export interface ITransactionWithFeePayerSigner<
+    TAddress extends string = string,
+    TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
+> {
+    readonly feePayer: Address<TAddress>;
+    readonly feePayerSigner: TSigner;
+}
+
+export function setTransactionFeePayerSigner<TFeePayerAddress extends string, TTransaction extends BaseTransaction>(
+    feePayerSigner: TransactionSigner<TFeePayerAddress>,
+    transaction:
+        | (TTransaction & ITransactionWithSignatures)
+        | (TTransaction & ITransactionWithFeePayer<string> & ITransactionWithSignatures),
+): Omit<TTransaction, keyof ITransactionWithSignatures> & ITransactionWithFeePayerSigner<TFeePayerAddress>;
+
+export function setTransactionFeePayerSigner<TFeePayerAddress extends string, TTransaction extends BaseTransaction>(
+    feePayerSigner: TransactionSigner<TFeePayerAddress>,
+    transaction: TTransaction | (TTransaction & ITransactionWithFeePayer<string>),
+): TTransaction & ITransactionWithFeePayerSigner<TFeePayerAddress>;
+
+export function setTransactionFeePayerSigner<TFeePayerAddress extends string, TTransaction extends BaseTransaction>(
+    feePayerSigner: TransactionSigner<TFeePayerAddress>,
+    transaction:
+        | TTransaction
+        | (TTransaction & ITransactionWithFeePayer<string>)
+        | (TTransaction & ITransactionWithSignatures)
+        | (TTransaction & ITransactionWithFeePayer<string> & ITransactionWithSignatures),
+) {
+    if ('feePayer' in transaction && feePayerSigner.address === transaction.feePayer) {
+        if ('feePayerSigner' in transaction) return transaction;
+        const out = { ...transaction, feePayerSigner };
+        Object.freeze(out);
+        return out;
+    }
+    const out = {
+        ...getUnsignedTransaction(transaction),
+        feePayer: feePayerSigner.address,
+        feePayerSigner,
+    };
+    Object.freeze(out);
+    return out;
+}

--- a/packages/signers/src/index.ts
+++ b/packages/signers/src/index.ts
@@ -1,5 +1,6 @@
 export * from './account-signer-meta';
 export * from './add-signers';
+export * from './fee-payer-signer';
 export * from './keypair-signer';
 export * from './message-modifying-signer';
 export * from './message-partial-signer';

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -9,4 +9,5 @@ export * from './message';
 export * from './serializers';
 export * from './signatures';
 export * from './types';
+export * from './unsigned-transaction';
 export * from './wire-transaction';


### PR DESCRIPTION
### Context

The `@solana/signers` package allows us to store `TransactionSigners` inside instructions' account meta which can then be extracted in order to sign the transaction they belong to.

### Problem

Signing transactions that way currently doesn't take the fee payer into account. It works most of the time as it is likely that the fee payer will end up being required as a signer inside one of the instructions. However, when that's not the case, the fee payer will have to manually sign the transaction on top of using the `signTransactionWithSigners` function.

### Solution

This PR fixes that by storing the fee payer signer inside the transaction object, much like we do with the instruction account metas.

It offers a new `setTransactionFeePayerSigner` which, on top of adding the `feePayer` address, also add a `feePayerSigner` attribute that stores the fee payer as a `TransactionSigner`.

That way, when using the `@solana/signers` package, you get to attach all relevant signers to a transaction and then use `signTransactionWithSigners` to handle the whole signing process, including the fee payer.