### PR TITLE
chore: get automerge working again

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [master]
     paths:
-      - ./packages/library-legacy/**
+      - ./packages/library-legacy/
 
 jobs:
   web3-commit-lint:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,7 +30,9 @@ pull_request_rules:
     conditions:
       - and:
           - status-success=all-web3-checks
-          - status-success="Validate commit message"
+          - or:
+              - -files~=^packages/library-legacy/
+              - status-success="Validate commit message"
           - label=automerge
           - label!=no-automerge
     actions:


### PR DESCRIPTION
Automerge was largely busted because it was doing a check for the CI step ‘Validate Commit Message.’ We don't do that step anymore, except on changes to `library-legacy/`
