### PR TITLE
refactor(experimental): remove the size option of getBytesCodec

### DIFF
--- a/.changeset/silly-months-happen.md
+++ b/.changeset/silly-months-happen.md
@@ -1,0 +1,21 @@
+---
+'@solana/codecs-data-structures': patch
+'@solana/transactions': patch
+'@solana/options': patch
+---
+
+Removed the size option of `getBytesCodec`
+
+The `getBytesCodec` function now always returns a `VariableSizeCodec` that uses as many bytes as necessary to encode and/or decode byte arrays. In order to fix or prefix the size of a `getBytesCodec`, you may now use the `fixCodecSize` or `prefixCodecSide` accordingly. Here are some examples:
+
+```ts
+// Before.
+getBytesCodec(); // Variable.
+getBytesCodec({ size: 5 }); // Fixed.
+getBytesCodec({ size: getU16Codec() }); // Prefixed.
+
+// After.
+getBytesCodec(); // Variable.
+fixCodecSize(getBytesCodec(), 5); // Fixed.
+prefixCodecSize(getBytesCodec(), getU16Codec()); // Prefixed.
+```

--- a/packages/codecs-data-structures/README.md
+++ b/packages/codecs-data-structures/README.md
@@ -554,26 +554,24 @@ const bytes = getBytesCodec().encode(new Uint8Array([42])); // 0x2a
 const value = getBytesCodec().decode(bytes); // 0x2a
 ```
 
-By default, when decoding a `Uint8Array`, all the remaining bytes will be used. However, the `getBytesCodec` function accepts a `size` option that allows us to configure how many bytes should be included in our decoded `Uint8Array`. It can be one of the following three strategies:
+The `getBytesCodec` function will encode and decode `Uint8Arrays` using as much bytes as necessary. If you'd like to restrict the number of bytes used by this codec, you may combine it with the [`fixCodecSize`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#fixing-the-size-of-codecs) or [`prefixCodecSize`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/codecs-core#prefixing-the-size-of-codecs) primitives.
 
--   `Codec<number>`: When a number codec is provided, that codec will be used to encode and decode a size prefix for that `Uint8Array`. This prefix allows us to know when to stop reading the `Uint8Array` when decoding an arbitrary byte array.
--   `number`: When a fixed number is provided, a `FixedSizeCodec` of that size will be returned such that exactly that amount of bytes will be used to encode and decode the `Uint8Array`.
--   `"variable"`: When the string `"variable"` is passed as a size, a `VariableSizeCodec` will be returned without any size boundary. This is the default behaviour.
+Here are some examples of how you might use the `getBytesCodec` function.
 
 ```ts
-// Default behaviour: variable size.
+// Variable size.
 getBytesCodec().encode(new Uint8Array([42]));
 // 0x2a
 //   └-- Uint8Array content using any bytes available.
 
-// Custom size: u16 size.
-getBytesCodec({ size: getU16Codec() }).encode(new Uint8Array([42]));
+// Prefixing the size with a 2-byte u16.
+prefixCodecSize(getBytesCodec(), getU16Codec()).encode(new Uint8Array([42]));
 // 0x01002a
 //   |   └-- Uint8Array content.
 //   └-- 2-byte prefix telling us to read 1 bytes
 
-// Custom size: 5 bytes.
-getBytesCodec({ size: 5 }).encode(new Uint8Array([42]));
+// Fixing the size to 5 bytes.
+fixCodecSize(getBytesCodec(), 5).encode(new Uint8Array([42]));
 // 0x2a00000000
 //   └-- Uint8Array content padded to use exactly 5 bytes.
 ```

--- a/packages/codecs-data-structures/src/__tests__/bytes-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/bytes-test.ts
@@ -1,76 +1,57 @@
+import { fixCodecSize, isVariableSize, prefixCodecSize } from '@solana/codecs-core';
 import { getU8Codec } from '@solana/codecs-numbers';
-import { SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH, SolanaError } from '@solana/errors';
 
 import { getBytesCodec } from '../bytes';
 import { b } from './__setup__';
 
 describe('getBytesCodec', () => {
-    const bytes = getBytesCodec;
-    const u8 = getU8Codec;
+    const codec = getBytesCodec();
 
-    it('encodes prefixed bytes', () => {
-        const bytesU8 = bytes({ size: u8() });
-
-        expect(bytesU8.encode(new Uint8Array([42, 3]))).toStrictEqual(b('022a03'));
-        expect(bytesU8.read(b('022a03ffff'), 0)).toStrictEqual([new Uint8Array([42, 3]), 3]);
-        expect(bytesU8.read(b('ff022a03ffff'), 1)).toStrictEqual([new Uint8Array([42, 3]), 4]);
-
-        // Not enough bytes.
-        expect(() => bytesU8.read(b('022a'), 0)).toThrow(
-            new SolanaError(SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH, {
-                bytesLength: 1,
-                codecDescription: 'prefixDecoderSize',
-                expected: 2,
-            }),
-        );
+    it('encodes empty byte arrays', () => {
+        expect(codec.encode(b(''))).toStrictEqual(b(''));
     });
 
-    it('encodes fixed bytes', () => {
-        const bytes2 = bytes({ size: 2 });
-        const bytes5 = bytes({ size: 5 });
-
-        // Exact size.
-        expect(bytes2.encode(new Uint8Array([1, 2]))).toStrictEqual(b('0102'));
-        expect(bytes2.read(b('0102'), 0)).toStrictEqual([new Uint8Array([1, 2]), 2]);
-        expect(bytes2.read(b('ff0102'), 1)).toStrictEqual([new Uint8Array([1, 2]), 3]);
-
-        // Too small (padded).
-        expect(bytes5.encode(new Uint8Array([1, 2]))).toStrictEqual(b('0102000000'));
-        expect(bytes5.read(b('0102000000'), 0)).toStrictEqual([new Uint8Array([1, 2, 0, 0, 0]), 5]);
-        expect(bytes5.read(b('ff0102000000'), 1)).toStrictEqual([new Uint8Array([1, 2, 0, 0, 0]), 6]);
-        expect(() => bytes5.read(b('0102'), 0)).toThrow(
-            new SolanaError(SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH, {
-                bytesLength: 2,
-                codecDescription: 'fixCodecSize',
-                expected: 5,
-            }),
-        );
-
-        // Too large (truncated).
-        expect(bytes2.encode(new Uint8Array([1, 2, 3, 4, 5]))).toStrictEqual(b('0102'));
-        expect(bytes2.read(b('0102030405'), 0)).toStrictEqual([new Uint8Array([1, 2]), 2]);
-        expect(bytes2.read(b('ff0102030405'), 1)).toStrictEqual([new Uint8Array([1, 2]), 3]);
+    it('decodes empty byte arrays', () => {
+        expect(codec.decode(b(''))).toStrictEqual(b(''));
     });
 
-    it('encodes variable bytes', () => {
-        expect(bytes().encode(new Uint8Array([]))).toStrictEqual(b(''));
-        expect(bytes().read(b(''), 0)).toStrictEqual([new Uint8Array([]), 0]);
-
-        expect(bytes().encode(new Uint8Array([0]))).toStrictEqual(b('00'));
-        expect(bytes().read(b('00'), 0)).toStrictEqual([new Uint8Array([0]), 1]);
-
-        expect(bytes().encode(new Uint8Array([42, 255]))).toStrictEqual(b('2aff'));
-        expect(bytes().read(b('2aff'), 0)).toStrictEqual([new Uint8Array([42, 255]), 2]);
-        expect(bytes().read(b('ff2aff'), 1)).toStrictEqual([new Uint8Array([42, 255]), 3]);
+    it('encodes byte arrays as-is', () => {
+        expect(codec.encode(b('00'))).toStrictEqual(b('00'));
+        expect(codec.encode(b('2aff'))).toStrictEqual(b('2aff'));
+        expect(codec.encode(b('1234567890'))).toStrictEqual(b('1234567890'));
     });
 
-    it('has the right sizes', () => {
-        expect(bytes({ size: 42 }).fixedSize).toBe(42);
-        expect(bytes().getSizeFromValue(new Uint8Array(42))).toBe(42);
-        expect(bytes().maxSize).toBeUndefined();
-        expect(bytes({ size: 'variable' }).getSizeFromValue(new Uint8Array(42))).toBe(42);
-        expect(bytes({ size: 'variable' }).maxSize).toBeUndefined();
-        expect(bytes({ size: u8() }).getSizeFromValue(new Uint8Array(42))).toBe(1 + 42);
-        expect(bytes({ size: u8() }).maxSize).toBeUndefined();
+    it('decodes byte arrays as-is', () => {
+        expect(codec.decode(b('00'))).toStrictEqual(b('00'));
+        expect(codec.decode(b('2aff'))).toStrictEqual(b('2aff'));
+        expect(codec.decode(b('1234567890'))).toStrictEqual(b('1234567890'));
+    });
+
+    it('pushes the offset forward when writing', () => {
+        expect(codec.write(b('2aff'), new Uint8Array(10), 3)).toBe(5);
+    });
+
+    it('pushes the offset forward when reading', () => {
+        expect(codec.read(b('ffff2aff00'), 2)).toStrictEqual([b('2aff00'), 5]);
+    });
+
+    it('can use fixCodecSize to become a fixed-size codec', () => {
+        const prefixedCoded = fixCodecSize(getBytesCodec(), 3);
+        expect(prefixedCoded.encode(b('2aff'))).toStrictEqual(b('2aff00'));
+        expect(prefixedCoded.encode(b('2aff00'))).toStrictEqual(b('2aff00'));
+        expect(prefixedCoded.encode(b('2aff0000'))).toStrictEqual(b('2aff00'));
+        expect(prefixedCoded.decode(b('2aff00'))).toStrictEqual(b('2aff00'));
+    });
+
+    it('can use prefixCodecSize to prepend the byte array length', () => {
+        const prefixedCoded = prefixCodecSize(getBytesCodec(), getU8Codec());
+        expect(prefixedCoded.encode(b('2aff'))).toStrictEqual(b('022aff'));
+        expect(prefixedCoded.decode(b('022aff'))).toStrictEqual(b('2aff'));
+        expect(prefixedCoded.getSizeFromValue(b('2aff'))).toBe(3);
+    });
+
+    it('returns a variable size codec', () => {
+        expect(isVariableSize(codec)).toBe(true);
+        expect(codec.getSizeFromValue(b('2aff'))).toBe(2);
     });
 });

--- a/packages/codecs-data-structures/src/__typetests__/bytes-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/bytes-typetest.ts
@@ -1,42 +1,18 @@
-import {
-    FixedSizeCodec,
-    FixedSizeDecoder,
-    FixedSizeEncoder,
-    ReadonlyUint8Array,
-    VariableSizeCodec,
-    VariableSizeDecoder,
-    VariableSizeEncoder,
-} from '@solana/codecs-core';
-import { NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
+import { ReadonlyUint8Array, VariableSizeCodec, VariableSizeDecoder, VariableSizeEncoder } from '@solana/codecs-core';
 
 import { getBytesCodec, getBytesDecoder, getBytesEncoder } from '../bytes';
 
 {
-    // [getBytesEncoder]: It knows if the encoder is fixed size or variable size.
-    getBytesEncoder({ size: 42 }) satisfies FixedSizeEncoder<ReadonlyUint8Array | Uint8Array, 42>;
+    // [getBytesEncoder]: It always returns a variable size encoder.
     getBytesEncoder() satisfies VariableSizeEncoder<ReadonlyUint8Array | Uint8Array>;
-    getBytesEncoder({ size: 'variable' }) satisfies VariableSizeEncoder<ReadonlyUint8Array | Uint8Array>;
-    getBytesEncoder({ size: {} as NumberEncoder }) satisfies VariableSizeEncoder<ReadonlyUint8Array | Uint8Array>;
 }
 
 {
-    // [getBytesDecoder]: It knows if the decoder is fixed size or variable size.
-    getBytesDecoder({ size: 42 }) satisfies FixedSizeDecoder<ReadonlyUint8Array, 42>;
+    // [getBytesDecoder]: It always returns a variable size decoder.
     getBytesDecoder() satisfies VariableSizeDecoder<ReadonlyUint8Array>;
-    getBytesDecoder({ size: 'variable' }) satisfies VariableSizeDecoder<ReadonlyUint8Array>;
-    getBytesDecoder({ size: {} as NumberDecoder }) satisfies VariableSizeDecoder<ReadonlyUint8Array>;
 }
 
 {
-    // [getBytesCodec]: It knows if the codec is fixed size or variable size.
-    getBytesCodec({ size: 42 }) satisfies FixedSizeCodec<ReadonlyUint8Array | Uint8Array, ReadonlyUint8Array, 42>;
+    // [getBytesCodec]: It always returns a variable size codec.
     getBytesCodec() satisfies VariableSizeCodec<ReadonlyUint8Array | Uint8Array, ReadonlyUint8Array>;
-    getBytesCodec({ size: 'variable' }) satisfies VariableSizeCodec<
-        ReadonlyUint8Array | Uint8Array,
-        ReadonlyUint8Array
-    >;
-    getBytesCodec({ size: {} as NumberCodec }) satisfies VariableSizeCodec<
-        ReadonlyUint8Array | Uint8Array,
-        ReadonlyUint8Array
-    >;
 }

--- a/packages/codecs-data-structures/src/bytes.ts
+++ b/packages/codecs-data-structures/src/bytes.ts
@@ -1,113 +1,50 @@
 import {
-    Codec,
     combineCodec,
     createDecoder,
     createEncoder,
-    Decoder,
-    Encoder,
-    fixDecoderSize,
-    FixedSizeCodec,
-    FixedSizeDecoder,
-    FixedSizeEncoder,
-    fixEncoderSize,
-    prefixDecoderSize,
-    prefixEncoderSize,
     ReadonlyUint8Array,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
 } from '@solana/codecs-core';
-import { NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
-
-/** Defines the config for bytes codecs. */
-export type BytesCodecConfig<TSize extends NumberCodec | NumberDecoder | NumberEncoder> = {
-    /**
-     * The size of the byte array. It can be one of the following:
-     * - a {@link NumberSerializer} that prefixes the byte array with its size.
-     * - a fixed number of bytes.
-     * - or `'variable'` to use the rest of the byte array.
-     * @defaultValue `'variable'`
-     */
-    size?: TSize | number | 'variable';
-};
 
 /**
- * Encodes sized bytes.
+ * Encodes byte arrays as provided.
  *
- * @param config - A set of config for the encoder.
+ * To control the size of the encoded byte array, you can use
+ * the `fixEncoderSize` or `prefixEncoderSize` functions.
  */
-export function getBytesEncoder<TSize extends number>(
-    config: BytesCodecConfig<NumberEncoder> & { size: TSize },
-): FixedSizeEncoder<ReadonlyUint8Array | Uint8Array, TSize>;
-export function getBytesEncoder(
-    config?: BytesCodecConfig<NumberEncoder>,
-): VariableSizeEncoder<ReadonlyUint8Array | Uint8Array>;
-export function getBytesEncoder(
-    config: BytesCodecConfig<NumberEncoder> = {},
-): Encoder<ReadonlyUint8Array | Uint8Array> {
-    const size = config.size ?? 'variable';
-    const byteEncoder: Encoder<ReadonlyUint8Array | Uint8Array> = createEncoder({
+export function getBytesEncoder(): VariableSizeEncoder<ReadonlyUint8Array | Uint8Array> {
+    return createEncoder({
         getSizeFromValue: value => value.length,
         write: (value, bytes, offset) => {
             bytes.set(value, offset);
             return offset + value.length;
         },
     });
-
-    if (size === 'variable') {
-        return byteEncoder;
-    }
-
-    if (typeof size === 'number') {
-        return fixEncoderSize(byteEncoder, size);
-    }
-
-    return prefixEncoderSize(byteEncoder, size);
 }
 
 /**
- * Decodes sized bytes.
+ * Decodes byte arrays as-is.
  *
- * @param config - A set of config for the decoder.
+ * To control the size of the decoded byte array, you can use
+ * the `fixDecoderSize` or `prefixDecoderSize` functions.
  */
-export function getBytesDecoder<TSize extends number>(
-    config: BytesCodecConfig<NumberDecoder> & { size: TSize },
-): FixedSizeDecoder<ReadonlyUint8Array, TSize>;
-export function getBytesDecoder(config?: BytesCodecConfig<NumberDecoder>): VariableSizeDecoder<ReadonlyUint8Array>;
-export function getBytesDecoder(config: BytesCodecConfig<NumberDecoder> = {}): Decoder<ReadonlyUint8Array> {
-    const size = config.size ?? 'variable';
-
-    const byteDecoder: Decoder<ReadonlyUint8Array> = createDecoder({
+export function getBytesDecoder(): VariableSizeDecoder<ReadonlyUint8Array> {
+    return createDecoder({
         read: (bytes, offset) => {
             const slice = bytes.slice(offset);
             return [slice, offset + slice.length];
         },
     });
-
-    if (size === 'variable') {
-        return byteDecoder;
-    }
-
-    if (typeof size === 'number') {
-        return fixDecoderSize(byteDecoder, size);
-    }
-
-    return prefixDecoderSize(byteDecoder, size);
 }
 
 /**
  * Creates a sized bytes codec.
  *
- * @param config - A set of config for the codec.
+ * To control the size of the encoded and decoded byte arrays,
+ * you can use the `fixCodecSize` or `prefixCodecSize` functions.
  */
-export function getBytesCodec<TSize extends number>(
-    config: BytesCodecConfig<NumberCodec> & { size: TSize },
-): FixedSizeCodec<ReadonlyUint8Array | Uint8Array, ReadonlyUint8Array, TSize>;
-export function getBytesCodec(
-    config?: BytesCodecConfig<NumberCodec>,
-): VariableSizeCodec<ReadonlyUint8Array | Uint8Array, ReadonlyUint8Array>;
-export function getBytesCodec(
-    config: BytesCodecConfig<NumberCodec> = {},
-): Codec<ReadonlyUint8Array | Uint8Array, ReadonlyUint8Array> {
-    return combineCodec(getBytesEncoder(config), getBytesDecoder(config));
+export function getBytesCodec(): VariableSizeCodec<ReadonlyUint8Array | Uint8Array, ReadonlyUint8Array> {
+    return combineCodec(getBytesEncoder(), getBytesDecoder());
 }

--- a/packages/codecs-data-structures/src/zeroable-nullable.ts
+++ b/packages/codecs-data-structures/src/zeroable-nullable.ts
@@ -1,9 +1,11 @@
 import {
     combineCodec,
     containsBytes,
+    fixDecoderSize,
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
+    fixEncoderSize,
     mapDecoder,
     mapEncoder,
     ReadonlyUint8Array,
@@ -40,7 +42,7 @@ export function getZeroableNullableEncoder<TFrom, TSize extends number>(
 ): FixedSizeEncoder<TFrom | null, TSize> {
     const zeroValue = getZeroValue(item.fixedSize, config.zeroValue);
     return getUnionEncoder(
-        [mapEncoder(getBytesEncoder({ size: item.fixedSize }), (_value: null) => zeroValue), item],
+        [mapEncoder(fixEncoderSize(getBytesEncoder(), item.fixedSize), (_value: null) => zeroValue), item],
         variant => Number(variant !== null),
     ) as FixedSizeEncoder<TFrom | null, TSize>;
 }
@@ -58,7 +60,7 @@ export function getZeroableNullableDecoder<TTo, TSize extends number>(
 ): FixedSizeDecoder<TTo | null, TSize> {
     const zeroValue = getZeroValue(item.fixedSize, config.zeroValue);
     return getUnionDecoder(
-        [mapDecoder(getBytesDecoder({ size: item.fixedSize }), () => null), item],
+        [mapDecoder(fixDecoderSize(getBytesDecoder(), item.fixedSize), () => null), item],
         (bytes, offset) => (containsBytes(bytes, zeroValue, offset) ? 0 : 1),
     ) as FixedSizeDecoder<TTo | null, TSize>;
 }

--- a/packages/options/src/zeroable-option-codec.ts
+++ b/packages/options/src/zeroable-option-codec.ts
@@ -1,9 +1,11 @@
 import {
     combineCodec,
     containsBytes,
+    fixDecoderSize,
     FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
+    fixEncoderSize,
     mapDecoder,
     mapEncoder,
     ReadonlyUint8Array,
@@ -42,7 +44,7 @@ export function getZeroableOptionEncoder<TFrom, TSize extends number>(
     const zeroValue = getZeroValue(item.fixedSize, config.zeroValue);
     return getUnionEncoder(
         [
-            mapEncoder(getBytesEncoder({ size: item.fixedSize }), (_value: None | null) => zeroValue),
+            mapEncoder(fixEncoderSize(getBytesEncoder(), item.fixedSize), (_value: None | null) => zeroValue),
             mapEncoder(item, (value: Some<TFrom> | TFrom) => (isOption(value) && isSome(value) ? value.value : value)),
         ],
         (variant: OptionOrNullable<TFrom>) => {
@@ -66,7 +68,7 @@ export function getZeroableOptionDecoder<TTo, TSize extends number>(
     const zeroValue = getZeroValue(item.fixedSize, config.zeroValue);
     return getUnionDecoder(
         [
-            mapDecoder(getBytesDecoder({ size: item.fixedSize }), () => none<TTo>()),
+            mapDecoder(fixDecoderSize(getBytesDecoder(), item.fixedSize), () => none<TTo>()),
             mapDecoder(item, value => some(value)),
         ],
         (bytes, offset) => (containsBytes(bytes, zeroValue, offset) ? 0 : 1),

--- a/packages/transactions/src/serializers/instruction.ts
+++ b/packages/transactions/src/serializers/instruction.ts
@@ -2,6 +2,8 @@ import {
     combineCodec,
     mapDecoder,
     mapEncoder,
+    prefixDecoderSize,
+    prefixEncoderSize,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
@@ -27,7 +29,7 @@ export function getInstructionEncoder(): VariableSizeEncoder<Instruction> {
             getStructEncoder([
                 ['programAddressIndex', getU8Encoder()],
                 ['accountIndices', getArrayEncoder(getU8Encoder(), { size: getShortU16Encoder() })],
-                ['data', getBytesEncoder({ size: getShortU16Encoder() })],
+                ['data', prefixEncoderSize(getBytesEncoder(), getShortU16Encoder())],
             ]),
             // Convert an instruction to have all fields defined
             (instruction: Instruction): Required<Instruction> => {
@@ -53,7 +55,7 @@ export function getInstructionDecoder(): VariableSizeDecoder<Instruction> {
             getStructDecoder([
                 ['programAddressIndex', getU8Decoder()],
                 ['accountIndices', getArrayDecoder(getU8Decoder(), { size: getShortU16Decoder() })],
-                ['data', getBytesDecoder({ size: getShortU16Decoder() }) as VariableSizeDecoder<Uint8Array>],
+                ['data', prefixDecoderSize(getBytesDecoder(), getShortU16Decoder()) as VariableSizeDecoder<Uint8Array>],
             ]),
             // Convert an instruction to exclude optional fields if they are empty
             (instruction: Required<Instruction>): Instruction => {

--- a/packages/transactions/src/serializers/transaction.ts
+++ b/packages/transactions/src/serializers/transaction.ts
@@ -1,6 +1,8 @@
 import {
     combineCodec,
+    fixDecoderSize,
     FixedSizeDecoder,
+    fixEncoderSize,
     mapDecoder,
     mapEncoder,
     VariableSizeCodec,
@@ -26,7 +28,7 @@ import { getCompiledMessageDecoder, getCompiledMessageEncoder } from './message'
 
 function getCompiledTransactionEncoder(): VariableSizeEncoder<CompiledTransaction> {
     return getStructEncoder([
-        ['signatures', getArrayEncoder(getBytesEncoder({ size: 64 }), { size: getShortU16Encoder() })],
+        ['signatures', getArrayEncoder(fixEncoderSize(getBytesEncoder(), 64), { size: getShortU16Encoder() })],
         ['compiledMessage', getCompiledMessageEncoder()],
     ]);
 }
@@ -35,7 +37,7 @@ export function getCompiledTransactionDecoder(): VariableSizeDecoder<CompiledTra
     return getStructDecoder([
         [
             'signatures',
-            getArrayDecoder(getBytesDecoder({ size: 64 }) as FixedSizeDecoder<SignatureBytes, 64>, {
+            getArrayDecoder(fixDecoderSize(getBytesDecoder(), 64) as FixedSizeDecoder<SignatureBytes, 64>, {
                 size: getShortU16Decoder(),
             }),
         ],


### PR DESCRIPTION
This PR removes the size option of `getBytesCodec`.

The `getBytesCodec` function now always returns a `VariableSizeCodec` that uses as many bytes as necessary to encode and/or decode byte arrays. In order to fix or prefix the size of a `getBytesCodec`, we may now use the `fixCodecSize` or `prefixCodecSide` accordingly. Here are some examples:

```ts
// Before.
getBytesCodec(); // Variable.
getBytesCodec({ size: 5 }); // Fixed.
getBytesCodec({ size: getU16Codec() }); // Prefixed.

// After
getBytesCodec(); // Variable.
fixCodecSize(getBytesCodec(), 5); // Fixed.
prefixCodecSize(getBytesCodec(), getU16Codec()); // Prefixed.
```

This has the following advantages:
- It avoids unnecessary API repetition.
- It makes the codec API more composable and more predicable — there is no longer two ways of doing the same thing.
- Last but not least, it improves tree-shakeability — e.g. `fixCodecSize` and `prefixCodecSize` won't be bundled unless you actually need them.