### PR TITLE
Add transaction-messages as a dependency of library + re-export

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -80,6 +80,7 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/signers": "workspace:*",
         "@solana/transaction-confirmation": "workspace:*",
+        "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
     "bundlewatch": {

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -11,6 +11,7 @@ export * from '@solana/rpc-parsed-types';
 export * from '@solana/rpc-subscriptions';
 export * from '@solana/rpc-types';
 export * from '@solana/signers';
+export * from '@solana/transaction-messages';
 export * from '@solana/transactions';
 export * from './airdrop';
 export * from './decode-transaction';

--- a/packages/transaction-messages/src/create-transaction-message.ts
+++ b/packages/transaction-messages/src/create-transaction-message.ts
@@ -1,13 +1,13 @@
-import { TransactionMessage, TransactionVersion } from './transaction-message';
+import { NewTransactionVersion, TransactionMessage } from './transaction-message';
 
-type TransactionConfig<TVersion extends TransactionVersion> = Readonly<{
+type TransactionConfig<TVersion extends NewTransactionVersion> = Readonly<{
     version: TVersion;
 }>;
 
-export function createTransactionMessage<TVersion extends TransactionVersion>(
+export function createTransactionMessage<TVersion extends NewTransactionVersion>(
     config: TransactionConfig<TVersion>,
 ): Extract<TransactionMessage, { version: TVersion }>;
-export function createTransactionMessage<TVersion extends TransactionVersion>({
+export function createTransactionMessage<TVersion extends NewTransactionVersion>({
     version,
 }: TransactionConfig<TVersion>): TransactionMessage {
     const out: TransactionMessage = {

--- a/packages/transaction-messages/src/index.ts
+++ b/packages/transaction-messages/src/index.ts
@@ -1,1 +1,2 @@
+export * from './create-transaction-message';
 export * from './transaction-message';

--- a/packages/transaction-messages/src/transaction-message.ts
+++ b/packages/transaction-messages/src/transaction-message.ts
@@ -1,7 +1,7 @@
 import { IAccountMeta, IInstruction } from '@solana/instructions';
 
 export type BaseTransactionMessage<
-    TVersion extends TransactionVersion = TransactionVersion,
+    TVersion extends NewTransactionVersion = NewTransactionVersion,
     TInstruction extends IInstruction = IInstruction,
 > = Readonly<{
     instructions: readonly TInstruction[];
@@ -16,4 +16,4 @@ type LegacyTransactionMessage = BaseTransactionMessage<'legacy', ILegacyInstruct
 type V0TransactionMessage = BaseTransactionMessage<0, IInstruction>;
 
 export type TransactionMessage = LegacyTransactionMessage | V0TransactionMessage;
-export type TransactionVersion = 'legacy' | 0;
+export type NewTransactionVersion = 'legacy' | 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       '@solana/transaction-confirmation':
         specifier: workspace:*
         version: link:../transaction-confirmation
+      '@solana/transaction-messages':
+        specifier: workspace:*
+        version: link:../transaction-messages
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions


### PR DESCRIPTION
Renamed TransactionVersion to NewTransactionVersion to avoid a clash with the transactions export

This will ensure that going forward there are no type duplicates between transactions and transaction-messages as I copy things over

I'll continue to add the `New` prefix and keeping existing code to make this non-destructive until everything is fully moved over 