### PR TITLE
refactor(experimental): sysvars package: rent

### DIFF
--- a/packages/sysvars/src/__tests__/rent-test.ts
+++ b/packages/sysvars/src/__tests__/rent-test.ts
@@ -1,0 +1,34 @@
+import type { GetAccountInfoApi } from '@solana/rpc-api';
+import type { Rpc } from '@solana/rpc-spec';
+
+import { fetchSysvarRent, getSysvarRentCodec } from '../rent';
+import { createLocalhostSolanaRpc } from './__setup__';
+
+describe('rent', () => {
+    let rpc: Rpc<GetAccountInfoApi>;
+    beforeEach(() => {
+        rpc = createLocalhostSolanaRpc();
+    });
+    it('decode', () => {
+        // prettier-ignore
+        const rentState = new Uint8Array([
+            0, 225, 245, 5, 0, 0, 0, 0, // lamportsPerByteYear
+            0, 225, 245, 5, 0, 0, 0, 0, // exemptionThreshold
+            8,                          // burnPercent
+        ]);
+        expect(getSysvarRentCodec().decode(rentState)).toMatchObject({
+            burnPercent: 8,
+            exemptionThreshold: 4.94065646e-316,
+            lamportsPerByteYear: 100_000_000n,
+        });
+    });
+    it('fetch', async () => {
+        expect.assertions(1);
+        const rent = await fetchSysvarRent(rpc);
+        expect(rent).toMatchObject({
+            burnPercent: expect.any(Number),
+            exemptionThreshold: expect.any(Number),
+            lamportsPerByteYear: expect.any(BigInt),
+        });
+    });
+});

--- a/packages/sysvars/src/__tests__/sysvar-test.ts
+++ b/packages/sysvars/src/__tests__/sysvar-test.ts
@@ -9,6 +9,7 @@ import {
     SYSVAR_FEES_ADDRESS,
     SYSVAR_LAST_RESTART_SLOT_ADDRESS,
     SYSVAR_RECENT_BLOCKHASHES_ADDRESS,
+    SYSVAR_RENT_ADDRESS,
 } from '../sysvar';
 import { createLocalhostSolanaRpc } from './__setup__';
 
@@ -120,6 +121,22 @@ describe('sysvar account', () => {
                         },
                     },
                 ]),
+            });
+        });
+    });
+    describe('rent', () => {
+        it('fetch encoded', async () => {
+            expect.assertions(3);
+            await assertValidEncodedSysvarAccount(SYSVAR_RENT_ADDRESS);
+        });
+        it('fetch JSON-parsed', async () => {
+            expect.assertions(3);
+            await assertValidJsonParsedSysvarAccount(SYSVAR_RENT_ADDRESS, {
+                data: {
+                    burnPercent: expect.any(Number),
+                    exemptionThreshold: expect.any(Number),
+                    lamportsPerByteYear: expect.any(String), // JsonParsed converts to string
+                },
             });
         });
     });

--- a/packages/sysvars/src/__typetests__/sysvar-typetest.ts
+++ b/packages/sysvars/src/__typetests__/sysvar-typetest.ts
@@ -8,6 +8,7 @@ import { fetchSysvarEpochSchedule, type SysvarEpochSchedule } from '../epoch-sch
 import { fetchSysvarFees, type SysvarFees } from '../fees';
 import { fetchSysvarLastRestartSlot, type SysvarLastRestartSlot } from '../last-restart-slot';
 import { fetchSysvarRecentBlockhashes, type SysvarRecentBlockhashes } from '../recent-blockhashes';
+import { fetchSysvarRent, type SysvarRent } from '../rent';
 import { fetchEncodedSysvarAccount, fetchJsonParsedSysvarAccount, SYSVAR_CLOCK_ADDRESS } from '../sysvar';
 
 const rpc = null as unknown as Parameters<typeof fetchEncodedSysvarAccount>[0];
@@ -96,4 +97,12 @@ const rpc = null as unknown as Parameters<typeof fetchEncodedSysvarAccount>[0];
     fetchSysvarRecentBlockhashes(rpc) satisfies Promise<SysvarRecentBlockhashes>;
     // @ts-expect-error Returns a `SysvarRecentBlockhashes`.
     fetchSysvarRecentBlockhashes(rpc) satisfies Promise<{ foo: string }>;
+}
+
+// `fetchSysvarRent`
+{
+    // Returns a `SysvarRent`.
+    fetchSysvarRent(rpc) satisfies Promise<SysvarRent>;
+    // @ts-expect-error Returns a `SysvarRent`.
+    fetchSysvarRent(rpc) satisfies Promise<{ foo: string }>;
 }

--- a/packages/sysvars/src/index.ts
+++ b/packages/sysvars/src/index.ts
@@ -4,4 +4,5 @@ export * from './epoch-schedule';
 export * from './fees';
 export * from './last-restart-slot';
 export * from './recent-blockhashes';
+export * from './rent';
 export * from './sysvar';

--- a/packages/sysvars/src/rent.ts
+++ b/packages/sysvars/src/rent.ts
@@ -1,0 +1,63 @@
+import { assertAccountExists, decodeAccount, type FetchAccountConfig } from '@solana/accounts';
+import {
+    combineCodec,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    getF64Decoder,
+    getF64Encoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+} from '@solana/codecs';
+import type { GetAccountInfoApi } from '@solana/rpc-api';
+import type { Rpc } from '@solana/rpc-spec';
+import { getLamportsDecoder, getLamportsEncoder, type LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
+
+import { fetchEncodedSysvarAccount, SYSVAR_RENT_ADDRESS } from './sysvar';
+
+type SysvarRentSize = 17;
+
+/**
+ * The `Rent` sysvar.
+ *
+ * Configuration for network rent.
+ */
+export type SysvarRent = Readonly<{
+    burnPercent: number;
+    exemptionThreshold: number;
+    lamportsPerByteYear: LamportsUnsafeBeyond2Pow53Minus1;
+}>;
+
+export function getSysvarRentEncoder(): FixedSizeEncoder<SysvarRent, SysvarRentSize> {
+    return getStructEncoder([
+        ['lamportsPerByteYear', getLamportsEncoder()],
+        ['exemptionThreshold', getF64Encoder()],
+        ['burnPercent', getU8Encoder()],
+    ]) as FixedSizeEncoder<SysvarRent, SysvarRentSize>;
+}
+
+export function getSysvarRentDecoder(): FixedSizeDecoder<SysvarRent, SysvarRentSize> {
+    return getStructDecoder([
+        ['lamportsPerByteYear', getLamportsDecoder()],
+        ['exemptionThreshold', getF64Decoder()],
+        ['burnPercent', getU8Decoder()],
+    ]) as FixedSizeDecoder<SysvarRent, SysvarRentSize>;
+}
+
+export function getSysvarRentCodec(): FixedSizeCodec<SysvarRent, SysvarRent, SysvarRentSize> {
+    return combineCodec(getSysvarRentEncoder(), getSysvarRentDecoder());
+}
+
+/**
+ * Fetch the `Rent` sysvar.
+ *
+ * Configuration for network rent.
+ */
+export async function fetchSysvarRent(rpc: Rpc<GetAccountInfoApi>, config?: FetchAccountConfig): Promise<SysvarRent> {
+    const account = await fetchEncodedSysvarAccount(rpc, SYSVAR_RENT_ADDRESS, config);
+    assertAccountExists(account);
+    const decoded = decodeAccount(account, getSysvarRentDecoder());
+    return decoded.data;
+}

--- a/packages/sysvars/src/sysvar.ts
+++ b/packages/sysvars/src/sysvar.ts
@@ -24,6 +24,8 @@ export const SYSVAR_LAST_RESTART_SLOT_ADDRESS =
     'SysvarLastRestartS1ot1111111111111111111111' as Address<'SysvarLastRestartS1ot1111111111111111111111'>;
 export const SYSVAR_RECENT_BLOCKHASHES_ADDRESS =
     'SysvarRecentB1ockHashes11111111111111111111' as Address<'SysvarRecentB1ockHashes11111111111111111111'>;
+export const SYSVAR_RENT_ADDRESS =
+    'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
 
 type SysvarAddress =
     | typeof SYSVAR_CLOCK_ADDRESS
@@ -32,7 +34,8 @@ type SysvarAddress =
     | typeof SYSVAR_FEES_ADDRESS
     | typeof SYSVAR_INSTRUCTIONS_ADDRESS
     | typeof SYSVAR_LAST_RESTART_SLOT_ADDRESS
-    | typeof SYSVAR_RECENT_BLOCKHASHES_ADDRESS;
+    | typeof SYSVAR_RECENT_BLOCKHASHES_ADDRESS
+    | typeof SYSVAR_RENT_ADDRESS;
 
 /**
  * Fetch an encoded sysvar account.


### PR DESCRIPTION
This commit introduces the `Rent` sysvar to the `@solana/sysvars` package.
