### PR TITLE
refactor(experimental): add lamports codec

### DIFF
--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -64,6 +64,7 @@
     ],
     "dependencies": {
         "@solana/addresses": "workspace:*",
+        "@solana/codecs-numbers": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*"
     },

--- a/packages/rpc-types/src/__tests__/lamports-test.ts
+++ b/packages/rpc-types/src/__tests__/lamports-test.ts
@@ -1,6 +1,12 @@
 import { SOLANA_ERROR__LAMPORTS_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
-import { assertIsLamports } from '../lamports';
+import {
+    assertIsLamports,
+    getLamportsDecoder,
+    getLamportsEncoder,
+    lamports,
+    LamportsUnsafeBeyond2Pow53Minus1,
+} from '../lamports';
 
 describe('assertIsLamports()', () => {
     it('throws when supplied a negative number', () => {
@@ -30,5 +36,20 @@ describe('assertIsLamports()', () => {
         expect(() => {
             assertIsLamports(2n ** 64n - 1n);
         }).not.toThrow();
+    });
+
+    describe('getLamportsCodec', () => {
+        it('serializes a lamports value into an 8-byte buffer', () => {
+            const lamportsValue = lamports(1_000_000_000n);
+            const encoder = getLamportsEncoder();
+            const buffer = encoder.encode(lamportsValue);
+            expect(buffer).toStrictEqual(new Uint8Array([0, 202, 154, 59, 0, 0, 0, 0]));
+        });
+        it('deserializes an 8-byte buffer into a lamports value', () => {
+            const buffer = new Uint8Array([0, 29, 50, 247, 69, 0, 0, 0]);
+            const decoder = getLamportsDecoder();
+            const lamportsValue = decoder.decode(buffer);
+            expect(lamportsValue).toStrictEqual<LamportsUnsafeBeyond2Pow53Minus1>(lamports(300_500_000_000n));
+        });
     });
 });

--- a/packages/rpc-types/src/lamports.ts
+++ b/packages/rpc-types/src/lamports.ts
@@ -1,3 +1,5 @@
+import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder, mapDecoder } from '@solana/codecs-core';
+import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
 import { SOLANA_ERROR__LAMPORTS_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
 // FIXME(solana-labs/solana/issues/30341) Beware that any value above 9007199254740991 may be
@@ -7,6 +9,19 @@ export type LamportsUnsafeBeyond2Pow53Minus1 = bigint & { readonly __brand: uniq
 
 // Largest possible value to be represented by a u64
 const maxU64Value = 18446744073709551615n; // 2n ** 64n - 1n
+
+let memoizedU64Encoder: FixedSizeEncoder<bigint, 8> | undefined;
+let memoizedU64Decoder: FixedSizeDecoder<bigint, 8> | undefined;
+
+function getMemoizedU64Encoder(): FixedSizeEncoder<bigint, 8> {
+    if (!memoizedU64Encoder) memoizedU64Encoder = getU64Encoder();
+    return memoizedU64Encoder;
+}
+
+function getMemoizedU64Decoder(): FixedSizeDecoder<bigint, 8> {
+    if (!memoizedU64Decoder) memoizedU64Decoder = getU64Decoder();
+    return memoizedU64Decoder;
+}
 
 export function isLamports(putativeLamports: bigint): putativeLamports is LamportsUnsafeBeyond2Pow53Minus1 {
     return putativeLamports >= 0 && putativeLamports <= maxU64Value;
@@ -23,4 +38,20 @@ export function assertIsLamports(
 export function lamports(putativeLamports: bigint): LamportsUnsafeBeyond2Pow53Minus1 {
     assertIsLamports(putativeLamports);
     return putativeLamports;
+}
+
+export function getLamportsEncoder(): FixedSizeEncoder<LamportsUnsafeBeyond2Pow53Minus1, 8> {
+    return getMemoizedU64Encoder();
+}
+
+export function getLamportsDecoder(): FixedSizeDecoder<LamportsUnsafeBeyond2Pow53Minus1, 8> {
+    return mapDecoder(getMemoizedU64Decoder(), lamports);
+}
+
+export function getLamportsCodec(): FixedSizeCodec<
+    LamportsUnsafeBeyond2Pow53Minus1,
+    LamportsUnsafeBeyond2Pow53Minus1,
+    8
+> {
+    return combineCodec(getLamportsEncoder(), getLamportsDecoder());
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -834,6 +834,9 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/codecs-numbers':
+        specifier: workspace:*
+        version: link:../codecs-numbers
       '@solana/codecs-strings':
         specifier: workspace:*
         version: link:../codecs-strings


### PR DESCRIPTION
Similar to the commit before it, this change adds a codec to `@solana/rpc-types`
for working with the `LamportsUnsafeBeyond2Pow53Minus1` opaque type.

It's not enough to just use the `u64Codec` directly, since TypeScript won't just
infer `LamportsUnsafeBeyond2Pow53Minus1` from a `bigint`. So we have to set up a
`mapCodec` for this coercion.
