### PR TITLE
Move comments about signature busting to the callsites that bust the signatures

### DIFF
--- a/packages/signers/src/fee-payer-signer.ts
+++ b/packages/signers/src/fee-payer-signer.ts
@@ -43,6 +43,7 @@ export function setTransactionFeePayerSigner<TFeePayerAddress extends string, TT
         return out;
     }
     const out = {
+        // A change in fee payer implies that any existing signatures are invalid.
         ...getUnsignedTransaction(transaction),
         feePayer: feePayerSigner.address,
         feePayerSigner,

--- a/packages/transactions/src/blockhash.ts
+++ b/packages/transactions/src/blockhash.ts
@@ -63,6 +63,7 @@ export function setTransactionLifetimeUsingBlockhash(
         return transaction;
     }
     const out = {
+        // A change in lifetime constraint implies that any existing signatures are invalid.
         ...getUnsignedTransaction(transaction),
         lifetimeConstraint: blockhashLifetimeConstraint,
     };

--- a/packages/transactions/src/durable-nonce.ts
+++ b/packages/transactions/src/durable-nonce.ts
@@ -192,6 +192,7 @@ export function setTransactionLifetimeUsingDurableNonce<
     }
 
     const out = {
+        // A change in lifetime constraint implies that any existing signatures are invalid.
         ...getUnsignedTransaction(transaction),
         instructions: newInstructions,
         lifetimeConstraint: {

--- a/packages/transactions/src/fee-payer.ts
+++ b/packages/transactions/src/fee-payer.ts
@@ -32,6 +32,7 @@ export function setTransactionFeePayer<TFeePayerAddress extends string, TTransac
         return transaction;
     }
     const out = {
+        // A change in fee payer implies that any existing signatures are invalid.
         ...getUnsignedTransaction(transaction),
         feePayer,
     };

--- a/packages/transactions/src/instructions.ts
+++ b/packages/transactions/src/instructions.ts
@@ -14,6 +14,7 @@ export function appendTransactionInstructions<TTransaction extends BaseTransacti
     transaction: TTransaction | (ITransactionWithSignatures & TTransaction),
 ): Omit<TTransaction, keyof ITransactionWithSignatures> | TTransaction {
     const out = {
+        // The addition of an instruction implies that any existing signatures are invalid.
         ...getUnsignedTransaction(transaction),
         instructions: [...transaction.instructions, ...instructions],
     };
@@ -33,6 +34,7 @@ export function prependTransactionInstructions<TTransaction extends BaseTransact
     transaction: TTransaction | (ITransactionWithSignatures & TTransaction),
 ): Omit<TTransaction, keyof ITransactionWithSignatures> | TTransaction {
     const out = {
+        // The addition of an instruction implies that any existing signatures are invalid.
         ...getUnsignedTransaction(transaction),
         instructions: [...instructions, ...transaction.instructions],
     };

--- a/packages/transactions/src/unsigned-transaction.ts
+++ b/packages/transactions/src/unsigned-transaction.ts
@@ -5,7 +5,6 @@ export function getUnsignedTransaction<TTransaction extends BaseTransaction>(
     transaction: TTransaction | (ITransactionWithSignatures & TTransaction),
 ): Omit<ITransactionWithSignatures & TTransaction, keyof ITransactionWithSignatures> | TTransaction {
     if ('signatures' in transaction) {
-        // The implication of the lifetime constraint changing is that any existing signatures are invalid.
         const {
             signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
             ...unsignedTransaction


### PR DESCRIPTION
This comment was orphaned when `getUnsignedTransaction()` was extracted
