### PR TITLE
Move dependencies out of `devDependencies` where they are used in the implementation

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -66,6 +66,7 @@
         "node": ">=17.4"
     },
     "dependencies": {
+        "@solana/addresses": "workspace:*",
         "@solana/errors": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/instructions": "workspace:*",
@@ -73,7 +74,6 @@
         "@solana/transactions": "workspace:*"
     },
     "devDependencies": {
-        "@solana/addresses": "workspace:*",
         "@solana/keys": "workspace:*",
         "@solana/rpc-types": "workspace:*",
         "@solana/web3.js": "workspace:../library-legacy"

--- a/packages/library-legacy-sham/package.json
+++ b/packages/library-legacy-sham/package.json
@@ -69,10 +69,10 @@
         "@noble/ed25519": "^2.0.0",
         "@noble/hashes": "^1.3.3",
         "@solana/addresses": "workspace:*",
-        "@solana/transactions": "workspace:*"
+        "@solana/transactions": "workspace:*",
+        "@solana/rpc-types": "workspace:*"
     },
     "devDependencies": {
-        "@solana/rpc-types": "workspace:*",
         "@solana/web3.js-legacy": "workspace:../library-legacy"
     },
     "bundlewatch": {

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -64,12 +64,10 @@
     ],
     "dependencies": {
         "@solana/addresses": "workspace:*",
+        "@solana/codecs-core": "workspace:*",
         "@solana/codecs-numbers": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*"
-    },
-    "devDependencies": {
-        "@solana/codecs-core": "workspace:*"
     },
     "bundlewatch": {
         "defaultCompression": "gzip",

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -68,15 +68,15 @@
     "dependencies": {
         "@solana/accounts": "workspace:*",
         "@solana/codecs": "workspace:*",
-        "@solana/errors": "workspace:*"
+        "@solana/errors": "workspace:*",
+        "@solana/rpc-types": "workspace:*"
     },
     "devDependencies": {
         "@solana/addresses": "workspace:*",
         "@solana/rpc-api": "workspace:*",
         "@solana/rpc-parsed-types": "workspace:*",
         "@solana/rpc-spec": "workspace:*",
-        "@solana/rpc-transport-http": "workspace:*",
-        "@solana/rpc-types": "workspace:*"
+        "@solana/rpc-transport-http": "workspace:*"
     },
     "bundlewatch": {
         "defaultCompression": "gzip",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -70,10 +70,8 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*",
         "@solana/functional": "workspace:*",
-        "@solana/keys": "workspace:*"
-    },
-    "devDependencies": {
         "@solana/instructions": "workspace:*",
+        "@solana/keys": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
     "bundlewatch": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
 
   packages/compat:
     dependencies:
+      '@solana/addresses':
+        specifier: workspace:*
+        version: link:../addresses
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
@@ -252,9 +255,6 @@ importers:
         specifier: workspace:*
         version: link:../transactions
     devDependencies:
-      '@solana/addresses':
-        specifier: workspace:*
-        version: link:../addresses
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
@@ -571,13 +571,13 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/rpc-types':
+        specifier: workspace:*
+        version: link:../rpc-types
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
     devDependencies:
-      '@solana/rpc-types':
-        specifier: workspace:*
-        version: link:../rpc-types
       '@solana/web3.js-legacy':
         specifier: workspace:../library-legacy
         version: link:../library-legacy
@@ -843,6 +843,9 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/codecs-core':
+        specifier: workspace:*
+        version: link:../codecs-core
       '@solana/codecs-numbers':
         specifier: workspace:*
         version: link:../codecs-numbers
@@ -852,10 +855,6 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-    devDependencies:
-      '@solana/codecs-core':
-        specifier: workspace:*
-        version: link:../codecs-core
 
   packages/signers:
     dependencies:
@@ -893,6 +892,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      '@solana/rpc-types':
+        specifier: workspace:*
+        version: link:../rpc-types
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -909,9 +911,6 @@ importers:
       '@solana/rpc-transport-http':
         specifier: workspace:*
         version: link:../rpc-transport-http
-      '@solana/rpc-types':
-        specifier: workspace:*
-        version: link:../rpc-types
 
   packages/test-config:
     dependencies:
@@ -995,13 +994,12 @@ importers:
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional
-      '@solana/keys':
-        specifier: workspace:*
-        version: link:../keys
-    devDependencies:
       '@solana/instructions':
         specifier: workspace:*
         version: link:../instructions
+      '@solana/keys':
+        specifier: workspace:*
+        version: link:../keys
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types


### PR DESCRIPTION
Discovered these by running `compile:js` in each individual package, doing a `git clean -dfx .` between each.