### PR TITLE
Create benchmarks for tuning the Node transport

### DIFF
--- a/packages/fetch-impl/package.json
+++ b/packages/fetch-impl/package.json
@@ -27,6 +27,7 @@
     ],
     "sideEffects": false,
     "scripts": {
+        "benchmark": "./src/__benchmarks__/run.ts",
         "compile:js": "tsup",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
         "dev": "jest -c node_modules/@solana/test-config/jest-dev.config.ts --rootDir . --watch",
@@ -63,6 +64,7 @@
         "jest-runner-eslint": "^2.1.2",
         "jest-runner-prettier": "^1.0.0",
         "prettier": "^3.1",
+        "tinybench": "^2.6.0",
         "tsup": "^8.0.1",
         "typescript": "^5.1.6"
     }

--- a/packages/fetch-impl/src/__benchmarks__/run.ts
+++ b/packages/fetch-impl/src/__benchmarks__/run.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env -S pnpx tsx
+
+import { ok } from 'node:assert';
+import process from 'node:process';
+
+import { Bench } from 'tinybench';
+import { Agent, Dispatcher } from 'undici';
+
+import fetchImpl from '../index.node';
+
+const NUM_CONCURRENT_REQUESTS = 1024;
+const URL = process.argv[2];
+ok(URL, 'You must supply the URL of a rate-limit-free Solana JSON-RPC server as the first argument to this script');
+
+const bench = new Bench({
+    throws: true,
+});
+
+let dispatcher: Dispatcher | undefined;
+function createDispatcher(options: Agent.Options) {
+    dispatcher = new Agent({
+        ...options,
+        // One second fewer than the Solana RPC's keepalive timeout.
+        // Read more: https://github.com/solana-labs/solana/issues/27859#issuecomment-1340097889
+        keepAliveTimeout: 19000,
+    });
+}
+
+let id = 0;
+function getTestInit() {
+    return {
+        body: JSON.stringify({
+            id: ++id,
+            jsonrpc: '2.0',
+            method: 'getLatestBlockhash',
+        }),
+        headers: {
+            'content-type': 'application/json',
+        },
+        method: 'POST',
+    };
+}
+
+async function makeConcurrentRequests(num: number = NUM_CONCURRENT_REQUESTS) {
+    await Promise.all(
+        Array.from({ length: num }).map(() =>
+            fetchImpl(URL, {
+                dispatcher,
+                ...getTestInit(),
+            }),
+        ),
+    );
+}
+
+bench
+    .add('no dispatcher', () => makeConcurrentRequests(), {
+        beforeEach() {
+            dispatcher = undefined;
+        },
+    })
+    // FIXME: https://github.com/nodejs/undici/issues/2808
+    // .add('unlimited connections http/2', () => makeConcurrentRequests(), {
+    //     beforeEach: createDispatcher.bind(null, { allowH2: true, connections: null }),
+    // })
+    .add('unlimited connections', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { connections: null }),
+    })
+    .add('16 connections', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { connections: 16 }),
+    })
+    // FIXME: https://github.com/nodejs/undici/issues/2808
+    // .add('16 connections, http/2', () => makeConcurrentRequests(), {
+    //     beforeEach: createDispatcher.bind(null, { allowH2: true, connections: 16 }),
+    // })
+    .add('16 connections, pipeline 2 wide', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { connections: 16, pipelining: 2 }),
+    })
+    .add('32 connections', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { connections: 32 }),
+    })
+    // FIXME: https://github.com/nodejs/undici/issues/2808
+    // .add('32 connections, http/2', () => makeConcurrentRequests(), {
+    //     beforeEach: createDispatcher.bind(null, { allowH2: true, connections: 32 }),
+    // })
+    .add('32 connections, pipeline 2 wide', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { connections: 32, pipelining: 2 }),
+    })
+    .add('64 connections', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { connections: 64 }),
+    })
+    // FIXME: https://github.com/nodejs/undici/issues/2808
+    // .add('64 connections, http/2', () => makeConcurrentRequests(), {
+    //     beforeEach: createDispatcher.bind(null, { allowH2: true, connections: 64 }),
+    // })
+    .add('64 connections, pipeline 2 wide', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { connections: 64, pipelining: 2 }),
+    });
+
+(async () => {
+    await bench.run();
+
+    console.table(bench.table());
+})();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,6 +883,9 @@ importers:
       prettier:
         specifier: ^3.1
         version: 3.1.0
+      tinybench:
+        specifier: ^2.6.0
+        version: 2.6.0
       tsup:
         specifier: ^8.0.1
         version: 8.0.1(@swc/core@1.3.93)(typescript@5.1.6)


### PR DESCRIPTION
The benchmark script just requests the `getLatestBlockhash` method 1024 times in parallel, and takes the average of 10 trials.

```shell
$ cd packages/fetch-impl/
$ pnpm benchmark https://api.devnet.solana.com/{API TOKEN FOR NO RATE LIMIT}
┌─────────┬───────────────────────────────────┬─────────┬────────────────────┬───────────┬─────────┐
│ (index) │ Task Name                         │ ops/sec │ Average Time (ns)  │ Margin    │ Samples │
├─────────┼───────────────────────────────────┼─────────┼────────────────────┼───────────┼─────────┤
│ 0       │ 'no dispatcher'                   │ '1'     │  548031484.6       │ '±49.40%' │ 10      │
│ 1       │ 'unlimited connections'           │ '0'     │ 4383004893.2       │ '±1.45%'  │ 10      │
│ 2       │ '16 connections'                  │ '0'     │ 2471023787.6000013 │ '±16.11%' │ 10      │
│ 3       │ '16 connections, pipeline 2 wide' │ '0'     │ 1233930233.3       │ '±25.32%' │ 10      │
│ 4       │ '32 connections'                  │ '1'     │  710945192.1000015 │ '±1.20%'  │ 10      │
│ 5       │ '32 connections, pipeline 2 wide' │ '1'     │  714453463.8999975 │ '±4.74%'  │ 10      │
│ 6       │ '64 connections'                  │ '0'     │ 1475681069.7000008 │ '±52.78%' │ 10      │
│ 7       │ '64 connections, pipeline 2 wide' │ '0'     │ 2452998898.200004  │ '±18.71%' │ 10      │
└─────────┴───────────────────────────────────┴─────────┴────────────────────┴───────────┴─────────┘