### PR TITLE
Export a non-confirming transaction sender factory

### DIFF
--- a/packages/library/src/send-transaction-internal.ts
+++ b/packages/library/src/send-transaction-internal.ts
@@ -77,7 +77,7 @@ function getSendTransactionConfigWithAdjustedPreflightCommitment(
     return config;
 }
 
-async function sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
+export async function sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
     abortSignal,
     commitment,
     rpc,

--- a/packages/library/src/send-transaction.ts
+++ b/packages/library/src/send-transaction.ts
@@ -27,6 +27,7 @@ import {
     SendableTransaction,
     sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT,
     sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT,
+    sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT,
 } from './send-transaction-internal';
 
 interface SendAndConfirmDurableNonceTransactionFactoryConfig {
@@ -37,6 +38,10 @@ interface SendAndConfirmDurableNonceTransactionFactoryConfig {
 interface SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig {
     rpc: Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
     rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>;
+}
+
+interface SendTransactionWithoutConfirmingFactoryConfig {
+    rpc: Rpc<SendTransactionApi>;
 }
 
 type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
@@ -54,6 +59,23 @@ type SendAndConfirmDurableNonceTransactionFunction = (
         'confirmDurableNonceTransaction' | 'rpc' | 'transaction'
     >,
 ) => Promise<void>;
+
+type SendTransactionWithoutConfirmingFunction = (
+    transaction: SendableTransaction,
+    config: Omit<Parameters<typeof sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT>[0], 'rpc' | 'transaction'>,
+) => Promise<void>;
+
+export function sendTransactionWithoutConfirmingFactory({
+    rpc,
+}: SendTransactionWithoutConfirmingFactoryConfig): SendTransactionWithoutConfirmingFunction {
+    return async function sendTransactionWithoutConfirming(transaction, config) {
+        await sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
+            ...config,
+            rpc,
+            transaction,
+        });
+    };
+}
 
 export function sendAndConfirmDurableNonceTransactionFactory({
     rpc,


### PR DESCRIPTION
# Summary

Folks can use this to create a transaction sender that does not confirm the transaction.

Closes #2121
