### PR TITLE
Patch `jest-runner-prettier` to work with Prettier 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
             "jsdom": "^22",
             "mock-socket": "^9.3.1",
             "shelljs": ">=0.8.5"
+        },
+        "patchedDependencies": {
+            "jest-runner-prettier@1.0.0": "patches/jest-runner-prettier@1.0.0.patch"
         }
     },
     "prettier": "@solana/prettier-config-solana"

--- a/patches/jest-runner-prettier@1.0.0.patch
+++ b/patches/jest-runner-prettier@1.0.0.patch
@@ -1,0 +1,44 @@
+diff --git a/dist/run.js b/dist/run.js
+index fdee17d2377dd013d55de1d54bee9d241894e800..7139e496da63da74b3e7966f4a3f5a613a7f3b3b 100644
+--- a/dist/run.js
++++ b/dist/run.js
+@@ -11,7 +11,7 @@ export default async ({ testPath }) => {
+         ...config,
+         filepath: testPath,
+     };
+-    const isPretty = prettier.check(contents, prettierConfig);
++    const isPretty = await prettier.check(contents, prettierConfig);
+     if (isPretty) {
+         return pass({
+             start,
+@@ -19,7 +19,7 @@ export default async ({ testPath }) => {
+             test: { path: testPath },
+         });
+     }
+-    const formatted = prettier.format(contents, prettierConfig);
++    const formatted = await prettier.format(contents, prettierConfig);
+     return fail({
+         start,
+         end: Date.now(),
+diff --git a/src/run.ts b/src/run.ts
+index 1775851defdca87b753f1f9bae1cb663332eb640..b6c72e13f82d9e9ed3aef5095f8b8d82e2b4391b 100644
+--- a/src/run.ts
++++ b/src/run.ts
+@@ -19,7 +19,7 @@ export default async ({ testPath }: Parameters): Promise<TestResult> => {
+     filepath: testPath,
+   };
+ 
+-  const isPretty = prettier.check(contents, prettierConfig);
++  const isPretty = await prettier.check(contents, prettierConfig);
+   if (isPretty) {
+     return pass({
+       start,
+@@ -28,7 +28,7 @@ export default async ({ testPath }: Parameters): Promise<TestResult> => {
+     });
+   }
+ 
+-  const formatted = prettier.format(contents, prettierConfig);
++  const formatted = await prettier.format(contents, prettierConfig);
+ 
+   return fail({
+     start,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,11 @@ overrides:
   mock-socket: ^9.3.1
   shelljs: '>=0.8.5'
 
+patchedDependencies:
+  jest-runner-prettier@1.0.0:
+    hash: wxyu3ekhzy6qhvwrai2xltdhn4
+    path: patches/jest-runner-prettier@1.0.0.patch
+
 importers:
 
   .:
@@ -87,7 +92,7 @@ importers:
         version: 2.2.0(eslint@8.57.0)(jest@29.7.0)
       jest-runner-prettier:
         specifier: ^1.0.0
-        version: 1.0.0(jest@29.7.0)(prettier@3.1.0)
+        version: 1.0.0(patch_hash=wxyu3ekhzy6qhvwrai2xltdhn4)(jest@29.7.0)(prettier@3.1.0)
       jest-watch-master:
         specifier: ^1.0.0
         version: 1.0.0(jest-validate@29.7.0)(jest@29.7.0)
@@ -9161,7 +9166,7 @@ packages:
       - jest-runner
     dev: true
 
-  /jest-runner-prettier@1.0.0(jest@29.7.0)(prettier@3.1.0):
+  /jest-runner-prettier@1.0.0(patch_hash=wxyu3ekhzy6qhvwrai2xltdhn4)(jest@29.7.0)(prettier@3.1.0):
     resolution: {integrity: sha512-da4LdL12MyUo6DPsebcsmi1pOrWr3o3K5MxL5IAyqe99Lb4j3SpH4HIDGc4rHCAUJvvkeEi2Kv1USa5W2Tw65w==}
     peerDependencies:
       jest: '>= 27.0.0'
@@ -9180,6 +9185,7 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
+    patched: true
 
   /jest-runner@27.5.1:
     resolution: {integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==}


### PR DESCRIPTION
# Summary

I completely forgot about https://github.com/keplersj/jest-runner-prettier/issues/586 and this has been broken for a while.

# Test Plan

This is why I love `pnpm`

```shell
pnpm patch jest-runner-prettier
# add the awaits everywhere
pnpm patch-commit '/tmp/67d6a1a8e116289cd91a5e6eeb4f413d'
```

Break formatting in a file. `pnpm test:prettier`. Finally it registers.
