### PR TITLE
refactor(experimental): graphql: fix bigint inputs

### DIFF
--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -39,61 +39,6 @@ describe('block', () => {
         });
         rpcGraphQL = createRpcGraphQL(rpc);
     });
-
-    // The `block` query takes a `BigInt` as a parameter. We need to test this
-    // for various input types that might occur outside of a JavaScript
-    // context, such as string or number.
-    describe('bigint parameter', () => {
-        const source = /* GraphQL */ `
-            query testQuery($block: Slot!) {
-                block(slot: $block) {
-                    blockhash
-                }
-            }
-        `;
-        it('can accept a bigint parameter', async () => {
-            expect.assertions(2);
-            mockRpcTransport.mockResolvedValueOnce(mockBlockFull);
-            const variables = { block: 511226n };
-            const result = await rpcGraphQL.query(source, variables);
-            expect(result).not.toHaveProperty('errors');
-            expect(result).toMatchObject({
-                data: {
-                    block: {
-                        blockhash: expect.any(String),
-                    },
-                },
-            });
-        });
-        it('can accept a number parameter', async () => {
-            expect.assertions(2);
-            mockRpcTransport.mockResolvedValueOnce(mockBlockFull);
-            const variables = { block: 511226 };
-            const result = await rpcGraphQL.query(source, variables);
-            expect(result).not.toHaveProperty('errors');
-            expect(result).toMatchObject({
-                data: {
-                    block: {
-                        blockhash: expect.any(String),
-                    },
-                },
-            });
-        });
-        it('can accept a string parameter', async () => {
-            expect.assertions(2);
-            mockRpcTransport.mockResolvedValueOnce(mockBlockFull);
-            const variables = { block: '511226' };
-            const result = await rpcGraphQL.query(source, variables);
-            expect(result).not.toHaveProperty('errors');
-            expect(result).toMatchObject({
-                data: {
-                    block: {
-                        blockhash: expect.any(String),
-                    },
-                },
-            });
-        });
-    });
     describe('basic queries', () => {
         it("can query a block's block time", async () => {
             expect.assertions(1);

--- a/packages/rpc-graphql/src/resolvers/__tests__/block-inputs-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/block-inputs-test.ts
@@ -1,0 +1,140 @@
+import {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
+
+import { createRpcGraphQL, RpcGraphQL } from '../..';
+import { mockBlockFull } from '../../__tests__/__setup__';
+
+type GraphQLCompliantRpc = Rpc<
+    GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi
+>;
+
+// The `block` query takes a `BigInt` as a parameter. We need to test this
+// for various input types that might occur outside of a JavaScript
+// context, such as string or number.
+describe('block inputs', () => {
+    let mockRpcTransport: jest.Mock;
+    let rpc: GraphQLCompliantRpc;
+    let rpcGraphQL: RpcGraphQL;
+    beforeEach(() => {
+        mockRpcTransport = jest.fn();
+        rpc = new Proxy<GraphQLCompliantRpc>({} as GraphQLCompliantRpc, {
+            get(target, p) {
+                if (!target[p as keyof GraphQLCompliantRpc]) {
+                    const pendingRpcRequest = { send: mockRpcTransport };
+                    target[p as keyof GraphQLCompliantRpc] = jest
+                        .fn()
+                        .mockReturnValue(pendingRpcRequest) as GraphQLCompliantRpc[keyof GraphQLCompliantRpc];
+                }
+                return target[p as keyof GraphQLCompliantRpc];
+            },
+        });
+        rpcGraphQL = createRpcGraphQL(rpc);
+    });
+    // Does not accept raw bigint, ie. 511226n
+    it('can accept a bigint parameter as variable', async () => {
+        expect.assertions(2);
+        const source = /* GraphQL */ `
+            query testQuery($block: Slot!) {
+                block(slot: $block) {
+                    blockhash
+                }
+            }
+        `;
+        mockRpcTransport.mockResolvedValueOnce(mockBlockFull);
+        const result = await rpcGraphQL.query(source, { block: 511226n });
+        expect(result).not.toHaveProperty('errors');
+        expect(result).toMatchObject({
+            data: {
+                block: {
+                    blockhash: expect.any(String),
+                },
+            },
+        });
+    });
+    it('can accept a number parameter', async () => {
+        expect.assertions(2);
+        const source = /* GraphQL */ `
+            query testQuery {
+                block(slot: 511226) {
+                    blockhash
+                }
+            }
+        `;
+        mockRpcTransport.mockResolvedValueOnce(mockBlockFull);
+        const result = await rpcGraphQL.query(source);
+        expect(result).not.toHaveProperty('errors');
+        expect(result).toMatchObject({
+            data: {
+                block: {
+                    blockhash: expect.any(String),
+                },
+            },
+        });
+    });
+    it('can accept a number parameter as variable', async () => {
+        expect.assertions(2);
+        const source = /* GraphQL */ `
+            query testQuery($block: Slot!) {
+                block(slot: $block) {
+                    blockhash
+                }
+            }
+        `;
+        mockRpcTransport.mockResolvedValueOnce(mockBlockFull);
+        const result = await rpcGraphQL.query(source, { block: 511226 });
+        expect(result).not.toHaveProperty('errors');
+        expect(result).toMatchObject({
+            data: {
+                block: {
+                    blockhash: expect.any(String),
+                },
+            },
+        });
+    });
+    it('can accept a string parameter', async () => {
+        expect.assertions(2);
+        const source = /* GraphQL */ `
+            query testQuery {
+                block(slot: "511226") {
+                    blockhash
+                }
+            }
+        `;
+        mockRpcTransport.mockResolvedValueOnce(mockBlockFull);
+        const result = await rpcGraphQL.query(source);
+        expect(result).not.toHaveProperty('errors');
+        expect(result).toMatchObject({
+            data: {
+                block: {
+                    blockhash: expect.any(String),
+                },
+            },
+        });
+    });
+    it('can accept a string parameter as variable', async () => {
+        expect.assertions(2);
+        const source = /* GraphQL */ `
+            query testQuery($block: Slot!) {
+                block(slot: $block) {
+                    blockhash
+                }
+            }
+        `;
+        mockRpcTransport.mockResolvedValueOnce(mockBlockFull);
+        const result = await rpcGraphQL.query(source, { block: '511226' });
+        expect(result).not.toHaveProperty('errors');
+        expect(result).toMatchObject({
+            data: {
+                block: {
+                    blockhash: expect.any(String),
+                },
+            },
+        });
+    });
+});

--- a/packages/rpc-graphql/src/resolvers/types.ts
+++ b/packages/rpc-graphql/src/resolvers/types.ts
@@ -19,7 +19,7 @@ const stringScalarAlias = {
 
 const bigIntScalarAlias = {
     __parseLiteral(ast: { kind: Kind; value: string | number | bigint | boolean }): bigint | null {
-        if (ast.kind === Kind.STRING) {
+        if (ast.kind === Kind.STRING || ast.kind === Kind.INT || ast.kind === Kind.FLOAT) {
             return BigInt(ast.value);
         }
         return null;


### PR DESCRIPTION
When working in the GraphQL playground, providing a raw integer will not parse
properly into the `Slot` type. This change fixes the `BigIntScalar` type to
accept raw integer and float inputs.
