### PR TITLE
refactor(experimental): improve codec field and variant types

### DIFF
--- a/packages/codecs-data-structures/src/__tests__/data-enum-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/data-enum-test.ts
@@ -4,7 +4,7 @@ import { getStringCodec } from '@solana/codecs-strings';
 
 import { getArrayCodec } from '../array';
 import { getBooleanCodec } from '../boolean';
-import { DataEnumToCodecTuple, getDataEnumCodec } from '../data-enum';
+import { getDataEnumCodec } from '../data-enum';
 import { getStructCodec } from '../struct';
 import { getTupleCodec } from '../tuple';
 import { getUnitCodec } from '../unit';
@@ -29,46 +29,38 @@ describe('getDataEnumCodec', () => {
         | { __kind: 'KeyPress'; fields: [string] } // Tuple variant.
         | { __kind: 'PageUnload' }; // Empty variant (using empty struct).
 
-    const getWebEvent = (): DataEnumToCodecTuple<WebEvent> => [
-        ['PageLoad', unit()],
+    const getWebEvent = () =>
         [
-            'Click',
-            struct<{ x: number; y: number }>([
-                ['x', u8()],
-                ['y', u8()],
-            ]),
-        ],
-        ['KeyPress', struct<{ fields: [string] }>([['fields', tuple([string()])]])],
-        ['PageUnload', struct<object>([])],
-    ];
+            ['PageLoad', unit()],
+            [
+                'Click',
+                struct([
+                    ['x', u8()],
+                    ['y', u8()],
+                ]),
+            ],
+            ['KeyPress', struct([['fields', tuple([string()])]])],
+            ['PageUnload', struct([])],
+        ] as const;
 
-    type SameSizeVariants =
-        | { __kind: 'A'; value: number }
-        | { __kind: 'B'; x: number; y: number }
-        | { __kind: 'C'; items: Array<boolean> };
-
-    const getSameSizeVariants = (): DataEnumToCodecTuple<SameSizeVariants> => [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ['A', struct<any>([['value', u16()]])],
+    const getSameSizeVariants = () =>
         [
-            'B',
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            struct<any>([
-                ['x', u8()],
-                ['y', u8()],
-            ]),
-        ],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ['C', struct<any>([['items', array(boolean(), { size: 2 })]])],
-    ];
+            ['A', struct([['value', u16()]])],
+            [
+                'B',
+                struct([
+                    ['x', u8()],
+                    ['y', u8()],
+                ]),
+            ],
+            ['C', struct([['items', array(boolean(), { size: 2 })]])],
+        ] as const;
 
-    type U64EnumFrom = { __kind: 'A' } | { __kind: 'B'; value: number | bigint };
-    type U64EnumTo = { __kind: 'A' } | { __kind: 'B'; value: bigint };
-
-    const getU64Enum = (): DataEnumToCodecTuple<U64EnumFrom, U64EnumTo> => [
-        ['A', unit()],
-        ['B', struct<{ value: bigint | number }, { value: bigint }>([['value', u64()]])],
-    ];
+    const getU64Enum = () =>
+        [
+            ['A', unit()],
+            ['B', struct([['value', u64()]])],
+        ] as const;
 
     it('encodes empty variants', () => {
         const pageLoad: WebEvent = { __kind: 'PageLoad' };

--- a/packages/codecs-data-structures/src/__tests__/struct-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/struct-test.ts
@@ -31,7 +31,7 @@ describe('getStructCodec', () => {
         expect(person.decode(b('03000000426f621c'))).toStrictEqual({ age: 28, name: 'Bob' });
 
         // Different From and To types.
-        const structU64 = struct<{ value: number | bigint }, { value: bigint }>([['value', u64()]]);
+        const structU64 = struct([['value', u64()]]);
         expect(structU64.encode({ value: 2 })).toStrictEqual(b('0200000000000000'));
         expect(structU64.encode({ value: 2n })).toStrictEqual(b('0200000000000000'));
         expect(structU64.decode(b('0200000000000000'))).toStrictEqual({ value: 2n });

--- a/packages/codecs-data-structures/src/__typetests__/data-enum-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/data-enum-typetest.ts
@@ -1,15 +1,16 @@
 import { Codec, Decoder, Encoder } from '@solana/codecs-core';
+import { getU64Codec } from '@solana/codecs-numbers';
 
 import { getDataEnumCodec, getDataEnumDecoder, getDataEnumEncoder } from '../data-enum';
-
-type Variants = { __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number };
+import { getStructCodec } from '../struct';
+import { getUnitCodec } from '../unit';
 
 {
     // [getDataEnumEncoder]: It constructs data enums from a list of encoder variants.
     getDataEnumEncoder([
         ['A', {} as Encoder<{ value: string }>],
         ['B', {} as Encoder<{ x: number; y: number }>],
-    ]) satisfies Encoder<Variants>;
+    ]) satisfies Encoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
 }
 
 {
@@ -17,7 +18,7 @@ type Variants = { __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: nu
     getDataEnumDecoder([
         ['A', {} as Decoder<{ value: string }>],
         ['B', {} as Decoder<{ x: number; y: number }>],
-    ]) satisfies Decoder<Variants>;
+    ]) satisfies Decoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
 }
 
 {
@@ -25,5 +26,37 @@ type Variants = { __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: nu
     getDataEnumCodec([
         ['A', {} as Codec<{ value: string }>],
         ['B', {} as Codec<{ x: number; y: number }>],
-    ]) satisfies Codec<Variants>;
+    ]) satisfies Codec<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+}
+
+{
+    // [getDataEnumCodec]: It can infer complex data enum types from provided variants.
+    getDataEnumCodec([
+        ['PageLoad', {} as Codec<void>],
+        [
+            'Click',
+            getStructCodec([
+                ['x', {} as Codec<number>],
+                ['y', {} as Codec<number>],
+            ]),
+        ],
+        ['KeyPress', getStructCodec([['fields', {} as Codec<[string]>]])],
+        ['PageUnload', {} as Codec<object>],
+    ]) satisfies Codec<
+        | { __kind: 'PageLoad' }
+        | { __kind: 'Click'; x: number; y: number }
+        | { __kind: 'KeyPress'; fields: [string] }
+        | { __kind: 'PageUnload' }
+    >;
+}
+
+{
+    // [getDataEnumCodec]: It can infer codec data enum with different from and to types.
+    getDataEnumCodec([
+        ['A', getUnitCodec()],
+        ['B', getStructCodec([['value', getU64Codec()]])],
+    ]) satisfies Codec<
+        { __kind: 'A' } | { __kind: 'B'; value: number | bigint },
+        { __kind: 'A' } | { __kind: 'B'; value: bigint }
+    >;
 }

--- a/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
@@ -52,3 +52,70 @@ import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
     getStructCodec([['age', getU32Codec()]]) satisfies FixedSizeCodec<{ age: number }>;
     getStructCodec([['name', getStringCodec()]]) satisfies VariableSizeCodec<{ name: string }>;
 }
+
+{
+    // [getStructEncoder]: It can infer complex struct types from fields.
+    getStructEncoder([
+        ['name', {} as VariableSizeEncoder<string>],
+        ['id', {} as FixedSizeEncoder<number | bigint>],
+        [
+            'address',
+            getStructEncoder([
+                ['street', {} as VariableSizeEncoder<string>],
+                ['city', {} as VariableSizeEncoder<string>],
+                ['country', {} as VariableSizeEncoder<string>],
+            ]),
+        ],
+    ]) satisfies VariableSizeEncoder<{
+        name: string;
+        id: number | bigint;
+        address: { street: string; city: string; country: string };
+    }>;
+}
+
+{
+    // [getStructDecoder]: It can infer complex struct types from fields.
+    getStructDecoder([
+        ['name', {} as VariableSizeDecoder<string>],
+        ['id', {} as FixedSizeDecoder<bigint>],
+        [
+            'address',
+            getStructDecoder([
+                ['street', {} as VariableSizeDecoder<string>],
+                ['city', {} as VariableSizeDecoder<string>],
+                ['country', {} as VariableSizeDecoder<string>],
+            ]),
+        ],
+    ]) satisfies VariableSizeDecoder<{
+        name: string;
+        id: bigint;
+        address: { street: string; city: string; country: string };
+    }>;
+}
+
+{
+    // [getStructCodec]: It can infer complex struct types from fields.
+    getStructCodec([
+        ['name', {} as VariableSizeCodec<string>],
+        ['id', {} as FixedSizeCodec<number | bigint, bigint>],
+        [
+            'address',
+            getStructCodec([
+                ['street', {} as VariableSizeCodec<string>],
+                ['city', {} as VariableSizeCodec<string>],
+                ['country', {} as VariableSizeCodec<string>],
+            ]),
+        ],
+    ]) satisfies VariableSizeCodec<
+        {
+            name: string;
+            id: number | bigint;
+            address: { street: string; city: string; country: string };
+        },
+        {
+            name: string;
+            id: bigint;
+            address: { street: string; city: string; country: string };
+        }
+    >;
+}


### PR DESCRIPTION
This PR improves the type inferences of `getStructCodec` and `getDataEnumCodec` such that it becomes easier to create custom codecs using them.

Thank you @lithdew for raising this in #2159 and for providing a detailed explanation of the implementation.

Fixes #2159.