### PR TITLE
refactor(experimental): refactor getNullableCodec and getOptionCodec to use getUnionCodec

### DIFF
--- a/packages/codecs-data-structures/src/__tests__/nullable-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/nullable-test.ts
@@ -1,4 +1,3 @@
-import { FixedSizeCodec } from '@solana/codecs-core';
 import { getU8Codec, getU16Codec, getU64Codec } from '@solana/codecs-numbers';
 import { getStringCodec } from '@solana/codecs-strings';
 import { SOLANA_ERROR__CODECS__EXPECTED_FIXED_LENGTH, SolanaError } from '@solana/errors';
@@ -102,6 +101,6 @@ describe('getNullableCodec', () => {
         expect(nullable(u8(), { fixed: true, prefix: u16() }).fixedSize).toBe(3);
 
         // Zero-size items.
-        expect(nullable(unit() as FixedSizeCodec<void> & { fixedSize: 0 }).fixedSize).toBe(1);
+        expect(nullable(unit()).fixedSize).toBe(1);
     });
 });

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -67,6 +67,7 @@
     },
     "dependencies": {
         "@solana/codecs-core": "workspace:*",
+        "@solana/codecs-data-structures": "workspace:*",
         "@solana/codecs-numbers": "workspace:*"
     },
     "bundlewatch": {

--- a/packages/options/src/__tests__/option-codec-test.ts
+++ b/packages/options/src/__tests__/option-codec-test.ts
@@ -1,3 +1,4 @@
+import { getUnitCodec } from '@solana/codecs-data-structures';
 import { getU8Codec, getU16Codec, getU64Codec } from '@solana/codecs-numbers';
 
 import { none, some } from '../option';
@@ -9,6 +10,7 @@ describe('getOptionCodec', () => {
     const u8 = getU8Codec;
     const u16 = getU16Codec;
     const u64 = getU64Codec;
+    const unit = getUnitCodec;
 
     it('encodes options', () => {
         // None.
@@ -121,5 +123,8 @@ describe('getOptionCodec', () => {
         expect(option(u8(), { fixed: true }).fixedSize).toBe(2);
         expect(option(u64(), { fixed: true }).fixedSize).toBe(9);
         expect(option(u8(), { fixed: true, prefix: u16() }).fixedSize).toBe(3);
+
+        // Zero-size items.
+        expect(option(unit()).fixedSize).toBe(1);
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,6 +583,9 @@ importers:
       '@solana/codecs-core':
         specifier: workspace:*
         version: link:../codecs-core
+      '@solana/codecs-data-structures':
+        specifier: workspace:*
+        version: link:../codecs-data-structures
       '@solana/codecs-numbers':
         specifier: workspace:*
         version: link:../codecs-numbers


### PR DESCRIPTION
This PR refactors the implementation of `getNullableCodec` and `getOptionCodec` so they use the new `getUnionCodec` internally.