### PR TITLE
refactor(experimental): move block-notifications to unstable methods

### DIFF
--- a/packages/rpc-subscriptions-api/src/index.ts
+++ b/packages/rpc-subscriptions-api/src/index.ts
@@ -23,13 +23,12 @@ import { SlotsUpdatesNotificationsApi } from './slots-updates-notifications';
 import { VoteNotificationsApi } from './vote-notifications';
 
 export type SolanaRpcSubscriptionsApi = AccountNotificationsApi &
-    BlockNotificationsApi &
     LogsNotificationsApi &
     ProgramNotificationsApi &
     RootNotificationsApi &
     SignatureNotificationsApi &
     SlotNotificationsApi;
-export type SolanaRpcSubscriptionsApiUnstable = SlotsUpdatesNotificationsApi & VoteNotificationsApi;
+export type SolanaRpcSubscriptionsApiUnstable = BlockNotificationsApi & SlotsUpdatesNotificationsApi & VoteNotificationsApi;
 
 export type {
     AccountNotificationsApi,


### PR DESCRIPTION
`BlockNotifications` is actually an unstable method. Move it to the unstable
API.
