### PR TITLE
Negative error codes now get decoded correctly by the production error decoder

### DIFF
--- a/.changeset/breezy-items-reflect.md
+++ b/.changeset/breezy-items-reflect.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': patch
+---
+
+Fixed a bug that prevented the production error decoder from decoding negative error codes

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -32,7 +32,7 @@ When your bundler sets the constant `__DEV__` to `false`, error messages will be
 For instance, to recover the error text for the error with code `123`:
 
 ```shell
-npx @solana/errors decode 123
+npx @solana/errors decode -- 123
 ```
 
 ## Adding a new error

--- a/packages/errors/src/__tests__/message-formatter-test.ts
+++ b/packages/errors/src/__tests__/message-formatter-test.ts
@@ -22,7 +22,7 @@ describe('getErrorMessage', () => {
                 // @ts-expect-error Mock error codes don't conform to `SolanaErrorCode`
                 123,
             );
-            expect(message).toBe('Solana error #123; Decode this error by running `npx @solana/errors -- decode 123`');
+            expect(message).toBe('Solana error #123; Decode this error by running `npx @solana/errors decode -- 123`');
         });
         it('does not call the context encoder when the error has no context', () => {
             getErrorMessage(
@@ -55,7 +55,7 @@ describe('getErrorMessage', () => {
             const context = { foo: 'bar' };
             const message = getErrorMessage(123 as SolanaErrorCode, context);
             expect(message).toBe(
-                "Solana error #123; Decode this error by running `npx @solana/errors -- decode 123 'ENCODED_CONTEXT'`",
+                "Solana error #123; Decode this error by running `npx @solana/errors decode -- 123 'ENCODED_CONTEXT'`",
             );
         });
         it('renders no encoded context in the decoding advice when the context has no keys', async () => {
@@ -63,7 +63,7 @@ describe('getErrorMessage', () => {
             jest.mocked(encodeContextObject).mockReturnValue('ENCODED_CONTEXT');
             const context = {};
             const message = getErrorMessage(123 as SolanaErrorCode, context);
-            expect(message).toBe('Solana error #123; Decode this error by running `npx @solana/errors -- decode 123`');
+            expect(message).toBe('Solana error #123; Decode this error by running `npx @solana/errors decode -- 123`');
         });
     });
     describe('in dev mode', () => {

--- a/packages/errors/src/__tests__/message-formatter-test.ts
+++ b/packages/errors/src/__tests__/message-formatter-test.ts
@@ -22,7 +22,7 @@ describe('getErrorMessage', () => {
                 // @ts-expect-error Mock error codes don't conform to `SolanaErrorCode`
                 123,
             );
-            expect(message).toBe('Solana error #123; Decode this error by running `npx @solana/errors decode 123`');
+            expect(message).toBe('Solana error #123; Decode this error by running `npx @solana/errors -- decode 123`');
         });
         it('does not call the context encoder when the error has no context', () => {
             getErrorMessage(
@@ -55,7 +55,7 @@ describe('getErrorMessage', () => {
             const context = { foo: 'bar' };
             const message = getErrorMessage(123 as SolanaErrorCode, context);
             expect(message).toBe(
-                "Solana error #123; Decode this error by running `npx @solana/errors decode 123 'ENCODED_CONTEXT'`",
+                "Solana error #123; Decode this error by running `npx @solana/errors -- decode 123 'ENCODED_CONTEXT'`",
             );
         });
         it('renders no encoded context in the decoding advice when the context has no keys', async () => {
@@ -63,7 +63,7 @@ describe('getErrorMessage', () => {
             jest.mocked(encodeContextObject).mockReturnValue('ENCODED_CONTEXT');
             const context = {};
             const message = getErrorMessage(123 as SolanaErrorCode, context);
-            expect(message).toBe('Solana error #123; Decode this error by running `npx @solana/errors decode 123`');
+            expect(message).toBe('Solana error #123; Decode this error by running `npx @solana/errors -- decode 123`');
         });
     });
     describe('in dev mode', () => {

--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -17,7 +17,7 @@ export function getErrorMessage<TErrorCode extends SolanaErrorCode>(code: TError
     if (__DEV__) {
         return getHumanReadableErrorMessage(code, context);
     } else {
-        let decodingAdviceMessage = `Solana error #${code}; Decode this error by running \`npx @solana/errors -- decode ${code}`;
+        let decodingAdviceMessage = `Solana error #${code}; Decode this error by running \`npx @solana/errors decode -- ${code}`;
         if (Object.keys(context).length) {
             /**
              * DANGER: Be sure that the shell command is escaped in such a way that makes it

--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -17,7 +17,7 @@ export function getErrorMessage<TErrorCode extends SolanaErrorCode>(code: TError
     if (__DEV__) {
         return getHumanReadableErrorMessage(code, context);
     } else {
-        let decodingAdviceMessage = `Solana error #${code}; Decode this error by running \`npx @solana/errors decode ${code}`;
+        let decodingAdviceMessage = `Solana error #${code}; Decode this error by running \`npx @solana/errors -- decode ${code}`;
         if (Object.keys(context).length) {
             /**
              * DANGER: Be sure that the shell command is escaped in such a way that makes it


### PR DESCRIPTION
# Test Plan

```
cd packages/errors/
pnpm turbo compile:js
npx . decode -- -32003

[Decoded] Solana error code #-32003
    - Transaction signature verification failure
```

Closes #2357.
