### PR TITLE
[vote-program] adding instruction update validator identity

### DIFF
--- a/packages/library-legacy/src/programs/vote.ts
+++ b/packages/library-legacy/src/programs/vote.ts
@@ -551,7 +551,7 @@ export class VoteProgram {
   ): Transaction {
     if (params.lamports > currentVoteAccountBalance - rentExemptMinimum) {
       throw new Error(
-        'Withdraw will leave vote account with insufficient funds.',
+        'Withdraw will leave vote account with insuffcient funds.',
       );
     }
     return VoteProgram.withdraw(params);

--- a/packages/library-legacy/src/programs/vote.ts
+++ b/packages/library-legacy/src/programs/vote.ts
@@ -88,6 +88,15 @@ export type WithdrawFromVoteAccountParams = {
 };
 
 /**
+ * Update validator identity (node pubkey) vote account instruction params.
+ */
+export type UpdateValidatorIdentityParams = {
+  votePubkey: PublicKey;
+  authorizedWithdrawerPubkey: PublicKey;
+  nodePubkey: PublicKey;
+}
+
+/**
  * Vote Instruction class
  */
 export class VoteInstruction {
@@ -258,7 +267,7 @@ export type VoteInstructionType =
   // It would be preferable for this type to be `keyof VoteInstructionInputData`
   // but Typedoc does not transpile `keyof` expressions.
   // See https://github.com/TypeStrong/typedoc/issues/1894
-  'Authorize' | 'AuthorizeWithSeed' | 'InitializeAccount' | 'Withdraw';
+  'Authorize' | 'AuthorizeWithSeed' | 'InitializeAccount' | 'Withdraw' | 'UpdateValidatorIdentity';
 
 /** @internal */
 export type VoteAuthorizeWithSeedArgs = Readonly<{
@@ -286,6 +295,7 @@ type VoteInstructionInputData = {
   Withdraw: IInstructionInputData & {
     lamports: number;
   };
+  UpdateValidatorIdentity: IInstructionInputData;
 };
 
 const VOTE_INSTRUCTION_LAYOUTS = Object.freeze<{
@@ -314,6 +324,12 @@ const VOTE_INSTRUCTION_LAYOUTS = Object.freeze<{
       BufferLayout.u32('instruction'),
       BufferLayout.ns64('lamports'),
     ]),
+  },
+  UpdateValidatorIdentity: {
+    index: 4,
+    layout: BufferLayout.struct<
+      VoteInstructionInputData['UpdateValidatorIdentity']
+    >([BufferLayout.u32('instruction')]),
   },
   AuthorizeWithSeed: {
     index: 10,
@@ -535,9 +551,32 @@ export class VoteProgram {
   ): Transaction {
     if (params.lamports > currentVoteAccountBalance - rentExemptMinimum) {
       throw new Error(
-        'Withdraw will leave vote account with insuffcient funds.',
+        'Withdraw will leave vote account with insufficient funds.',
       );
     }
     return VoteProgram.withdraw(params);
+  }
+
+  /**
+   * Generate a transaction to update the validator identity (node pubkey) of a Vote account.
+   */
+  static updateValidatorIdentity(
+    params: UpdateValidatorIdentityParams
+  ): Transaction {
+    const { votePubkey, authorizedWithdrawerPubkey, nodePubkey } = params;
+    const type = VOTE_INSTRUCTION_LAYOUTS.UpdateValidatorIdentity;
+    const data = encodeData(type);
+
+    const keys = [
+      { pubkey: votePubkey, isSigner: false, isWritable: true },
+      { pubkey: nodePubkey, isSigner: true, isWritable: false },
+      { pubkey: authorizedWithdrawerPubkey, isSigner: true, isWritable: false },
+    ];
+
+    return new Transaction().add({
+      keys,
+      programId: this.programId,
+      data,
+    });
   }
 }


### PR DESCRIPTION
I would like to use the `UpdateValidatorIdentity` instruction of VoteProgram in TS code and it is not available in the current web3.js library.
https://github.com/solana-labs/solana/blob/v1.18.4/sdk/program/src/vote/instruction.rs#L381