### PR TITLE
refactor: polyfill importKey to satisfy instance of CryptoKey

### DIFF
--- a/packages/webcrypto-ed25519-polyfill/src/__tests__/secrets-test.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/__tests__/secrets-test.ts
@@ -160,6 +160,10 @@ describe('importKeyPolyfill', () => {
         it('allows importing valid public key bytes', () => {
             expect(() => importKeyPolyfill('raw', MOCK_PUBLIC_KEY_BYTES, false, ['verify'])).not.toThrow();
         });
+        it('imported public key to be instance of CryptoKey', () => {
+            const key = importKeyPolyfill('raw', MOCK_PUBLIC_KEY_BYTES, false, ['verify']);
+            expect(key).toBeInstanceOf(CryptoKey);
+        });
         it('allows importing with empty keyUsages', () => {
             expect(() => importKeyPolyfill('raw', MOCK_PUBLIC_KEY_BYTES, false, [])).not.toThrow();
         });
@@ -243,6 +247,10 @@ describe('importKeyPolyfill', () => {
 
         it('allows importing valid private key bytes', () => {
             expect(() => importKeyPolyfill('pkcs8', mockSecretKeyWithHeader, false, ['sign'])).not.toThrow();
+        });
+        it('imported private key to be instance of CryptoKey', () => {
+            const key = importKeyPolyfill('pkcs8', mockSecretKeyWithHeader, false, ['sign']);
+            expect(key).toBeInstanceOf(CryptoKey);
         });
         it('allows importing with empty keyUsages', () => {
             expect(() => importKeyPolyfill('pkcs8', mockSecretKeyWithHeader, false, [])).not.toThrow();
@@ -331,6 +339,11 @@ describe('generateKeyPolyfill', () => {
         jest.spyOn(globalThis.crypto, 'getRandomValues').mockReturnValue(expectedSecretKey);
         generateKeyPolyfill(/* extractable */ false, ['sign', 'verify']);
         expect(weakMapSetSpy).toHaveBeenCalledWith(expect.anything(), expectedSecretKey);
+    });
+    it('generated keys to be instance of CryptoKey', () => {
+        const key = generateKeyPolyfill(/* extractable */ false, ['sign', 'verify']);
+        expect(key.publicKey).toBeInstanceOf(CryptoKey);
+        expect(key.privateKey).toBeInstanceOf(CryptoKey);
     });
     describe.each(['public', 'private'])('when generating a %s key', type => {
         let keyPair: CryptoKeyPair;

--- a/packages/webcrypto-ed25519-polyfill/src/secrets.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/secrets.ts
@@ -99,12 +99,16 @@ function createKeyPair_INTERNAL_ONLY_DO_NOT_EXPORT(
         type: 'private',
         usages: Object.freeze(keyUsages.filter(usage => usage === 'sign')) as KeyUsage[],
     } as CryptoKey;
+    Object.setPrototypeOf(privateKey, CryptoKey.prototype);
+
     const publicKey = {
         ...base,
         extractable: true,
         type: 'public',
         usages: Object.freeze(keyUsages.filter(usage => usage === 'verify')) as KeyUsage[],
     } as CryptoKey;
+    Object.setPrototypeOf(publicKey, CryptoKey.prototype);
+
     return Object.freeze({
         privateKey: Object.freeze(privateKey),
         publicKey: Object.freeze(publicKey),
@@ -219,6 +223,7 @@ export function importKeyPolyfill(
             type: 'public',
             usages: Object.freeze(keyUsages.filter(usage => usage === 'verify')) as KeyUsage[],
         } as CryptoKey;
+        Object.setPrototypeOf(publicKey, CryptoKey.prototype);
 
         const cache = (publicKeyBytesStore ||= new WeakMap());
         cache.set(publicKey, bytes);
@@ -248,6 +253,7 @@ export function importKeyPolyfill(
             type: 'private',
             usages: Object.freeze(keyUsages.filter(usage => usage === 'sign')) as KeyUsage[],
         } as CryptoKey;
+        Object.setPrototypeOf(privateKey, CryptoKey.prototype);
 
         const cache = (storageKeyBySecretKey_INTERNAL_ONLY_DO_NOT_EXPORT ||= new WeakMap());
         cache.set(privateKey, secretKeyBytes);


### PR DESCRIPTION
libraries like [jose](https://github.com/panva/jose) do check if keys are `instanceOf CryptoKey` (e.g. https://github.com/panva/jose/blob/main/src/runtime/browser/webcrypto.ts#L3)

Using `Object.setPrototypeOf` the created keys from the ED25519 polyfill can also satisfy this check.