### PR TITLE
refactor(experimental): nit: rename Endian enum variants

### DIFF
--- a/.changeset/famous-buttons-switch.md
+++ b/.changeset/famous-buttons-switch.md
@@ -1,0 +1,17 @@
+---
+'@solana/codecs-numbers': patch
+---
+
+Used capitalised variant names for `Endian` enum
+
+This makes the enum more consistent with other enums in the library.
+
+```ts
+// Before.
+Endian.BIG;
+Endian.LITTLE;
+
+// After.
+Endian.Big;
+Endian.Little;
+```

--- a/packages/codecs-core/README.md
+++ b/packages/codecs-core/README.md
@@ -594,7 +594,7 @@ const getBigEndianU64Codec = () => reverseCodec(getU64Codec());
 Note that number codecs can already do that for you via their `endian` option.
 
 ```ts
-const getBigEndianU64Codec = () => getU64Codec({ endian: Endian.BIG });
+const getBigEndianU64Codec = () => getU64Codec({ endian: Endian.Big });
 ```
 
 As usual, the `reverseEncoder` and `reverseDecoder` functions can also be used to achieve that.

--- a/packages/codecs-numbers/README.md
+++ b/packages/codecs-numbers/README.md
@@ -42,16 +42,16 @@ By default, integers are stored using little endianness but you may change this 
 
 ```ts
 // Big-endian unsigned integers.
-getU16Codec({ endian: Endian.BIG }).encode(42); // 0x002a
-getU32Codec({ endian: Endian.BIG }).encode(42); // 0x0000002a
-getU64Codec({ endian: Endian.BIG }).encode(42); // 0x000000000000002a
-getU128Codec({ endian: Endian.BIG }).encode(42); // 0x0000000000000000000000000000002a
+getU16Codec({ endian: Endian.Big }).encode(42); // 0x002a
+getU32Codec({ endian: Endian.Big }).encode(42); // 0x0000002a
+getU64Codec({ endian: Endian.Big }).encode(42); // 0x000000000000002a
+getU128Codec({ endian: Endian.Big }).encode(42); // 0x0000000000000000000000000000002a
 
 // Big-endian signed integers.
-getI16Codec({ endian: Endian.BIG }).encode(-42); // 0xffd6
-getI32Codec({ endian: Endian.BIG }).encode(-42); // 0xffffffd6
-getI64Codec({ endian: Endian.BIG }).encode(-42); // 0xffffffffffffffd6
-getI128Codec({ endian: Endian.BIG }).encode(-42); // 0xffffffffffffffffffffffffffffffd6
+getI16Codec({ endian: Endian.Big }).encode(-42); // 0xffd6
+getI32Codec({ endian: Endian.Big }).encode(-42); // 0xffffffd6
+getI64Codec({ endian: Endian.Big }).encode(-42); // 0xffffffffffffffd6
+getI128Codec({ endian: Endian.Big }).encode(-42); // 0xffffffffffffffffffffffffffffffd6
 ```
 
 All integer codecs are of type `Codec<number>` except for the `u64`, `u128`, `i64` and `i128` codecs which are of type `Codec<number | bigint, bigint>`. This means we can provide either a `number` of a `bigint` value to encode but the decoded value will always be a `bigint`. This is because JavaScript's native `number` type does not support numbers larger than `2^53 - 1` and these large integer codecs have the potential to go over that value.
@@ -84,8 +84,8 @@ getF64Codec().encode(-1.5); // 0x000000000000f8bf
 Similarly to the integer codecs, they are stored in little-endian by default but may be stored in big-endian using the `endian` option.
 
 ```ts
-getF32Codec({ endian: Endian.BIG }).encode(-1.5); // 0xbfc00000
-getF64Codec({ endian: Endian.BIG }).encode(-1.5); // 0xbff8000000000000
+getF32Codec({ endian: Endian.Big }).encode(-1.5); // 0xbfc00000
+getF64Codec({ endian: Endian.Big }).encode(-1.5); // 0xbff8000000000000
 ```
 
 Note that based on the selected codec, some of the precision of the number you are encoding may be lost when decoding it. For instance, when storing `3.1415` using a `f32` codec, you will not get the exact same number back.

--- a/packages/codecs-numbers/src/__tests__/f32-test.ts
+++ b/packages/codecs-numbers/src/__tests__/f32-test.ts
@@ -9,7 +9,7 @@ describe('getF32Codec', () => {
     it('encodes and decodes f32 numbers', () => {
         expect.hasAssertions();
         const f32LE = f32();
-        const f32BE = f32({ endian: Endian.BIG });
+        const f32BE = f32({ endian: Endian.Big });
 
         assertValid(f32LE, 0, '00000000');
         assertValid(f32BE, 0, '00000000');

--- a/packages/codecs-numbers/src/__tests__/f64-test.ts
+++ b/packages/codecs-numbers/src/__tests__/f64-test.ts
@@ -9,7 +9,7 @@ describe('getF64Codec', () => {
     it('encodes and decodes f64 numbers', () => {
         expect.hasAssertions();
         const f64LE = f64();
-        const f64BE = f64({ endian: Endian.BIG });
+        const f64BE = f64({ endian: Endian.Big });
 
         assertValid(f64LE, 0, '0000000000000000');
         assertValid(f64BE, 0, '0000000000000000');

--- a/packages/codecs-numbers/src/__tests__/i128-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i128-test.ts
@@ -15,7 +15,7 @@ describe('getI128Codec', () => {
     it('encodes and decodes i128 numbers', () => {
         expect.hasAssertions();
         const i128LE = i128();
-        const i128BE = i128({ endian: Endian.BIG });
+        const i128BE = i128({ endian: Endian.Big });
 
         assertValid(i128LE, 0n, '00000000000000000000000000000000');
         assertValid(i128BE, 0n, '00000000000000000000000000000000');

--- a/packages/codecs-numbers/src/__tests__/i16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i16-test.ts
@@ -15,7 +15,7 @@ describe('getI16Codec', () => {
     it('encodes and decodes i16 numbers', () => {
         expect.hasAssertions();
         const i16LE = i16();
-        const i16BE = i16({ endian: Endian.BIG });
+        const i16BE = i16({ endian: Endian.Big });
 
         assertValid(i16LE, 0, '0000');
         assertValid(i16BE, 0, '0000');

--- a/packages/codecs-numbers/src/__tests__/i32-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i32-test.ts
@@ -15,7 +15,7 @@ describe('getI32Codec', () => {
     it('encodes and decodes i32 numbers', () => {
         expect.hasAssertions();
         const i32LE = i32();
-        const i32BE = i32({ endian: Endian.BIG });
+        const i32BE = i32({ endian: Endian.Big });
 
         assertValid(i32LE, 0, '00000000');
         assertValid(i32BE, 0, '00000000');

--- a/packages/codecs-numbers/src/__tests__/i64-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i64-test.ts
@@ -15,7 +15,7 @@ describe('getI64Codec', () => {
     it('encodes and decodes i64 numbers', () => {
         expect.hasAssertions();
         const i64LE = i64();
-        const i64BE = i64({ endian: Endian.BIG });
+        const i64BE = i64({ endian: Endian.Big });
 
         assertValid(i64LE, 0n, '0000000000000000');
         assertValid(i64BE, 0n, '0000000000000000');

--- a/packages/codecs-numbers/src/__tests__/u128-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u128-test.ts
@@ -16,7 +16,7 @@ describe('getU128Codec', () => {
     it('encodes and decodes u128 numbers', () => {
         expect.hasAssertions();
         const u128LE = u128();
-        const u128BE = u128({ endian: Endian.BIG });
+        const u128BE = u128({ endian: Endian.Big });
 
         assertValid(u128LE, 1n, '01000000000000000000000000000000');
         assertValid(u128BE, 1n, '00000000000000000000000000000001');

--- a/packages/codecs-numbers/src/__tests__/u16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u16-test.ts
@@ -16,7 +16,7 @@ describe('getU16Codec', () => {
     it('encodes and decodes u16 numbers', () => {
         expect.hasAssertions();
         const u16LE = u16();
-        const u16BE = u16({ endian: Endian.BIG });
+        const u16BE = u16({ endian: Endian.Big });
 
         assertValid(u16LE, 1, '0100');
         assertValid(u16BE, 1, '0001');

--- a/packages/codecs-numbers/src/__tests__/u32-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u32-test.ts
@@ -16,7 +16,7 @@ describe('getU32Codec', () => {
     it('encodes and decodes u32 numbers', () => {
         expect.hasAssertions();
         const u32LE = u32();
-        const u32BE = u32({ endian: Endian.BIG });
+        const u32BE = u32({ endian: Endian.Big });
 
         assertValid(u32LE, 1, '01000000');
         assertValid(u32BE, 1, '00000001');

--- a/packages/codecs-numbers/src/__tests__/u64-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u64-test.ts
@@ -16,7 +16,7 @@ describe('getU64Codec', () => {
     it('encodes and decodes u64 numbers', () => {
         expect.hasAssertions();
         const u64LE = u64();
-        const u64BE = u64({ endian: Endian.BIG });
+        const u64BE = u64({ endian: Endian.Big });
 
         assertValid(u64LE, 1n, '0100000000000000');
         assertValid(u64BE, 1n, '0000000000000001');

--- a/packages/codecs-numbers/src/common.ts
+++ b/packages/codecs-numbers/src/common.ts
@@ -28,13 +28,13 @@ export type FixedSizeNumberCodec<TSize extends number = number> =
 export type NumberCodecConfig = {
     /**
      * Whether the serializer should use little-endian or big-endian encoding.
-     * @defaultValue `Endian.LITTLE`
+     * @defaultValue `Endian.Little`
      */
     endian?: Endian;
 };
 
 /** Defines the endianness of a number serializer. */
 export enum Endian {
-    LITTLE,
-    BIG,
+    Little,
+    Big,
 }

--- a/packages/codecs-numbers/src/utils.ts
+++ b/packages/codecs-numbers/src/utils.ts
@@ -28,7 +28,7 @@ type NumberFactoryDecoderInput<TTo, TSize extends number> = NumberFactorySharedI
 };
 
 function isLittleEndian(config?: NumberCodecConfig): boolean {
-    return config?.endian === Endian.BIG ? false : true;
+    return config?.endian === Endian.Big ? false : true;
 }
 
 export function numberEncoderFactory<TFrom extends bigint | number, TSize extends number>(


### PR DESCRIPTION
This PR uses capitalised variant names for the `Endian` enum in order to make the it more consistent with other enums in the library.

```ts
// Before.
Endian.BIG;
Endian.LITTLE;

// After.
Endian.Big;
Endian.Little;
```