### PR TITLE
`SolanaError` now supports the `cause` property

### DIFF
--- a/packages/errors/src/__typetests__/error-typetest.ts
+++ b/packages/errors/src/__typetests__/error-typetest.ts
@@ -42,3 +42,14 @@ if (isSolanaError(e, SOLANA_ERROR__TRANSACTION_MISSING_SIGNATURES)) {
     // @ts-expect-error Context belongs to another error code
     e.context satisfies SolanaErrorContext[typeof SOLANA_ERROR__TRANSACTION_SIGNATURE_NOT_COMPUTABLE];
 }
+
+// `SolanaErrorContext` must not contain any keys reserved by `ErrorOptions` (eg. `cause`)
+null as unknown as SolanaErrorContext satisfies {
+    [Code in keyof SolanaErrorContext]: SolanaErrorContext[Code] extends undefined
+        ? undefined
+        : {
+              [PP in keyof SolanaErrorContext[Code]]: PP extends keyof ErrorOptions
+                  ? never
+                  : SolanaErrorContext[Code][PP];
+          };
+};

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "DOM",
             "ES2015",
+            "ES2022.Error"
         ],
         "resolveJsonModule": true
     },


### PR DESCRIPTION
# Summary

The runtime has built-in support for ‘sub exceptions.’ You can read about it here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause

> It is used when catching and re-throwing an error with a more-specific or useful error message in order to still have access to the original error.

This PR brings `cause` to `SolanaError` so that we can use it to rethrow errors under one umbrella error. Developers will have access to the inner error via `SolanaError#cause`.

The first error that will make use of this is the websocket close error, in the next PR.

# Test Plan

```shell
pnpm turbo test:unit:node test:unit:browser
```
