### PR TITLE
mergify: Don't tag spl teams as "community"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,9 @@ pull_request_rules:
   - name: Add community label to outside contributions
     conditions:
       - author≠@core-contributors
+      - author≠@spl-maintainers
+      - author≠@spl-triage
+      - author≠@spl-write
       - author≠mergify[bot]
       - author≠dependabot[bot]
       - author≠github-actions[bot]
@@ -12,6 +15,9 @@ pull_request_rules:
   - name: Request review of community contributions from community PR subscribers
     conditions:
       - author≠@core-contributors
+      - author≠@spl-maintainers
+      - author≠@spl-triage
+      - author≠@spl-write
       - author≠mergify[bot]
       - author≠dependabot[bot]
       - author≠github-actions[bot]


### PR DESCRIPTION
#### Problem

All of @lorisleiva 's PRs get tagged "community", which means that the community-pr-subscribers get emails on every single one of them, but he's not "community"!

#### Solution

Don't tag spl teams as "community" in mergify.