### PR TITLE
refactor(experimental): repair `SolanaRpcMethodsMainnet` type inference

### DIFF
--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -63,7 +63,7 @@ import { RequestAirdropApi } from './requestAirdrop';
 import { SendTransactionApi } from './sendTransaction';
 import { SimulateTransactionApi } from './simulateTransaction';
 
-export type SolanaRpcApi = GetAccountInfoApi &
+type SolanaRpcApiForAllClusters = GetAccountInfoApi &
     GetBalanceApi &
     GetBlockApi &
     GetBlockCommitmentApi &
@@ -113,12 +113,13 @@ export type SolanaRpcApi = GetAccountInfoApi &
     GetVoteAccountsApi &
     IsBlockhashValidApi &
     MinimumLedgerSlotApi &
-    RequestAirdropApi &
     SendTransactionApi &
     SimulateTransactionApi;
-export type SolanaRpcApiDevnet = SolanaRpcApi;
-export type SolanaRpcApiTestnet = SolanaRpcApi;
-export type SolanaRpcApiMainnet = Omit<SolanaRpcApi, 'requestAirdrop'>;
+type SolanaRpcApiForTestClusters = SolanaRpcApiForAllClusters & RequestAirdropApi;
+export type SolanaRpcApi = SolanaRpcApiForTestClusters;
+export type SolanaRpcApiDevnet = SolanaRpcApiForTestClusters;
+export type SolanaRpcApiTestnet = SolanaRpcApiForTestClusters;
+export type SolanaRpcApiMainnet = SolanaRpcApiForAllClusters;
 
 export type {
     GetAccountInfoApi,

--- a/packages/rpc/src/__typetests__/rpc-clusters-typetest.ts
+++ b/packages/rpc/src/__typetests__/rpc-clusters-typetest.ts
@@ -88,8 +88,7 @@ createSolanaRpc({ transport: testnetTransport }) satisfies RpcMainnet<SolanaRpcA
 
 // Mainnet cluster should be `RpcMainnet`
 createSolanaRpc({ transport: mainnetTransport }) satisfies Rpc<SolanaRpcApiMainnet>;
-//@ts-expect-error Should not have `requestAirdrop` method
-createSolanaRpc({ transport: mainnetTransport }) satisfies Rpc<SolanaRpcApi>;
+createSolanaRpc({ transport: mainnetTransport }) satisfies RpcMainnet<SolanaRpcApiMainnet>;
 //@ts-expect-error Should not have `requestAirdrop` method
 createSolanaRpc({ transport: mainnetTransport }) satisfies Rpc<RequestAirdropApi>;
 //@ts-expect-error Should not be a devnet RPC

--- a/packages/rpc/src/rpc.ts
+++ b/packages/rpc/src/rpc.ts
@@ -11,6 +11,6 @@ type RpcConfig<TTransport extends RpcTransport> = Readonly<{
 export function createSolanaRpc<TTransport extends RpcTransport>(
     config: RpcConfig<TTransport>,
 ): RpcFromTransport<SolanaRpcApiFromTransport<TTransport>, TTransport> {
-    const api = createSolanaRpcApi<SolanaRpcApiFromTransport<TTransport>>(DEFAULT_RPC_CONFIG);
+    const api = createSolanaRpcApi(DEFAULT_RPC_CONFIG);
     return createRpc({ ...config, api }) as RpcFromTransport<SolanaRpcApiFromTransport<TTransport>, TTransport>;
 }


### PR DESCRIPTION
Repair the type inference for `SolanaRpcMethodsMainnet` by eliminating the
`Omit<..>` from the type and relaxing some type conditionals in
`createSolanaRpc(..)`.

Closes #2164 

Note: This solves the type inference issue but not the speed of type resolution.
I'm noticing only about a 1 second hang when I type `.`.

What was the tool for testing this response time?
