### PR TITLE
Upgrade `mock-socket` to 9.3.1 and reenable test

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pnpm": {
         "overrides": {
             "jsdom": "^22",
-            "mock-socket": "^9.3.0",
+            "mock-socket": "^9.3.1",
             "shelljs": ">=0.8.5"
         }
     },

--- a/packages/rpc-subscriptions-transport-websocket/src/__tests__/websocket-connection-test.ts
+++ b/packages/rpc-subscriptions-transport-websocket/src/__tests__/websocket-connection-test.ts
@@ -40,9 +40,8 @@ describe('createWebSocketConnection', () => {
         });
         await expect(connectionPromise).rejects.toThrow('WebSocket failed to connect');
     });
-    // https://github.com/thoov/mock-socket/issues/384
-    it.failing('throws when the connection is aborted before the connection is established', async () => {
-        expect.assertions(1);
+    it('throws when the connection is aborted before the connection is established', async () => {
+        expect.assertions(2);
         const abortController = new AbortController();
         const connectionPromise = createWebSocketConnection({
             sendBufferHighWatermark: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: '6.0'
 
 overrides:
   jsdom: ^22
-  mock-socket: ^9.3.0
+  mock-socket: ^9.3.1
   shelljs: '>=0.8.5'
 
 importers:
@@ -11492,7 +11492,7 @@ packages:
     resolution: {integrity: sha512-a+UJGfowNIWvtIKIQBHoEWIUqRxxQHFx4CXT+R5KxxKBtEQ5rS3pPOV/5299sHzqbmeCzxxY5qE4+yfXePePig==}
     dependencies:
       jest-diff: 29.7.0
-      mock-socket: 9.3.0
+      mock-socket: 9.3.1
     dev: true
 
   /jest-worker@27.5.1:
@@ -12176,8 +12176,8 @@ packages:
       yargs-unparser: 2.0.0
     dev: true
 
-  /mock-socket@9.3.0:
-    resolution: {integrity: sha512-TFaQaIxXbzNke3z9nhSnMJFQn8l7QPmF+Luhh8MPHqkmr6B4fPquOTSILCjGUyxDBPv9AFxuaTGmRINDHDmkdQ==}
+  /mock-socket@9.3.1:
+    resolution: {integrity: sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==}
     engines: {node: '>= 8'}
     dev: true
 


### PR DESCRIPTION
Otherwise blocked on https://github.com/romgain/jest-websocket-mock/issues/171.