### PR TITLE
refactor(experimental): export missing pad-codec file

### DIFF
--- a/packages/codecs-core/src/index.ts
+++ b/packages/codecs-core/src/index.ts
@@ -5,5 +5,6 @@ export * from './combine-codec';
 export * from './fix-codec';
 export * from './map-codec';
 export * from './offset-codec';
+export * from './pad-codec';
 export * from './resize-codec';
 export * from './reverse-codec';


### PR DESCRIPTION
I'm an idiot and forgot to export the file on my previous PR.