### PR TITLE
fix: splice bytes in-place when reading buffers

### DIFF
--- a/packages/library-legacy/src/message/legacy.ts
+++ b/packages/library-legacy/src/message/legacy.ts
@@ -284,25 +284,21 @@ export class Message {
     const accountCount = shortvec.decodeLength(byteArray);
     let accountKeys = [];
     for (let i = 0; i < accountCount; i++) {
-      const account = byteArray.slice(0, PUBLIC_KEY_LENGTH);
-      byteArray = byteArray.slice(PUBLIC_KEY_LENGTH);
+      const account = byteArray.splice(0, PUBLIC_KEY_LENGTH);
       accountKeys.push(new PublicKey(Buffer.from(account)));
     }
 
-    const recentBlockhash = byteArray.slice(0, PUBLIC_KEY_LENGTH);
-    byteArray = byteArray.slice(PUBLIC_KEY_LENGTH);
+    const recentBlockhash = byteArray.splice(0, PUBLIC_KEY_LENGTH);
 
     const instructionCount = shortvec.decodeLength(byteArray);
     let instructions: CompiledInstruction[] = [];
     for (let i = 0; i < instructionCount; i++) {
       const programIdIndex = byteArray.shift()!;
       const accountCount = shortvec.decodeLength(byteArray);
-      const accounts = byteArray.slice(0, accountCount);
-      byteArray = byteArray.slice(accountCount);
+      const accounts = byteArray.splice(0, accountCount);
       const dataLength = shortvec.decodeLength(byteArray);
-      const dataSlice = byteArray.slice(0, dataLength);
+      const dataSlice = byteArray.splice(0, dataLength);
       const data = bs58.encode(Buffer.from(dataSlice));
-      byteArray = byteArray.slice(dataLength);
       instructions.push({
         programIdIndex,
         accounts,

--- a/packages/library-legacy/src/transaction/legacy.ts
+++ b/packages/library-legacy/src/transaction/legacy.ts
@@ -904,8 +904,7 @@ export class Transaction {
     const signatureCount = shortvec.decodeLength(byteArray);
     let signatures = [];
     for (let i = 0; i < signatureCount; i++) {
-      const signature = byteArray.slice(0, SIGNATURE_LENGTH_IN_BYTES);
-      byteArray = byteArray.slice(SIGNATURE_LENGTH_IN_BYTES);
+      const signature = byteArray.splice(0, SIGNATURE_LENGTH_IN_BYTES);
       signatures.push(bs58.encode(Buffer.from(signature)));
     }
 

--- a/packages/library-legacy/src/validator-info.ts
+++ b/packages/library-legacy/src/validator-info.ts
@@ -83,10 +83,8 @@ export class ValidatorInfo {
 
     const configKeys: Array<ConfigKey> = [];
     for (let i = 0; i < 2; i++) {
-      const publicKey = new PublicKey(byteArray.slice(0, PUBLIC_KEY_LENGTH));
-      byteArray = byteArray.slice(PUBLIC_KEY_LENGTH);
-      const isSigner = byteArray.slice(0, 1)[0] === 1;
-      byteArray = byteArray.slice(1);
+      const publicKey = new PublicKey(byteArray.splice(0, PUBLIC_KEY_LENGTH));
+      const isSigner = byteArray.splice(0, 1)[0] === 1;
       configKeys.push({publicKey, isSigner});
     }
 


### PR DESCRIPTION
# Summary

I noticed many places where we:

1. Read a section of bytes from an array, from index A-B
2. Overwrite the entire byte array with the bytes from B onward

This is done in two steps using `Array#slice` twice. What we're looking for here is the mutative, one-step `Array#slice`.

# Test Plan

CI run
