### PR TITLE
Allow devs to supply a dispatcher to the Node implementation of `fetch`

### DIFF
--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -43,6 +43,8 @@ export function getBaseConfig(platform: Platform, formats: Format[], _options: O
                           external: [
                               // Despite inlining `@solana/text-encoding-impl`, do not recursively inline `fastestsmallesttextencoderdecoder`.
                               'fastestsmallesttextencoderdecoder',
+                              // Despite inlining `@solana/fetch-impl`, do not recursively inline `undici`.
+                              'undici',
                               // Despite inlining `@solana/ws-impl`, do not recursively inline `ws`.
                               'ws',
                           ],

--- a/packages/fetch-impl/package.json
+++ b/packages/fetch-impl/package.json
@@ -35,12 +35,17 @@
         "test:prettier": "jest -c node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",
         "test:treeshakability:node": "agadoo dist/index.node.js",
-        "test:typecheck": "tsc --noEmit"
+        "test:typecheck": "tsc --noEmit",
+        "test:unit:browser": "jest -c node_modules/@solana/test-config/jest-unit.config.browser.ts --rootDir . --silent --passWithNoTests",
+        "test:unit:node": "jest -c node_modules/@solana/test-config/jest-unit.config.node.ts --rootDir . --silent"
     },
     "browserslist": [
         "supports bigint and not dead",
         "maintained node versions"
     ],
+    "dependencies": {
+        "undici": "^6.2.2"
+    },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.2",
         "@solana/test-config": "workspace:*",

--- a/packages/fetch-impl/src/__tests__/fetch-test.node.ts
+++ b/packages/fetch-impl/src/__tests__/fetch-test.node.ts
@@ -1,0 +1,21 @@
+import { Dispatcher, fetch as fetchImpl } from 'undici';
+
+import fetch from '../index.node';
+
+jest.mock('undici');
+
+describe('fetch', () => {
+    it('should call the underlying `fetch` with the `dispatcher` supplied in `requestInit`', () => {
+        const explicitDispatcher = Symbol('explicitDispatcher') as unknown as Dispatcher;
+        fetch('http://solana.com', { dispatcher: explicitDispatcher });
+        expect(fetchImpl).toHaveBeenCalledWith('http://solana.com', {
+            dispatcher: explicitDispatcher,
+        });
+    });
+    it('should call the underlying `fetch` with an undefined `dispatcher` when an undefined is explicitly supplied in `requestInit`', () => {
+        fetch('http://solana.com', { dispatcher: undefined });
+        expect(fetchImpl).toHaveBeenCalledWith('http://solana.com', {
+            dispatcher: undefined,
+        });
+    });
+});

--- a/packages/fetch-impl/src/index.node.ts
+++ b/packages/fetch-impl/src/index.node.ts
@@ -1,2 +1,1 @@
-// TODO(https://github.com/solana-labs/solana-web3.js/issues/1787) Write HTTP/2 implementation.
-export default globalThis.fetch; // The Fetch API is supported natively in Node 18+.
+export { fetch as default } from 'undici';

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -63,7 +63,8 @@
         "maintained node versions"
     ],
     "dependencies": {
-        "@solana/rpc-spec": "workspace:*"
+        "@solana/rpc-spec": "workspace:*",
+        "undici": "^6.6.2"
     },
     "devDependencies": {
         "@solana/build-scripts": "workspace:*",

--- a/packages/rpc-transport-http/src/__tests__/http-transport-dispatcher-test.browser.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-dispatcher-test.browser.ts
@@ -1,0 +1,53 @@
+import type { Dispatcher } from 'undici';
+
+const WARNING_MESSAGE =
+    'You have supplied a `Dispatcher` to `createHttpTransport()`. It has been ignored because ' +
+    'Undici dispatchers only work in Node environments. To eliminate this warning, omit the ' +
+    '`dispatcher_NODE_ONLY` property from your config when running in a non-Node environment.';
+
+describe('createHttpTransport()', () => {
+    let createHttpTransport: typeof import('../http-transport').createHttpTransport;
+    beforeEach(async () => {
+        jest.spyOn(console, 'warn').mockImplementation();
+        await jest.isolateModulesAsync(async () => {
+            createHttpTransport =
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                (await import('../http-transport')).createHttpTransport;
+        });
+    });
+    describe('in development mode', () => {
+        beforeEach(() => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (globalThis as any).__DEV__ = true;
+        });
+        it('warns when configured with a dispatcher', () => {
+            createHttpTransport({ dispatcher_NODE_ONLY: {} as Dispatcher, url: 'fake://url' });
+            expect(console.warn).toHaveBeenCalledWith(WARNING_MESSAGE);
+        });
+        it('warns when configured with an undefined dispatcher', () => {
+            createHttpTransport({ dispatcher_NODE_ONLY: undefined, url: 'fake://url' });
+            expect(console.warn).toHaveBeenCalledWith(WARNING_MESSAGE);
+        });
+        it('only warns once no matter how many times it is configured with a dispatcher', () => {
+            createHttpTransport({ dispatcher_NODE_ONLY: undefined, url: 'fake://url' });
+            createHttpTransport({ dispatcher_NODE_ONLY: {} as Dispatcher, url: 'fake://url' });
+            createHttpTransport({ dispatcher_NODE_ONLY: null as unknown as Dispatcher, url: 'fake://url' });
+            expect(console.warn).toHaveBeenCalledTimes(1);
+        });
+    });
+    describe('in production mode', () => {
+        beforeEach(() => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (globalThis as any).__DEV__ = false;
+        });
+        it('does not warn when configured with a dispatcher', () => {
+            createHttpTransport({ dispatcher_NODE_ONLY: {} as Dispatcher, url: 'fake://url' });
+            expect(console.warn).not.toHaveBeenCalledWith(WARNING_MESSAGE);
+        });
+        it('does not warn when configured with an undefined dispatcher', () => {
+            createHttpTransport({ dispatcher_NODE_ONLY: undefined, url: 'fake://url' });
+            expect(console.warn).not.toHaveBeenCalledWith(WARNING_MESSAGE);
+        });
+    });
+});

--- a/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
@@ -75,7 +75,7 @@ describe('createHttpRequest with custom headers', () => {
     it('is impossible to override the `Accept` header', () => {
         const makeHttpRequest = createHttpTransport({
             headers: { aCcEpT: 'text/html' },
-            url: 'fake://url',
+            url: 'http://localhost',
         });
         makeHttpRequest({ payload: 123 });
         expect(fetchImpl).toHaveBeenCalledWith(
@@ -90,7 +90,7 @@ describe('createHttpRequest with custom headers', () => {
     it('is impossible to override the `Content-Length` header', () => {
         const makeHttpRequest = createHttpTransport({
             headers: { 'cOnTeNt-LeNgTh': '420' },
-            url: 'fake://url',
+            url: 'http://localhost',
         });
         makeHttpRequest({ payload: 123 });
         expect(fetchImpl).toHaveBeenCalledWith(
@@ -105,7 +105,7 @@ describe('createHttpRequest with custom headers', () => {
     it('is impossible to override the `Content-Type` header', () => {
         const makeHttpRequest = createHttpTransport({
             headers: { 'cOnTeNt-TyPe': 'text/html' },
-            url: 'fake://url',
+            url: 'http://localhost',
         });
         makeHttpRequest({ payload: 123 });
         expect(fetchImpl).toHaveBeenCalledWith(
@@ -123,7 +123,7 @@ describe('createHttpRequest with custom headers', () => {
             createTransportWithForbiddenHeaders = () =>
                 createHttpTransport({
                     headers: { 'sEc-FeTcH-mOdE': 'no-cors' },
-                    url: 'fake://url',
+                    url: 'http://localhost',
                 });
         });
         it('throws in dev mode', () => {

--- a/packages/rpc/src/rpc-transport.ts
+++ b/packages/rpc/src/rpc-transport.ts
@@ -6,10 +6,10 @@ import { RpcTransportFromClusterUrl } from './rpc-clusters';
 import { getRpcTransportWithRequestCoalescing } from './rpc-request-coalescer';
 import { getSolanaRpcPayloadDeduplicationKey } from './rpc-request-deduplication';
 
-type Config<TClusterUrl extends ClusterUrl> = Readonly<{
-    headers?: Parameters<typeof createHttpTransport>[0]['headers'];
+type RpcTransportConfig = Parameters<typeof createHttpTransport>[0];
+interface Config<TClusterUrl extends ClusterUrl> extends RpcTransportConfig {
     url: TClusterUrl;
-}>;
+}
 
 /**
  * Lowercasing header names makes it easier to override user-supplied headers.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -830,6 +830,10 @@ importers:
         version: 1.1.1
 
   packages/fetch-impl:
+    dependencies:
+      undici:
+        specifier: ^6.2.2
+        version: 6.6.2
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^1.0.2
@@ -2522,6 +2526,9 @@ importers:
       '@solana/rpc-spec':
         specifier: workspace:*
         version: link:../rpc-spec
+      undici:
+        specifier: ^6.6.2
+        version: 6.6.2
     devDependencies:
       '@solana/build-scripts':
         specifier: workspace:*
@@ -4859,7 +4866,6 @@ packages:
   /@fastify/busboy@2.1.0:
     resolution: {integrity: sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==}
     engines: {node: '>=14'}
-    dev: true
 
   /@graphql-tools/merge@8.3.1(graphql@15.8.0):
     resolution: {integrity: sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==}
@@ -6350,7 +6356,7 @@ packages:
   /@types/bn.js@5.1.1:
     resolution: {integrity: sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==}
     dependencies:
-      '@types/node': 18.11.19
+      '@types/node': 20.11.20
     dev: true
 
   /@types/bs58@4.0.1:
@@ -6387,7 +6393,7 @@ packages:
   /@types/express-serve-static-core@4.17.41:
     resolution: {integrity: sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==}
     dependencies:
-      '@types/node': 18.11.19
+      '@types/node': 20.11.20
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -6458,13 +6464,13 @@ packages:
   /@types/mz@2.7.4:
     resolution: {integrity: sha512-Zs0imXxyWT20j3Z2NwKpr0IO2LmLactBblNyLua5Az4UHuqOQ02V3jPTgyKwDkuc33/ahw+C3O1PIZdrhFMuQA==}
     dependencies:
-      '@types/node': 18.11.19
+      '@types/node': 20.11.20
     dev: true
 
   /@types/node-fetch@2.1.0:
     resolution: {integrity: sha512-7qhZIMCvHDJMZtdirrb/SkmTs2Dg8oVCLpUCOxNKm36xBdUZhh2JDWO/BeOdI5UyStyaCmeRv5UskaiH7kAgdg==}
     dependencies:
-      '@types/node': 18.11.19
+      '@types/node': 20.11.20
     dev: true
 
   /@types/node@12.20.55:
@@ -12141,7 +12147,7 @@ packages:
       '@httptoolkit/subscriptions-transport-ws': 0.11.2(graphql@15.8.0)
       '@httptoolkit/websocket-stream': 6.0.1
       '@types/cors': 2.8.13
-      '@types/node': 18.11.19
+      '@types/node': 20.11.20
       base64-arraybuffer: 0.1.5
       body-parser: 1.20.2
       cacheable-lookup: 6.1.0
@@ -14524,7 +14530,6 @@ packages:
     engines: {node: '>=18.0'}
     dependencies:
       '@fastify/busboy': 2.1.0
-    dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}


### PR DESCRIPTION
# Summary

The current version of web3.js allows folks to supply what's called an ‘HTTP Agent.’ This is a class that mediates how network requests should be fetched. One example is to establish a connection pool for a given URL, and keep connections open for a time so that TLS/SSL negotiation doesn't have to be done on every request.

The new web3.js up until this point has punted on how to reintroduce this concept. In this PR we bring it back in the form of allowing callers to create transports with custom Undici `Dispatchers`.

It only works in Node. If you supply the `dispatcher_NODE_ONLY` property in non-Node environments you'll get a console warning that your config has been ignored.

# Alternate designs considered

I desperately wanted to avoid the situation in this PR, which was to create a config property on transports that's only usable in Node.

Alternate approaches considered:

1. Create a special transport for use in Node. Callers would have to `createDefaultNodeRpcTransport()` and/or `solanaRpcFactoryForNode()` which I thought was a bridge too far.
2. Encourage people to [inject a global dispatcher](https://stackoverflow.com/a/77526783/802047). This is a terrible idea for all of the reasons that global state is terrible:
    * Applies to all connections in the process
    * Your global dispatcher can be unset by someone _else_
    * There might already be a global dispatcher installed (eg. a `ProxyAgent`) and you might unknowingly replace it
3. Export a `Dispatcher` setter that lets you install a dispatcher accessible _only_ to `@solana/fetch-impl`. Besides having most of the bad features of #&#8203;2, this would not work. We inline `@solana/fetch-impl` in the build, meaning there's no longer anywhere to export such a method from.

# Test Plan

```shell
cd packages/fetch-impl/
pnpm test:unit:node
cd ../rpc-transport-http/
pnpm test:unit:node
```

See benchmark tests in next PR.

Closes #2126.