### PR TITLE
Make the Prettier task behave more like your editor

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,10 @@
 .changeset/
 .github/workflows/PULL_REQUEST_TEMPLATE.md
 
+declarations/
+dist/
+doc/
+lib/
+
 pnpm-lock.yaml
 pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "build": "turbo run build",
         "compile": "turbo run compile:js compile:typedefs",
         "lint": "turbo run test:lint",
-        "style:fix": "turbo style:fix && prettier --write '{.,!packages}/**/*.{ts,js,md,json,ya?ml}'",
+        "style:fix": "turbo style:fix && pnpm prettier --log-level warn --ignore-unknown --write '{.,!packages}/*'",
         "test": "turbo run test:unit:browser test:unit:node",
         "test:live-with-test-validator": "turbo run test:live-with-test-validator",
         "test:live-with-test-validator:setup": "./scripts/setup-test-validator.sh"

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -40,7 +40,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/crypto-impl/package.json
+++ b/packages/crypto-impl/package.json
@@ -30,7 +30,7 @@
         "compile:js": "tsup",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
         "dev": "jest -c ../../node_modules/@solana/test-config/jest-dev.config.ts --rootDir . --watch",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -40,7 +40,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -40,7 +40,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/library-legacy-sham/package.json
+++ b/packages/library-legacy-sham/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/library-legacy/package.json
+++ b/packages/library-legacy/package.json
@@ -50,7 +50,7 @@
     "test:live": "TEST_LIVE=1 pnpm run test:unit:node",
     "test:live-with-test-validator": "start-server-and-test '../../scripts/start-shared-test-validator.sh' http://127.0.0.1:8899/health test:live",
     "test:prettier": "prettier --check '{,{src,test}/**/}*.{j,t}s'",
-    "test:prettier:fix": "prettier --write '{,{src,test}/**/}*.{j,t}s'",
+    "test:prettier:fix": "pnpm prettier --write '{,{src,test}/**/}*.{j,t}s'",
     "test:typecheck": "tsc --noEmit",
     "test:unit:node": "cross-env NODE_ENV=test TS_NODE_COMPILER_OPTIONS='{ \"module\": \"commonjs\", \"target\": \"es2019\" }' ts-mocha --require esm './test/**/*.test.ts'"
   },

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -42,7 +42,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "sed -i 's/@solana\\/web3\\.js-experimental/@solana\\/web3\\.js/g' package.json && sed -i 's/@solana\\/web3\\.js/@solana\\/web3\\.js-bak/g' ../library-legacy/package.json && pnpm prepublishOnly && pnpm publish-impl && git reset --hard",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-subscriptions-transport-websocket/package.json
+++ b/packages/rpc-subscriptions-transport-websocket/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -40,7 +40,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/text-encoding-impl/package.json
+++ b/packages/text-encoding-impl/package.json
@@ -31,7 +31,7 @@
         "compile:js": "tsup",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
         "dev": "jest -c ../../node_modules/@solana/test-config/jest-dev.config.ts --rootDir . --watch",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -38,7 +38,7 @@
         "dev": "jest -c ../../node_modules/@solana/test-config/jest-dev.config.ts --rootDir . --watch",
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-packages": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -39,7 +39,7 @@
         "prepublishOnly": "pnpm pkg delete devDependencies",
         "publish-impl": "npm view $npm_package_name@$npm_package_version > /dev/null 2>&1 || pnpm publish --tag ${PUBLISH_TAG:-preview} --access public --no-git-checks",
         "publish-packages": "pnpm prepublishOnly && pnpm publish-impl",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:typecheck": "tsc --noEmit",

--- a/packages/ws-impl/package.json
+++ b/packages/ws-impl/package.json
@@ -30,7 +30,7 @@
         "compile:js": "tsup",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
         "dev": "jest -c ../../node_modules/@solana/test-config/jest-dev.config.ts --rootDir . --watch",
-        "style:fix": "pnpm eslint --fix src/* && pnpm prettier -w src/* package.json",
+        "style:fix": "pnpm eslint --fix src/* && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent",
         "test:prettier": "jest -c ../../node_modules/@solana/test-config/jest-prettier.config.ts --rootDir . --silent",
         "test:treeshakability:browser": "agadoo dist/index.browser.js",


### PR DESCRIPTION
# Summary

1. Run `prettier` over all of the files that your editor would
2. Omit files via `.prettierignore` rather than trying to allowlist them via CLI
3. Stop logspew via `--log-level warn`
4. Make unrecognized files (like `*.sh`) not-an-error via `--ignore-unknown`
5. Actually run the _workspace_ version of Prettier rather than your machine's global version, by prefixing `prettier` with `pnpm`

# Test Plan

Expect the CI to fail on this PR. See the next PR.
