### PR TITLE
refactor(experimental): fix a few RPC methods

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
@@ -46,7 +46,7 @@ describe('getLeaderSchedule', () => {
             describe('when called with no identity and no slot', () => {
                 it('returns the leader schedule for all cluster nodes in the current epoch', async () => {
                     expect.assertions(3);
-                    const res = await rpc.getLeaderSchedule({ commitment }).send();
+                    const res = await rpc.getLeaderSchedule(null, { commitment }).send();
                     // Does not need null check (default slot)
                     expect(res).toStrictEqual(expect.any(Object));
                     for (const key of Object.keys(res)) {
@@ -79,7 +79,7 @@ describe('getLeaderSchedule', () => {
                     expect.assertions(1);
                     const identity = await getValidatorAddress();
                     const res = await rpc
-                        .getLeaderSchedule({
+                        .getLeaderSchedule(null, {
                             commitment,
                             identity,
                         })
@@ -114,7 +114,7 @@ describe('getLeaderSchedule', () => {
             it('returns an empty object', async () => {
                 expect.assertions(1);
                 const res = await rpc
-                    .getLeaderSchedule({
+                    .getLeaderSchedule(null, {
                         commitment,
                         // See scripts/fixtures/GQE2yjns7SKKuMc89tveBDpzYHwXfeuB2PGAbGaPWc6G.json
                         identity: 'GQE2yjns7SKKuMc89tveBDpzYHwXfeuB2PGAbGaPWc6G' as Address,
@@ -128,7 +128,7 @@ describe('getLeaderSchedule', () => {
             it('returns an empty object', async () => {
                 expect.assertions(1);
                 const res = await rpc
-                    .getLeaderSchedule({
+                    .getLeaderSchedule(null, {
                         commitment,
                         // Randomly generated
                         identity: 'BnWCFuxmi6uH3ceVx4R8qcbWBMPVVYVVFWtAiiTA1PAu' as Address,

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-leader-schedule-type-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-leader-schedule-type-test.ts
@@ -1,0 +1,34 @@
+import { Address } from '@solana/addresses';
+import { Rpc, Slot } from '@solana/rpc-types';
+
+import { GetLeaderScheduleApi } from '../getLeaderSchedule';
+
+const rpc = null as unknown as Rpc<GetLeaderScheduleApi>;
+const slot = 0n as Slot;
+const identity = 'Joe11111111111111111111111111111' as Address<'Joe11111111111111111111111111111'>;
+
+async () => {
+    {
+        const result = await rpc.getLeaderSchedule(slot).send();
+        // Can be null if the slot corresponds to an epoch that does not exist
+        result satisfies Record<Address, Slot[]> | null;
+    }
+
+    {
+        const result = await rpc.getLeaderSchedule(null).send();
+        // Won't be null
+        result satisfies Record<Address, Slot[]>;
+    }
+
+    {
+        const result = await rpc.getLeaderSchedule(slot, { identity }).send();
+        // Can be null if the slot corresponds to an epoch that does not exist
+        result satisfies Readonly<{ [key: Address]: Slot[] | undefined }> | null;
+    }
+
+    {
+        const result = await rpc.getLeaderSchedule(null, { identity }).send();
+        // Won't be null
+        result satisfies Readonly<{ [key: Address]: Slot[] | undefined }>;
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-supply-type-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-supply-type-test.ts
@@ -1,0 +1,47 @@
+import { Address } from '@solana/addresses';
+import { Rpc } from '@solana/rpc-types';
+
+import { GetSupplyApi } from '../getSupply';
+
+const rpc = null as unknown as Rpc<GetSupplyApi>;
+
+async () => {
+    {
+        const result = await rpc.getSupply({ excludeNonCirculatingAccountsList: true }).send();
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: never[];
+            }>;
+        }>;
+    }
+
+    {
+        const result = await rpc.getSupply().send();
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: Address[];
+            }>;
+        }>;
+        // @ts-expect-error should not be `never`
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: never[];
+            }>;
+        }>;
+    }
+
+    {
+        const result = await rpc.getSupply({ excludeNonCirculatingAccountsList: false }).send();
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: Address[];
+            }>;
+        }>;
+        // @ts-expect-error should not be `never`
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: never[];
+            }>;
+        }>;
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/getSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getSupply.ts
@@ -3,7 +3,6 @@ import type { Commitment, IRpcApiMethods, LamportsUnsafeBeyond2Pow53Minus1, RpcR
 
 type GetSupplyConfig = Readonly<{
     commitment?: Commitment;
-    excludeNonCirculatingAccountsList?: boolean;
 }>;
 
 type GetSupplyApiResponseBase = RpcResponse<{
@@ -19,14 +18,18 @@ type GetSupplyApiResponseWithNonCirculatingAccounts = GetSupplyApiResponseBase &
     Readonly<{
         value: Readonly<{
             /** an array of account addresses of non-circulating accounts */
-            nonCirculatingAccounts: [Address];
+            nonCirculatingAccounts: Address[];
         }>;
     }>;
 
 type GetSupplyApiResponseWithoutNonCirculatingAccounts = GetSupplyApiResponseBase &
     Readonly<{
         value: Readonly<{
-            nonCirculatingAccounts: [];
+            /** As per the docs:
+             * "If `excludeNonCirculatingAccountsList` is enabled, the returned array will be empty."
+             * See: https://solana.com/docs/rpc/http/getsupply
+             */
+            nonCirculatingAccounts: never[];
         }>;
     }>;
 
@@ -40,5 +43,10 @@ export interface GetSupplyApi extends IRpcApiMethods {
                 excludeNonCirculatingAccountsList: true;
             }>,
     ): GetSupplyApiResponseWithoutNonCirculatingAccounts;
-    getSupply(config?: GetSupplyConfig): GetSupplyApiResponseWithNonCirculatingAccounts;
+    getSupply(
+        config?: GetSupplyConfig &
+            Readonly<{
+                excludeNonCirculatingAccountsList?: false;
+            }>,
+    ): GetSupplyApiResponseWithNonCirculatingAccounts;
 }


### PR DESCRIPTION
This change simply fixes a handful of incorrect RPC method signatures, as per
the RPC docs.

Stems from errors found in #2087.
