### PR TITLE
refactor(experimental): add padLeftCodec and padRightCodec helpers to @solana/codecs-core

### DIFF
--- a/packages/codecs-core/README.md
+++ b/packages/codecs-core/README.md
@@ -532,6 +532,34 @@ const getU32InTheMiddleDecoder = () => offsetDecoder(biggerU32Decoder, { preOffs
 const getU32InTheMiddleCodec = () => combineCodec(getU32InTheMiddleEncoder(), getU32InTheMiddleDecoder());
 ```
 
+## Padding codecs
+
+The `padLeftCodec` and `padRightCodec` helpers can be used to add padding to the left or right of a given codec. They accept an `offset` number that tells us how big the padding should be.
+
+```ts
+const getLeftPaddedCodec = () => padLeftCodec(getU16Codec(), 4);
+getLeftPaddedCodec().encode(0xffff);
+// 0x00000000ffff
+//   |       └-- Our encoded u16 number.
+//   └-- Our 4-byte padding.
+
+const getRightPaddedCodec = () => padRightCodec(getU16Codec(), 4);
+getRightPaddedCodec().encode(0xffff);
+// 0xffff00000000
+//   |   └-- Our 4-byte padding.
+//   └-- Our encoded u16 number.
+```
+
+Note that both the `padLeftCodec` and `padRightCodec` functions are simple wrappers around the `offsetCodec` and `resizeCodec` functions. For more complex padding strategies, you may want to use the `offsetCodec` and `resizeCodec` functions directly instead.
+
+As usual, encoder-only and decoder-only helpers are available for these padding functions. Namely, `padLeftEncoder`, `padRightEncoder`, `padLeftDecoder` and `padRightDecoder`.
+
+```ts
+const getMyPaddedEncoder = () => padLeftEncoder(getU16Encoder());
+const getMyPaddedDecoder = () => padLeftDecoder(getU16Decoder());
+const getMyPaddedCodec = () => combineCodec(getMyPaddedEncoder(), getMyPaddedDecoder());
+```
+
 ## Reversing codecs
 
 The `reverseCodec` helper reverses the bytes of the provided `FixedSizeCodec`.

--- a/packages/codecs-core/src/__tests__/__setup__.ts
+++ b/packages/codecs-core/src/__tests__/__setup__.ts
@@ -1,4 +1,4 @@
-import { Codec, createCodec } from '../codec';
+import { Codec, createCodec, FixedSizeCodec } from '../codec';
 
 export const b = (s: string) => base16.encode(s);
 
@@ -16,19 +16,47 @@ export const base16: Codec<string> = createCodec({
     },
 });
 
-export const getMockCodec = (
-    config: {
-        defaultValue?: string;
-        description?: string;
-        size?: number | null;
-    } = {},
-) =>
-    createCodec({
+type GetMockCodecConfig = {
+    defaultValue?: string;
+    description?: string;
+    innerSize?: number;
+    size?: number | null;
+};
+
+type GetMockCodecReturnType = Codec<unknown> & {
+    readonly getSizeFromValue: jest.Mock;
+    readonly read: jest.Mock;
+    readonly write: jest.Mock;
+};
+
+export function getMockCodec<TSize extends number>(
+    config: GetMockCodecConfig & { size: TSize },
+): FixedSizeCodec<unknown, unknown, TSize> & GetMockCodecReturnType;
+export function getMockCodec(config?: GetMockCodecConfig): GetMockCodecReturnType;
+export function getMockCodec(config: GetMockCodecConfig = {}): GetMockCodecReturnType {
+    const innerSize = config.innerSize ?? config.size ?? 0;
+    return createCodec({
         ...(config.size != null ? { fixedSize: config.size } : { getSizeFromValue: jest.fn().mockReturnValue(0) }),
-        read: jest.fn().mockReturnValue([config.defaultValue ?? '', 0]),
-        write: jest.fn().mockReturnValue(0),
-    }) as Codec<unknown> & {
-        readonly getSizeFromValue: jest.Mock;
-        readonly read: jest.Mock;
-        readonly write: jest.Mock;
-    };
+        read: jest.fn().mockImplementation((_bytes, offset) => [config.defaultValue ?? '', offset + innerSize]),
+        write: jest.fn().mockImplementation((_value, _bytes, offset) => offset + innerSize),
+    }) as GetMockCodecReturnType;
+}
+
+export function expectNewPreOffset(
+    codec: FixedSizeCodec<unknown>,
+    mockCodec: FixedSizeCodec<unknown>,
+    preOffset: number,
+    expectedNewPreOffset: number,
+) {
+    const bytes = new Uint8Array(Array.from({ length: codec.fixedSize }, () => 0));
+    codec.write(null, bytes, preOffset);
+    expect(mockCodec.write).toHaveBeenCalledWith(null, bytes, expectedNewPreOffset);
+    codec.read(bytes, preOffset)[1];
+    expect(mockCodec.read).toHaveBeenCalledWith(bytes, expectedNewPreOffset);
+}
+
+export function expectNewPostOffset(codec: FixedSizeCodec<unknown>, preOffset: number, expectedNewPostOffset: number) {
+    const bytes = new Uint8Array(Array.from({ length: codec.fixedSize }, () => 0));
+    expect(codec.write(null, bytes, preOffset)).toBe(expectedNewPostOffset);
+    expect(codec.read(bytes, preOffset)[1]).toBe(expectedNewPostOffset);
+}

--- a/packages/codecs-core/src/__tests__/pad-codec-test.ts
+++ b/packages/codecs-core/src/__tests__/pad-codec-test.ts
@@ -1,0 +1,46 @@
+import { padLeftCodec, padRightCodec } from '../pad-codec';
+import { expectNewPostOffset, expectNewPreOffset, getMockCodec } from './__setup__';
+
+describe('padLeftCodec', () => {
+    it('offsets and resizes the codec', () => {
+        const mockCodec = getMockCodec({ size: 8 });
+        const codec = padLeftCodec(mockCodec, 4);
+        expect(codec.fixedSize).toBe(12);
+        expectNewPreOffset(codec, mockCodec, /* preOffset */ 0, /* newPreOffset */ 4);
+        expectNewPostOffset(codec, /* preOffset */ 0, /* newPostOffset */ 12);
+        // Before: 0x[pre=0]ffffffffffffffff[post=8]
+        // After:  0x00000000[pre=4]ffffffffffffffff[post=12]
+    });
+
+    it('does nothing with a zero offset', () => {
+        const mockCodec = getMockCodec({ size: 8 });
+        const codec = padLeftCodec(mockCodec, 0);
+        expect(codec.fixedSize).toBe(8);
+        expectNewPreOffset(codec, mockCodec, /* preOffset */ 0, /* newPreOffset */ 0);
+        expectNewPostOffset(codec, /* preOffset */ 0, /* newPostOffset */ 8);
+        // Before: 0x[pre=0]ffffffffffffffff[post=8]
+        // After:  0x[pre=0]ffffffffffffffff[post=8]
+    });
+});
+
+describe('padRightCodec', () => {
+    it('offsets and resizes the codec', () => {
+        const mockCodec = getMockCodec({ size: 8 });
+        const codec = padRightCodec(mockCodec, 4);
+        expect(codec.fixedSize).toBe(12);
+        expectNewPreOffset(codec, mockCodec, /* preOffset */ 0, /* newPreOffset */ 0);
+        expectNewPostOffset(codec, /* preOffset */ 0, /* newPostOffset */ 12);
+        // Before: 0x[pre=0]ffffffffffffffff[post=8]
+        // After:  0x[pre=0]ffffffffffffffff00000000[post=12]
+    });
+
+    it('does nothing with a zero offset', () => {
+        const mockCodec = getMockCodec({ size: 8 });
+        const codec = padRightCodec(mockCodec, 0);
+        expect(codec.fixedSize).toBe(8);
+        expectNewPreOffset(codec, mockCodec, /* preOffset */ 0, /* newPreOffset */ 0);
+        expectNewPostOffset(codec, /* preOffset */ 0, /* newPostOffset */ 8);
+        // Before: 0x[pre=0]ffffffffffffffff[post=8]
+        // After:  0x[pre=0]ffffffffffffffff[post=8]
+    });
+});

--- a/packages/codecs-core/src/__typetests__/pad-codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/pad-codec-typetest.ts
@@ -1,0 +1,71 @@
+import {
+    Codec,
+    Decoder,
+    Encoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '../codec';
+import {
+    padLeftCodec,
+    padLeftDecoder,
+    padLeftEncoder,
+    padRightCodec,
+    padRightDecoder,
+    padRightEncoder,
+} from '../pad-codec';
+
+type BrandedEncoder = Encoder<42> & { readonly __brand: unique symbol };
+type BrandedDecoder = Decoder<42> & { readonly __brand: unique symbol };
+type BrandedCodec = Codec<42> & { readonly __brand: unique symbol };
+
+{
+    // [padLeftEncoder]: It returns the same encoder type as the one provided.
+    padLeftEncoder({} as BrandedEncoder, 8) satisfies BrandedEncoder;
+    padLeftEncoder({} as FixedSizeEncoder<string, 42>, 8) satisfies FixedSizeEncoder<string, 42>;
+    padLeftEncoder({} as VariableSizeEncoder<string>, 8) satisfies VariableSizeEncoder<string>;
+    padLeftEncoder({} as Encoder<string>, 8) satisfies Encoder<string>;
+}
+
+{
+    // [padLeftDecoder]: It returns the same decoder type as the one provided.
+    padLeftDecoder({} as BrandedDecoder, 8) satisfies BrandedDecoder;
+    padLeftDecoder({} as FixedSizeDecoder<string, 42>, 8) satisfies FixedSizeDecoder<string, 42>;
+    padLeftDecoder({} as VariableSizeDecoder<string>, 8) satisfies VariableSizeDecoder<string>;
+    padLeftDecoder({} as Decoder<string>, 8) satisfies Decoder<string>;
+}
+
+{
+    // [padLeftCodec]: It returns the same codec type as the one provided.
+    padLeftCodec({} as BrandedCodec, 8) satisfies BrandedCodec;
+    padLeftCodec({} as FixedSizeCodec<string, string, 42>, 8) satisfies FixedSizeCodec<string, string, 42>;
+    padLeftCodec({} as VariableSizeCodec<string>, 8) satisfies VariableSizeCodec<string>;
+    padLeftCodec({} as Codec<string>, 8) satisfies Codec<string>;
+}
+
+{
+    // [padRightEncoder]: It returns the same encoder type as the one provided.
+    padRightEncoder({} as BrandedEncoder, 8) satisfies BrandedEncoder;
+    padRightEncoder({} as FixedSizeEncoder<string, 42>, 8) satisfies FixedSizeEncoder<string, 42>;
+    padRightEncoder({} as VariableSizeEncoder<string>, 8) satisfies VariableSizeEncoder<string>;
+    padRightEncoder({} as Encoder<string>, 8) satisfies Encoder<string>;
+}
+
+{
+    // [padRightDecoder]: It returns the same decoder type as the one provided.
+    padRightDecoder({} as BrandedDecoder, 8) satisfies BrandedDecoder;
+    padRightDecoder({} as FixedSizeDecoder<string, 42>, 8) satisfies FixedSizeDecoder<string, 42>;
+    padRightDecoder({} as VariableSizeDecoder<string>, 8) satisfies VariableSizeDecoder<string>;
+    padRightDecoder({} as Decoder<string>, 8) satisfies Decoder<string>;
+}
+
+{
+    // [padRightCodec]: It returns the same codec type as the one provided.
+    padRightCodec({} as BrandedCodec, 8) satisfies BrandedCodec;
+    padRightCodec({} as FixedSizeCodec<string, string, 42>, 8) satisfies FixedSizeCodec<string, string, 42>;
+    padRightCodec({} as VariableSizeCodec<string>, 8) satisfies VariableSizeCodec<string>;
+    padRightCodec({} as Codec<string>, 8) satisfies Codec<string>;
+}

--- a/packages/codecs-core/src/pad-codec.ts
+++ b/packages/codecs-core/src/pad-codec.ts
@@ -1,0 +1,64 @@
+import { Codec, Decoder, Encoder, Offset } from './codec';
+import { combineCodec } from './combine-codec';
+import { offsetDecoder, offsetEncoder } from './offset-codec';
+import { resizeDecoder, resizeEncoder } from './resize-codec';
+
+/**
+ * Adds left padding to the given encoder.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function padLeftEncoder<TEncoder extends Encoder<any>>(encoder: TEncoder, offset: Offset): TEncoder {
+    return offsetEncoder(
+        resizeEncoder(encoder, size => size + offset),
+        { preOffset: ({ preOffset }) => preOffset + offset },
+    );
+}
+
+/**
+ * Adds right padding to the given encoder.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function padRightEncoder<TEncoder extends Encoder<any>>(encoder: TEncoder, offset: Offset): TEncoder {
+    return offsetEncoder(
+        resizeEncoder(encoder, size => size + offset),
+        { postOffset: ({ postOffset }) => postOffset + offset },
+    );
+}
+
+/**
+ * Adds left padding to the given decoder.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function padLeftDecoder<TDecoder extends Decoder<any>>(decoder: TDecoder, offset: Offset): TDecoder {
+    return offsetDecoder(
+        resizeDecoder(decoder, size => size + offset),
+        { preOffset: ({ preOffset }) => preOffset + offset },
+    );
+}
+
+/**
+ * Adds right padding to the given decoder.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function padRightDecoder<TDecoder extends Decoder<any>>(decoder: TDecoder, offset: Offset): TDecoder {
+    return offsetDecoder(
+        resizeDecoder(decoder, size => size + offset),
+        { postOffset: ({ postOffset }) => postOffset + offset },
+    );
+}
+
+/**
+ * Adds left padding to the given codec.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function padLeftCodec<TCodec extends Codec<any>>(codec: TCodec, offset: Offset): TCodec {
+    return combineCodec(padLeftEncoder(codec, offset), padLeftDecoder(codec, offset)) as TCodec;
+}
+
+/**
+ * Adds right padding to the given codec.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function padRightCodec<TCodec extends Codec<any>>(codec: TCodec, offset: Offset): TCodec {
+    return combineCodec(padRightEncoder(codec, offset), padRightDecoder(codec, offset)) as TCodec;
+}

--- a/packages/codecs/README.md
+++ b/packages/codecs/README.md
@@ -59,6 +59,7 @@ The `@solana/codecs` package is composed of several smaller packages, each with 
     -   [Fixing the size of codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#fixing-the-size-of-codecs).
     -   [Adjusting the size of codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#adjusting-the-size-of-codecs).
     -   [Offsetting codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#offsetting-codecs).
+    -   [Padding codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#padding-codecs).
     -   [Reversing codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#reversing-codecs).
     -   [Byte helpers](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#byte-helpers).
 -   [`@solana/codecs-numbers`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-numbers) This package offers codecs for numbers of various sizes and characteristics.


### PR DESCRIPTION
This PR adds new `padLeftCodec` and `padRightCodec` helper functions. See copy/pasted documentation below:

---


## Padding codecs

The `padLeftCodec` and `padRightCodec` helpers can be used to add padding to the left or right of a given codec. They accept an `offset` number that tells us how big the padding should be.

```ts
const getLeftPaddedCodec = () => padLeftCodec(getU16Codec(), 4);
getLeftPaddedCodec().encode(0xffff);
// 0x00000000ffff
//   |       └-- Our encoded u16 number.
//   └-- Our 4-byte padding.

const getRightPaddedCodec = () => padRightCodec(getU16Codec(), 4);
getRightPaddedCodec().encode(0xffff);
// 0xffff00000000
//   |   └-- Our 4-byte padding.
//   └-- Our encoded u16 number.
```

Note that both the `padLeftCodec` and `padRightCodec` functions are simple wrappers around the `offsetCodec` and `resizeCodec` functions. For more complex padding strategies, you may want to use the `offsetCodec` and `resizeCodec` functions directly instead.

As usual, encoder-only and decoder-only helpers are available for these padding functions. Namely, `padLeftEncoder`, `padRightEncoder`, `padLeftDecoder` and `padRightDecoder`.

```ts
const getMyPaddedEncoder = () => padLeftEncoder(getU16Encoder());
const getMyPaddedDecoder = () => padLeftDecoder(getU16Decoder());
const getMyPaddedCodec = () => combineCodec(getMyPaddedEncoder(), getMyPaddedDecoder());
```