### PR TITLE
A set of benchmarks for `@solana/keys`

### DIFF
--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -33,6 +33,7 @@
         "web3"
     ],
     "scripts": {
+        "benchmark": "./src/__benchmarks__/run.ts",
         "compile:js": "tsup --config build-scripts/tsup.config.package.ts",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node ../../node_modules/@solana/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c ../../node_modules/@solana/test-config/jest-dev.config.ts --rootDir . --watch",
@@ -78,5 +79,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "devDependencies": {
+        "tinybench": "^2.6.0"
     }
 }

--- a/packages/keys/src/__benchmarks__/run.ts
+++ b/packages/keys/src/__benchmarks__/run.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env -S pnpx tsx --
+
+import { Bench } from 'tinybench';
+
+import { generateKeyPair, SignatureBytes, signBytes, verifySignature } from '../index';
+
+Object.assign(globalThis, {
+    __BROWSER__: false,
+    __DEV__: false,
+    __NODEJS__: true,
+    __REACTNATIVE____: false,
+});
+
+const bench = new Bench({
+    throws: true,
+});
+
+let keyPair: CryptoKeyPair;
+async function generateKeyPairForTest() {
+    keyPair = await generateKeyPair();
+}
+
+let randomBytes: Uint8Array;
+function generateRandomBytesForTest() {
+    randomBytes ||= new Uint8Array(32);
+    crypto.getRandomValues(randomBytes);
+}
+
+let signature: SignatureBytes;
+async function generateSignatureForBytes() {
+    signature = await signBytes(keyPair.privateKey, randomBytes);
+}
+
+bench
+    .add('generateKeyPair', generateKeyPair)
+    .add('signBytes', async () => await signBytes(keyPair.privateKey, randomBytes), {
+        async beforeEach() {
+            generateRandomBytesForTest();
+            await generateKeyPairForTest();
+        },
+    })
+    .add('verifySignature', async () => await verifySignature(keyPair.publicKey, signature, randomBytes), {
+        async beforeEach() {
+            generateRandomBytesForTest();
+            await generateKeyPairForTest();
+            await generateSignatureForBytes();
+        },
+    });
+
+(async () => {
+    await bench.run();
+    console.table(bench.table());
+})();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,10 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+    devDependencies:
+      tinybench:
+        specifier: ^2.6.0
+        version: 2.6.0
 
   packages/library:
     dependencies:


### PR DESCRIPTION
Node LTS (20)
```
┌─────────┬───────────────────┬──────────┬───────────────────┬──────────┬─────────┐
│ (index) │ Task Name         │ ops/sec  │ Average Time (ns) │ Margin   │ Samples │
├─────────┼───────────────────┼──────────┼───────────────────┼──────────┼─────────┤
│ 0       │ 'generateKeyPair' │ '10,138' │ 98630.77218934878 │ '±2.25%' │ 5070    │
│ 1       │ 'signBytes'       │ '14,355' │ 69658.12245750854 │ '±2.16%' │ 7178    │
│ 2       │ 'verifySignature' │ '6,735'  │ 148476.5546318311 │ '±1.25%' │ 3368    │
└─────────┴───────────────────┴──────────┴───────────────────┴──────────┴─────────┘
```

Node 21
```
┌─────────┬───────────────────┬──────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name         │ ops/sec  │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼───────────────────┼──────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'generateKeyPair' │ '11,864' │ 84284.08410584877  │ '±2.39%' │ 5933    │
│ 1       │ 'signBytes'       │ '15,353' │ 65131.59020450661  │ '±1.34%' │ 7677    │
│ 2       │ 'verifySignature' │ '6,917'  │ 144570.39404451908 │ '±0.51%' │ 3459    │
└─────────┴───────────────────┴──────────┴────────────────────┴──────────┴─────────┘
```