### PR TITLE
Only get the cached abortable iterable factory cache error message in dev mode

### DIFF
--- a/packages/rpc-subscriptions/src/cached-abortable-iterable.ts
+++ b/packages/rpc-subscriptions/src/cached-abortable-iterable.ts
@@ -7,7 +7,7 @@ type CacheEntry<TIterable extends AsyncIterable<unknown>> = {
 type CacheKey = string | symbol;
 type Config<TInput extends unknown[], TIterable extends AsyncIterable<unknown>> = Readonly<{
     getAbortSignalFromInputArgs: (...args: TInput) => AbortSignal;
-    getCacheEntryMissingError: (cacheKey: CacheKey) => Error;
+    getCacheEntryMissingErrorMessage?: (cacheKey: CacheKey) => string;
     getCacheKeyFromInputArgs: (...args: TInput) =>
         | CacheKey
         // `undefined` implies 'do not cache'
@@ -32,7 +32,7 @@ function registerIterableCleanup(iterable: AsyncIterable<unknown>, cleanupFn: Ca
 
 export function getCachedAbortableIterableFactory<TInput extends unknown[], TIterable extends AsyncIterable<unknown>>({
     getAbortSignalFromInputArgs,
-    getCacheEntryMissingError,
+    getCacheEntryMissingErrorMessage,
     getCacheKeyFromInputArgs,
     onCacheHit,
     onCreateIterable,
@@ -41,7 +41,7 @@ export function getCachedAbortableIterableFactory<TInput extends unknown[], TIte
     function getCacheEntryOrThrow(cacheKey: CacheKey) {
         const currentCacheEntry = cache.get(cacheKey);
         if (!currentCacheEntry) {
-            throw getCacheEntryMissingError(cacheKey);
+            throw new Error(getCacheEntryMissingErrorMessage ? getCacheEntryMissingErrorMessage(cacheKey) : undefined);
         }
         return currentCacheEntry;
     }

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-coalescer.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-coalescer.ts
@@ -60,11 +60,10 @@ export function getRpcSubscriptionsWithSubscriptionCoalescing<TRpcSubscriptionsM
                     AsyncIterable<unknown>
                 >({
                     getAbortSignalFromInputArgs: ({ abortSignal }) => abortSignal,
-                    getCacheEntryMissingError(deduplicationKey) {
-                        return new Error(
-                            `Invariant: Found no cache entry for subscription with deduplication key \`${deduplicationKey?.toString()}\``,
-                        );
-                    },
+                    getCacheEntryMissingErrorMessage: __DEV__
+                        ? deduplicationKey =>
+                              `Invariant: Found no cache entry for subscription with deduplication key \`${deduplicationKey?.toString()}\``
+                        : undefined,
                     getCacheKeyFromInputArgs: () => deduplicationKey,
                     async onCacheHit(_iterable, _config) {
                         /**

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-connection-sharding.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-connection-sharding.ts
@@ -22,11 +22,9 @@ export function getWebSocketTransportWithConnectionSharding<TTransport extends R
 }: Config<TTransport>): TTransport {
     return getCachedAbortableIterableFactory({
         getAbortSignalFromInputArgs: ({ signal }) => signal,
-        getCacheEntryMissingError(shardKey) {
-            return new Error(
-                `Invariant: Found no cache entry for connection with shard key \`${shardKey?.toString()}\``,
-            );
-        },
+        getCacheEntryMissingErrorMessage: __DEV__
+            ? shardKey => `Invariant: Found no cache entry for connection with shard key \`${shardKey?.toString()}\``
+            : undefined,
         getCacheKeyFromInputArgs: ({ payload }) => (getShard ? getShard(payload) : NULL_SHARD_CACHE_KEY),
         onCacheHit: (connection, { payload }) => connection.send_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(payload),
         onCreateIterable: (abortSignal, config) =>


### PR DESCRIPTION
# Summary

This is the first step on the way to evicting invariant violation strings (error that should never happen, therefore would be nonsensical to build error catching around) from the production code.

Here we reorganize things so that in `__DEV__` mode the error has a message, but otherwise it gets stripped out.
