### PR TITLE
Rename all transaction/airdrop sender factories with the ‘Factory’ suffix

### DIFF
--- a/packages/library/src/__tests__/airdrop-internal-test.ts
+++ b/packages/library/src/__tests__/airdrop-internal-test.ts
@@ -3,7 +3,7 @@ import { Signature } from '@solana/keys';
 import type { GetSignatureStatusesApi, RequestAirdropApi } from '@solana/rpc-core';
 import { lamports, type Rpc } from '@solana/rpc-types';
 
-import { requestAndConfirmAirdrop } from '../airdrop';
+import { requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT } from '../airdrop-internal';
 
 const FOREVER_PROMISE = new Promise(() => {
     /* never resolve */
@@ -27,7 +27,7 @@ describe('requestAndConfirmAirdrop', () => {
     it('aborts the `requestAirdrop` request when aborted', async () => {
         expect.assertions(2);
         const abortController = new AbortController();
-        requestAndConfirmAirdrop({
+        requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: abortController.signal,
             commitment: 'finalized',
             confirmSignatureOnlyTransaction,
@@ -47,7 +47,7 @@ describe('requestAndConfirmAirdrop', () => {
         expect.assertions(2);
         const abortController = new AbortController();
         sendAirdropRequest.mockResolvedValue('abc' as Signature);
-        requestAndConfirmAirdrop({
+        requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: abortController.signal,
             commitment: 'finalized',
             confirmSignatureOnlyTransaction,
@@ -71,7 +71,7 @@ describe('requestAndConfirmAirdrop', () => {
     it('passes the expected input to the airdrop request', async () => {
         expect.assertions(1);
         sendAirdropRequest.mockResolvedValue('abc' as Signature);
-        requestAndConfirmAirdrop({
+        requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmSignatureOnlyTransaction,
@@ -84,7 +84,7 @@ describe('requestAndConfirmAirdrop', () => {
     it('passes the expected input to the transaction confirmer', async () => {
         expect.assertions(1);
         sendAirdropRequest.mockResolvedValue('abc' as Signature);
-        requestAndConfirmAirdrop({
+        requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmSignatureOnlyTransaction,
@@ -103,7 +103,7 @@ describe('requestAndConfirmAirdrop', () => {
         expect.assertions(1);
         sendAirdropRequest.mockResolvedValue('abc' as Signature);
         confirmSignatureOnlyTransaction.mockResolvedValue(undefined);
-        const airdropPromise = requestAndConfirmAirdrop({
+        const airdropPromise = requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmSignatureOnlyTransaction,

--- a/packages/library/src/__tests__/send-transaction-internal-test.ts
+++ b/packages/library/src/__tests__/send-transaction-internal-test.ts
@@ -11,7 +11,10 @@ import {
     ITransactionWithFeePayer,
 } from '@solana/transactions';
 
-import { sendAndConfirmDurableNonceTransaction, sendAndConfirmTransaction } from '../send-transaction';
+import {
+    sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT,
+    sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT,
+} from '../send-transaction-internal';
 
 jest.mock('@solana/transactions');
 
@@ -41,7 +44,7 @@ describe('sendAndConfirmTransaction', () => {
         );
     });
     it('encodes the transaction into wire format before sending', () => {
-        sendAndConfirmTransaction({
+        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmRecentTransaction,
@@ -58,7 +61,7 @@ describe('sendAndConfirmTransaction', () => {
             preflightCommitment: 'confirmed' as Commitment,
             skipPreflight: false,
         } as Parameters<SendTransactionApi['sendTransaction']>[1];
-        sendAndConfirmTransaction({
+        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...sendTransactionConfig,
             abortSignal: new AbortController().signal,
             commitment: 'finalized' as Commitment,
@@ -82,7 +85,7 @@ describe('sendAndConfirmTransaction', () => {
         } as Parameters<SendTransactionApi['sendTransaction']>[1];
         sendTransaction.mockResolvedValue('abc' as Signature);
         const abortSignal = new AbortController().signal;
-        sendAndConfirmTransaction({
+        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...sendTransactionConfig,
             abortSignal,
             commitment: 'finalized' as Commitment,
@@ -104,7 +107,7 @@ describe('sendAndConfirmTransaction', () => {
     `(
         'when missing a `preflightCommitment` and the commitment is $commitment, applies a downgraded `preflightCommitment`',
         ({ commitment, expectedPreflightCommitment }) => {
-            sendAndConfirmTransaction({
+            sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment,
                 confirmRecentTransaction,
@@ -133,7 +136,7 @@ describe('sendAndConfirmTransaction', () => {
     `(
         'honours the explicit `preflightCommitment` no matter that the commitment is $commitment',
         ({ commitment, preflightCommitment, expectedPreflightCommitment }) => {
-            sendAndConfirmTransaction({
+            sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment,
                 confirmRecentTransaction,
@@ -151,7 +154,7 @@ describe('sendAndConfirmTransaction', () => {
     );
     it('when missing a `preflightCommitment` and the commitment is the same as the server default for `preflightCommitment`, does not apply a `preflightCommitment`', () => {
         expect.assertions(1);
-        sendAndConfirmTransaction({
+        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmRecentTransaction,
@@ -165,7 +168,7 @@ describe('sendAndConfirmTransaction', () => {
         sendTransaction.mockResolvedValue('abc');
         confirmRecentTransaction.mockResolvedValue(undefined);
         await expect(
-            sendAndConfirmTransaction({
+            sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment: 'finalized',
                 confirmRecentTransaction,
@@ -198,7 +201,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
         );
     });
     it('encodes the transaction into wire format before sending', () => {
-        sendAndConfirmDurableNonceTransaction({
+        sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmDurableNonceTransaction,
@@ -215,7 +218,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
             preflightCommitment: 'confirmed' as Commitment,
             skipPreflight: false,
         } as Parameters<SendTransactionApi['sendTransaction']>[1];
-        sendAndConfirmDurableNonceTransaction({
+        sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...sendTransactionConfig,
             abortSignal: new AbortController().signal,
             commitment: 'finalized' as Commitment,
@@ -239,7 +242,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
         } as Parameters<SendTransactionApi['sendTransaction']>[1];
         sendTransaction.mockResolvedValue('abc' as Signature);
         const abortSignal = new AbortController().signal;
-        sendAndConfirmDurableNonceTransaction({
+        sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...sendTransactionConfig,
             abortSignal,
             commitment: 'finalized' as Commitment,
@@ -261,7 +264,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
     `(
         'when missing a `preflightCommitment` and the commitment is $commitment, applies a downgraded `preflightCommitment`',
         ({ commitment, expectedPreflightCommitment }) => {
-            sendAndConfirmDurableNonceTransaction({
+            sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment,
                 confirmDurableNonceTransaction,
@@ -290,7 +293,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
     `(
         'honours the explicit `preflightCommitment` no matter that the commitment is $commitment',
         ({ commitment, preflightCommitment, expectedPreflightCommitment }) => {
-            sendAndConfirmDurableNonceTransaction({
+            sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment,
                 confirmDurableNonceTransaction,
@@ -308,7 +311,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
     );
     it('when missing a `preflightCommitment` and the commitment is the same as the server default for `preflightCommitment`, does not apply a `preflightCommitment`', () => {
         expect.assertions(1);
-        sendAndConfirmDurableNonceTransaction({
+        sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmDurableNonceTransaction,
@@ -322,7 +325,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
         sendTransaction.mockResolvedValue('abc');
         confirmDurableNonceTransaction.mockResolvedValue(undefined);
         await expect(
-            sendAndConfirmDurableNonceTransaction({
+            sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment: 'finalized',
                 confirmDurableNonceTransaction,

--- a/packages/library/src/airdrop-internal.ts
+++ b/packages/library/src/airdrop-internal.ts
@@ -1,0 +1,34 @@
+import { Address } from '@solana/addresses';
+import { Signature } from '@solana/keys';
+import { RequestAirdropApi } from '@solana/rpc-core';
+import { Commitment, LamportsUnsafeBeyond2Pow53Minus1, Rpc } from '@solana/rpc-types';
+
+import { createDefaultSignatureOnlyRecentTransactionConfirmer } from './airdrop-confirmer';
+
+type RequestAndConfirmAirdropConfig = Readonly<{
+    abortSignal?: AbortSignal;
+    commitment: Commitment;
+    confirmSignatureOnlyTransaction: ReturnType<typeof createDefaultSignatureOnlyRecentTransactionConfirmer>;
+    lamports: LamportsUnsafeBeyond2Pow53Minus1;
+    recipientAddress: Address;
+    rpc: Rpc<RequestAirdropApi>;
+}>;
+
+export async function requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT({
+    abortSignal,
+    commitment,
+    confirmSignatureOnlyTransaction,
+    lamports,
+    recipientAddress,
+    rpc,
+}: RequestAndConfirmAirdropConfig): Promise<Signature> {
+    const airdropTransactionSignature = await rpc
+        .requestAirdrop(recipientAddress, lamports, { commitment })
+        .send({ abortSignal });
+    await confirmSignatureOnlyTransaction({
+        abortSignal,
+        commitment,
+        signature: airdropTransactionSignature,
+    });
+    return airdropTransactionSignature;
+}

--- a/packages/library/src/airdrop.ts
+++ b/packages/library/src/airdrop.ts
@@ -1,54 +1,32 @@
-import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
 import type { GetSignatureStatusesApi, RequestAirdropApi, SignatureNotificationsApi } from '@solana/rpc-core';
 import type { Rpc, RpcSubscriptions } from '@solana/rpc-types';
-import { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 import { createDefaultSignatureOnlyRecentTransactionConfirmer } from './airdrop-confirmer';
+import { requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT } from './airdrop-internal';
 
-type AirdropRequesterConfig = Readonly<{
+type AirdropFunction = (
+    config: Omit<
+        Parameters<typeof requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
+        'confirmSignatureOnlyTransaction' | 'rpc'
+    >,
+) => Promise<Signature>;
+
+type AirdropFactoryConfig = Readonly<{
     rpc: Rpc<RequestAirdropApi & GetSignatureStatusesApi>;
     rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi>;
 }>;
 
-export function createDefaultAirdropRequester({ rpc, rpcSubscriptions }: AirdropRequesterConfig) {
+export function airdropFactory({ rpc, rpcSubscriptions }: AirdropFactoryConfig): AirdropFunction {
     const confirmSignatureOnlyTransaction = createDefaultSignatureOnlyRecentTransactionConfirmer({
         rpc,
         rpcSubscriptions,
     });
-    return async function requestAirdrop(
-        config: Omit<Parameters<typeof requestAndConfirmAirdrop>[0], 'confirmSignatureOnlyTransaction' | 'rpc'>,
-    ) {
-        return await requestAndConfirmAirdrop({
+    return async function airdrop(config) {
+        return await requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...config,
             confirmSignatureOnlyTransaction,
             rpc,
         });
     };
-}
-
-export async function requestAndConfirmAirdrop({
-    abortSignal,
-    commitment,
-    confirmSignatureOnlyTransaction,
-    lamports,
-    recipientAddress,
-    rpc,
-}: Readonly<{
-    abortSignal?: AbortSignal;
-    commitment: Commitment;
-    confirmSignatureOnlyTransaction: ReturnType<typeof createDefaultSignatureOnlyRecentTransactionConfirmer>;
-    lamports: LamportsUnsafeBeyond2Pow53Minus1;
-    recipientAddress: Address;
-    rpc: Rpc<RequestAirdropApi>;
-}>): Promise<Signature> {
-    const airdropTransactionSignature = await rpc
-        .requestAirdrop(recipientAddress, lamports, { commitment })
-        .send({ abortSignal });
-    await confirmSignatureOnlyTransaction({
-        abortSignal,
-        commitment,
-        signature: airdropTransactionSignature,
-    });
-    return airdropTransactionSignature;
 }

--- a/packages/library/src/send-transaction-internal.ts
+++ b/packages/library/src/send-transaction-internal.ts
@@ -1,0 +1,131 @@
+import { Signature } from '@solana/keys';
+import { SendTransactionApi } from '@solana/rpc-core';
+import { Commitment, commitmentComparator, Rpc } from '@solana/rpc-types';
+import {
+    BaseTransaction,
+    getBase64EncodedWireTransaction,
+    IDurableNonceTransaction,
+    IFullySignedTransaction,
+    ITransactionWithBlockhashLifetime,
+    ITransactionWithFeePayer,
+} from '@solana/transactions';
+
+import {
+    createDefaultDurableNonceTransactionConfirmer,
+    createDefaultRecentTransactionConfirmer,
+} from './transaction-confirmation';
+
+interface SendAndConfirmDurableNonceTransactionConfig
+    extends SendTransactionBaseConfig,
+        SendTransactionConfigWithoutEncoding {
+    confirmDurableNonceTransaction: ReturnType<typeof createDefaultDurableNonceTransactionConfirmer>;
+    transaction: SendableTransaction & IDurableNonceTransaction;
+}
+
+interface SendAndConfirmTransactionWithBlockhashLifetimeConfig
+    extends SendTransactionBaseConfig,
+        SendTransactionConfigWithoutEncoding {
+    confirmRecentTransaction: ReturnType<typeof createDefaultRecentTransactionConfirmer>;
+    transaction: SendableTransaction & ITransactionWithBlockhashLifetime;
+}
+
+interface SendTransactionBaseConfig extends SendTransactionConfigWithoutEncoding {
+    abortSignal?: AbortSignal;
+    commitment: Commitment;
+    rpc: Rpc<SendTransactionApi>;
+    transaction: SendableTransaction;
+}
+
+interface SendTransactionConfigWithoutEncoding
+    extends Omit<NonNullable<Parameters<SendTransactionApi['sendTransaction']>[1]>, 'encoding'> {}
+
+export type SendableTransaction = BaseTransaction &
+    (ITransactionWithBlockhashLifetime | IDurableNonceTransaction) &
+    ITransactionWithFeePayer &
+    IFullySignedTransaction;
+
+function getSendTransactionConfigWithAdjustedPreflightCommitment(
+    commitment: Commitment,
+    config?: SendTransactionConfigWithoutEncoding,
+): SendTransactionConfigWithoutEncoding | void {
+    if (
+        // The developer has supplied no value for `preflightCommitment`.
+        !config?.preflightCommitment &&
+        // The value of `commitment` is lower than the server default of `preflightCommitment`.
+        commitmentComparator(commitment, 'finalized' /* default value of `preflightCommitment` */) < 0
+    ) {
+        return {
+            ...config,
+            // In the common case, it is unlikely that you want to simulate a transaction at
+            // `finalized` commitment when your standard of commitment for confirming the
+            // transaction is lower. Cap the simulation commitment level to the level of the
+            // confirmation commitment.
+            preflightCommitment: commitment,
+        };
+    }
+    // The commitment at which the developer wishes to confirm the transaction is at least as
+    // high as the commitment at which they want to simulate it. Honour the config as-is.
+    return config;
+}
+
+async function sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
+    abortSignal,
+    commitment,
+    rpc,
+    transaction,
+    ...sendTransactionConfig
+}: SendTransactionBaseConfig): Promise<Signature> {
+    const base64EncodedWireTransaction = getBase64EncodedWireTransaction(transaction);
+    return await rpc
+        .sendTransaction(base64EncodedWireTransaction, {
+            ...getSendTransactionConfigWithAdjustedPreflightCommitment(commitment, sendTransactionConfig),
+            encoding: 'base64',
+        })
+        .send({ abortSignal });
+}
+
+export async function sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
+    abortSignal,
+    commitment,
+    confirmDurableNonceTransaction,
+    rpc,
+    transaction,
+    ...sendTransactionConfig
+}: SendAndConfirmDurableNonceTransactionConfig): Promise<Signature> {
+    const transactionSignature = await sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
+        ...sendTransactionConfig,
+        abortSignal,
+        commitment,
+        rpc,
+        transaction,
+    });
+    await confirmDurableNonceTransaction({
+        abortSignal,
+        commitment,
+        transaction,
+    });
+    return transactionSignature;
+}
+
+export async function sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+    abortSignal,
+    commitment,
+    confirmRecentTransaction,
+    rpc,
+    transaction,
+    ...sendTransactionConfig
+}: SendAndConfirmTransactionWithBlockhashLifetimeConfig): Promise<Signature> {
+    const transactionSignature = await sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
+        ...sendTransactionConfig,
+        abortSignal,
+        commitment,
+        rpc,
+        transaction,
+    });
+    await confirmRecentTransaction({
+        abortSignal,
+        commitment,
+        transaction,
+    });
+    return transactionSignature;
+}


### PR DESCRIPTION
# Summary

The goal of this PR is to make it abundantly clear what kind of transaction sender you're creating by renaming these to `{METHOD}Factory`. This will make them come up first in autocomplete when someone types, for instance, `sendAndConfirm`.

Closes #2120.