### PR TITLE
refactor(experimental): codecs: refactor `message` out of codec assertions

### DIFF
--- a/packages/codecs-core/src/codec.ts
+++ b/packages/codecs-core/src/codec.ts
@@ -168,27 +168,22 @@ export function isFixedSize(codec: { fixedSize: number } | { maxSize?: number })
 
 export function assertIsFixedSize<TFrom, TSize extends number>(
     encoder: FixedSizeEncoder<TFrom, TSize> | VariableSizeEncoder<TFrom>,
-    message?: string,
 ): asserts encoder is FixedSizeEncoder<TFrom, TSize>;
 export function assertIsFixedSize<TTo, TSize extends number>(
     decoder: FixedSizeDecoder<TTo, TSize> | VariableSizeDecoder<TTo>,
-    message?: string,
 ): asserts decoder is FixedSizeDecoder<TTo, TSize>;
 export function assertIsFixedSize<TFrom, TTo extends TFrom, TSize extends number>(
     codec: FixedSizeCodec<TFrom, TTo, TSize> | VariableSizeCodec<TFrom, TTo>,
-    message?: string,
 ): asserts codec is FixedSizeCodec<TFrom, TTo, TSize>;
 export function assertIsFixedSize<TSize extends number>(
     codec: { fixedSize: TSize } | { maxSize?: number },
-    message?: string,
 ): asserts codec is { fixedSize: TSize };
 export function assertIsFixedSize(
     codec: { fixedSize: number } | { maxSize?: number },
-    message?: string,
 ): asserts codec is { fixedSize: number } {
     if (!isFixedSize(codec)) {
         // TODO: Coded error.
-        throw new Error(message ?? 'Expected a fixed-size codec, got a variable-size one.');
+        throw new Error('Expected a fixed-size codec, got a variable-size one.');
     }
 }
 
@@ -202,28 +197,19 @@ export function isVariableSize(codec: { fixedSize: number } | { maxSize?: number
     return !isFixedSize(codec);
 }
 
-export function assertIsVariableSize<T>(
-    encoder: Encoder<T>,
-    message?: string,
-): asserts encoder is VariableSizeEncoder<T>;
-export function assertIsVariableSize<T>(
-    decoder: Decoder<T>,
-    message?: string,
-): asserts decoder is VariableSizeDecoder<T>;
+export function assertIsVariableSize<T>(encoder: Encoder<T>): asserts encoder is VariableSizeEncoder<T>;
+export function assertIsVariableSize<T>(decoder: Decoder<T>): asserts decoder is VariableSizeDecoder<T>;
 export function assertIsVariableSize<TFrom, TTo extends TFrom>(
     codec: Codec<TFrom, TTo>,
-    message?: string,
 ): asserts codec is VariableSizeCodec<TFrom, TTo>;
 export function assertIsVariableSize(
     codec: { fixedSize: number } | { maxSize?: number },
-    message?: string,
 ): asserts codec is { maxSize?: number };
 export function assertIsVariableSize(
     codec: { fixedSize: number } | { maxSize?: number },
-    message?: string,
 ): asserts codec is { maxSize?: number } {
     if (!isVariableSize(codec)) {
         // TODO: Coded error.
-        throw new Error(message ?? 'Expected a variable-size codec, got a fixed-size one.');
+        throw new Error('Expected a variable-size codec, got a fixed-size one.');
     }
 }

--- a/packages/codecs-core/src/reverse-codec.ts
+++ b/packages/codecs-core/src/reverse-codec.ts
@@ -14,7 +14,12 @@ import { combineCodec } from './combine-codec';
 export function reverseEncoder<TFrom, TSize extends number>(
     encoder: FixedSizeEncoder<TFrom, TSize>,
 ): FixedSizeEncoder<TFrom, TSize> {
-    assertIsFixedSize(encoder, 'Cannot reverse a codec of variable size.');
+    try {
+        assertIsFixedSize(encoder);
+    } catch (e) {
+        // TODO: Coded error, also proper catch handling
+        throw new Error('Cannot reverse a codec of variable size.');
+    }
     return createEncoder({
         ...encoder,
         write: (value: TFrom, bytes, offset) => {
@@ -32,7 +37,12 @@ export function reverseEncoder<TFrom, TSize extends number>(
 export function reverseDecoder<TTo, TSize extends number>(
     decoder: FixedSizeDecoder<TTo, TSize>,
 ): FixedSizeDecoder<TTo, TSize> {
-    assertIsFixedSize(decoder, 'Cannot reverse a codec of variable size.');
+    try {
+        assertIsFixedSize(decoder);
+    } catch (e) {
+        // TODO: Coded error, also proper catch handling
+        throw new Error('Cannot reverse a codec of variable size.');
+    }
     return createDecoder({
         ...decoder,
         read: (bytes, offset) => {

--- a/packages/codecs-data-structures/src/boolean.ts
+++ b/packages/codecs-data-structures/src/boolean.ts
@@ -42,7 +42,12 @@ export function getBooleanEncoder<TSize extends number>(
 export function getBooleanEncoder(config: BooleanCodecConfig<NumberEncoder>): Encoder<boolean>;
 export function getBooleanEncoder(config: BooleanCodecConfig<NumberEncoder> = {}): Encoder<boolean> {
     const size = config.size ?? getU8Encoder();
-    assertIsFixedSize(size, 'Codec [bool] requires a fixed size.');
+    try {
+        assertIsFixedSize(size);
+    } catch (e) {
+        // TODO: Coded error, also proper catch handling
+        throw new Error('Codec [bool] requires a fixed size.');
+    }
     return mapEncoder(size, (value: boolean) => (value ? 1 : 0));
 }
 
@@ -58,7 +63,12 @@ export function getBooleanDecoder<TSize extends number>(
 export function getBooleanDecoder(config: BooleanCodecConfig<NumberDecoder>): Decoder<boolean>;
 export function getBooleanDecoder(config: BooleanCodecConfig<NumberDecoder> = {}): Decoder<boolean> {
     const size = config.size ?? getU8Decoder();
-    assertIsFixedSize(size, 'Codec [bool] requires a fixed size.');
+    try {
+        assertIsFixedSize(size);
+    } catch (e) {
+        // TODO: Coded error, also proper catch handling
+        throw new Error('Codec [bool] requires a fixed size.');
+    }
     return mapDecoder(size, (value: number | bigint): boolean => Number(value) === 1);
 }
 

--- a/packages/codecs-data-structures/src/nullable.ts
+++ b/packages/codecs-data-structures/src/nullable.ts
@@ -74,8 +74,18 @@ export function getNullableEncoder<TFrom>(
 
     const isZeroSizeItem = isFixedSize(item) && isFixedSize(prefix) && item.fixedSize === 0;
     if (fixed || isZeroSizeItem) {
-        assertIsFixedSize(item, 'Fixed nullables can only be used with fixed-size codecs.');
-        assertIsFixedSize(prefix, 'Fixed nullables can only be used with fixed-size prefix.');
+        try {
+            assertIsFixedSize(item);
+        } catch (e) {
+            // TODO: Coded error, also proper catch handling
+            throw new Error('Fixed nullables can only be used with fixed-size codecs.');
+        }
+        try {
+            assertIsFixedSize(prefix);
+        } catch (e) {
+            // TODO: Coded error, also proper catch handling
+            throw new Error('Fixed nullables can only be used with fixed-size prefix.');
+        }
         const fixedSize = prefix.fixedSize + item.fixedSize;
         return createEncoder({
             fixedSize,
@@ -131,8 +141,18 @@ export function getNullableDecoder<TTo>(
     let fixedSize: number | null = null;
     const isZeroSizeItem = isFixedSize(item) && isFixedSize(prefix) && item.fixedSize === 0;
     if (fixed || isZeroSizeItem) {
-        assertIsFixedSize(item, 'Fixed nullables can only be used with fixed-size codecs.');
-        assertIsFixedSize(prefix, 'Fixed nullables can only be used with fixed-size prefix.');
+        try {
+            assertIsFixedSize(item);
+        } catch (e) {
+            // TODO: Coded error, also proper catch handling
+            throw new Error('Fixed nullables can only be used with fixed-size codecs.');
+        }
+        try {
+            assertIsFixedSize(prefix);
+        } catch (e) {
+            // TODO: Coded error, also proper catch handling
+            throw new Error('Fixed nullables can only be used with fixed-size prefix.');
+        }
         fixedSize = prefix.fixedSize + item.fixedSize;
     }
 

--- a/packages/options/src/option-codec.ts
+++ b/packages/options/src/option-codec.ts
@@ -75,8 +75,18 @@ export function getOptionEncoder<TFrom>(
 
     const isZeroSizeItem = isFixedSize(item) && isFixedSize(prefix) && item.fixedSize === 0;
     if (fixed || isZeroSizeItem) {
-        assertIsFixedSize(item, 'Fixed options can only be used with fixed-size codecs.');
-        assertIsFixedSize(prefix, 'Fixed options can only be used with fixed-size prefix.');
+        try {
+            assertIsFixedSize(item);
+        } catch (e) {
+            // TODO: Coded error, also proper catch handling
+            throw new Error('Fixed options can only be used with fixed-size codecs.');
+        }
+        try {
+            assertIsFixedSize(prefix);
+        } catch (e) {
+            // TODO: Coded error, also proper catch handling
+            throw new Error('Fixed options can only be used with fixed-size prefix.');
+        }
         const fixedSize = prefix.fixedSize + item.fixedSize;
         return createEncoder({
             fixedSize,
@@ -139,8 +149,18 @@ export function getOptionDecoder<TTo>(
     let fixedSize: number | null = null;
     const isZeroSizeItem = isFixedSize(item) && isFixedSize(prefix) && item.fixedSize === 0;
     if (fixed || isZeroSizeItem) {
-        assertIsFixedSize(item, 'Fixed options can only be used with fixed-size codecs.');
-        assertIsFixedSize(prefix, 'Fixed options can only be used with fixed-size prefix.');
+        try {
+            assertIsFixedSize(item);
+        } catch (e) {
+            // TODO: Coded error, also proper catch handling
+            throw new Error('Fixed options can only be used with fixed-size codecs.');
+        }
+        try {
+            assertIsFixedSize(prefix);
+        } catch (e) {
+            // TODO: Coded error, also proper catch handling
+            throw new Error('Fixed options can only be used with fixed-size prefix.');
+        }
         fixedSize = prefix.fixedSize + item.fixedSize;
     }
 


### PR DESCRIPTION
As mentioned in
[this PR comment](https://github.com/solana-labs/solana-web3.js/pull/2188#discussion_r1501789028),
if you need to provide some kind of "reason" or "message" to an error, it's
usually a smell.

Now that we have custom error codes and can perform proper error handling, we
can replace this mechanism for piping error messages (effectively "reasons") to
fixed codec assertions!

This change refactors out `message` from `assertIsFixed`. In a later commit,
I'll replace the thrown error with a coded `SolanaError` and add the necessary
`catch` statements downstream.
