### PR TITLE
refactor(experimental): add createKeyPairFromBytes helper

### DIFF
--- a/packages/compat/src/keypair.ts
+++ b/packages/compat/src/keypair.ts
@@ -1,4 +1,4 @@
-import { createPrivateKeyFromBytes } from '@solana/keys';
+import { createKeyPairFromBytes } from '@solana/keys';
 import { Keypair } from '@solana/web3.js';
 
 /**
@@ -7,12 +7,8 @@ import { Keypair } from '@solana/web3.js';
  * @returns         A CryptoKeyPair
  */
 export async function fromLegacyKeypair(keypair: Keypair, extractable?: boolean): Promise<CryptoKeyPair> {
-    const [publicKey, privateKey] = await Promise.all([
-        crypto.subtle.importKey('raw', keypair.publicKey.toBytes(), 'Ed25519', true, ['verify']),
-        createPrivateKeyFromBytes(keypair.secretKey.slice(0, 32), extractable),
-    ]);
-    return {
-        privateKey,
-        publicKey,
-    } as CryptoKeyPair;
+    const bytes = new Uint8Array(64);
+    bytes.set(keypair.secretKey);
+    bytes.set(keypair.publicKey.toBytes(), /* offset */ 32);
+    return createKeyPairFromBytes(bytes, extractable);
 }

--- a/packages/errors/src/__tests__/RPC_INTEGER_OVERFLOW-test.ts
+++ b/packages/errors/src/__tests__/RPC_INTEGER_OVERFLOW-test.ts
@@ -17,7 +17,7 @@ describe('SOLANA_ERROR__RPC_INTEGER_OVERFLOW', () => {
             }),
         ).toHaveProperty(
             'message',
-            'The 3rd argument to the `someMethod` RPC method was `1`. This number is unsafe for use with the Solana JSON-RPC because it exceeds `Number.MAX_SAFE_INTEGER`',
+            'The 3rd argument to the `someMethod` RPC method was `1`. This number is unsafe for use with the Solana JSON-RPC because it exceeds `Number.MAX_SAFE_INTEGER`.',
         );
     });
     it('features an informative error message for a violation with a deep path', () => {
@@ -32,7 +32,7 @@ describe('SOLANA_ERROR__RPC_INTEGER_OVERFLOW', () => {
             }),
         ).toHaveProperty(
             'message',
-            'The 1st argument to the `someMethod` RPC method at path `foo.bar` was `1`. This number is unsafe for use with the Solana JSON-RPC because it exceeds `Number.MAX_SAFE_INTEGER`',
+            'The 1st argument to the `someMethod` RPC method at path `foo.bar` was `1`. This number is unsafe for use with the Solana JSON-RPC because it exceeds `Number.MAX_SAFE_INTEGER`.',
         );
     });
 });

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -9,6 +9,7 @@
 export const SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES = 1 as const;
 export const SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE = 2 as const;
 export const SOLANA_ERROR__RPC_INTEGER_OVERFLOW = 3 as const;
+export const SOLANA_ERROR__INVALID_KEYPAIR_BYTES = 4 as const;
 
 /**
  * A union of every Solana error code
@@ -28,4 +29,5 @@ export const SOLANA_ERROR__RPC_INTEGER_OVERFLOW = 3 as const;
 export type SolanaErrorCode =
     | typeof SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES
     | typeof SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE
-    | typeof SOLANA_ERROR__RPC_INTEGER_OVERFLOW;
+    | typeof SOLANA_ERROR__RPC_INTEGER_OVERFLOW
+    | typeof SOLANA_ERROR__INVALID_KEYPAIR_BYTES;

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -1,4 +1,5 @@
 import {
+    SOLANA_ERROR__INVALID_KEYPAIR_BYTES,
     SOLANA_ERROR__RPC_INTEGER_OVERFLOW,
     SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES,
     SolanaErrorCode,
@@ -26,5 +27,8 @@ export type SolanaErrorContext = DefaultUnspecifiedErrorContextToUndefined<{
         optionalPathLabel: string;
         path?: string;
         value: bigint;
+    };
+    [SOLANA_ERROR__INVALID_KEYPAIR_BYTES]: {
+        byteLength: number;
     };
 }>;

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -1,4 +1,5 @@
 import {
+    SOLANA_ERROR__INVALID_KEYPAIR_BYTES,
     SOLANA_ERROR__RPC_INTEGER_OVERFLOW,
     SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES,
     SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE,
@@ -17,11 +18,12 @@ export const SolanaErrorMessages: Readonly<{
     // TypeScript will fail to build this project if add an error code without a message.
     [P in SolanaErrorCode]: string;
 }> = {
+    [SOLANA_ERROR__INVALID_KEYPAIR_BYTES]: 'Key pair bytes must be of length 64, got $byteLength.',
     [SOLANA_ERROR__RPC_INTEGER_OVERFLOW]:
         'The $argumentLabel argument to the `$methodName` RPC method$optionalPathLabel was ' +
         '`$value`. This number is unsafe for use with the Solana JSON-RPC because it exceeds ' +
-        '`Number.MAX_SAFE_INTEGER`',
-    [SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES]: 'Transaction is missing signatures for addresses: $addresses',
+        '`Number.MAX_SAFE_INTEGER`.',
+    [SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES]: 'Transaction is missing signatures for addresses: $addresses.',
     [SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE]:
         "Could not determine this transaction's signature. Make sure that the transaction has " +
         'been signed by its fee payer.',

--- a/packages/keys/README.md
+++ b/packages/keys/README.md
@@ -65,6 +65,22 @@ import { generateKeyPair } from '@solana/keys';
 const { privateKey, publicKey } = await generateKeyPair();
 ```
 
+### `createKeyPairFromBytes()`
+
+Given a 64-bytes `Uint8Array` secret key, creates an Ed25519 public/private key pair for use with other methods in this package that accept `CryptoKey` objects.
+
+```ts
+import fs from 'fs';
+import { createKeyPairFromBytes } from '@solana/keys';
+
+// Get bytes from local keypair file.
+const keypairFile = fs.readFileSync('~/.config/solana/id.json');
+const keypairBytes = new Uint8Array(JSON.parse(keypairFile.toString()));
+
+// Create a CryptoKeyPair from the bytes.
+const { privateKey, publicKey } = await createKeyPairFromBytes(keypairBytes);
+```
+
 ### `isSignature()`
 
 This is a type guard that accepts a string as input. It will both return `true` if the string conforms to the `Signature` type and will refine the type for use in your program.

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -67,7 +67,8 @@
     "dependencies": {
         "@solana/assertions": "workspace:*",
         "@solana/codecs-core": "workspace:*",
-        "@solana/codecs-strings": "workspace:*"
+        "@solana/codecs-strings": "workspace:*",
+        "@solana/errors": "workspace:*"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1011,6 +1011,9 @@ importers:
       '@solana/codecs-strings':
         specifier: workspace:*
         version: link:../codecs-strings
+      '@solana/errors':
+        specifier: workspace:*
+        version: link:../errors
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2


### PR DESCRIPTION
Adds a helper function that creates a crypto KeyPair from a 64-bytes secret key.