### PR TITLE
refactor(experimental): add function to create Solana RPC Subscriptions using only an URL

### DIFF
--- a/packages/rpc-subscriptions/src/__typetests__/rpc-subscriptions-clusters-typetest.ts
+++ b/packages/rpc-subscriptions/src/__typetests__/rpc-subscriptions-clusters-typetest.ts
@@ -2,7 +2,12 @@ import type { SolanaRpcSubscriptionsApi, SolanaRpcSubscriptionsApiUnstable } fro
 import type { RpcSubscriptions, RpcSubscriptionsTransport } from '@solana/rpc-subscriptions-spec';
 import { devnet, mainnet, testnet } from '@solana/rpc-types';
 
-import { createSolanaRpcSubscriptions, createSolanaRpcSubscriptions_UNSTABLE } from '../rpc-subscriptions';
+import {
+    createSolanaRpcSubscriptions,
+    createSolanaRpcSubscriptions_UNSTABLE,
+    createSolanaRpcSubscriptionsFromTransport,
+    createSolanaRpcSubscriptionsFromTransport_UNSTABLE,
+} from '../rpc-subscriptions';
 import type {
     RpcSubscriptionsDevnet,
     RpcSubscriptionsMainnet,
@@ -13,163 +18,219 @@ import type {
 } from '../rpc-subscriptions-clusters';
 import { createDefaultRpcSubscriptionsTransport } from '../rpc-subscriptions-transport';
 
-// Creating default websocket transports
+// Define cluster-aware URLs and transports.
 
 const genericUrl = 'http://localhost:8899';
 const devnetUrl = devnet('https://api.devnet.solana.com');
 const testnetUrl = testnet('https://api.testnet.solana.com');
 const mainnetUrl = mainnet('https://api.mainnet-beta.solana.com');
 
-// No cluster specified should be generic `RpcSubscriptionsTransport`
-createDefaultRpcSubscriptionsTransport({ url: genericUrl }) satisfies RpcSubscriptionsTransport;
-//@ts-expect-error Should not be a devnet transport
-createDefaultRpcSubscriptionsTransport({ url: genericUrl }) satisfies RpcSubscriptionsTransportDevnet;
-//@ts-expect-error Should not be a testnet transport
-createDefaultRpcSubscriptionsTransport({ url: genericUrl }) satisfies RpcSubscriptionsTransportTestnet;
-//@ts-expect-error Should not be a mainnet transport
-createDefaultRpcSubscriptionsTransport({ url: genericUrl }) satisfies RpcSubscriptionsTransportMainnet;
+const genericTransport = createDefaultRpcSubscriptionsTransport({ url: genericUrl });
+const devnetTransport = createDefaultRpcSubscriptionsTransport({ url: devnetUrl });
+const testnetTransport = createDefaultRpcSubscriptionsTransport({ url: testnetUrl });
+const mainnetTransport = createDefaultRpcSubscriptionsTransport({ url: mainnetUrl });
 
-// Devnet cluster should be `RpcSubscriptionsTransportDevnet`
-createDefaultRpcSubscriptionsTransport({ url: devnetUrl }) satisfies RpcSubscriptionsTransportDevnet;
-//@ts-expect-error Should not be a testnet transport
-createDefaultRpcSubscriptionsTransport({ url: devnetUrl }) satisfies RpcSubscriptionsTransportTestnet;
-//@ts-expect-error Should not be a mainnet transport
-createDefaultRpcSubscriptionsTransport({ url: devnetUrl }) satisfies RpcSubscriptionsTransportMainnet;
+// [DEFINE] createDefaultRpcSubscriptionsTransport.
+{
+    // No cluster specified should be generic `RpcSubscriptionsTransport`.
+    {
+        genericTransport satisfies RpcSubscriptionsTransport;
+        //@ts-expect-error Should not be a devnet transport
+        genericTransport satisfies RpcSubscriptionsTransportDevnet;
+        //@ts-expect-error Should not be a testnet transport
+        genericTransport satisfies RpcSubscriptionsTransportTestnet;
+        //@ts-expect-error Should not be a mainnet transport
+        genericTransport satisfies RpcSubscriptionsTransportMainnet;
+    }
 
-// Testnet cluster should be `RpcSubscriptionsTransportTestnet`
-createDefaultRpcSubscriptionsTransport({ url: testnetUrl }) satisfies RpcSubscriptionsTransportTestnet;
-//@ts-expect-error Should not be a devnet transport
-createDefaultRpcSubscriptionsTransport({ url: testnetUrl }) satisfies RpcSubscriptionsTransportDevnet;
-//@ts-expect-error Should not be a mainnet transport
-createDefaultRpcSubscriptionsTransport({ url: testnetUrl }) satisfies RpcSubscriptionsTransportMainnet;
+    // Devnet cluster should be `RpcSubscriptionsTransportDevnet`.
+    {
+        devnetTransport satisfies RpcSubscriptionsTransportDevnet;
+        //@ts-expect-error Should not be a testnet transport
+        devnetTransport satisfies RpcSubscriptionsTransportTestnet;
+        //@ts-expect-error Should not be a mainnet transport
+        devnetTransport satisfies RpcSubscriptionsTransportMainnet;
+    }
 
-// Mainnet cluster should be `RpcSubscriptionsTransportMainnet`
-createDefaultRpcSubscriptionsTransport({ url: mainnetUrl }) satisfies RpcSubscriptionsTransportMainnet;
-//@ts-expect-error Should not be a devnet transport
-createDefaultRpcSubscriptionsTransport({ url: mainnetUrl }) satisfies RpcSubscriptionsTransportDevnet;
-//@ts-expect-error Should not be a testnet transport
-createDefaultRpcSubscriptionsTransport({ url: mainnetUrl }) satisfies RpcSubscriptionsTransportTestnet;
+    // Testnet cluster should be `RpcSubscriptionsTransportTestnet`.
+    {
+        testnetTransport satisfies RpcSubscriptionsTransportTestnet;
+        //@ts-expect-error Should not be a devnet transport
+        testnetTransport satisfies RpcSubscriptionsTransportDevnet;
+        //@ts-expect-error Should not be a mainnet transport
+        testnetTransport satisfies RpcSubscriptionsTransportMainnet;
+    }
 
-// Creating JSON Subscription RPC clients
+    // Mainnet cluster should be `RpcSubscriptionsTransportMainnet`.
+    {
+        mainnetTransport satisfies RpcSubscriptionsTransportMainnet;
+        //@ts-expect-error Should not be a devnet transport
+        mainnetTransport satisfies RpcSubscriptionsTransportDevnet;
+        //@ts-expect-error Should not be a testnet transport
+        mainnetTransport satisfies RpcSubscriptionsTransportTestnet;
+    }
+}
 
-const genericWebSocketTransport = createDefaultRpcSubscriptionsTransport({
-    sendBufferHighWatermark: 0,
-    url: genericUrl,
-});
-const devnetWebSocketTransport = createDefaultRpcSubscriptionsTransport({
-    sendBufferHighWatermark: 0,
-    url: devnetUrl,
-});
-const testnetWebSocketTransport = createDefaultRpcSubscriptionsTransport({
-    sendBufferHighWatermark: 0,
-    url: testnetUrl,
-});
-const mainnetWebSocketTransport = createDefaultRpcSubscriptionsTransport({
-    sendBufferHighWatermark: 0,
-    url: mainnetUrl,
-});
+// [DEFINE] createSolanaRpcSubscriptionsFromTransport.
+{
+    const genericRpc = createSolanaRpcSubscriptionsFromTransport(genericTransport);
+    const devnetRpc = createSolanaRpcSubscriptionsFromTransport(devnetTransport);
+    const tesnetRpc = createSolanaRpcSubscriptionsFromTransport(testnetTransport);
+    const mainnetRpc = createSolanaRpcSubscriptionsFromTransport(mainnetTransport);
 
-// Checking stable vs unstable subscriptions
+    // Checking stable subscriptions.
+    {
+        genericRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        devnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        tesnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        mainnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 
-createSolanaRpcSubscriptions({
-    transport: genericWebSocketTransport,
-}) satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-// @ts-expect-error Should not have unstable subscriptions
-createSolanaRpcSubscriptions(config) satisfies RpcSubscriptions<
-    SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable
->;
+        // @ts-expect-error Should not have unstable subscriptions
+        genericRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        // @ts-expect-error Should not have unstable subscriptions
+        devnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        // @ts-expect-error Should not have unstable subscriptions
+        tesnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        // @ts-expect-error Should not have unstable subscriptions
+        mainnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+    }
 
-createSolanaRpcSubscriptions_UNSTABLE({ transport: genericWebSocketTransport }) satisfies RpcSubscriptions<
-    SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable
->;
+    // No cluster specified should be generic `RpcSubscriptions`.
+    {
+        genericRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a devnet RPC
+        genericRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a testnet RPC
+        genericRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a mainnet RPC
+        genericRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
+    }
 
-// Checking cluster-level subscriptions API
+    // Devnet cluster should be `RpcSubscriptionsDevnet`.
+    {
+        devnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        devnetRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a testnet RPC
+        devnetRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a mainnet RPC
+        devnetRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
+    }
 
-// No cluster specified should be generic `RpcSubscriptions`
-createSolanaRpcSubscriptions({
-    transport: genericWebSocketTransport,
-}) satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: genericWebSocketTransport,
-    //@ts-expect-error Should not be a devnet RPC
-}) satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: genericWebSocketTransport,
-    //@ts-expect-error Should not be a testnet RPC
-}) satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: genericWebSocketTransport,
-    //@ts-expect-error Should not be a mainnet RPC
-}) satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
+    // Testnet cluster should be `RpcSubscriptionsTestnet`.
+    {
+        tesnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        tesnetRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a devnet RPC
+        tesnetRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a mainnet RPC
+        tesnetRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
+    }
 
-// Devnet cluster should be `RpcSubscriptionsDevnet`
-createSolanaRpcSubscriptions({
-    transport: devnetWebSocketTransport,
-}) satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: devnetWebSocketTransport,
-}) satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: devnetWebSocketTransport,
-    //@ts-expect-error Should not be a testnet RPC
-}) satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: devnetWebSocketTransport,
-    //@ts-expect-error Should not be a mainnet RPC
-}) satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
-//@ts-expect-error Should not have unstable subscriptions
-createSolanaRpcSubscriptions({ transport: devnetWebSocketTransport }) satisfies RpcSubscriptionsDevnet<
-    SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable
->;
-// Unstable methods present with proper initializer
-createSolanaRpcSubscriptions_UNSTABLE({ transport: devnetWebSocketTransport }) satisfies RpcSubscriptionsDevnet<
-    SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable
->;
+    // Mainnet cluster should be `RpcSubscriptionsMainnet`.
+    {
+        mainnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        mainnetRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a devnet RPC
+        mainnetRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a testnet RPC
+        mainnetRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
+    }
+}
 
-// Testnet cluster should be `RpcSubscriptionsTestnet`
-createSolanaRpcSubscriptions({
-    transport: testnetWebSocketTransport,
-}) satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: testnetWebSocketTransport,
-}) satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: testnetWebSocketTransport,
-    //@ts-expect-error Should not be a devnet RPC
-}) satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: testnetWebSocketTransport,
-    //@ts-expect-error Should not be a mainnet RPC
-}) satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
-//@ts-expect-error Should not have unstable subscriptions
-createSolanaRpcSubscriptions({ transport: testnetWebSocketTransport }) satisfies RpcSubscriptionsTestnet<
-    SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable
->;
-// Unstable methods present with proper initializer
-createSolanaRpcSubscriptions_UNSTABLE({ transport: testnetWebSocketTransport }) satisfies RpcSubscriptionsTestnet<
-    SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable
->;
+// [DEFINE] createSolanaRpcSubscriptionsFromTransport_UNSTABLE.
+{
+    const genericRpc = createSolanaRpcSubscriptionsFromTransport_UNSTABLE(genericTransport);
+    const devnetRpc = createSolanaRpcSubscriptionsFromTransport_UNSTABLE(devnetTransport);
+    const tesnetRpc = createSolanaRpcSubscriptionsFromTransport_UNSTABLE(testnetTransport);
+    const mainnetRpc = createSolanaRpcSubscriptionsFromTransport_UNSTABLE(mainnetTransport);
 
-// Mainnet cluster should be `RpcSubscriptionsMainnet`
-createSolanaRpcSubscriptions({
-    transport: mainnetWebSocketTransport,
-}) satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: mainnetWebSocketTransport,
-}) satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: mainnetWebSocketTransport,
-    //@ts-expect-error Should not be a devnet RPC
-}) satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
-createSolanaRpcSubscriptions({
-    transport: mainnetWebSocketTransport,
-    //@ts-expect-error Should not be a testnet RPC
-}) satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
-//@ts-expect-error Should not have unstable subscriptions
-createSolanaRpcSubscriptions({ transport: mainnetWebSocketTransport }) satisfies RpcSubscriptionsMainnet<
-    SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable
->;
-// Unstable methods present with proper initializer
-createSolanaRpcSubscriptions_UNSTABLE({ transport: mainnetWebSocketTransport }) satisfies RpcSubscriptionsMainnet<
-    SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable
->;
+    // Checking unstable subscriptions.
+    {
+        genericRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        devnetRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        tesnetRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        mainnetRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+    }
+}
+
+// [DEFINE] createSolanaRpcSubscriptions.
+{
+    const genericRpc = createSolanaRpcSubscriptions(genericUrl);
+    const devnetRpc = createSolanaRpcSubscriptions(devnetUrl);
+    const tesnetRpc = createSolanaRpcSubscriptions(testnetUrl);
+    const mainnetRpc = createSolanaRpcSubscriptions(mainnetUrl);
+
+    // Checking stable subscriptions.
+    {
+        genericRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        devnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        tesnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        mainnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+
+        // @ts-expect-error Should not have unstable subscriptions
+        genericRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        // @ts-expect-error Should not have unstable subscriptions
+        devnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        // @ts-expect-error Should not have unstable subscriptions
+        tesnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        // @ts-expect-error Should not have unstable subscriptions
+        mainnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+    }
+
+    // No cluster specified should be generic `RpcSubscriptions`.
+    {
+        genericRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a devnet RPC
+        genericRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a testnet RPC
+        genericRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a mainnet RPC
+        genericRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
+    }
+
+    // Devnet cluster should be `RpcSubscriptionsDevnet`.
+    {
+        devnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        devnetRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a testnet RPC
+        devnetRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a mainnet RPC
+        devnetRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
+    }
+
+    // Testnet cluster should be `RpcSubscriptionsTestnet`.
+    {
+        tesnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        tesnetRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a devnet RPC
+        tesnetRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a mainnet RPC
+        tesnetRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
+    }
+
+    // Mainnet cluster should be `RpcSubscriptionsMainnet`.
+    {
+        mainnetRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        mainnetRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a devnet RPC
+        mainnetRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi>;
+        //@ts-expect-error Should not be a testnet RPC
+        mainnetRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi>;
+    }
+}
+
+// [DEFINE] createSolanaRpcSubscriptions_UNSTABLE.
+{
+    const genericRpc = createSolanaRpcSubscriptions_UNSTABLE(genericUrl);
+    const devnetRpc = createSolanaRpcSubscriptions_UNSTABLE(devnetUrl);
+    const tesnetRpc = createSolanaRpcSubscriptions_UNSTABLE(testnetUrl);
+    const mainnetRpc = createSolanaRpcSubscriptions_UNSTABLE(mainnetUrl);
+
+    // Checking unstable subscriptions.
+    {
+        genericRpc satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        devnetRpc satisfies RpcSubscriptionsDevnet<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        tesnetRpc satisfies RpcSubscriptionsTestnet<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+        mainnetRpc satisfies RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi & SolanaRpcSubscriptionsApiUnstable>;
+    }
+}

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-transport.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-transport.ts
@@ -6,21 +6,20 @@ import { getWebSocketTransportWithAutoping } from './rpc-subscriptions-autopinge
 import { RpcSubscriptionsTransportFromClusterUrl } from './rpc-subscriptions-clusters';
 import { getWebSocketTransportWithConnectionSharding } from './rpc-subscriptions-connection-sharding';
 
-type Config<TClusterUrl extends ClusterUrl> = Readonly<{
+export type DefaultRpcSubscriptionsTransportConfig<TClusterUrl extends ClusterUrl> = Readonly<{
     url: TClusterUrl;
+    /**
+     * You might like to open more subscriptions per connection than your RPC provider allows
+     * for. Using the initial payload as input, return a shard key from this method to assign
+     * subscriptions to separate connections. One socket will be opened per shard key.
+     */
+    getShard?: (payload: unknown) => string;
+    intervalMs?: number;
+    sendBufferHighWatermark?: number;
 }>;
 
 export function createDefaultRpcSubscriptionsTransport<TClusterUrl extends ClusterUrl>(
-    config: Config<TClusterUrl> & {
-        /**
-         * You might like to open more subscriptions per connection than your RPC provider allows
-         * for. Using the initial payload as input, return a shard key from this method to assign
-         * subscriptions to separate connections. One socket will be opened per shard key.
-         */
-        getShard?: (payload: unknown) => string;
-        intervalMs?: number;
-        sendBufferHighWatermark?: number;
-    },
+    config: DefaultRpcSubscriptionsTransportConfig<TClusterUrl>,
 ): RpcSubscriptionsTransportFromClusterUrl<TClusterUrl> {
     const { getShard, intervalMs, ...rest } = config;
     return pipe(


### PR DESCRIPTION
This PR changes the `createSolanaRpcSubscriptions` and `createSolanaRpcSubscriptions_UNSTABLE` functions so that they accepts a `ClusterUrl` as a first parameter and an optional config object as a second parameter.

This makes it much easier for 95% of RPC Subscription use-cases to get started with the library:

```ts
const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8899");

// Cluster-aware RPC Subscriptions:
const rpcSubscriptions = createSolanaRpcSubscriptions(devnet("ws://api.devnet.solana.com"));
const rpcSubscriptions = createSolanaRpcSubscriptions(testnet("ws://api.testnet.solana.com"));
const rpcSubscriptions = createSolanaRpcSubscriptions(mainnet("ws://api.mainnet-beta.solana.com"));

// With configs:
const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8899", {
  intervalMs: 500,
  sendBufferHighWatermark: 0,
});
```

Additionally, this PR adds the `createSolanaRpcSubscriptionsFromTransport` and `createSolanaRpcSubscriptionsFromTransport_UNSTABLE` function allowing the remaining 5% of use-cases to customize their own transport just as easily:

```ts
const rpcSubscriptions = createSolanaRpcSubscriptionsFromTransport(myCustomTransport);
```

Note that these functions are cluster aware so, if `myCustomTransport` is of type `RpcSubscriptionsTransportMainnet`, then `rpcSubscriptions` will automatically be of type `RpcSubscriptionsMainnet<SolanaRpcSubscriptionsApi>`.

Finally, this PR refactors the cluster typetests to make it clearer what we are trying to tests.

---

Fixes #2119