### PR TITLE
Move address table lookup compile + codec into transaction-messages

### DIFF
--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -64,6 +64,9 @@
     ],
     "dependencies": {
         "@solana/addresses": "workspace:*",
+        "@solana/codecs-core": "workspace:*",
+        "@solana/codecs-data-structures": "workspace:*",
+        "@solana/codecs-numbers": "workspace:*",
         "@solana/errors": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/rpc-types": "workspace:*"

--- a/packages/transaction-messages/src/codecs/__tests__/address-table-lookup-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/address-table-lookup-test.ts
@@ -1,6 +1,6 @@
 import type { Address } from '@solana/addresses';
 
-import type { getCompiledAddressTableLookups } from '../../compile-address-table-lookups';
+import type { getCompiledAddressTableLookups } from '../../compile/address-table-lookups';
 import {
     getAddressTableLookupCodec,
     getAddressTableLookupDecoder,

--- a/packages/transaction-messages/src/codecs/address-table-lookup.ts
+++ b/packages/transaction-messages/src/codecs/address-table-lookup.ts
@@ -9,7 +9,7 @@ import {
 import { getArrayDecoder, getArrayEncoder, getStructDecoder, getStructEncoder } from '@solana/codecs-data-structures';
 import { getShortU16Decoder, getShortU16Encoder, getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
 
-import type { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
+import type { getCompiledAddressTableLookups } from '../compile/address-table-lookups';
 
 type AddressTableLookup = ReturnType<typeof getCompiledAddressTableLookups>[number];
 

--- a/packages/transaction-messages/src/codecs/index.ts
+++ b/packages/transaction-messages/src/codecs/index.ts
@@ -1,0 +1,1 @@
+export * from './address-table-lookup';

--- a/packages/transaction-messages/src/compile/__tests__/address-table-lookups-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/address-table-lookups-test.ts
@@ -1,8 +1,8 @@
 import { Address, getAddressComparator } from '@solana/addresses';
 import { AccountRole } from '@solana/instructions';
-import { OrderedAccounts } from '@solana/transaction-messages';
 
-import { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
+import { getCompiledAddressTableLookups } from '../../compile/address-table-lookups';
+import { OrderedAccounts } from '../accounts';
 
 const MOCK_ADDRESSES: ReadonlyArray<Address> = [
     'BRwZRKsvKkG45g59269qZ5e8UaECFim5Qfxex44UKwDG',

--- a/packages/transaction-messages/src/compile/address-table-lookups.ts
+++ b/packages/transaction-messages/src/compile/address-table-lookups.ts
@@ -1,6 +1,7 @@
 import { Address, getAddressComparator } from '@solana/addresses';
 import { AccountRole } from '@solana/instructions';
-import { OrderedAccounts } from '@solana/transaction-messages';
+
+import { OrderedAccounts } from '../compile/accounts';
 
 type AddressTableLookup = Readonly<{
     lookupTableAddress: Address;

--- a/packages/transaction-messages/src/compile/index.ts
+++ b/packages/transaction-messages/src/compile/index.ts
@@ -1,1 +1,2 @@
 export * from './accounts';
+export * from './address-table-lookups';

--- a/packages/transaction-messages/src/index.ts
+++ b/packages/transaction-messages/src/index.ts
@@ -1,4 +1,5 @@
 export * from './blockhash';
+export * from './codecs';
 export * from './compile';
 export * from './create-transaction-message';
 export * from './durable-nonce';

--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -1,7 +1,7 @@
 import { Address } from '@solana/addresses';
+import { getCompiledAddressTableLookups } from '@solana/transaction-messages';
 
 import { ITransactionWithBlockhashLifetime } from '../blockhash';
-import { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
 import { getCompiledMessageHeader } from '../compile-header';
 import { getCompiledInstructions } from '../compile-instructions';
 import { getCompiledLifetimeToken } from '../compile-lifetime-token';
@@ -10,7 +10,10 @@ import { ITransactionWithFeePayer } from '../fee-payer';
 import { compileTransactionMessage } from '../message';
 import { BaseTransaction } from '../types';
 
-jest.mock('../compile-address-table-lookups');
+jest.mock('@solana/transaction-messages', () => ({
+    ...jest.requireActual('@solana/transaction-messages'),
+    getCompiledAddressTableLookups: jest.fn(),
+}));
 jest.mock('../compile-header');
 jest.mock('../compile-instructions');
 jest.mock('../compile-lifetime-token');
@@ -76,6 +79,7 @@ describe('compileTransactionMessage', () => {
         });
         it('sets `instructions` to the return value of `getCompiledInstructions`', () => {
             const message = compileTransactionMessage(baseTx);
+            console.log({ message });
             expect(getCompiledInstructions).toHaveBeenCalledWith(
                 baseTx.instructions,
                 expect.any(Array) /* orderedAccounts */,

--- a/packages/transactions/src/decompile-transaction.ts
+++ b/packages/transactions/src/decompile-transaction.ts
@@ -10,10 +10,10 @@ import { pipe } from '@solana/functional';
 import { AccountRole, IAccountLookupMeta, IAccountMeta, IInstruction } from '@solana/instructions';
 import { SignatureBytes } from '@solana/keys';
 import type { Blockhash } from '@solana/rpc-types';
+import type { getCompiledAddressTableLookups } from '@solana/transaction-messages';
 
 import { setTransactionLifetimeUsingBlockhash } from './blockhash';
 import { CompilableTransaction } from './compilable-transaction';
-import type { getCompiledAddressTableLookups } from './compile-address-table-lookups';
 import { CompiledTransaction } from './compile-transaction';
 import { createTransaction } from './create-transaction';
 import { isAdvanceNonceAccountInstruction, Nonce, setTransactionLifetimeUsingDurableNonce } from './durable-nonce';

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -1,7 +1,10 @@
-import { getAddressMapFromInstructions, getOrderedAccountsFromAddressMap } from '@solana/transaction-messages';
+import {
+    getAddressMapFromInstructions,
+    getCompiledAddressTableLookups,
+    getOrderedAccountsFromAddressMap,
+} from '@solana/transaction-messages';
 
 import { CompilableTransaction } from './compilable-transaction';
-import { getCompiledAddressTableLookups } from './compile-address-table-lookups';
 import { getCompiledMessageHeader } from './compile-header';
 import { getCompiledInstructions } from './compile-instructions';
 import { getCompiledLifetimeToken } from './compile-lifetime-token';

--- a/packages/transactions/src/serializers/message.ts
+++ b/packages/transactions/src/serializers/message.ts
@@ -14,10 +14,10 @@ import {
 import { getArrayDecoder, getArrayEncoder, getStructDecoder, getStructEncoder } from '@solana/codecs-data-structures';
 import { getShortU16Decoder, getShortU16Encoder } from '@solana/codecs-numbers';
 import { getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
+import type { getCompiledAddressTableLookups } from '@solana/transaction-messages';
+import { getAddressTableLookupDecoder, getAddressTableLookupEncoder } from '@solana/transaction-messages';
 
-import type { getCompiledAddressTableLookups } from '../compile-address-table-lookups';
 import { CompiledMessage } from '../message';
-import { getAddressTableLookupDecoder, getAddressTableLookupEncoder } from './address-table-lookup';
 import { getMessageHeaderDecoder, getMessageHeaderEncoder } from './header';
 import { getInstructionDecoder, getInstructionEncoder } from './instruction';
 import { getTransactionVersionDecoder, getTransactionVersionEncoder } from './transaction-version';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -969,6 +969,15 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/codecs-core':
+        specifier: workspace:*
+        version: link:../codecs-core
+      '@solana/codecs-data-structures':
+        specifier: workspace:*
+        version: link:../codecs-data-structures
+      '@solana/codecs-numbers':
+        specifier: workspace:*
+        version: link:../codecs-numbers
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors


### PR DESCRIPTION
This PR moves the logic to compile address lookup tables, and the associated codec, into transaction-messages 