### PR TITLE
Forbid `Proxy-*` and `Sec-*` headers via TypeScript

### DIFF
--- a/packages/rpc-transport-http/src/http-transport-headers.ts
+++ b/packages/rpc-transport-http/src/http-transport-headers.ts
@@ -29,9 +29,8 @@ type ForbiddenHeaders =
     | 'Keep-Alive'
     | 'Origin'
     | 'Permissions-Policy'
-    // No currently available Typescript technique allows you to match on a prefix.
-    // | 'Proxy-'
-    // | 'Sec-'
+    | `Proxy-${string}`
+    | `Sec-${string}`
     | 'Referer'
     | 'TE'
     | 'Trailer'
@@ -61,9 +60,9 @@ const FORBIDDEN_HEADERS: Record<string, boolean> = {
     'keep-alive': true,
     origin: true,
     'permissions-policy': true,
-    // No currently available Typescript technique allows you to match on a prefix.
-    // 'proxy-':true,
-    // 'sec-':true,
+    // Prefix matching is implemented in code, below.
+    // 'proxy-': true,
+    // 'sec-': true,
     referer: true,
     te: true,
     trailer: true,


### PR DESCRIPTION
# Test Plan

```ts
createHttpTransport({
    headers: {
        'Proxy-Foo': 'Bar', // ERROR
        'proxy-foo': 'Bar', // ERROR
        'PROXY-FOO': 'Bar', // ERROR
        'Sec-Foo': 'Bar', // ERROR
        'sec-foo': 'Bar', // ERROR
        'SEC-FOO': 'Bar', // ERROR
    },
});
```