### PR TITLE
refactor(experimental): add blockhash codec and type assertions

### DIFF
--- a/packages/rpc-types/src/blockhash.ts
+++ b/packages/rpc-types/src/blockhash.ts
@@ -1,5 +1,13 @@
-import type { Encoder } from '@solana/codecs-core';
-import { getBase58Encoder } from '@solana/codecs-strings';
+import {
+    combineCodec,
+    Decoder,
+    Encoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    mapEncoder,
+} from '@solana/codecs-core';
+import { getBase58Decoder, getBase58Encoder, getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
 import {
     SOLANA_ERROR__BLOCKHASH_STRING_LENGTH_OUT_OF_RANGE,
     SOLANA_ERROR__INVALID_BLOCKHASH_BYTE_LENGTH,
@@ -8,10 +16,40 @@ import {
 
 export type Blockhash = string & { readonly __brand: unique symbol };
 
-let base58Encoder: Encoder<string> | undefined;
+let memoizedBase58Encoder: Encoder<string> | undefined;
+let memoizedBase58Decoder: Decoder<string> | undefined;
+
+function getMemoizedBase58Encoder(): Encoder<string> {
+    if (!memoizedBase58Encoder) memoizedBase58Encoder = getBase58Encoder();
+    return memoizedBase58Encoder;
+}
+
+function getMemoizedBase58Decoder(): Decoder<string> {
+    if (!memoizedBase58Decoder) memoizedBase58Decoder = getBase58Decoder();
+    return memoizedBase58Decoder;
+}
+
+export function isBlockhash(putativeBlockhash: string): putativeBlockhash is Blockhash {
+    // Fast-path; see if the input string is of an acceptable length.
+    if (
+        // Lowest value (32 bytes of zeroes)
+        putativeBlockhash.length < 32 ||
+        // Highest value (32 bytes of 255)
+        putativeBlockhash.length > 44
+    ) {
+        return false;
+    }
+    // Slow-path; actually attempt to decode the input string.
+    const base58Encoder = getMemoizedBase58Encoder();
+    const bytes = base58Encoder.encode(putativeBlockhash);
+    const numBytes = bytes.byteLength;
+    if (numBytes !== 32) {
+        return false;
+    }
+    return true;
+}
 
 export function assertIsBlockhash(putativeBlockhash: string): asserts putativeBlockhash is Blockhash {
-    if (!base58Encoder) base58Encoder = getBase58Encoder();
     // Fast-path; see if the input string is of an acceptable length.
     if (
         // Lowest value (32 bytes of zeroes)
@@ -24,6 +62,7 @@ export function assertIsBlockhash(putativeBlockhash: string): asserts putativeBl
         });
     }
     // Slow-path; actually attempt to decode the input string.
+    const base58Encoder = getMemoizedBase58Encoder();
     const bytes = base58Encoder.encode(putativeBlockhash);
     const numBytes = bytes.byteLength;
     if (numBytes !== 32) {
@@ -31,4 +70,34 @@ export function assertIsBlockhash(putativeBlockhash: string): asserts putativeBl
             actualLength: numBytes,
         });
     }
+}
+
+export function blockhash(putativeBlockhash: string): Blockhash {
+    assertIsBlockhash(putativeBlockhash);
+    return putativeBlockhash as Blockhash;
+}
+
+export function getBlockhashEncoder(): FixedSizeEncoder<Blockhash, 32> {
+    return mapEncoder(getStringEncoder({ encoding: getMemoizedBase58Encoder(), size: 32 }), putativeBlockhash =>
+        blockhash(putativeBlockhash),
+    );
+}
+
+export function getBlockhashDecoder(): FixedSizeDecoder<Blockhash, 32> {
+    return getStringDecoder({ encoding: getMemoizedBase58Decoder(), size: 32 }) as FixedSizeDecoder<Blockhash, 32>;
+}
+
+export function getBlockhashCodec(): FixedSizeCodec<Blockhash, Blockhash, 32> {
+    return combineCodec(getBlockhashEncoder(), getBlockhashDecoder());
+}
+
+export function getBlockhashComparator(): (x: string, y: string) => number {
+    return new Intl.Collator('en', {
+        caseFirst: 'lower',
+        ignorePunctuation: false,
+        localeMatcher: 'best fit',
+        numeric: false,
+        sensitivity: 'variant',
+        usage: 'sort',
+    }).compare;
 }


### PR DESCRIPTION
Similar to the `AddressCodec` in `@solana/addresses`, we could use a typed
32-byte codec that can chain base64 encoding into its serialization, for
`Blockhash`.

Here I've added the same kind of combined codec as `getAddressCodec` to the
`blockhash` type in `@solana/rpc-types`.

Note: The implementation is almost identical, with the exception of the types,
and the tests are exactly the same as `getAddressCodec`.

I've also added some more assertions to `blockhash` to keep the API consistent.
