### PR TITLE
Rewrite the error context encoder using base64 strings

### DIFF
--- a/.changeset/metal-radios-switch.md
+++ b/.changeset/metal-radios-switch.md
@@ -1,0 +1,5 @@
+---
+"@solana/errors": patch
+---
+
+The encoded `SolanaError` context that is thrown in production is now base64-encoded for compatibility with more terminal shells

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -34,7 +34,7 @@
     ],
     "bin": "./bin/cli.js",
     "scripts": {
-        "compile:js": "tsup --config build-scripts/tsup.config.package.ts && tsup src/cli.ts --format esm",
+        "compile:js": "tsup --config build-scripts/tsup.config.package.ts && tsup src/cli.ts --define.__NODEJS__ true --format esm --treeshake",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json && node ../../node_modules/@solana/build-scripts/add-js-extension-to-types.mjs",
         "dev": "jest -c ../../node_modules/@solana/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "pnpm pkg delete devDependencies",

--- a/packages/errors/src/__tests__/context-test.ts
+++ b/packages/errors/src/__tests__/context-test.ts
@@ -1,0 +1,88 @@
+import { decodeEncodedContext, encodeContextObject } from '../context';
+
+async function getTestContext() {
+    return {
+        a: 1n,
+        b: '"bar"',
+        c: "'baz'",
+        d: '!=$&ymbo;s\\',
+        e: [1, ["'2a'", '"2b"', '2c'], 3],
+        f: Symbol('hi'),
+        g: { foo: 'bar' },
+        h: new URL('http://anza.xyz'),
+        i: ((await crypto.subtle.generateKey('Ed25519', false /* extractable */, ['sign', 'verify'])) as CryptoKeyPair)
+            .privateKey,
+        j: Object.create(null),
+        k: null,
+        l: undefined,
+        m: "'",
+        n: "\\'",
+        o: "\\\\'",
+        p: '🚀',
+        q: 'حب',
+        r: 'प्यार',
+        s: '爱',
+    } as const;
+}
+const EXPECTED_URL_ENCODED_CONTEXT =
+    'a=1n&' +
+    'b=%22bar%22&' +
+    "c='baz'&" +
+    'd=!%3D%24%26ymbo%3Bs%5C&' +
+    "e=%5B1%2C%20%5B'2a'%2C%20%222b%22%2C%202c%5D%2C%203%5D&" +
+    'f=Symbol(hi)&' +
+    'g=%5Bobject%20Object%5D&' +
+    'h=http%3A%2F%2Fanza.xyz%2F&' +
+    'i=%5Bobject%20CryptoKey%5D&' +
+    'j=%5Bobject%20Object%5D&' +
+    'k=null&' +
+    'l=undefined&' +
+    "m='&" +
+    "n=%5C'&" +
+    "o=%5C%5C'&" +
+    'p=%F0%9F%9A%80&' +
+    'q=%D8%AD%D8%A8&' +
+    'r=%E0%A4%AA%E0%A5%8D%E0%A4%AF%E0%A4%BE%E0%A4%B0&' +
+    's=%E7%88%B1';
+
+describe('decodeEncodedContext', () => {
+    it('produces the expected context object from a URL-encoded search string', () => {
+        const encodedContext = btoa(EXPECTED_URL_ENCODED_CONTEXT);
+        expect(decodeEncodedContext(encodedContext)).toStrictEqual({
+            a: '1n',
+            b: '"bar"',
+            c: "'baz'",
+            d: '!=$&ymbo;s\\',
+            e: '[1, [\'2a\', "2b", 2c], 3]',
+            f: 'Symbol(hi)',
+            g: '[object Object]',
+            h: 'http://anza.xyz/',
+            i: '[object CryptoKey]',
+            j: '[object Object]',
+            k: 'null',
+            l: 'undefined',
+            m: "'",
+            n: "\\'",
+            o: "\\\\'",
+            p: '🚀',
+            q: 'حب',
+            r: 'प्यार',
+            s: '爱',
+        });
+    });
+});
+
+describe('encodeContextObject', () => {
+    let context: object;
+    beforeEach(async () => {
+        context = await getTestContext();
+    });
+    it('produces a string with no single quotes in it', () => {
+        const encodedContext = encodeContextObject(context);
+        expect(encodedContext).not.toContain("'");
+    });
+    it('produces encoded context that base64 decodes to the expected URL-encoded search string', () => {
+        const encodedContext = encodeContextObject(context);
+        expect(atob(encodedContext)).toBe(EXPECTED_URL_ENCODED_CONTEXT);
+    });
+});

--- a/packages/errors/src/cli.ts
+++ b/packages/errors/src/cli.ts
@@ -3,6 +3,7 @@ import { Command, InvalidArgumentError } from 'commander';
 
 import { version } from '../package.json';
 import { SolanaErrorCode } from './codes';
+import { decodeEncodedContext } from './context';
 import { getHumanReadableErrorMessage } from './message-formatter';
 import { SolanaErrorMessages } from './messages';
 
@@ -23,9 +24,13 @@ program
         }
         return code;
     })
-    .argument('[encodedContext]', 'encoded context to interpolate into the error message', encodedContext =>
-        Object.fromEntries(new URLSearchParams(encodedContext).entries()),
-    )
+    .argument('[encodedContext]', 'encoded context to interpolate into the error message', encodedContext => {
+        try {
+            return decodeEncodedContext(encodedContext);
+        } catch (e) {
+            throw new InvalidArgumentError('Encoded context malformed');
+        }
+    })
     .action((code: number, context) => {
         const message = getHumanReadableErrorMessage(code as SolanaErrorCode, context);
         console.log(`


### PR DESCRIPTION
# Summary

Biggest reason for doing this is that terminal escaping is hard. Base64 is guaranteed not to have any problematic characters in it.

# Test Plan

```shell
~/src/solana-web3.js-git/packages/errors$ npx . decode 2800000 'YWN0dWFsTGVuZ3RoPTM0NQ=='

[Decoded] Solana error code #2800000
    - Expected base58 encoded address to decode to a byte array of length 32. Actual length: 345.

[Context]
    {
        "actualLength": "345"
    }
```
