### PR TITLE
Add ReadonlyUint8Array to codecs + allow decoding from it

### DIFF
--- a/packages/codecs-core/src/__tests__/codec-test.ts
+++ b/packages/codecs-core/src/__tests__/codec-test.ts
@@ -1,4 +1,5 @@
 import { Codec, createCodec, createDecoder, createEncoder, Encoder } from '../codec';
+import { ReadonlyUint8Array } from '../readonly-uint8array';
 
 describe('Encoder', () => {
     it('can define Encoder instances', () => {
@@ -27,7 +28,7 @@ describe('Decoder', () => {
     it('can define Decoder instances', () => {
         const myDecoder = createDecoder({
             fixedSize: 32,
-            read: (bytes: Uint8Array, offset) => {
+            read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
                 const slice = bytes.slice(offset, offset + 32);
                 const str = [...slice].map(charCode => String.fromCharCode(charCode)).join('');
                 return [str, offset + 32];
@@ -45,7 +46,7 @@ describe('Codec', () => {
     it('can define Codec instances', () => {
         const myCodec: Codec<string> = createCodec({
             fixedSize: 32,
-            read: (bytes: Uint8Array, offset) => {
+            read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
                 const slice = bytes.slice(offset, offset + 32);
                 const str = [...slice].map(charCode => String.fromCharCode(charCode)).join('');
                 return [str, offset + 32];

--- a/packages/codecs-core/src/__tests__/combine-codec.ts
+++ b/packages/codecs-core/src/__tests__/combine-codec.ts
@@ -6,6 +6,7 @@ import {
 
 import { createDecoder, createEncoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '../codec';
 import { combineCodec } from '../combine-codec';
+import { ReadonlyUint8Array } from '../readonly-uint8array';
 
 describe('combineCodec', () => {
     it('can join encoders and decoders with the same type', () => {
@@ -19,7 +20,7 @@ describe('combineCodec', () => {
 
         const u8Decoder = createDecoder({
             fixedSize: 1,
-            read: (bytes: Uint8Array, offset = 0) => [bytes[offset], offset + 1],
+            read: (bytes: ReadonlyUint8Array | Uint8Array, offset = 0) => [bytes[offset], offset + 1],
         });
 
         const u8Codec = combineCodec(u8Encoder, u8Decoder);
@@ -40,7 +41,7 @@ describe('combineCodec', () => {
 
         const u8Decoder: FixedSizeDecoder<bigint> = createDecoder({
             fixedSize: 1,
-            read: (bytes: Uint8Array, offset = 0) => [BigInt(bytes[offset]), offset + 1],
+            read: (bytes: ReadonlyUint8Array | Uint8Array, offset = 0) => [BigInt(bytes[offset]), offset + 1],
         });
 
         const u8Codec: FixedSizeCodec<bigint | number, bigint> = combineCodec(u8Encoder, u8Decoder);

--- a/packages/codecs-core/src/__tests__/map-codec-test.ts
+++ b/packages/codecs-core/src/__tests__/map-codec-test.ts
@@ -1,9 +1,10 @@
 import { Codec, createCodec, createDecoder, createEncoder } from '../codec';
 import { mapCodec, mapDecoder, mapEncoder } from '../map-codec';
+import { ReadonlyUint8Array } from '../readonly-uint8array';
 
 const numberCodec: Codec<number> = createCodec({
     fixedSize: 1,
-    read: (bytes: Uint8Array): [number, number] => [bytes[0], 1],
+    read: (bytes: ReadonlyUint8Array | Uint8Array): [number, number] => [bytes[0], 1],
     write: (value: number, bytes, offset) => {
         bytes.set([value], offset);
         return offset + 1;
@@ -74,7 +75,7 @@ describe('mapCodec', () => {
         type Strict = { discriminator: number; label: string };
         const strictCodec: Codec<Strict> = createCodec({
             fixedSize: 2,
-            read: (bytes: Uint8Array): [Strict, number] => [
+            read: (bytes: ReadonlyUint8Array | Uint8Array): [Strict, number] => [
                 { discriminator: bytes[0], label: 'x'.repeat(bytes[1]) },
                 1,
             ],
@@ -118,7 +119,10 @@ describe('mapCodec', () => {
     it('can loosen a tuple codec', () => {
         const codec: Codec<[number, string]> = createCodec({
             fixedSize: 2,
-            read: (bytes: Uint8Array): [[number, string], number] => [[bytes[0], 'x'.repeat(bytes[1])], 2],
+            read: (bytes: ReadonlyUint8Array | Uint8Array): [[number, string], number] => [
+                [bytes[0], 'x'.repeat(bytes[1])],
+                2,
+            ],
             write: (value: [number, string], bytes, offset) => {
                 bytes.set([value[0], value[1].length], offset);
                 return offset + 2;
@@ -163,7 +167,7 @@ describe('mapDecoder', () => {
     it('can map an encoder to another encoder', () => {
         const decoder = createDecoder({
             fixedSize: 1,
-            read: (bytes: Uint8Array, offset = 0) => [bytes[offset], offset + 1],
+            read: (bytes: ReadonlyUint8Array | Uint8Array, offset = 0) => [bytes[offset], offset + 1],
         });
 
         const decoderB = mapDecoder(decoder, (value: number): string => 'x'.repeat(value));

--- a/packages/codecs-core/src/assertions.ts
+++ b/packages/codecs-core/src/assertions.ts
@@ -5,10 +5,16 @@ import {
     SolanaError,
 } from '@solana/errors';
 
+import { ReadonlyUint8Array } from './readonly-uint8array';
+
 /**
  * Asserts that a given byte array is not empty.
  */
-export function assertByteArrayIsNotEmptyForCodec(codecDescription: string, bytes: Uint8Array, offset = 0) {
+export function assertByteArrayIsNotEmptyForCodec(
+    codecDescription: string,
+    bytes: ReadonlyUint8Array | Uint8Array,
+    offset = 0,
+) {
     if (bytes.length - offset <= 0) {
         throw new SolanaError(SOLANA_ERROR__CODECS__CANNOT_DECODE_EMPTY_BYTE_ARRAY, {
             codecDescription,
@@ -22,7 +28,7 @@ export function assertByteArrayIsNotEmptyForCodec(codecDescription: string, byte
 export function assertByteArrayHasEnoughBytesForCodec(
     codecDescription: string,
     expected: number,
-    bytes: Uint8Array,
+    bytes: ReadonlyUint8Array | Uint8Array,
     offset = 0,
 ) {
     const bytesLength = bytes.length - offset;

--- a/packages/codecs-core/src/bytes.ts
+++ b/packages/codecs-core/src/bytes.ts
@@ -1,3 +1,5 @@
+import { ReadonlyUint8Array } from './readonly-uint8array';
+
 /**
  * Concatenates an array of `Uint8Array`s into a single `Uint8Array`.
  * Reuses the original byte array when applicable.
@@ -26,7 +28,7 @@ export const mergeBytes = (byteArrays: Uint8Array[]): Uint8Array => {
  * Pads a `Uint8Array` with zeroes to the specified length.
  * If the array is longer than the specified length, it is returned as-is.
  */
-export const padBytes = (bytes: Uint8Array, length: number): Uint8Array => {
+export const padBytes = (bytes: ReadonlyUint8Array | Uint8Array, length: number): ReadonlyUint8Array | Uint8Array => {
     if (bytes.length >= length) return bytes;
     const paddedBytes = new Uint8Array(length).fill(0);
     paddedBytes.set(bytes);
@@ -38,5 +40,5 @@ export const padBytes = (bytes: Uint8Array, length: number): Uint8Array => {
  * If the array is longer than the specified length, it is truncated.
  * If the array is shorter than the specified length, it is padded with zeroes.
  */
-export const fixBytes = (bytes: Uint8Array, length: number): Uint8Array =>
+export const fixBytes = (bytes: ReadonlyUint8Array | Uint8Array, length: number): ReadonlyUint8Array | Uint8Array =>
     padBytes(bytes.length <= length ? bytes : bytes.slice(0, length), length);

--- a/packages/codecs-core/src/codec.ts
+++ b/packages/codecs-core/src/codec.ts
@@ -4,6 +4,8 @@ import {
     SolanaError,
 } from '@solana/errors';
 
+import { ReadonlyUint8Array } from './readonly-uint8array';
+
 /**
  * Defines an offset in bytes.
  */
@@ -38,12 +40,12 @@ export type Encoder<TFrom> = FixedSizeEncoder<TFrom> | VariableSizeEncoder<TFrom
 
 type BaseDecoder<TTo> = {
     /** Decodes the provided byte array at the given offset (or zero) and returns the value directly. */
-    readonly decode: (bytes: Uint8Array, offset?: Offset) => TTo;
+    readonly decode: (bytes: ReadonlyUint8Array | Uint8Array, offset?: Offset) => TTo;
     /**
      * Reads the encoded value from the provided byte array at the given offset.
      * Returns the decoded value and the offset of the next byte after the encoded value.
      */
-    readonly read: (bytes: Uint8Array, offset: Offset) => [TTo, Offset];
+    readonly read: (bytes: ReadonlyUint8Array | Uint8Array, offset: Offset) => [TTo, Offset];
 };
 
 export type FixedSizeDecoder<TTo, TSize extends number = number> = BaseDecoder<TTo> & {

--- a/packages/codecs-core/src/fix-codec.ts
+++ b/packages/codecs-core/src/fix-codec.ts
@@ -13,6 +13,7 @@ import {
     Offset,
 } from './codec';
 import { combineCodec } from './combine-codec';
+import { ReadonlyUint8Array } from './readonly-uint8array';
 
 /**
  * Creates a fixed-size encoder from a given encoder.
@@ -51,7 +52,7 @@ export function fixDecoder<TTo, TSize extends number>(
 ): FixedSizeDecoder<TTo, TSize> {
     return createDecoder({
         fixedSize: fixedBytes,
-        read: (bytes: Uint8Array, offset: Offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset: Offset) => {
             assertByteArrayHasEnoughBytesForCodec('fixCodec', fixedBytes, bytes, offset);
             // Slice the byte array to the fixed size if necessary.
             if (offset > 0 || bytes.length > fixedBytes) {

--- a/packages/codecs-core/src/index.ts
+++ b/packages/codecs-core/src/index.ts
@@ -6,5 +6,6 @@ export * from './fix-codec';
 export * from './map-codec';
 export * from './offset-codec';
 export * from './pad-codec';
+export * from './readonly-uint8array';
 export * from './resize-codec';
 export * from './reverse-codec';

--- a/packages/codecs-core/src/map-codec.ts
+++ b/packages/codecs-core/src/map-codec.ts
@@ -13,6 +13,7 @@ import {
     VariableSizeDecoder,
     VariableSizeEncoder,
 } from './codec';
+import { ReadonlyUint8Array } from './readonly-uint8array';
 
 /**
  * Converts an encoder A to a encoder B by mapping their values.
@@ -46,23 +47,23 @@ export function mapEncoder<TOldFrom, TNewFrom>(
  */
 export function mapDecoder<TOldTo, TNewTo, TSize extends number>(
     decoder: FixedSizeDecoder<TOldTo, TSize>,
-    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo,
+    map: (value: TOldTo, bytes: ReadonlyUint8Array | Uint8Array, offset: number) => TNewTo,
 ): FixedSizeDecoder<TNewTo, TSize>;
 export function mapDecoder<TOldTo, TNewTo>(
     decoder: VariableSizeDecoder<TOldTo>,
-    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo,
+    map: (value: TOldTo, bytes: ReadonlyUint8Array | Uint8Array, offset: number) => TNewTo,
 ): VariableSizeDecoder<TNewTo>;
 export function mapDecoder<TOldTo, TNewTo>(
     decoder: Decoder<TOldTo>,
-    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo,
+    map: (value: TOldTo, bytes: ReadonlyUint8Array | Uint8Array, offset: number) => TNewTo,
 ): Decoder<TNewTo>;
 export function mapDecoder<TOldTo, TNewTo>(
     decoder: Decoder<TOldTo>,
-    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo,
+    map: (value: TOldTo, bytes: ReadonlyUint8Array | Uint8Array, offset: number) => TNewTo,
 ): Decoder<TNewTo> {
     return createDecoder({
         ...decoder,
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             const [value, newOffset] = decoder.read(bytes, offset);
             return [map(value, bytes, offset), newOffset];
         },
@@ -87,22 +88,22 @@ export function mapCodec<TOldFrom, TNewFrom, TTo extends TNewFrom & TOldFrom>(
 export function mapCodec<TOldFrom, TNewFrom, TOldTo extends TOldFrom, TNewTo extends TNewFrom, TSize extends number>(
     codec: FixedSizeCodec<TOldFrom, TOldTo, TSize>,
     unmap: (value: TNewFrom) => TOldFrom,
-    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo,
+    map: (value: TOldTo, bytes: ReadonlyUint8Array | Uint8Array, offset: number) => TNewTo,
 ): FixedSizeCodec<TNewFrom, TNewTo, TSize>;
 export function mapCodec<TOldFrom, TNewFrom, TOldTo extends TOldFrom, TNewTo extends TNewFrom>(
     codec: VariableSizeCodec<TOldFrom, TOldTo>,
     unmap: (value: TNewFrom) => TOldFrom,
-    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo,
+    map: (value: TOldTo, bytes: ReadonlyUint8Array | Uint8Array, offset: number) => TNewTo,
 ): VariableSizeCodec<TNewFrom, TNewTo>;
 export function mapCodec<TOldFrom, TNewFrom, TOldTo extends TOldFrom, TNewTo extends TNewFrom>(
     codec: Codec<TOldFrom, TOldTo>,
     unmap: (value: TNewFrom) => TOldFrom,
-    map: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo,
+    map: (value: TOldTo, bytes: ReadonlyUint8Array | Uint8Array, offset: number) => TNewTo,
 ): Codec<TNewFrom, TNewTo>;
 export function mapCodec<TOldFrom, TNewFrom, TOldTo extends TOldFrom, TNewTo extends TNewFrom>(
     codec: Codec<TOldFrom, TOldTo>,
     unmap: (value: TNewFrom) => TOldFrom,
-    map?: (value: TOldTo, bytes: Uint8Array, offset: number) => TNewTo,
+    map?: (value: TOldTo, bytes: ReadonlyUint8Array | Uint8Array, offset: number) => TNewTo,
 ): Codec<TNewFrom, TNewTo> {
     return createCodec({
         ...mapEncoder(codec, unmap),

--- a/packages/codecs-core/src/offset-codec.ts
+++ b/packages/codecs-core/src/offset-codec.ts
@@ -1,6 +1,7 @@
 import { assertByteArrayOffsetIsNotOutOfRange } from './assertions';
 import { Codec, createDecoder, createEncoder, Decoder, Encoder, Offset } from './codec';
 import { combineCodec } from './combine-codec';
+import { ReadonlyUint8Array } from './readonly-uint8array';
 
 type OffsetConfig = {
     postOffset?: PostOffsetFunction;
@@ -9,7 +10,7 @@ type OffsetConfig = {
 
 type PreOffsetFunctionScope = {
     /** The entire byte array. */
-    bytes: Uint8Array;
+    bytes: ReadonlyUint8Array | Uint8Array;
     /** The original offset prior to encode or decode. */
     preOffset: Offset;
     /** Wraps the offset to the byte array length. */

--- a/packages/codecs-core/src/readonly-uint8array.ts
+++ b/packages/codecs-core/src/readonly-uint8array.ts
@@ -1,0 +1,4 @@
+type TypedArrayMutableProperties = 'copyWithin' | 'fill' | 'reverse' | 'set' | 'sort';
+export interface ReadonlyUint8Array extends Omit<Uint8Array, TypedArrayMutableProperties> {
+    readonly [n: number]: number;
+}

--- a/packages/codecs-core/src/reverse-codec.ts
+++ b/packages/codecs-core/src/reverse-codec.ts
@@ -38,7 +38,7 @@ export function reverseDecoder<TTo, TSize extends number>(
         read: (bytes, offset) => {
             const reverseEnd = offset + decoder.fixedSize;
             if (offset === 0 && bytes.length === reverseEnd) {
-                return decoder.read(bytes.reverse(), offset);
+                return decoder.read(new Uint8Array([...bytes]).reverse(), offset);
             }
             const reversedBytes = bytes.slice();
             reversedBytes.set(bytes.slice(offset, reverseEnd).reverse(), offset);

--- a/packages/codecs-data-structures/src/array.ts
+++ b/packages/codecs-data-structures/src/array.ts
@@ -9,6 +9,7 @@ import {
     FixedSizeDecoder,
     FixedSizeEncoder,
     getEncodedSize,
+    ReadonlyUint8Array,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -120,7 +121,7 @@ export function getArrayDecoder<TTo>(item: Decoder<TTo>, config: ArrayCodecConfi
 
     return createDecoder({
         ...(fixedSize !== null ? { fixedSize } : { maxSize }),
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             const array: TTo[] = [];
             if (typeof size === 'object' && bytes.slice(offset).length === 0) {
                 return [array, offset];

--- a/packages/codecs-data-structures/src/bytes.ts
+++ b/packages/codecs-data-structures/src/bytes.ts
@@ -13,6 +13,7 @@ import {
     FixedSizeEncoder,
     fixEncoder,
     getEncodedSize,
+    ReadonlyUint8Array,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -81,7 +82,7 @@ export function getBytesDecoder(config: BytesCodecConfig<NumberDecoder> = {}): D
     const size = config.size ?? 'variable';
 
     const byteDecoder: Decoder<Uint8Array> = createDecoder({
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             const slice = bytes.slice(offset);
             return [slice, offset + slice.length];
         },
@@ -96,7 +97,7 @@ export function getBytesDecoder(config: BytesCodecConfig<NumberDecoder> = {}): D
     }
 
     return createDecoder({
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             assertByteArrayIsNotEmptyForCodec('bytes', bytes, offset);
             const [lengthBigInt, lengthOffset] = size.read(bytes, offset);
             const length = Number(lengthBigInt);

--- a/packages/codecs-data-structures/src/discriminated-union.ts
+++ b/packages/codecs-data-structures/src/discriminated-union.ts
@@ -9,6 +9,7 @@ import {
     Encoder,
     getEncodedSize,
     isFixedSize,
+    ReadonlyUint8Array,
 } from '@solana/codecs-core';
 import { getU8Decoder, getU8Encoder, NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
 import {
@@ -174,7 +175,7 @@ export function getDiscriminatedUnionDecoder<
     const fixedSize = getDiscriminatedUnionFixedSize(variants, prefix);
     return createDecoder({
         ...(fixedSize !== null ? { fixedSize } : { maxSize: getDiscriminatedUnionMaxSize(variants, prefix) }),
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             assertByteArrayIsNotEmptyForCodec('discriminatedUnion', bytes, offset);
             const [discriminator, dOffset] = prefix.read(bytes, offset);
             offset = dOffset;

--- a/packages/codecs-data-structures/src/nullable.ts
+++ b/packages/codecs-data-structures/src/nullable.ts
@@ -11,6 +11,7 @@ import {
     FixedSizeEncoder,
     getEncodedSize,
     isFixedSize,
+    ReadonlyUint8Array,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -140,7 +141,7 @@ export function getNullableDecoder<TTo>(
         ...(fixedSize === null
             ? { maxSize: sumCodecSizes([prefix, item].map(getMaxSize)) ?? undefined }
             : { fixedSize }),
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             if (bytes.length - offset <= 0) {
                 return [null, offset];
             }

--- a/packages/codecs-data-structures/src/struct.ts
+++ b/packages/codecs-data-structures/src/struct.ts
@@ -10,6 +10,7 @@ import {
     FixedSizeDecoder,
     FixedSizeEncoder,
     getEncodedSize,
+    ReadonlyUint8Array,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -87,7 +88,7 @@ export function getStructDecoder<const TFields extends Fields<Decoder<any>>>(
 
     return createDecoder({
         ...(fixedSize === null ? { maxSize } : { fixedSize }),
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             const struct = {} as TTo;
             fields.forEach(([key, codec]) => {
                 const [value, newOffset] = codec.read(bytes, offset);

--- a/packages/codecs-data-structures/src/tuple.ts
+++ b/packages/codecs-data-structures/src/tuple.ts
@@ -10,6 +10,7 @@ import {
     FixedSizeDecoder,
     FixedSizeEncoder,
     getEncodedSize,
+    ReadonlyUint8Array,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -83,7 +84,7 @@ export function getTupleDecoder<const TItems extends readonly Decoder<any>[]>(
 
     return createDecoder({
         ...(fixedSize === null ? { maxSize } : { fixedSize }),
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             const values = [] as Array<any> & TTo;
             items.forEach(item => {
                 const [newValue, newOffset] = item.read(bytes, offset);

--- a/packages/codecs-data-structures/src/unit.ts
+++ b/packages/codecs-data-structures/src/unit.ts
@@ -5,6 +5,7 @@ import {
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
+    ReadonlyUint8Array,
 } from '@solana/codecs-core';
 
 /**
@@ -23,7 +24,7 @@ export function getUnitEncoder(): FixedSizeEncoder<void, 0> {
 export function getUnitDecoder(): FixedSizeDecoder<void, 0> {
     return createDecoder({
         fixedSize: 0,
-        read: (_bytes: Uint8Array, offset) => [undefined, offset],
+        read: (_bytes: ReadonlyUint8Array | Uint8Array, offset) => [undefined, offset],
     });
 }
 

--- a/packages/codecs-numbers/src/short-u16.ts
+++ b/packages/codecs-numbers/src/short-u16.ts
@@ -3,6 +3,7 @@ import {
     createDecoder,
     createEncoder,
     Offset,
+    ReadonlyUint8Array,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -52,7 +53,7 @@ export const getShortU16Encoder = (): VariableSizeEncoder<number> =>
 export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
     createDecoder({
         maxSize: 3,
-        read: (bytes: Uint8Array, offset): [number, Offset] => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset): [number, Offset] => {
             let value = 0;
             let byteCount = 0;
             while (++byteCount) {

--- a/packages/codecs-numbers/src/utils.ts
+++ b/packages/codecs-numbers/src/utils.ts
@@ -6,6 +6,7 @@ import {
     FixedSizeDecoder,
     FixedSizeEncoder,
     Offset,
+    ReadonlyUint8Array,
 } from '@solana/codecs-core';
 
 import { assertNumberIsBetweenForCodec } from './assertions';
@@ -65,7 +66,7 @@ export function numberDecoderFactory<TTo extends bigint | number, TSize extends 
  * Helper function to ensure that the ArrayBuffer is converted properly from a Uint8Array
  * Source: https://stackoverflow.com/questions/37228285/uint8array-to-arraybuffer
  */
-function toArrayBuffer(bytes: Uint8Array, offset?: number, length?: number): ArrayBuffer {
+function toArrayBuffer(bytes: ReadonlyUint8Array | Uint8Array, offset?: number, length?: number): ArrayBuffer {
     const bytesOffset = bytes.byteOffset + (offset ?? 0);
     const bytesLength = length ?? bytes.byteLength;
     return bytes.buffer.slice(bytesOffset, bytesOffset + bytesLength);

--- a/packages/codecs-strings/src/string.ts
+++ b/packages/codecs-strings/src/string.ts
@@ -13,6 +13,7 @@ import {
     FixedSizeEncoder,
     fixEncoder,
     getEncodedSize,
+    ReadonlyUint8Array,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -106,7 +107,7 @@ export function getStringDecoder(config: StringCodecConfig<NumberDecoder, Decode
     }
 
     return createDecoder({
-        read: (bytes: Uint8Array, offset = 0) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset = 0) => {
             assertByteArrayIsNotEmptyForCodec('string', bytes, offset);
             const [lengthBigInt, lengthOffset] = size.read(bytes, offset);
             const length = Number(lengthBigInt);

--- a/packages/options/src/option-codec.ts
+++ b/packages/options/src/option-codec.ts
@@ -11,6 +11,7 @@ import {
     FixedSizeEncoder,
     getEncodedSize,
     isFixedSize,
+    ReadonlyUint8Array,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -148,7 +149,7 @@ export function getOptionDecoder<TTo>(
         ...(fixedSize === null
             ? { maxSize: sumCodecSizes([prefix, item].map(getMaxSize)) ?? undefined }
             : { fixedSize }),
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             if (bytes.length - offset <= 0) {
                 return [none(), offset];
             }

--- a/packages/sysvars/src/slot-history.ts
+++ b/packages/sysvars/src/slot-history.ts
@@ -10,6 +10,7 @@ import {
     getU64Codec,
     getU64Decoder,
     getU64Encoder,
+    ReadonlyUint8Array,
 } from '@solana/codecs';
 import {
     SOLANA_ERROR__CODECS__ENUM_DISCRIMINATOR_OUT_OF_RANGE,
@@ -103,7 +104,7 @@ export function getSysvarSlotHistoryEncoder(): FixedSizeEncoder<SysvarSlotHistor
 export function getSysvarSlotHistoryDecoder(): FixedSizeDecoder<SysvarSlotHistory, SysvarSlotHistorySize> {
     return createDecoder({
         fixedSize: SLOT_HISTORY_ACCOUNT_DATA_STATIC_SIZE,
-        read: (bytes: Uint8Array, offset) => {
+        read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             // Byte length should be exact.
             if (bytes.length != SLOT_HISTORY_ACCOUNT_DATA_STATIC_SIZE) {
                 throw new SolanaError(SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH, {


### PR DESCRIPTION
This PR adds the proposed `ReadonlyUint8Array` type to `codecs-core`. The `Decoder` interface is modified to allow decoding from a `ReadonlyUint8Array | Uint8Array`. This will allow us to use `ReadonlyUint8Array` for various byte encodings, while still being able to decode them as normal byte arrays.

The only place where I needed to add an extra copy is in `reverseCodec`, which was reversing the input bytes in place. It now creates and reverses a new Uint8Array from the input bytes. 

Addresses #2362.