### PR TITLE
move static accounts compile into transaction-messages

### DIFF
--- a/packages/transaction-messages/src/compile/__tests__/static-accounts-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/static-accounts-test.ts
@@ -1,8 +1,8 @@
 import { Address } from '@solana/addresses';
 import { AccountRole } from '@solana/instructions';
-import { OrderedAccounts } from '@solana/transaction-messages';
 
-import { getCompiledStaticAccounts } from '../compile-static-accounts';
+import { OrderedAccounts } from '../../compile/accounts';
+import { getCompiledStaticAccounts } from '../../compile/static-accounts';
 
 let _nextMockAddress = 0;
 function getMockAddress() {

--- a/packages/transaction-messages/src/compile/index.ts
+++ b/packages/transaction-messages/src/compile/index.ts
@@ -5,3 +5,4 @@ export * from './address-table-lookups';
 export * from './header';
 export * from './instructions';
 export * from './lifetime-token';
+export * from './static-accounts';

--- a/packages/transaction-messages/src/compile/static-accounts.ts
+++ b/packages/transaction-messages/src/compile/static-accounts.ts
@@ -1,5 +1,6 @@
 import { Address } from '@solana/addresses';
-import { OrderedAccounts } from '@solana/transaction-messages';
+
+import { OrderedAccounts } from './accounts';
 
 export function getCompiledStaticAccounts(orderedAccounts: OrderedAccounts): Address[] {
     const firstLookupTableAccountIndex = orderedAccounts.findIndex(account => 'lookupTableAddress' in account);

--- a/packages/transactions/src/__tests__/message-test.ts
+++ b/packages/transactions/src/__tests__/message-test.ts
@@ -4,10 +4,10 @@ import {
     getCompiledInstructions,
     getCompiledLifetimeToken,
     getCompiledMessageHeader,
+    getCompiledStaticAccounts,
 } from '@solana/transaction-messages';
 
 import { ITransactionWithBlockhashLifetime } from '../blockhash';
-import { getCompiledStaticAccounts } from '../compile-static-accounts';
 import { ITransactionWithFeePayer } from '../fee-payer';
 import { compileTransactionMessage } from '../message';
 import { BaseTransaction } from '../types';
@@ -18,8 +18,8 @@ jest.mock('@solana/transaction-messages', () => ({
     getCompiledInstructions: jest.fn(),
     getCompiledLifetimeToken: jest.fn(),
     getCompiledMessageHeader: jest.fn(),
+    getCompiledStaticAccounts: jest.fn(),
 }));
-jest.mock('../compile-static-accounts');
 
 const MOCK_LIFETIME_CONSTRAINT =
     'SOME_CONSTRAINT' as unknown as ITransactionWithBlockhashLifetime['lifetimeConstraint'];

--- a/packages/transactions/src/message.ts
+++ b/packages/transactions/src/message.ts
@@ -4,11 +4,11 @@ import {
     getCompiledInstructions,
     getCompiledLifetimeToken,
     getCompiledMessageHeader,
+    getCompiledStaticAccounts,
     getOrderedAccountsFromAddressMap,
 } from '@solana/transaction-messages';
 
 import { CompilableTransaction } from './compilable-transaction';
-import { getCompiledStaticAccounts } from './compile-static-accounts';
 
 type BaseCompiledMessage = Readonly<{
     header: ReturnType<typeof getCompiledMessageHeader>;


### PR DESCRIPTION
Again no codec to move since they just compile to an array of addresses