### PR TITLE
Extract core RPC enum-error handling functionality

### DIFF
--- a/packages/errors/src/rpc-enum-errors.ts
+++ b/packages/errors/src/rpc-enum-errors.ts
@@ -1,0 +1,54 @@
+import { SolanaErrorCode } from './codes';
+import { SolanaErrorContext } from './context';
+import { SolanaError } from './error';
+
+type Config = Readonly<{
+    /**
+     * Oh, hello. You might wonder what in tarnation is going on here. Allow us to explain.
+     *
+     * One of the goals of `@solana/errors` is to allow errors that are not interesting to your
+     * application to shake out of your app bundle in production. This means that we must never
+     * export large hardcoded maps of error codes/messages.
+     *
+     * Unfortunately, where instruction and transaction errors from the RPC are concerned, we have
+     * no choice but to keep a map between the RPC `rpcEnumError` enum name and its corresponding
+     * `SolanaError` code. In the interest of implementing that map in as few bytes of source code
+     * as possible, we do the following:
+     *
+     *   1. Reserve a block of sequential error codes for the enum in question
+     *   2. Hardcode the list of enum names in that same order
+     *   3. Match the enum error name from the RPC with its index in that list, and reconstruct the
+     *      `SolanaError` code by adding the `errorCodeBaseOffset` to that index
+     */
+    errorCodeBaseOffset: number;
+    getErrorContext: (
+        errorCode: SolanaErrorCode,
+        rpcErrorName: string,
+        rpcErrorContext?: unknown,
+    ) => SolanaErrorContext[SolanaErrorCode];
+    orderedErrorNames: string[];
+    rpcEnumError: string | { [key: string]: unknown };
+}>;
+
+export function getSolanaErrorFromRpcError(
+    { errorCodeBaseOffset, getErrorContext, orderedErrorNames, rpcEnumError }: Config,
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    constructorOpt: Function,
+): SolanaError {
+    let rpcErrorName;
+    let rpcErrorContext;
+    if (typeof rpcEnumError === 'string') {
+        rpcErrorName = rpcEnumError;
+    } else {
+        rpcErrorName = Object.keys(rpcEnumError)[0];
+        rpcErrorContext = rpcEnumError[rpcErrorName];
+    }
+    const codeOffset = orderedErrorNames.indexOf(rpcErrorName);
+    const errorCode = (errorCodeBaseOffset + codeOffset) as SolanaErrorCode;
+    const errorContext = getErrorContext(errorCode, rpcErrorName, rpcErrorContext);
+    const err = new SolanaError(errorCode, errorContext);
+    if ('captureStackTrace' in Error && typeof Error.captureStackTrace === 'function') {
+        Error.captureStackTrace(err, constructorOpt);
+    }
+    return err;
+}


### PR DESCRIPTION
# Summary

In a future PR when we add `InstructionError` the core mucking code is going to look exactly the same as this. Let's extract it to share with that function, down the line.

Addresses #2118.