### PR TITLE
Start the test validator at the beginning of a CI run, and keep it up until the end

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -55,6 +55,12 @@ jobs:
         if: steps.cache-test-validator.outputs.cache-hit != 'true'
         run: scripts/setup-test-validator.sh
 
+      - name: Start Test Validator
+        id: test-validator
+        run: |
+          ./scripts/start-shared-test-validator.sh &
+          echo "TEST_VALIDATOR_PID=$!" >> "$GITHUB_OUTPUT"
+
       - name: Publish NPM
         run: |
           pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
@@ -62,6 +68,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Stop Test Validator
+        run: kill ${{ steps.test-validator.outputs.TEST_VALIDATOR_PID}}
 
       - name: Deploy Github Page
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -66,8 +66,17 @@ jobs:
         if: steps.cache-test-validator.outputs.cache-hit != 'true'
         run: scripts/setup-test-validator.sh
 
+      - name: Start Test Validator
+        id: test-validator
+        run: |
+          ./scripts/start-shared-test-validator.sh &
+          echo "TEST_VALIDATOR_PID=$!" >> "$GITHUB_OUTPUT"
+
       - name: Build & Test
         run: pnpm build --concurrency=100%
+
+      - name: Stop Test Validator
+        run: kill ${{ steps.test-validator.outputs.TEST_VALIDATOR_PID}}
 
       - name: Upload Experimental library build artifacts
         if: matrix.node == 'current'


### PR DESCRIPTION
I'm pretty sure that my validator start/stop script (for Jest) is racey, and that most of the CI flakiness is because of:

* one test releasing its lock on the test validator
* a second test ‘getting’ the lock on that same test validator
* the validator going down anyway

Let's just start the thing when the CI run starts, and stop it when it's done.