### PR TITLE
Extract the stack trace capture code into `@solana/errors`

### DIFF
--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -2,4 +2,5 @@ export * from './codes';
 export * from './error';
 export * from './json-rpc-error';
 export * from './instruction-error';
+export * from './stack-trace';
 export * from './transaction-error';

--- a/packages/errors/src/json-rpc-error.ts
+++ b/packages/errors/src/json-rpc-error.ts
@@ -18,6 +18,7 @@ import {
 } from './codes';
 import { SolanaErrorContext } from './context';
 import { SolanaError } from './error';
+import { safeCaptureStackTrace } from './stack-trace';
 import { getSolanaErrorFromTransactionError } from './transaction-error';
 
 interface RpcErrorResponse {
@@ -126,8 +127,6 @@ export function getSolanaErrorFromJsonRpcError({ code, data, message }: RpcError
         }
         out = new SolanaError(code as SolanaErrorCode, errorContext as SolanaErrorContext[SolanaErrorCode]);
     }
-    if ('captureStackTrace' in Error && typeof Error.captureStackTrace === 'function') {
-        Error.captureStackTrace(out, getSolanaErrorFromJsonRpcError);
-    }
+    safeCaptureStackTrace(out, getSolanaErrorFromJsonRpcError);
     return out;
 }

--- a/packages/errors/src/rpc-enum-errors.ts
+++ b/packages/errors/src/rpc-enum-errors.ts
@@ -1,6 +1,7 @@
 import { SolanaErrorCode } from './codes';
 import { SolanaErrorContext } from './context';
 import { SolanaError } from './error';
+import { safeCaptureStackTrace } from './stack-trace';
 
 type Config = Readonly<{
     /**
@@ -47,8 +48,6 @@ export function getSolanaErrorFromRpcError(
     const errorCode = (errorCodeBaseOffset + codeOffset) as SolanaErrorCode;
     const errorContext = getErrorContext(errorCode, rpcErrorName, rpcErrorContext);
     const err = new SolanaError(errorCode, errorContext);
-    if ('captureStackTrace' in Error && typeof Error.captureStackTrace === 'function') {
-        Error.captureStackTrace(err, constructorOpt);
-    }
+    safeCaptureStackTrace(err, constructorOpt);
     return err;
 }

--- a/packages/errors/src/stack-trace.ts
+++ b/packages/errors/src/stack-trace.ts
@@ -1,0 +1,5 @@
+export function safeCaptureStackTrace(...args: Parameters<typeof Error.captureStackTrace>): void {
+    if ('captureStackTrace' in Error && typeof Error.captureStackTrace === 'function') {
+        Error.captureStackTrace(...args);
+    }
+}

--- a/packages/rpc-subscriptions/src/rpc-integer-overflow-error.ts
+++ b/packages/rpc-subscriptions/src/rpc-integer-overflow-error.ts
@@ -1,4 +1,4 @@
-import { SOLANA_ERROR__RPC__INTEGER_OVERFLOW, SolanaError } from '@solana/errors';
+import { safeCaptureStackTrace, SOLANA_ERROR__RPC__INTEGER_OVERFLOW, SolanaError } from '@solana/errors';
 import type { KeyPath } from '@solana/rpc-transformers';
 
 export function createSolanaJsonRpcIntegerOverflowError(
@@ -38,8 +38,6 @@ export function createSolanaJsonRpcIntegerOverflowError(
         value,
         ...(path !== undefined ? { path } : undefined),
     });
-    if ('captureStackTrace' in Error && typeof Error.captureStackTrace === 'function') {
-        Error.captureStackTrace(error, createSolanaJsonRpcIntegerOverflowError);
-    }
+    safeCaptureStackTrace(error, createSolanaJsonRpcIntegerOverflowError);
     return error;
 }

--- a/packages/rpc/src/rpc-integer-overflow-error.ts
+++ b/packages/rpc/src/rpc-integer-overflow-error.ts
@@ -1,4 +1,4 @@
-import { SOLANA_ERROR__RPC__INTEGER_OVERFLOW, SolanaError } from '@solana/errors';
+import { safeCaptureStackTrace, SOLANA_ERROR__RPC__INTEGER_OVERFLOW, SolanaError } from '@solana/errors';
 import type { KeyPath } from '@solana/rpc-transformers';
 
 export function createSolanaJsonRpcIntegerOverflowError(
@@ -38,8 +38,6 @@ export function createSolanaJsonRpcIntegerOverflowError(
         value,
         ...(path !== undefined ? { path } : undefined),
     });
-    if ('captureStackTrace' in Error && typeof Error.captureStackTrace === 'function') {
-        Error.captureStackTrace(error, createSolanaJsonRpcIntegerOverflowError);
-    }
+    safeCaptureStackTrace(error, createSolanaJsonRpcIntegerOverflowError);
     return error;
 }


### PR DESCRIPTION
# Summary

This is used in enough places now that I feel it necessary to extract it into `@solana/errors`. This utility calls `Error.captureStackTrace()` for you, but only if it exists in the runtime.
