### PR TITLE
refactor(experimental): errors: remove cyclical dependency

### DIFF
--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -71,7 +71,6 @@
         "chalk": "^5.3.0"
     },
     "devDependencies": {
-        "@solana/addresses": "workspace:*",
         "@solana/build-scripts": "workspace:*",
         "@solana/eslint-config-solana": "^1.0.2",
         "@solana/test-config": "workspace:*",

--- a/packages/errors/src/__typetests__/error-typetest.ts
+++ b/packages/errors/src/__typetests__/error-typetest.ts
@@ -1,5 +1,3 @@
-import { address } from '@solana/addresses';
-
 import * as SolanaErrorCodeModule from '../codes';
 import { SolanaErrorCode } from '../codes';
 import { SolanaErrorContext } from '../context';
@@ -13,7 +11,7 @@ const { SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE, SOLANA_ERROR__TRANSA
 Object.values(SolanaErrorCodeModule) satisfies SolanaErrorCode[];
 
 const transactionMissingSignaturesError = new SolanaError(SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES, {
-    addresses: [address('123'), '456'],
+    addresses: ['123', '456'],
 });
 
 transactionMissingSignaturesError.context.__code satisfies typeof SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,9 +758,6 @@ importers:
         specifier: ^12.0.0
         version: 12.0.0
     devDependencies:
-      '@solana/addresses':
-        specifier: workspace:*
-        version: link:../addresses
       '@solana/build-scripts':
         specifier: workspace:*
         version: link:../build-scripts


### PR DESCRIPTION
In order to be able to add `SolanaError` to `@solana/addresses`, the
`devDependency` for `@solana/addresses` needs to be removed.
