### PR TITLE
refactor(experimental): nit: rename define to describe

### DIFF
--- a/packages/rpc-subscriptions/src/__typetests__/rpc-subscriptions-clusters-typetest.ts
+++ b/packages/rpc-subscriptions/src/__typetests__/rpc-subscriptions-clusters-typetest.ts
@@ -30,7 +30,7 @@ const devnetTransport = createDefaultRpcSubscriptionsTransport({ url: devnetUrl 
 const testnetTransport = createDefaultRpcSubscriptionsTransport({ url: testnetUrl });
 const mainnetTransport = createDefaultRpcSubscriptionsTransport({ url: mainnetUrl });
 
-// [DEFINE] createDefaultRpcSubscriptionsTransport.
+// [DESCRIBE] createDefaultRpcSubscriptionsTransport.
 {
     // No cluster specified should be generic `RpcSubscriptionsTransport`.
     {
@@ -71,7 +71,7 @@ const mainnetTransport = createDefaultRpcSubscriptionsTransport({ url: mainnetUr
     }
 }
 
-// [DEFINE] createSolanaRpcSubscriptionsFromTransport.
+// [DESCRIBE] createSolanaRpcSubscriptionsFromTransport.
 {
     const genericRpc = createSolanaRpcSubscriptionsFromTransport(genericTransport);
     const devnetRpc = createSolanaRpcSubscriptionsFromTransport(devnetTransport);
@@ -137,7 +137,7 @@ const mainnetTransport = createDefaultRpcSubscriptionsTransport({ url: mainnetUr
     }
 }
 
-// [DEFINE] createSolanaRpcSubscriptionsFromTransport_UNSTABLE.
+// [DESCRIBE] createSolanaRpcSubscriptionsFromTransport_UNSTABLE.
 {
     const genericRpc = createSolanaRpcSubscriptionsFromTransport_UNSTABLE(genericTransport);
     const devnetRpc = createSolanaRpcSubscriptionsFromTransport_UNSTABLE(devnetTransport);
@@ -153,7 +153,7 @@ const mainnetTransport = createDefaultRpcSubscriptionsTransport({ url: mainnetUr
     }
 }
 
-// [DEFINE] createSolanaRpcSubscriptions.
+// [DESCRIBE] createSolanaRpcSubscriptions.
 {
     const genericRpc = createSolanaRpcSubscriptions(genericUrl);
     const devnetRpc = createSolanaRpcSubscriptions(devnetUrl);
@@ -219,7 +219,7 @@ const mainnetTransport = createDefaultRpcSubscriptionsTransport({ url: mainnetUr
     }
 }
 
-// [DEFINE] createSolanaRpcSubscriptions_UNSTABLE.
+// [DESCRIBE] createSolanaRpcSubscriptions_UNSTABLE.
 {
     const genericRpc = createSolanaRpcSubscriptions_UNSTABLE(genericUrl);
     const devnetRpc = createSolanaRpcSubscriptions_UNSTABLE(devnetUrl);

--- a/packages/rpc/src/__typetests__/rpc-clusters-typetest.ts
+++ b/packages/rpc/src/__typetests__/rpc-clusters-typetest.ts
@@ -25,7 +25,7 @@ const devnetTransport = createDefaultRpcTransport({ url: devnetUrl });
 const testnetTransport = createDefaultRpcTransport({ url: testnetUrl });
 const mainnetTransport = createDefaultRpcTransport({ url: mainnetUrl });
 
-// [DEFINE] createDefaultRpcTransport.
+// [DESCRIBE] createDefaultRpcTransport.
 {
     // No cluster specified should be generic `RpcTransport`.
     {
@@ -66,7 +66,7 @@ const mainnetTransport = createDefaultRpcTransport({ url: mainnetUrl });
     }
 }
 
-// [DEFINE] createSolanaRpcFromTransport.
+// [DESCRIBE] createSolanaRpcFromTransport.
 {
     const genericRpc = createSolanaRpcFromTransport(genericTransport);
     const devnetRpc = createSolanaRpcFromTransport(devnetTransport);
@@ -121,7 +121,7 @@ const mainnetTransport = createDefaultRpcTransport({ url: mainnetUrl });
     }
 }
 
-// [DEFINE] createSolanaRpc.
+// [DESCRIBE] createSolanaRpc.
 {
     const genericRpc = createSolanaRpc(genericUrl);
     const devnetRpc = createSolanaRpc(devnetUrl);


### PR DESCRIPTION
Whilst working on this stack I realised I used the word `[DEFINE]` in comments to mimic the Jest structure but what I meant to write was actually `[DESCRIBE]`. This PR fixes this.