### PR TITLE
refactor(experimental): codecs: use `bigint` for range values on `u64` and `u128`

### DIFF
--- a/packages/codecs-numbers/src/u128.ts
+++ b/packages/codecs-numbers/src/u128.ts
@@ -7,7 +7,7 @@ export const getU128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder
     numberEncoderFactory({
         config,
         name: 'u128',
-        range: [0, BigInt('0xffffffffffffffffffffffffffffffff')],
+        range: [0n, BigInt('0xffffffffffffffffffffffffffffffff')],
         set: (view, value, le) => {
             const leftOffset = le ? 8 : 0;
             const rightOffset = le ? 0 : 8;

--- a/packages/codecs-numbers/src/u64.ts
+++ b/packages/codecs-numbers/src/u64.ts
@@ -7,7 +7,7 @@ export const getU64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
     numberEncoderFactory({
         config,
         name: 'u64',
-        range: [0, BigInt('0xffffffffffffffff')],
+        range: [0n, BigInt('0xffffffffffffffff')],
         set: (view, value, le) => view.setBigUint64(0, BigInt(value), le),
         size: 8,
     });


### PR DESCRIPTION
When working with `u64` and `u128` codecs, all range numerical values should be
`bigint`, since they are large, >8 byte numbers.

Simply flips the minimum range boundary to use `bigint`, for consistency.
