### PR TITLE
fix: downshift `preflightCommitment` to `processed` when bypassing preflight checks

### DIFF
--- a/.changeset/tricky-fishes-pull.md
+++ b/.changeset/tricky-fishes-pull.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-transformers': patch
+---
+
+Improve transaction sending reliability for those who skip preflight (simulation) when calling `sendTransaction`

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -5895,7 +5895,9 @@ export class Connection {
     const config: any = {encoding: 'base64'};
     const skipPreflight = options && options.skipPreflight;
     const preflightCommitment =
-      (options && options.preflightCommitment) || this.commitment;
+      skipPreflight === true
+        ? 'processed' // FIXME Remove when https://github.com/anza-xyz/agave/pull/483 is deployed.
+        : (options && options.preflightCommitment) || this.commitment;
 
     if (options && options.maxRetries != null) {
       config.maxRetries = options.maxRetries;

--- a/packages/library-legacy/test/connection.test.ts
+++ b/packages/library-legacy/test/connection.test.ts
@@ -4968,6 +4968,29 @@ describe('Connection', function () {
     });
   }
 
+  // FIXME Remove when https://github.com/anza-xyz/agave/pull/483 is deployed.
+  (
+    [undefined, 'processed', 'confirmed', 'finalized'] as (
+      | Commitment
+      | undefined
+    )[]
+  ).forEach(explicitPreflightCommitment => {
+    it(`sets \`preflightCommitment\` to \`processed\` when \`skipPreflight\` is \`true\`, no matter that \`preflightCommitment\` was set to \`${explicitPreflightCommitment}\``, () => {
+      const connection = new Connection(url);
+      const rpcRequestMethod = spy(connection, '_rpcRequest');
+      connection.sendEncodedTransaction('ENCODEDTRANSACTION', {
+        ...(explicitPreflightCommitment
+          ? {preflightCommitment: explicitPreflightCommitment}
+          : null),
+        skipPreflight: true,
+      });
+      expect(rpcRequestMethod).to.have.been.calledWithExactly(
+        'sendTransaction',
+        [match.any, match.has('preflightCommitment', 'processed')],
+      );
+    });
+  });
+
   it('get largest accounts', async () => {
     await mockRpcResponse({
       method: 'getLargestAccounts',

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -63,6 +63,7 @@
         "maintained node versions"
     ],
     "dependencies": {
+        "@solana/functional": "workspace:*",
         "@solana/rpc-types": "workspace:*",
         "@solana/rpc-spec": "workspace:*",
         "@solana/rpc-subscriptions-spec": "workspace:*"

--- a/packages/rpc-transformers/src/__tests__/params-transformer-test.ts
+++ b/packages/rpc-transformers/src/__tests__/params-transformer-test.ts
@@ -212,6 +212,28 @@ describe('getDefaultParamsTransformerForSolanaRpc', () => {
             },
         );
     });
+    // FIXME Remove when https://github.com/anza-xyz/agave/pull/483 is deployed.
+    it.each([undefined, 'processed', 'confirmed', 'finalized'])(
+        'sets the `preflightCommitment` to `processed` when `skipPreflight` is `true` and `preflightCommitment` is `%s` on calls to `sendTransaction`',
+        explicitPreflightCommitment => {
+            const patcher = getDefaultParamsTransformerForSolanaRpc();
+            expect(
+                patcher(
+                    [
+                        null,
+                        {
+                            // eslint-disable-next-line jest/no-conditional-in-test
+                            ...(explicitPreflightCommitment
+                                ? { preflightCommitment: explicitPreflightCommitment }
+                                : null),
+                            skipPreflight: true,
+                        },
+                    ],
+                    'sendTransaction',
+                ),
+            ).toContainEqual(expect.objectContaining({ preflightCommitment: 'processed' }));
+        },
+    );
     describe('given an integer overflow handler', () => {
         let onIntegerOverflow: jest.Mock;
         let paramsTransformer: (value: unknown) => unknown;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -806,6 +806,9 @@ importers:
 
   packages/rpc-transformers:
     dependencies:
+      '@solana/functional':
+        specifier: workspace:*
+        version: link:../functional
       '@solana/rpc-spec':
         specifier: workspace:*
         version: link:../rpc-spec


### PR DESCRIPTION
# Summary

There's a bug in the `sendTransaction` RPC method where, when bypassing preflight, we nevertheless materially use the value of `preflightCommitment` to determine how to behave when sending the transaction.

If you supply _nothing_ – as you might think appropriate when _skipping_ preflight – then the default of `finalized` will be used. Far from irrelevant, such a value can actually affect the retry behaviour of the send-transaction-service (STS). Read https://github.com/anza-xyz/agave/pull/483 for more detail.

In this PR, we try to get ahead of https://github.com/anza-xyz/agave/pull/483 by setting this value to `processed` in the client. Until the server PR is deployed widely, this should cover those who choose to upgrade

Addresses https://github.com/anza-xyz/agave/issues/479

# Test plan

```
pnpm turbo test:unit:node test:unit:browser
```
