### PR TITLE
A benchmark suite for the base58 encoder

### DIFF
--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -33,6 +33,7 @@
         "web3"
     ],
     "scripts": {
+        "benchmark": "./src/__benchmarks__/run.ts",
         "compile:js": "tsup --config build-scripts/tsup.config.package.ts",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node node_modules/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c node_modules/test-config/jest-dev.config.ts --rootDir . --watch",
@@ -87,6 +88,7 @@
         "prettier": "^3.1",
         "test-config": "workspace:*",
         "text-encoding-impl": "workspace:*",
+        "tinybench": "^2.6.0",
         "tsconfig": "workspace:*",
         "tsup": "^8.0.1",
         "typescript": "^5.2.2",

--- a/packages/codecs-strings/src/__benchmarks__/run.ts
+++ b/packages/codecs-strings/src/__benchmarks__/run.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env -S pnpx tsx
+
+import { webcrypto as crypto } from 'node:crypto';
+
+import { Bench } from 'tinybench';
+
+import { getBase58Codec } from '../base58';
+
+const bench = new Bench({
+    throws: true,
+});
+
+const bytes32 = new Uint8Array(32);
+let base58EncodedString: string;
+function randomizeBytes() {
+    crypto.getRandomValues(bytes32);
+}
+const base58Codec = getBase58Codec();
+
+bench
+    .add(
+        'Base58 decode',
+        () => {
+            base58Codec.decode(bytes32);
+        },
+        { beforeEach: randomizeBytes },
+    )
+    .add(
+        'Base58 encode',
+        () => {
+            base58Codec.encode(base58EncodedString);
+        },
+        {
+            beforeEach() {
+                randomizeBytes();
+                base58EncodedString = base58Codec.decode(bytes32);
+            },
+        },
+    );
+
+(async () => {
+    await bench.warmup();
+    await bench.run();
+
+    console.table(bench.table());
+})();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   jsdom: ^22
   mock-socket: ^9.3.0
@@ -250,7 +254,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.0.1
-        version: 8.0.1(@swc/core@1.3.93)(typescript@5.1.6)
+        version: 8.0.1(@swc/core@1.3.93)(typescript@5.2.2)
 
   packages/codecs:
     dependencies:
@@ -308,7 +312,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.0.1
-        version: 8.0.1(@swc/core@1.3.93)(typescript@5.1.6)
+        version: 8.0.1(@swc/core@1.3.93)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -585,6 +589,9 @@ importers:
       text-encoding-impl:
         specifier: workspace:*
         version: link:../text-encoding-impl
+      tinybench:
+        specifier: ^2.6.0
+        version: 2.6.0
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1856,7 +1863,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.0.1
-        version: 8.0.1(@swc/core@1.3.93)(typescript@5.1.6)
+        version: 8.0.1(@swc/core@1.3.93)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -5356,7 +5363,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 6.13.2(@typescript-eslint/parser@6.8.0)(eslint@8.51.0)(typescript@5.2.2)
       '@typescript-eslint/parser': 6.8.0(eslint@8.51.0)(typescript@5.2.2)
       eslint: 8.51.0
-      eslint-plugin-jest: 27.4.2(@typescript-eslint/eslint-plugin@6.13.2)(eslint@8.45.0)(jest@29.7.0)(typescript@5.1.6)
+      eslint-plugin-jest: 27.4.2(@typescript-eslint/eslint-plugin@6.13.2)(eslint@8.51.0)(jest@29.7.0)(typescript@5.2.2)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.51.0)
       eslint-plugin-simple-import-sort: 10.0.0(eslint@8.51.0)
       eslint-plugin-sort-keys-fix: 1.1.2
@@ -13312,6 +13319,10 @@ packages:
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  /tinybench@2.6.0:
+    resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
+    dev: true
+
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
@@ -14252,7 +14263,3 @@ packages:
   /zstd-codec@0.1.4:
     resolution: {integrity: sha512-KYnWoFWgGtWyQEKNnUcb3u8ZtKO8dn5d8u+oGpxPlopqsPyv60U8suDyfk7Z7UtAO6Sk5i1aVcAs9RbaB1n36A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
# Summary

These should form a basis for refactoring work – to ensure that changes don't regress performance.

# Test Plan

```shell
~/src/solana-web3.js-git/packages/codecs-strings$ pnpm benchmark

> @solana/codecs-strings@2.0.0-development benchmark /home/sol/src/solana-web3.js-git/packages/codecs-strings
> ./src/__benchmarks__/run.ts

Packages: +5
+++++
Progress: resolved 28, reused 5, downloaded 0, added 5, done
┌─────────┬─────────────────┬──────────┬────────────────────┬──────────┬─────────┐
│ (index) │    Task Name    │ ops/sec  │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼─────────────────┼──────────┼────────────────────┼──────────┼─────────┤
│    0    │ 'Base58 decode' │ '61,775' │ 16187.51705202282  │ '±0.43%' │  30888  │
│    1    │ 'Base58 encode' │ '42,444' │ 23560.373047174093 │ '±0.38%' │  21223  │
└─────────┴─────────────────┴──────────┴────────────────────┴──────────┴─────────┘
```
