### PR TITLE
refactor(experimental): improve getTupleCodec type inferences

### DIFF
--- a/.changeset/green-experts-hang.md
+++ b/.changeset/green-experts-hang.md
@@ -1,0 +1,7 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+Improve `getTupleCodec` type inferences and performance
+
+The tuple codec now infers its encoded/decoded type from the provided codec array and uses the new `DrainOuterGeneric` helper to reduce the number of TypeScript instantiations.

--- a/packages/codecs-data-structures/README.md
+++ b/packages/codecs-data-structures/README.md
@@ -137,16 +137,16 @@ const map = getMapDecoder(keyDecoder, valueDecoder).decode(bytes);
 The `getTupleCodec` function accepts any number of codecs — `T`, `U`, `V`, etc. — and returns a tuple codec of type `[T, U, V, …]` such that each item is in the order of the provided codecs.
 
 ```ts
-const itemCodecs = [getStringCodec(), getU8Codec(), getU64Codec()];
-const bytes = getTupleCodec(itemCodecs).encode(['alice', 42, 123]);
-const tuple = getTupleCodec(itemCodecs).decode(bytes);
+const codec = getTupleCodec([getStringCodec(), getU8Codec(), getU64Codec()]);
+const bytes = codec.encode(['alice', 42, 123]);
+const tuple = codec.decode(bytes);
 ```
 
 Separate `getTupleEncoder` and `getTupleDecoder` functions are also available.
 
 ```ts
-const bytes = getTupleEncoder(itemEncoders).encode(['alice', 42, 123]);
-const tuple = getTupleDecoder(itemDecoders).decode(bytes);
+const bytes = getTupleEncoder([getStringCodec(), getU8Codec()]).encode(['alice', 42]);
+const tuple = getTupleDecoder([getStringCodec(), getU8Codec()]).decode(bytes);
 ```
 
 ## Struct codec

--- a/packages/codecs-data-structures/src/__tests__/tuple-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/tuple-test.ts
@@ -27,7 +27,7 @@ describe('getTupleCodec', () => {
         expect(tuple([string(), u8()]).decode(b('0500000048656c6c6f2a'))).toStrictEqual(['Hello', 42]);
 
         // Different From and To types.
-        const tupleU8U64 = tuple<[number, bigint | number], [number, bigint]>([u8(), u64()]);
+        const tupleU8U64 = tuple([u8(), u64()]);
         expect(tupleU8U64.encode([1, 2])).toStrictEqual(b('010200000000000000'));
         expect(tupleU8U64.encode([1, 2n])).toStrictEqual(b('010200000000000000'));
         expect(tupleU8U64.decode(b('010200000000000000'))).toStrictEqual([1, 2n]);

--- a/packages/codecs-data-structures/src/__typetests__/tuple-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/tuple-typetest.ts
@@ -1,4 +1,7 @@
 import {
+    Codec,
+    Decoder,
+    Encoder,
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
@@ -13,21 +16,44 @@ import { getTupleCodec, getTupleDecoder, getTupleEncoder } from '../tuple';
 
 {
     // [getTupleEncoder]: It knows if the encoder is fixed size or variable size.
-    getTupleEncoder([]) satisfies FixedSizeEncoder<[]>;
-    getTupleEncoder([getU8Encoder()]) satisfies FixedSizeEncoder<[number]>;
-    getTupleEncoder([getU8Encoder(), getUtf8Encoder()]) satisfies VariableSizeEncoder<[number, string]>;
+    getTupleEncoder([]) satisfies FixedSizeEncoder<readonly []>;
+    getTupleEncoder([getU8Encoder()]) satisfies FixedSizeEncoder<readonly [number]>;
+    getTupleEncoder([getU8Encoder(), getUtf8Encoder()]) satisfies VariableSizeEncoder<readonly [number, string]>;
+}
+
+{
+    // [getTupleEncoder]: It infers the correct tuple type from the encoders.
+    getTupleEncoder([getU8Encoder(), getUtf8Encoder()]) satisfies Encoder<readonly [number, string]>;
+    // @ts-expect-error It does not combine all items into a single union type.
+    getTupleEncoder([getU8Encoder(), getUtf8Encoder()]) satisfies Encoder<readonly (number | string)[]>;
 }
 
 {
     // [getTupleDecoder]: It knows if the decoder is fixed size or variable size.
-    getTupleDecoder([]) satisfies FixedSizeDecoder<[]>;
-    getTupleDecoder([getU8Decoder()]) satisfies FixedSizeDecoder<[number]>;
-    getTupleDecoder([getU8Decoder(), getUtf8Decoder()]) satisfies VariableSizeDecoder<[number, string]>;
+    getTupleDecoder([]) satisfies FixedSizeDecoder<readonly []>;
+    getTupleDecoder([getU8Decoder()]) satisfies FixedSizeDecoder<readonly [number]>;
+    getTupleDecoder([getU8Decoder(), getUtf8Decoder()]) satisfies VariableSizeDecoder<readonly [number, string]>;
+}
+
+{
+    // [getTupleDecoder]: It infers the correct tuple type from the decoders.
+    getTupleDecoder([getU8Decoder(), getUtf8Decoder()]) satisfies Decoder<readonly [number, string]>;
+    // Because decoder types are returned (and not requested), Decoder<[number, string]> does satisfy Decoder<(number | string)[]>.
+    getTupleDecoder([getU8Decoder(), getUtf8Decoder()]) satisfies Decoder<readonly (number | string)[]>;
+    // @ts-expect-error However, we cannot do things like swapping the order of the types.
+    getTupleDecoder([getU8Decoder(), getUtf8Decoder()]) satisfies Decoder<readonly [string, number]>;
 }
 
 {
     // [getTupleCodec]: It knows if the codec is fixed size or variable size.
-    getTupleCodec([]) satisfies FixedSizeCodec<[]>;
-    getTupleCodec([getU8Codec()]) satisfies FixedSizeCodec<[number]>;
-    getTupleCodec([getU8Codec(), getUtf8Codec()]) satisfies VariableSizeCodec<[number, string]>;
+    getTupleCodec([]) satisfies FixedSizeCodec<readonly []>;
+    getTupleCodec([getU8Codec()]) satisfies FixedSizeCodec<readonly [number]>;
+    getTupleCodec([getU8Codec(), getUtf8Codec()]) satisfies VariableSizeCodec<readonly [number, string]>;
+}
+
+{
+    // [getTupleCodec]: It infers the correct tuple type from the codecs.
+    getTupleCodec([getU8Codec(), getUtf8Codec()]) satisfies Codec<readonly [number, string]>;
+    // @ts-expect-error It does not combine all items into a single union type.
+    getTupleCodec([getU8Codec(), getUtf8Codec()]) satisfies Codec<readonly (number | string)[]>;
 }

--- a/packages/codecs-data-structures/src/map.ts
+++ b/packages/codecs-data-structures/src/map.ts
@@ -87,7 +87,7 @@ export function getMapDecoder<TToKey, TToValue>(
     config: MapCodecConfig<NumberDecoder> = {},
 ): Decoder<Map<TToKey, TToValue>> {
     return mapDecoder(
-        getArrayDecoder(getTupleDecoder([key, value]), config as object),
+        getArrayDecoder(getTupleDecoder([key, value]), config as object) as Decoder<[TToKey, TToValue][]>,
         (entries: [TToKey, TToValue][]): Map<TToKey, TToValue> => new Map(entries),
     );
 }


### PR DESCRIPTION
This PR follows the footsteps of https://github.com/solana-labs/solana-web3.js/pull/2181 which improved the type inferences of `getStructCodec` and `getDataEnumCodec` by inferring the types from the provided codecs instead of inferring the other way around.

This PR does the same with the `getTupleCodec` and also makes use of the `DrainOuterGeneric` helper from the previous PR to reduce the amount of instantiations TypeScript does when resolving the codec types.