### PR TITLE
refactor(experimental): support custom discriminator property for getDataEnumCodec

### DIFF
--- a/.changeset/violet-brooms-report.md
+++ b/.changeset/violet-brooms-report.md
@@ -1,0 +1,15 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+DataEnum codecs now support custom discriminator properties
+
+```ts
+const codec = getDataEnumCodec([
+  ['click', getStructCodec([[['x', u32], ['y', u32]]])],
+  ['keyPress', getStructCodec([[['key', u32]]])]
+], { discriminator: 'event' });
+
+codec.encode({ event: 'click', x: 1, y: 2 });
+codec.encode({ event: 'keyPress', key: 3 });
+```

--- a/packages/codecs-data-structures/src/__typetests__/data-enum-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/data-enum-typetest.ts
@@ -5,58 +5,103 @@ import { getDataEnumCodec, getDataEnumDecoder, getDataEnumEncoder } from '../dat
 import { getStructCodec } from '../struct';
 import { getUnitCodec } from '../unit';
 
+// [DESCRIBE] getDataEnumEncoder.
 {
-    // [getDataEnumEncoder]: It constructs data enums from a list of encoder variants.
-    getDataEnumEncoder([
-        ['A', {} as Encoder<{ value: string }>],
-        ['B', {} as Encoder<{ x: number; y: number }>],
-    ]) satisfies Encoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+    // It constructs data enums from a list of encoder variants.
+    {
+        getDataEnumEncoder([
+            ['A', {} as Encoder<{ value: string }>],
+            ['B', {} as Encoder<{ x: number; y: number }>],
+        ]) satisfies Encoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+    }
+
+    // It can use a custom discriminator property.
+    {
+        getDataEnumEncoder(
+            [
+                ['A', {} as Encoder<{ value: string }>],
+                ['B', {} as Encoder<{ x: number; y: number }>],
+            ],
+            { discriminator: 'myType' },
+        ) satisfies Encoder<{ myType: 'A'; value: string } | { myType: 'B'; x: number; y: number }>;
+    }
 }
 
+// [DESCRIBE] getDataEnumDecoder.
 {
-    // [getDataEnumDecoder]: It constructs data enums from a list of decoder variants.
-    getDataEnumDecoder([
-        ['A', {} as Decoder<{ value: string }>],
-        ['B', {} as Decoder<{ x: number; y: number }>],
-    ]) satisfies Decoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+    // It constructs data enums from a list of decoder variants.
+    {
+        getDataEnumDecoder([
+            ['A', {} as Decoder<{ value: string }>],
+            ['B', {} as Decoder<{ x: number; y: number }>],
+        ]) satisfies Decoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+    }
+
+    // It can use a custom discriminator property.
+    {
+        getDataEnumDecoder(
+            [
+                ['A', {} as Decoder<{ value: string }>],
+                ['B', {} as Decoder<{ x: number; y: number }>],
+            ],
+            { discriminator: 'myType' },
+        ) satisfies Decoder<{ myType: 'A'; value: string } | { myType: 'B'; x: number; y: number }>;
+    }
 }
 
+// [DESCRIBE] getDataEnumCodec.
 {
-    // [getDataEnumCodec]: It constructs data enums from a list of codec variants.
-    getDataEnumCodec([
-        ['A', {} as Codec<{ value: string }>],
-        ['B', {} as Codec<{ x: number; y: number }>],
-    ]) satisfies Codec<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
-}
+    // It constructs data enums from a list of codec variants.
+    {
+        getDataEnumCodec([
+            ['A', {} as Codec<{ value: string }>],
+            ['B', {} as Codec<{ x: number; y: number }>],
+        ]) satisfies Codec<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+    }
 
-{
-    // [getDataEnumCodec]: It can infer complex data enum types from provided variants.
-    getDataEnumCodec([
-        ['PageLoad', {} as Codec<void>],
-        [
-            'Click',
-            getStructCodec([
-                ['x', {} as Codec<number>],
-                ['y', {} as Codec<number>],
-            ]),
-        ],
-        ['KeyPress', getStructCodec([['fields', {} as Codec<[string]>]])],
-        ['PageUnload', {} as Codec<object>],
-    ]) satisfies Codec<
-        | { __kind: 'Click'; x: number; y: number }
-        | { __kind: 'KeyPress'; fields: [string] }
-        | { __kind: 'PageLoad' }
-        | { __kind: 'PageUnload' }
-    >;
-}
+    // It can use a custom discriminator property.
+    {
+        getDataEnumCodec(
+            [
+                ['A', {} as Codec<{ value: string }>],
+                ['B', {} as Codec<{ x: number; y: number }>],
+            ],
+            { discriminator: 'myType' },
+        ) satisfies Codec<{ myType: 'A'; value: string } | { myType: 'B'; x: number; y: number }>;
+    }
 
-{
-    // [getDataEnumCodec]: It can infer codec data enum with different from and to types.
-    getDataEnumCodec([
-        ['A', getUnitCodec()],
-        ['B', getStructCodec([['value', getU64Codec()]])],
-    ]) satisfies Codec<
-        { __kind: 'A' } | { __kind: 'B'; value: bigint | number },
-        { __kind: 'A' } | { __kind: 'B'; value: bigint }
-    >;
+    // It can infer complex data enum types from provided variants.
+    {
+        getDataEnumCodec(
+            [
+                ['PageLoad', {} as Codec<void>],
+                [
+                    'Click',
+                    getStructCodec([
+                        ['x', {} as Codec<number>],
+                        ['y', {} as Codec<number>],
+                    ]),
+                ],
+                ['KeyPress', getStructCodec([['fields', {} as Codec<[string]>]])],
+                ['PageUnload', {} as Codec<object>],
+            ],
+            { discriminator: 'event' },
+        ) satisfies Codec<
+            | { event: 'Click'; x: number; y: number }
+            | { event: 'KeyPress'; fields: [string] }
+            | { event: 'PageLoad' }
+            | { event: 'PageUnload' }
+        >;
+    }
+
+    // It can infer codec data enum with different from and to types.
+    {
+        getDataEnumCodec([
+            ['A', getUnitCodec()],
+            ['B', getStructCodec([['value', getU64Codec()]])],
+        ]) satisfies Codec<
+            { __kind: 'A' } | { __kind: 'B'; value: bigint | number },
+            { __kind: 'A' } | { __kind: 'B'; value: bigint }
+        >;
+    }
 }


### PR DESCRIPTION
This PR adds support for custom discriminator properties for `getDataEnumCodecs`.

```ts
// Before.
const codec = getDataEnumCodec([
  ['click', getStructCodec([[['x', u32], ['y', u32]]])],
  ['keyPress', getStructCodec([[['key', u32]]])]
]);

codec.encode({ __kind: 'click', x: 1, y: 2 });
codec.encode({ __kind: 'keyPress', key: 3 });

// After.
const codec = getDataEnumCodec([
  ['click', getStructCodec([[['x', u32], ['y', u32]]])],
  ['keyPress', getStructCodec([[['key', u32]]])]
], { discriminator: 'event' });

codec.encode({ event: 'click', x: 1, y: 2 });
codec.encode({ event: 'keyPress', key: 3 });
```

Note that, to make this work, this PR updates a few exported types such as `GetDataEnumKind` or `GetDataEnumKindContent` which is used by Kinobi. I'll make sure to have a PR ready on Kinobi's side when this is ready to be merged.