### PR TITLE
refactor(experimental): errors: fix `README` link

### DIFF
--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -1,6 +1,6 @@
 /**
  * To add a new error, follow the instructions at
- * https://github.com/solana-labs/solana-web3.js/tree/master/packages/error#adding-a-new-error
+ * https://github.com/solana-labs/solana-web3.js/tree/master/packages/errors/#adding-a-new-error
  *
  * WARNING:
  *   - Don't remove error codes

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -14,7 +14,7 @@ export type DefaultUnspecifiedErrorContextToUndefined<T> = {
 
 /**
  * To add a new error, follow the instructions at
- * https://github.com/solana-labs/solana-web3.js/tree/master/packages/error#adding-a-new-error
+ * https://github.com/solana-labs/solana-web3.js/tree/master/packages/errors/#adding-a-new-error
  *
  * WARNING:
  *   - Don't change or remove members of an error's context.

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -11,7 +11,7 @@ import {
 
 /**
  * To add a new error, follow the instructions at
- * https://github.com/solana-labs/solana-web3.js/tree/master/packages/error#adding-a-new-error
+ * https://github.com/solana-labs/solana-web3.js/tree/master/packages/errors#adding-a-new-error
  *
  * WARNING:
  *   - Don't change the meaning of an error message.


### PR DESCRIPTION
Updates the links to the README in the `@solana/errors` package.
