### PR TITLE
Show no Turbo logs except when there is an error

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -14,17 +14,20 @@
                 "test:unit:browser",
                 "test:unit:node"
             ],
-            "outputs": ["dist/**"]
+            "outputs": ["dist/**"],
+            "outputMode": "errors-only"
         },
         "compile:js": {
             "dependsOn": ["^compile:js"],
             "inputs": ["tsconfig.*", "src/**"],
-            "outputs": ["dist/**"]
+            "outputs": ["dist/**"],
+            "outputMode": "errors-only"
         },
         "compile:typedefs": {
             "dependsOn": ["^compile:typedefs"],
             "inputs": ["tsconfig.*", "src/**"],
-            "outputs": ["dist/**/*.d.ts"]
+            "outputs": ["dist/**/*.d.ts"],
+            "outputMode": "errors-only"
         },
         "publish-packages": {
             "cache": false,
@@ -39,7 +42,8 @@
                 "test:treeshakability:browser",
                 "test:treeshakability:native",
                 "test:treeshakability:node"
-            ]
+            ],
+            "outputMode": "errors-only"
         },
         "publish-packages-legacy": {
             "cache": false,
@@ -52,42 +56,53 @@
                 "test:prettier",
                 "test:typecheck",
                 "test:unit:node"
-            ]
+            ],
+            "outputMode": "errors-only"
         },
         "style:fix": {
             "inputs": ["*"],
-            "outputs": ["*"]
+            "outputs": ["*"],
+            "outputMode": "errors-only"
         },
         "test:lint": {
-            "inputs": ["src/**"]
+            "inputs": ["src/**"],
+            "outputMode": "errors-only"
         },
         "test:live-with-test-validator": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**"]
+            "inputs": ["src/**"],
+            "outputMode": "errors-only"
         },
         "test:prettier": {
-            "inputs": ["*"]
+            "inputs": ["*"],
+            "outputMode": "errors-only"
         },
         "test:typecheck": {
             "dependsOn": ["^compile:typedefs"],
-            "inputs": ["tsconfig.*", "src/**"]
+            "inputs": ["tsconfig.*", "src/**"],
+            "outputMode": "errors-only"
         },
         "test:unit:browser": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**"]
+            "inputs": ["src/**"],
+            "outputMode": "errors-only"
         },
         "test:unit:node": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**"]
+            "inputs": ["src/**"],
+            "outputMode": "errors-only"
         },
         "test:treeshakability:browser": {
-            "dependsOn": ["compile:js"]
+            "dependsOn": ["compile:js"],
+            "outputMode": "errors-only"
         },
         "test:treeshakability:native": {
-            "dependsOn": ["compile:js"]
+            "dependsOn": ["compile:js"],
+            "outputMode": "errors-only"
         },
         "test:treeshakability:node": {
-            "dependsOn": ["compile:js"]
+            "dependsOn": ["compile:js"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js#build": {
             "dependsOn": [
@@ -101,20 +116,24 @@
                 "test:typecheck",
                 "test:unit:node"
             ],
-            "outputs": ["doc/**", "declarations/**", "lib/**"]
+            "outputs": ["doc/**", "declarations/**", "lib/**"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js#clean": {
-            "outputs": ["doc/**", "declarations/**", "lib/**"]
+            "outputs": ["doc/**", "declarations/**", "lib/**"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js#compile:docs": {
             "dependsOn": ["clean"],
             "inputs": ["src/**"],
-            "outputs": ["doc/**"]
+            "outputs": ["doc/**"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js#compile:js": {
             "dependsOn": ["clean", "^compile:js"],
             "inputs": ["babel.config.json", "rollup.config.mjs", "tsconfig.*", "src/**"],
-            "outputs": ["lib/**"]
+            "outputs": ["lib/**"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js#compile:typedefs": {
             "dependsOn": ["clean", "^compile:typedefs"],
@@ -125,26 +144,32 @@
                 "test/__shadow-jest-types.d.ts",
                 "tsconfig.*"
             ],
-            "outputs": ["declarations/**", "lib/**/*.d.ts"]
+            "outputs": ["declarations/**", "lib/**/*.d.ts"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js#test:lint": {
-            "inputs": ["src/**", "test/**"]
+            "inputs": ["src/**", "test/**"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js#test:live-with-test-validator": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**", "test/**"]
+            "inputs": ["src/**", "test/**"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js#test:typecheck": {
             "dependsOn": ["^compile:typedefs"],
-            "inputs": ["src/**", "test/**", "tsconfig.*"]
+            "inputs": ["src/**", "test/**", "tsconfig.*"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js#test:unit:node": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**", "test/**"]
+            "inputs": ["src/**", "test/**"],
+            "outputMode": "errors-only"
         },
         "@solana/web3.js-legacy-sham#compile:typedefs": {
             "dependsOn": ["@solana/web3.js#compile:typedefs", "^compile:typedefs"],
-            "inputs": ["tsconfig.*", "src/**", "test/**"]
+            "inputs": ["tsconfig.*", "src/**", "test/**"],
+            "outputMode": "errors-only"
         }
     },
     "remoteCache": {


### PR DESCRIPTION
# Summary

So many logs.

How would you folks feel about Turborepo showing _nothing_ unless there's an error?

```
• Packages in scope: @solana/accounts, @solana/addresses, @solana/assertions, @solana/build-scripts, @solana/codecs, @solana/codecs-core, @solana/codecs-data-structures, @solana/codecs-numbers, @solana/codecs-strings, @solana/compat, @solana/crypto-impl, @solana/errors, @solana/functional, @solana/instructions, @solana/keys, @solana/options, @solana/programs, @solana/rpc, @solana/rpc-api, @solana/rpc-graphql, @solana/rpc-parsed-types, @solana/rpc-spec, @solana/rpc-spec-types, @solana/rpc-subscriptions, @solana/rpc-subscriptions-api, @solana/rpc-subscriptions-spec, @solana/rpc-subscriptions-transport-websocket, @solana/rpc-transformers, @solana/rpc-transport-http, @solana/rpc-types, @solana/signers, @solana/sysvars, @solana/test-config, @solana/test-matchers, @solana/text-encoding-impl, @solana/transaction-confirmation, @solana/transactions, @solana/tsconfig, @solana/web3.js, @solana/web3.js-experimental, @solana/web3.js-legacy-sham, @solana/webcrypto-ed25519-polyfill, @solana/ws-impl
• Running test:lint in 43 packages
• Remote caching enabled
@solana/accounts:test:lint: cache miss, executing 9db95c74ecbf331c
@solana/accounts:test:lint:
@solana/accounts:test:lint: > @solana/accounts@2.0.0-preview.2 test:lint /home/sol/src/solana-web3.js-git/packages/accounts
@solana/accounts:test:lint: > jest -c ../../node_modules/@solana/test-config/jest-lint.config.ts --rootDir . --silent
@solana/accounts:test:lint:
                             PASS   ESLint  src/rpc-api/common.ts
@solana/accounts:test:lint:  PASS   ESLint  src/types/global.d.ts
@solana/accounts:test:lint:  PASS   ESLint  src/index.ts
@solana/accounts:test:lint:  PASS   ESLint  src/maybe-account.ts
@solana/accounts:test:lint:  PASS   ESLint  src/parse-account.ts
@solana/accounts:test:lint:  PASS   ESLint  src/account.ts
@solana/accounts:test:lint:  FAIL   ESLint  src/decode-account.ts
@solana/accounts:test:lint:
@solana/accounts:test:lint: /home/sol/src/solana-web3.js-git/packages/accounts/src/decode-account.tsa/accounts:test:lint:
@solana/accounts:test:lint:   68:9  error  Unexpected constant condition  no-constant-conditionsolana/accounts:test:lint:
@solana/accounts:test:lint:
@solana/accounts:test:lint: ✖ 1 problem (1 error, 0 warnings)
@solana/accounts:test:lint:
@solana/accounts:test:lint:  PASS   ESLint  src/__typetests__/maybe-account-typetest.ts
@solana/accounts:test:lint:  PASS   ESLint  src/rpc-api/getAccountInfo.ts
@solana/accounts:test:lint:  PASS   ESLint  src/__tests__/decode-account-test.ts
@solana/accounts:test:lint:  PASS   ESLint  src/__typetests__/fetch-account-typetest.ts
@solana/accounts:test:lint:  PASS   ESLint  src/__tests__/parse-account-test.ts
@solana/accounts:test:lint:  PASS   ESLint  src/__typetests__/decode-account-typetest.ts
@solana/accounts:test:lint:  PASS   ESLint  src/__tests__/fetch-account-test.ts
@solana/accounts:test:lint:  PASS   ESLint  src/__typetests__/parse-account-typetest.ts
@solana/accounts:test:lint:  PASS   ESLint  src/rpc-api/index.ts
@solana/accounts:test:lint:  PASS   ESLint  src/__tests__/maybe-account-test.ts
@solana/accounts:test:lint:  PASS   ESLint  src/__tests__/__setup__.ts
@solana/accounts:test:lint:  PASS   ESLint  src/rpc-api/getMultipleAccounts.ts
@solana/accounts:test:lint:  PASS   ESLint  src/fetch-account.ts

@solana/accounts:test:lint: Test Suites: 1 failed, 19 passed, 20 total
@solana/accounts:test:lint: Tests:       1 failed, 19 passed, 20 total
@solana/accounts:test:lint: Snapshots:   0 total
@solana/accounts:test:lint: Time:        1.519 s, estimated 2 s
@solana/accounts:test:lint:  ELIFECYCLE  Command failed with exit code 1.
@solana/accounts:test:lint: ERROR: command finished with error: command (/home/sol/src/solana-web3.js-git/packages/accounts) /home/sol/.local/share/pnpm/pnpm run test:lint exited (1)
@solana/accounts#test:lint: command (/home/sol/src/solana-web3.js-git/packages/accounts) /home/sol/.local/share/pnpm/pnpm run test:lint exited (1)
@solana/accounts:test:lint:
 Tasks:    38 successful, 39 total
Cached:    38 cached, 39 total
  Time:    11.009s st:lint:
Failed:    @solana/accounts#test:lint
@solana/accounts:test:lint:
 ERROR  run failed: command  exited (1)
```

Related discussion: https://github.com/vercel/turbo/issues/4042
