### PR TITLE
refactor(experimental): add prefixCodec to @solana/codecs-core

### DIFF
--- a/.changeset/chatty-flies-end.md
+++ b/.changeset/chatty-flies-end.md
@@ -1,0 +1,16 @@
+---
+'@solana/codecs-data-structures': patch
+'@solana/codecs-strings': patch
+'@solana/codecs-core': patch
+---
+
+Added a new `prefixCodec` primitive
+
+```ts
+const codec = prefixCodec(getBase58Codec(), getU32Codec());
+
+codec.encode('hello world');
+// 0x0b00000068656c6c6f20776f726c64
+//   |       └-- Our encoded base-58 string.
+//   └-- Our encoded u32 size prefix.
+```

--- a/packages/codecs-core/README.md
+++ b/packages/codecs-core/README.md
@@ -362,6 +362,31 @@ const get32BytesBase58Decoder = () => fixDecoder(getBase58Decoder(), 32);
 const get32BytesBase58Codec = () => combineCodec(get32BytesBase58Encoder(), get32BytesBase58Codec());
 ```
 
+## Prefixing the size of codecs
+
+The `prefixCodec` function allows you to store the byte size of any codec as a number prefix. This allows you to contain variable-size codecs to their actual size.
+
+When encoding, the size of the encoded data is stored before the encoded data itself. When decoding, the size is read first to know how many bytes to read next.
+
+For example, say we want to represent a variable-size base-58 string using a `u32` size prefix — the equivalent of a Borsh `String` in Rust. Here’s how you can use the `prefixCodec` function to achieve that.
+
+```ts
+const getU32Base58Codec = () => prefixCodec(getBase58Codec(), getU32Codec());
+
+getU32Base58Codec().encode('hello world');
+// 0x0b00000068656c6c6f20776f726c64
+//   |       └-- Our encoded base-58 string.
+//   └-- Our encoded u32 size prefix.
+```
+
+You may also use the `prefixEncoder` and `prefixDecoder` functions to separate your codec logic like so:
+
+```ts
+const getU32Base58Encoder = () => prefixEncoder(getBase58Encoder(), getU32Encoder());
+const getU32Base58Decoder = () => prefixDecoder(getBase58Decoder(), getU32Decoder());
+const getU32Base58Codec = () => combineCodec(getU32Base58Encoder(), getU32Base58Decoder());
+```
+
 ## Adjusting the size of codecs
 
 The `resizeCodec` helper re-defines the size of a given codec by accepting a function that takes the current size of the codec and returns a new size. This works for both fixed-size and variable-size codecs.

--- a/packages/codecs-core/src/__tests__/prefix-codec-test.ts
+++ b/packages/codecs-core/src/__tests__/prefix-codec-test.ts
@@ -1,0 +1,55 @@
+import { assertIsFixedSize, assertIsVariableSize, Codec } from '../codec';
+import { prefixCodec } from '../prefix-codec';
+import { b, getMockCodec } from './__setup__';
+
+describe('prefixCodec', () => {
+    it('encodes the byte length before the content', () => {
+        const numberCodec = getMockCodec({ size: 4 });
+        const contentCodec = getMockCodec({ size: 10 });
+        const prefixedCodec = prefixCodec(contentCodec, numberCodec as Codec<number>);
+
+        prefixedCodec.encode('helloworld');
+        expect(numberCodec.write).toHaveBeenCalledWith(10, expect.any(Uint8Array), 0);
+        expect(contentCodec.write).toHaveBeenCalledWith('helloworld', expect.any(Uint8Array), 0);
+    });
+
+    it('decodes the byte length before the reading the content', () => {
+        const numberCodec = getMockCodec({ size: 4 });
+        numberCodec.read.mockReturnValue([10, 4]);
+        const contentCodec = getMockCodec({ size: 10 });
+        const prefixedCodec = prefixCodec(contentCodec, numberCodec as Codec<number>);
+
+        prefixedCodec.decode(b('0a00000068656c6c6f776f726c64'));
+        expect(numberCodec.read).toHaveBeenCalledWith(b('0a00000068656c6c6f776f726c64'), 0);
+        expect(contentCodec.read).toHaveBeenCalledWith(b('68656c6c6f776f726c64'), 0);
+    });
+
+    it('lets the size codec fail if the byte length overflows the size codec', () => {
+        const numberCodec = getMockCodec({ size: 1 });
+        const overflowError = new Error('overflow');
+        numberCodec.write.mockImplementation((value: number) => {
+            // eslint-disable-next-line jest/no-conditional-in-test
+            if (value > 255) throw overflowError;
+        });
+        const contentCodec = getMockCodec({ size: 256 });
+        const prefixedCodec = prefixCodec(contentCodec, numberCodec as Codec<number>);
+        expect(() => prefixedCodec.encode(null)).toThrow(overflowError);
+    });
+
+    it('returns the correct fixed size', () => {
+        const numberCodec = getMockCodec({ size: 4 });
+        const contentCodec = getMockCodec({ size: 10 });
+        const prefixedCodec = prefixCodec(contentCodec, numberCodec as Codec<number>);
+        assertIsFixedSize(prefixedCodec);
+        expect(prefixedCodec.fixedSize).toBe(14);
+    });
+
+    it('returns the correct variable size', () => {
+        const numberCodec = getMockCodec({ size: 4 });
+        const contentCodec = getMockCodec();
+        contentCodec.getSizeFromValue.mockReturnValueOnce(10);
+        const prefixedCodec = prefixCodec(contentCodec, numberCodec as Codec<number>);
+        assertIsVariableSize(prefixedCodec);
+        expect(prefixedCodec.getSizeFromValue('helloworld')).toBe(14);
+    });
+});

--- a/packages/codecs-core/src/__typetests__/prefix-codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/prefix-codec-typetest.ts
@@ -1,0 +1,50 @@
+import {
+    Codec,
+    Decoder,
+    Encoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '../codec';
+import { prefixCodec, prefixDecoder, prefixEncoder } from '../prefix-codec';
+
+const u32Encoder = {} as FixedSizeEncoder<number, 4>;
+const u32Decoder = {} as FixedSizeDecoder<number, 4>;
+const u32Codec = {} as FixedSizeCodec<number, number, 4>;
+
+const shortU16Encoder = {} as VariableSizeEncoder<number>;
+const shortU16Decoder = {} as VariableSizeDecoder<number>;
+const shortU16Codec = {} as VariableSizeCodec<number>;
+
+{
+    // [prefixEncoder]: It knows if the encoder is fixed size or variable size.
+    prefixEncoder({} as FixedSizeEncoder<string>, u32Encoder) satisfies FixedSizeEncoder<string>;
+    prefixEncoder({} as VariableSizeEncoder<string>, u32Encoder) satisfies VariableSizeEncoder<string>;
+    prefixEncoder({} as Encoder<string>, u32Encoder) satisfies VariableSizeEncoder<string>;
+    prefixEncoder({} as FixedSizeEncoder<string>, shortU16Encoder) satisfies VariableSizeEncoder<string>;
+    prefixEncoder({} as VariableSizeEncoder<string>, shortU16Encoder) satisfies VariableSizeEncoder<string>;
+    prefixEncoder({} as Encoder<string>, shortU16Encoder) satisfies VariableSizeEncoder<string>;
+}
+
+{
+    // [prefixDecoder]: It knows if the decoder is fixed size or variable size.
+    prefixDecoder({} as FixedSizeDecoder<string>, u32Decoder) satisfies FixedSizeDecoder<string>;
+    prefixDecoder({} as VariableSizeDecoder<string>, u32Decoder) satisfies VariableSizeDecoder<string>;
+    prefixDecoder({} as Decoder<string>, u32Decoder) satisfies VariableSizeDecoder<string>;
+    prefixDecoder({} as FixedSizeDecoder<string>, shortU16Decoder) satisfies VariableSizeDecoder<string>;
+    prefixDecoder({} as VariableSizeDecoder<string>, shortU16Decoder) satisfies VariableSizeDecoder<string>;
+    prefixDecoder({} as Decoder<string>, shortU16Decoder) satisfies VariableSizeDecoder<string>;
+}
+
+{
+    // [prefixCodec]: It knows if the codec is fixed size or variable size.
+    prefixCodec({} as FixedSizeCodec<string>, u32Codec) satisfies FixedSizeCodec<string>;
+    prefixCodec({} as VariableSizeCodec<string>, u32Codec) satisfies VariableSizeCodec<string>;
+    prefixCodec({} as Codec<string>, u32Codec) satisfies VariableSizeCodec<string>;
+    prefixCodec({} as FixedSizeCodec<string>, shortU16Codec) satisfies VariableSizeCodec<string>;
+    prefixCodec({} as VariableSizeCodec<string>, shortU16Codec) satisfies VariableSizeCodec<string>;
+    prefixCodec({} as Codec<string>, shortU16Codec) satisfies VariableSizeCodec<string>;
+}

--- a/packages/codecs-core/src/index.ts
+++ b/packages/codecs-core/src/index.ts
@@ -6,6 +6,7 @@ export * from './fix-codec';
 export * from './map-codec';
 export * from './offset-codec';
 export * from './pad-codec';
+export * from './prefix-codec';
 export * from './readonly-uint8array';
 export * from './resize-codec';
 export * from './reverse-codec';

--- a/packages/codecs-core/src/prefix-codec.ts
+++ b/packages/codecs-core/src/prefix-codec.ts
@@ -1,0 +1,118 @@
+import { assertByteArrayHasEnoughBytesForCodec } from './assertions';
+import {
+    Codec,
+    createDecoder,
+    createEncoder,
+    Decoder,
+    Encoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    getEncodedSize,
+    isFixedSize,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from './codec';
+import { combineCodec } from './combine-codec';
+
+type NumberEncoder = Encoder<bigint | number> | Encoder<number>;
+type FixedSizeNumberEncoder<TSize extends number = number> =
+    | FixedSizeEncoder<bigint | number, TSize>
+    | FixedSizeEncoder<number, TSize>;
+type NumberDecoder = Decoder<bigint> | Decoder<number>;
+type FixedSizeNumberDecoder<TSize extends number = number> =
+    | FixedSizeDecoder<bigint, TSize>
+    | FixedSizeDecoder<number, TSize>;
+type NumberCodec = Codec<bigint | number, bigint> | Codec<number>;
+type FixedSizeNumberCodec<TSize extends number = number> =
+    | FixedSizeCodec<bigint | number, bigint, TSize>
+    | FixedSizeCodec<number, number, TSize>;
+
+/**
+ * Stores the size of the `encoder` in bytes as a prefix using the `prefix` encoder.
+ */
+export function prefixEncoder<TFrom>(
+    encoder: FixedSizeEncoder<TFrom>,
+    prefix: FixedSizeNumberEncoder,
+): FixedSizeEncoder<TFrom>;
+export function prefixEncoder<TFrom>(encoder: Encoder<TFrom>, prefix: NumberEncoder): VariableSizeEncoder<TFrom>;
+export function prefixEncoder<TFrom>(encoder: Encoder<TFrom>, prefix: NumberEncoder): Encoder<TFrom> {
+    const write = ((value, bytes, offset) => {
+        // Here we exceptionally use the `encode` function instead of the `write`
+        // function to contain the content of the encoder within its own bounds.
+        const encoderBytes = encoder.encode(value);
+        offset = prefix.write(encoderBytes.length, bytes, offset);
+        bytes.set(encoderBytes, offset);
+        return offset + encoderBytes.length;
+    }) as Encoder<TFrom>['write'];
+
+    if (isFixedSize(prefix) && isFixedSize(encoder)) {
+        return createEncoder({ ...encoder, fixedSize: prefix.fixedSize + encoder.fixedSize, write });
+    }
+
+    const prefixMaxSize = isFixedSize(prefix) ? prefix.fixedSize : prefix.maxSize ?? null;
+    const encoderMaxSize = isFixedSize(encoder) ? encoder.fixedSize : encoder.maxSize ?? null;
+    const maxSize = prefixMaxSize !== null && encoderMaxSize !== null ? prefixMaxSize + encoderMaxSize : null;
+
+    return createEncoder({
+        ...encoder,
+        ...(maxSize !== null ? { maxSize } : {}),
+        getSizeFromValue: value => {
+            const encoderSize = getEncodedSize(value, encoder);
+            return getEncodedSize(encoderSize, prefix) + encoderSize;
+        },
+        write,
+    });
+}
+
+/**
+ * Bounds the size of the `decoder` by reading the `prefix` encoder prefix.
+ */
+export function prefixDecoder<TTo>(
+    decoder: FixedSizeDecoder<TTo>,
+    prefix: FixedSizeNumberDecoder,
+): FixedSizeDecoder<TTo>;
+export function prefixDecoder<TTo>(decoder: Decoder<TTo>, prefix: NumberDecoder): VariableSizeDecoder<TTo>;
+export function prefixDecoder<TTo>(decoder: Decoder<TTo>, prefix: NumberDecoder): Decoder<TTo> {
+    const read = ((bytes, offset) => {
+        const [bigintSize, decoderOffset] = prefix.read(bytes, offset);
+        const size = Number(bigintSize);
+        offset = decoderOffset;
+        // Slice the byte array to the contained size if necessary.
+        if (offset > 0 || bytes.length > size) {
+            bytes = bytes.slice(offset, offset + size);
+        }
+        assertByteArrayHasEnoughBytesForCodec('prefixDecoder', size, bytes);
+        // Here we exceptionally use the `decode` function instead of the `read`
+        // function to contain the content of the decoder within its own bounds.
+        return [decoder.decode(bytes), offset + size];
+    }) as Decoder<TTo>['read'];
+
+    if (isFixedSize(prefix) && isFixedSize(decoder)) {
+        return createDecoder({ ...decoder, fixedSize: prefix.fixedSize + decoder.fixedSize, read });
+    }
+
+    const prefixMaxSize = isFixedSize(prefix) ? prefix.fixedSize : prefix.maxSize ?? null;
+    const decoderMaxSize = isFixedSize(decoder) ? decoder.fixedSize : decoder.maxSize ?? null;
+    const maxSize = prefixMaxSize !== null && decoderMaxSize !== null ? prefixMaxSize + decoderMaxSize : null;
+    return createDecoder({ ...decoder, ...(maxSize !== null ? { maxSize } : {}), read });
+}
+
+/**
+ * Bounds the size of the `codec` using the provided `prefix` codec prefix.
+ */
+export function prefixCodec<TFrom, TTo extends TFrom>(
+    codec: FixedSizeCodec<TFrom, TTo>,
+    prefix: FixedSizeNumberCodec,
+): FixedSizeCodec<TFrom, TTo>;
+export function prefixCodec<TFrom, TTo extends TFrom>(
+    codec: Codec<TFrom, TTo>,
+    prefix: NumberCodec,
+): VariableSizeCodec<TFrom, TTo>;
+export function prefixCodec<TFrom, TTo extends TFrom>(
+    codec: Codec<TFrom, TTo>,
+    prefix: NumberCodec,
+): Codec<TFrom, TTo> {
+    return combineCodec(prefixEncoder(codec, prefix), prefixDecoder(codec, prefix));
+}

--- a/packages/codecs-data-structures/src/__tests__/bytes-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/bytes-test.ts
@@ -19,7 +19,7 @@ describe('getBytesCodec', () => {
         expect(() => bytesU8.read(b('022a'), 0)).toThrow(
             new SolanaError(SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH, {
                 bytesLength: 1,
-                codecDescription: 'bytes',
+                codecDescription: 'prefixDecoder',
                 expected: 2,
             }),
         );

--- a/packages/codecs/README.md
+++ b/packages/codecs/README.md
@@ -57,6 +57,7 @@ The `@solana/codecs` package is composed of several smaller packages, each with 
     -   [Creating custom codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#creating-custom-codecs).
     -   [Mapping codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#mapping-codecs).
     -   [Fixing the size of codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#fixing-the-size-of-codecs).
+    -   [Prefixing the size of codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#prefixing-the-size-of-codecs).
     -   [Adjusting the size of codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#adjusting-the-size-of-codecs).
     -   [Offsetting codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#offsetting-codecs).
     -   [Padding codecs](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#padding-codecs).


### PR DESCRIPTION
This PR adds a new `prefixCodec` primitive to `@solana/codecs-core`. This primitives accepts any codec and prefixes its size using a `NumberCodec` provided as a second argument.

For instance:

```ts
const codec = prefixCodec(getBase58Codec(), getU32Codec());

codec.encode('hello world');
// 0x0b00000068656c6c6f20776f726c64
//   |       └-- Our encoded base-58 string.
//   └-- Our encoded u32 size prefix.
```

This PR also updates the `getStringCodec` and `getBytesCodec` as they can now use the `prefixCodec` primitive to simplify their internal logic.

P.S.: Now that `getStringCodec` and `getBytesCodec` are simple aggregator of `fixCodec` and `prefixCodec`, we should consider removing them or adjusting them further. (Pros: no default values => better tree-shakeability, Cons: slightly less friendly API?).

```ts
// With getStringCodec.
getStringCodec();
getStringCodec({ encoding: getBase58Codec() });
getStringCodec({ size: 32 });
getStringCodec({ size: getU16Codec() });
getStringCodec({ size: "variable" });

// Without getStringCodec.
prefixCodec(getUtf8Codec(), getU32Codec());
prefixCodec(getBase58Codec(), getU32Codec());
fixCodec(getUtf8Codec(), 32);
prefixCodec(getUtf8Codec(), getU16Codec());
getUtf8Codec();
```