### PR TITLE
refactor(experimental): use DrainOuterGeneric helper on codec type mappings

### DIFF
--- a/.changeset/heavy-students-relax.md
+++ b/.changeset/heavy-students-relax.md
@@ -1,0 +1,8 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+Use `DrainOuterGeneric` helper on codec type mappings
+
+This significantly reduces the number of TypeScript instantiations on object mappings, 
+which increases TypeScript performance and prevents "Type instantiation is excessively deep and possibly infinite" errors.

--- a/packages/codecs-data-structures/src/data-enum.ts
+++ b/packages/codecs-data-structures/src/data-enum.ts
@@ -17,7 +17,7 @@ import {
     SolanaError,
 } from '@solana/errors';
 
-import { getMaxSize, maxCodecSizes, sumCodecSizes } from './utils';
+import { DrainOuterGeneric, getMaxSize, maxCodecSizes, sumCodecSizes } from './utils';
 
 /**
  * Defines a data enum using discriminated union types.
@@ -74,21 +74,21 @@ export type DataEnumCodecConfig<TDiscriminator = NumberCodec | NumberDecoder | N
 type Variants<T> = readonly (readonly [string, T])[];
 type ArrayIndices<T extends readonly unknown[]> = Exclude<Partial<T>['length'], T['length']> & number;
 
-type GetEncoderTypeFromVariants<TVariants extends Variants<Encoder<any>>> = {
+type GetEncoderTypeFromVariants<TVariants extends Variants<Encoder<any>>> = DrainOuterGeneric<{
     [I in ArrayIndices<TVariants>]: (TVariants[I][1] extends Encoder<infer TFrom>
         ? TFrom extends object
             ? TFrom
             : object
         : never) & { __kind: TVariants[I][0] };
-}[ArrayIndices<TVariants>];
+}>[ArrayIndices<TVariants>];
 
-type GetDecoderTypeFromVariants<TVariants extends Variants<Decoder<any>>> = {
+type GetDecoderTypeFromVariants<TVariants extends Variants<Decoder<any>>> = DrainOuterGeneric<{
     [I in ArrayIndices<TVariants>]: (TVariants[I][1] extends Decoder<infer TTo>
         ? TTo extends object
             ? TTo
             : object
         : never) & { __kind: TVariants[I][0] };
-}[ArrayIndices<TVariants>];
+}>[ArrayIndices<TVariants>];
 
 /**
  * Creates a data enum encoder.

--- a/packages/codecs-data-structures/src/struct.ts
+++ b/packages/codecs-data-structures/src/struct.ts
@@ -15,18 +15,18 @@ import {
     VariableSizeEncoder,
 } from '@solana/codecs-core';
 
-import { getFixedSize, getMaxSize, sumCodecSizes } from './utils';
+import { DrainOuterGeneric, getFixedSize, getMaxSize, sumCodecSizes } from './utils';
 
 type Fields<T> = readonly (readonly [string, T])[];
 type ArrayIndices<T extends readonly unknown[]> = Exclude<Partial<T>['length'], T['length']> & number;
 
-type GetEncoderTypeFromFields<TFields extends Fields<Encoder<any>>> = {
+type GetEncoderTypeFromFields<TFields extends Fields<Encoder<any>>> = DrainOuterGeneric<{
     [I in ArrayIndices<TFields> as TFields[I][0]]: TFields[I][1] extends Encoder<infer TFrom> ? TFrom : never;
-};
+}>;
 
-type GetDecoderTypeFromFields<TFields extends Fields<Decoder<any>>> = {
+type GetDecoderTypeFromFields<TFields extends Fields<Decoder<any>>> = DrainOuterGeneric<{
     [I in ArrayIndices<TFields> as TFields[I][0]]: TFields[I][1] extends Decoder<infer TTo> ? TTo : never;
-};
+}>;
 
 /**
  * Creates a encoder for a custom object.

--- a/packages/codecs-data-structures/src/utils.ts
+++ b/packages/codecs-data-structures/src/utils.ts
@@ -1,5 +1,17 @@
 import { isFixedSize } from '@solana/codecs-core';
 
+/**
+ * Functionally, this type helper is equivalent to the identity type — i.e. `type Identity<T> = T`.
+ * However, wrapping generic object mappings in this type significantly reduces the number
+ * of instantiation expressions processed, which increases TypeScript performance and
+ * prevents "Type instantiation is excessively deep and possibly infinite" errors.
+ *
+ * This works because TypeScript doesn't create a new level of nesting when encountering conditional generic types.
+ * @see https://github.com/microsoft/TypeScript/issues/34933
+ * @see https://github.com/kysely-org/kysely/pull/483
+ */
+export type DrainOuterGeneric<T> = [T] extends [unknown] ? T : never;
+
 export function maxCodecSizes(sizes: (number | null)[]): number | null {
     return sizes.reduce(
         (all, size) => (all === null || size === null ? null : Math.max(all, size)),


### PR DESCRIPTION
This PR aims to solve #2295 by wrapping codec type mappings with the suggested `DrainOuterGeneric`.

The TypeScript diagnostics on a complex codec — using both data enums and structs — changes as follows. As you can see we get a significant reduction of instantiations.

```
Files:                         204 -> 205
Lines of Library:            38131 -> 38131
Lines of Definitions:        52284 -> 52300
Lines of TypeScript:            81 -> 81
Lines of JavaScript:             0 -> 0
Lines of JSON:                   0 -> 0
Lines of Other:                  0 -> 0
Identifiers:                 92492 -> 92518
Symbols:                    111465 -> 111877
Types:                       55305 -> 55390
Instantiations:             603991 -> 362113    // -40%
Memory used:               187111K -> 189767K
Assignability cache size:    21397 -> 21404
Identity cache size:           350 -> 350
Subtype cache size:            161 -> 161
Strict subtype cache size:     358 -> 354
I/O Read time:               0.01s -> 0.01s
Parse time:                  0.18s -> 0.18s
ResolveModule time:          0.02s -> 0.02s
ResolveTypeReference time:   0.00s -> 0.00s
ResolveLibrary time:         0.01s -> 0.01s
Program time:                0.23s -> 0.24s
Bind time:                   0.07s -> 0.07s
Check time:                  0.78s -> 0.72s
transformTime time:          0.00s -> 0.00s
commentTime time:            0.00s -> 0.00s
I/O Write time:              0.00s -> 0.00s
printTime time:              0.01s -> 0.01s
Emit time:                   0.01s -> 0.01s
Total time:                  1.09s -> 1.04s
```