### PR TITLE
Create CompilableTransactionMessage

### DIFF
--- a/packages/transaction-messages/src/__typetests__/transaction-message-typetests.ts
+++ b/packages/transaction-messages/src/__typetests__/transaction-message-typetests.ts
@@ -6,6 +6,7 @@ import {
     ITransactionMessageWithBlockhashLifetime,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '../blockhash';
+import { CompilableTransactionMessage } from '../compilable-transaction-message';
 import { createTransactionMessage } from '../create-transaction-message';
 import {
     IDurableNonceTransactionMessage,
@@ -222,3 +223,20 @@ prependTransactionMessageInstruction(
     ITransactionMessageWithFeePayer<'feePayer'> & {
         instructions: TransactionMessage['instructions'];
     };
+
+// CompilableTransactionMessage
+// @ts-expect-error missing fee payer + lifetime token
+null as unknown as BaseTransactionMessage satisfies CompilableTransactionMessage;
+// @ts-expect-error missing lifetime token
+null as unknown as BaseTransactionMessage & ITransactionMessageWithFeePayer satisfies CompilableTransactionMessage;
+null as unknown as BaseTransactionMessage &
+    // @ts-expect-error missing fee payer
+    ITransactionMessageWithBlockhashLifetime satisfies CompilableTransactionMessage;
+// @ts-expect-error missing fee payer
+null as unknown as BaseTransactionMessage & IDurableNonceTransactionMessage satisfies CompilableTransactionMessage;
+null as unknown as BaseTransactionMessage &
+    ITransactionMessageWithBlockhashLifetime &
+    ITransactionMessageWithFeePayer satisfies CompilableTransactionMessage;
+null as unknown as BaseTransactionMessage &
+    IDurableNonceTransactionMessage &
+    ITransactionMessageWithFeePayer satisfies CompilableTransactionMessage;

--- a/packages/transaction-messages/src/compilable-transaction-message.ts
+++ b/packages/transaction-messages/src/compilable-transaction-message.ts
@@ -1,0 +1,13 @@
+import { IInstruction } from '@solana/instructions';
+
+import { ITransactionMessageWithBlockhashLifetime } from './blockhash';
+import { IDurableNonceTransactionMessage } from './durable-nonce';
+import { ITransactionMessageWithFeePayer } from './fee-payer';
+import { BaseTransactionMessage, NewTransactionVersion } from './transaction-message';
+
+export type CompilableTransactionMessage<
+    TVersion extends NewTransactionVersion = NewTransactionVersion,
+    TInstruction extends IInstruction = IInstruction,
+> = BaseTransactionMessage<TVersion, TInstruction> &
+    ITransactionMessageWithFeePayer &
+    (IDurableNonceTransactionMessage | ITransactionMessageWithBlockhashLifetime);


### PR DESCRIPTION
This is just a copy of `CompilableTransaction` but in transaction-messages and using the new types

As CompilableTransaction is used in places in transactions that aren't moving to transaction-messages, I've copied instead of moving this

I've also added some type-tests. We had these implicitly in transactions by testing the inputs to partialSign/sign, but these will change to just be `CompilableTransactionMessage`, and there won't be sign functions in transaction-messages. So it makes sense to add some explicit type tests in transaction-messages instead. 
