### PR TITLE
Use readonly uint8array for sign input

### DIFF
--- a/packages/keys/src/signatures.ts
+++ b/packages/keys/src/signatures.ts
@@ -1,5 +1,5 @@
 import { assertSigningCapabilityIsAvailable, assertVerificationCapabilityIsAvailable } from '@solana/assertions';
-import { Encoder } from '@solana/codecs-core';
+import { Encoder, ReadonlyUint8Array } from '@solana/codecs-core';
 import { getBase58Encoder } from '@solana/codecs-strings';
 import {
     SOLANA_ERROR__KEYS__INVALID_SIGNATURE_BYTE_LENGTH,
@@ -56,7 +56,7 @@ export function isSignature(putativeSignature: string): putativeSignature is Sig
     return true;
 }
 
-export async function signBytes(key: CryptoKey, data: Uint8Array): Promise<SignatureBytes> {
+export async function signBytes(key: CryptoKey, data: ReadonlyUint8Array): Promise<SignatureBytes> {
     assertSigningCapabilityIsAvailable();
     const signedData = await crypto.subtle.sign('Ed25519', key, data);
     return new Uint8Array(signedData) as SignatureBytes;
@@ -67,7 +67,11 @@ export function signature(putativeSignature: string): Signature {
     return putativeSignature;
 }
 
-export async function verifySignature(key: CryptoKey, signature: SignatureBytes, data: Uint8Array): Promise<boolean> {
+export async function verifySignature(
+    key: CryptoKey,
+    signature: SignatureBytes,
+    data: ReadonlyUint8Array,
+): Promise<boolean> {
     assertVerificationCapabilityIsAvailable();
     return await crypto.subtle.verify('Ed25519', key, signature, data);
 }

--- a/packages/transactions/src/new-compile-transaction.ts
+++ b/packages/transactions/src/new-compile-transaction.ts
@@ -1,14 +1,10 @@
 import { Address } from '@solana/addresses';
+import { ReadonlyUint8Array } from '@solana/codecs-core';
 import { SignatureBytes } from '@solana/keys';
 
 import { CompilableTransaction } from './compilable-transaction';
 import { compileTransactionMessage } from './message';
 import { getCompiledMessageEncoder } from './serializers/message';
-
-type TypedArrayMutableProperties = 'copyWithin' | 'fill' | 'reverse' | 'set' | 'sort';
-interface ReadonlyUint8Array extends Omit<Uint8Array, TypedArrayMutableProperties> {
-    readonly [n: number]: number;
-}
 
 export type TransactionMessageBytes = ReadonlyUint8Array & { readonly __brand: unique symbol };
 export type OrderedMap<K extends string, V> = Record<K, V>;


### PR DESCRIPTION
This PR adds a shared `ReadonlyUint8Array` type and uses it for the input to `signBytes`. This will let us use it as the type of `messageBytes` in a signed transaction.

I haven't updated the sign output yet because I don't think it'll be necessary for my work and it'd be a larger change, but we probably should migrate more to readonly over time. 

See https://github.com/solana-labs/solana-web3.js/pull/2387#discussion_r1542038173

Addresses #2362.