### PR TITLE
Use matching commitment when fetching blockhashes in tests

### DIFF
--- a/packages/rpc-api/src/__tests__/get-fee-for-message-test.ts
+++ b/packages/rpc-api/src/__tests__/get-fee-for-message-test.ts
@@ -72,7 +72,7 @@ describe('getFeeForMessage', () => {
             describe('when called with a recent blockhash', () => {
                 it('returns the result as a bigint', async () => {
                     expect.assertions(1);
-                    const latestBlockhash = await rpc.getLatestBlockhash().send();
+                    const latestBlockhash = await rpc.getLatestBlockhash({ commitment }).send();
                     const message = getMockTransactionMessage(latestBlockhash.value.blockhash);
                     const result = await rpc.getFeeForMessage(message, { commitment }).send();
                     expect(result).toStrictEqual({

--- a/packages/rpc-api/src/__tests__/send-transaction-test.ts
+++ b/packages/rpc-api/src/__tests__/send-transaction-test.ts
@@ -87,7 +87,7 @@ describe('sendTransaction', () => {
                 expect.assertions(1);
                 const [secretKey, { value: latestBlockhash }] = await Promise.all([
                     getSecretKey(),
-                    rpc.getLatestBlockhash().send(),
+                    rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
                 ]);
                 const message = getMockTransactionMessage({
                     blockhash: latestBlockhash.blockhash,
@@ -113,7 +113,7 @@ describe('sendTransaction', () => {
     });
     it('fatals when called with a transaction having an invalid signature', async () => {
         expect.assertions(3);
-        const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+        const { value: latestBlockhash } = await rpc.getLatestBlockhash({ commitment: 'processed' }).send();
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
             feePayerAddressBytes: MOCK_PUBLIC_KEY_BYTES,
@@ -142,7 +142,7 @@ describe('sendTransaction', () => {
         expect.assertions(3);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -204,7 +204,7 @@ describe('sendTransaction', () => {
                 ])) as CryptoKeyPair;
                 return [keyPair.privateKey, new Uint8Array(await crypto.subtle.exportKey('raw', keyPair.publicKey))];
             })(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -264,7 +264,7 @@ describe('sendTransaction', () => {
             expect.assertions(2);
             const [secretKey, { value: latestBlockhash }] = await Promise.all([
                 getSecretKey(),
-                rpc.getLatestBlockhash().send(),
+                rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
             ]);
             const message = getMockTransactionMessage({
                 blockhash: latestBlockhash.blockhash,

--- a/packages/rpc-api/src/__tests__/simulate-transaction-test.ts
+++ b/packages/rpc-api/src/__tests__/simulate-transaction-test.ts
@@ -141,7 +141,7 @@ describe('simulateTransaction', () => {
                 expect.assertions(1);
                 const [secretKey, { value: latestBlockhash }] = await Promise.all([
                     getSecretKey(),
-                    rpc.getLatestBlockhash().send(),
+                    rpc.getLatestBlockhash({ commitment }).send(),
                 ]);
                 const message = getMockTransactionMessage({
                     blockhash: latestBlockhash.blockhash,
@@ -180,7 +180,7 @@ describe('simulateTransaction', () => {
         expect.assertions(2);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -212,7 +212,7 @@ describe('simulateTransaction', () => {
 
     it('throws when called with an invalid signature if `sigVerify` is true', async () => {
         expect.assertions(3);
-        const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+        const { value: latestBlockhash } = await rpc.getLatestBlockhash({ commitment: 'processed' }).send();
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
             feePayerAddressBytes: MOCK_PUBLIC_KEY_BYTES,
@@ -245,7 +245,7 @@ describe('simulateTransaction', () => {
 
     it('does not throw when called with an invalid signature when `sigVerify` is false', async () => {
         expect.assertions(1);
-        const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+        const { value: latestBlockhash } = await rpc.getLatestBlockhash({ commitment: 'processed' }).send();
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
             feePayerAddressBytes: MOCK_PUBLIC_KEY_BYTES,
@@ -361,7 +361,7 @@ describe('simulateTransaction', () => {
         expect.assertions(3);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -427,7 +427,7 @@ describe('simulateTransaction', () => {
                 ])) as CryptoKeyPair;
                 return [keyPair.privateKey, new Uint8Array(await crypto.subtle.exportKey('raw', keyPair.publicKey))];
             })(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -464,7 +464,7 @@ describe('simulateTransaction', () => {
         expect.assertions(1);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -512,7 +512,7 @@ describe('simulateTransaction', () => {
         expect.assertions(1);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -560,7 +560,7 @@ describe('simulateTransaction', () => {
         expect.assertions(1);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessageWithAdditionalAccount({
             accountAddressBytes: getBase58Encoder().encode('4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp'), // see scripts/fixtures/vote-account.json
@@ -625,7 +625,7 @@ describe('simulateTransaction', () => {
         expect.assertions(1);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -674,7 +674,7 @@ describe('simulateTransaction', () => {
         expect.assertions(1);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -721,7 +721,7 @@ describe('simulateTransaction', () => {
         expect.assertions(1);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,
@@ -774,7 +774,7 @@ describe('simulateTransaction', () => {
         expect.assertions(1);
         const [secretKey, { value: latestBlockhash }] = await Promise.all([
             getSecretKey(),
-            rpc.getLatestBlockhash().send(),
+            rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
         ]);
         const message = getMockTransactionMessage({
             blockhash: latestBlockhash.blockhash,


### PR DESCRIPTION
# Summary

You can get into some pretty weird situations in tests if all of the following are true:

- The test validator just started up
- You fetch a blockhash using `finalized` commitment before the first root has been made
- You're testing something to do with fees

In cases like this, you'll get the first blockhash ever, which basically lets you land transactions without paying a fee. If your test exercises fee-related exceptions, it just might fail.

# Test Plan

Fee-related tests in the next PR work.
