### PR TITLE
Eliminate copy in baseX encoder

### DIFF
--- a/packages/codecs-strings/src/baseX.ts
+++ b/packages/codecs-strings/src/baseX.ts
@@ -99,7 +99,12 @@ function partitionLeadingZeroes(value: string, zeroCharacter: string): [string, 
 
 function getBigIntFromBaseX(value: string, alphabet: string): bigint {
     const base = BigInt(alphabet.length);
-    return [...value].reduce((sum, char) => sum * base + BigInt(alphabet.indexOf(char)), 0n);
+    let sum = 0n;
+    for (const char of value) {
+        sum *= base;
+        sum += BigInt(alphabet.indexOf(char));
+    }
+    return sum;
 }
 
 function getBaseXFromBigInt(value: bigint, alphabet: string): string {


### PR DESCRIPTION
# Test Plan

No change in benchmarks.

```shell
cd packages/codecs-strings/
pnpm benchmark
```
