### PR TITLE
Move transaction-version codec to transaction-messages

### DIFF
--- a/packages/transaction-messages/src/codecs/__tests__/transaction-version-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/transaction-version-test.ts
@@ -1,6 +1,6 @@
 import { Decoder, Encoder } from '@solana/codecs-core';
 
-import { TransactionVersion } from '../../types';
+import { NewTransactionVersion } from '../../transaction-message';
 import {
     getTransactionVersionCodec,
     getTransactionVersionDecoder,
@@ -9,12 +9,12 @@ import {
 
 const VERSION_FLAG_MASK = 0x80;
 const VERSION_TEST_CASES = // Versions 0–127
-    [...Array(128).keys()].map(version => [version | VERSION_FLAG_MASK, version as TransactionVersion] as const);
+    [...Array(128).keys()].map(version => [version | VERSION_FLAG_MASK, version as NewTransactionVersion] as const);
 
 describe.each([getTransactionVersionCodec, getTransactionVersionEncoder])(
     'Transaction version encoder',
     serializerFactory => {
-        let transactionVersion: Encoder<TransactionVersion>;
+        let transactionVersion: Encoder<NewTransactionVersion>;
         beforeEach(() => {
             transactionVersion = serializerFactory();
         });
@@ -24,7 +24,7 @@ describe.each([getTransactionVersionCodec, getTransactionVersionEncoder])(
         it.each(VERSION_TEST_CASES)('serializes to `%s` when the version is `%s`', (expected, version) => {
             expect(transactionVersion.encode(version)).toEqual(new Uint8Array([expected]));
         });
-        it.each([-1 as TransactionVersion, 128 as TransactionVersion])(
+        it.each([-1 as NewTransactionVersion, 128 as NewTransactionVersion])(
             'throws when passed the out-of-range version `%s`',
             version => {
                 expect(() => transactionVersion.encode(version)).toThrow();
@@ -36,7 +36,7 @@ describe.each([getTransactionVersionCodec, getTransactionVersionEncoder])(
 describe.each([getTransactionVersionCodec, getTransactionVersionDecoder])(
     'Transaction version decoder',
     serializerFactory => {
-        let transactionVersion: Decoder<TransactionVersion>;
+        let transactionVersion: Decoder<NewTransactionVersion>;
         beforeEach(() => {
             transactionVersion = serializerFactory();
         });

--- a/packages/transaction-messages/src/codecs/index.ts
+++ b/packages/transaction-messages/src/codecs/index.ts
@@ -4,3 +4,4 @@
 export * from './address-table-lookup';
 export * from './header';
 export * from './instruction';
+export * from './transaction-version';

--- a/packages/transaction-messages/src/codecs/transaction-version.ts
+++ b/packages/transaction-messages/src/codecs/transaction-version.ts
@@ -8,11 +8,11 @@ import {
 } from '@solana/codecs-core';
 import { SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
-import { TransactionVersion } from '../types';
+import { NewTransactionVersion } from '../transaction-message';
 
 const VERSION_FLAG_MASK = 0x80;
 
-export function getTransactionVersionEncoder(): VariableSizeEncoder<TransactionVersion> {
+export function getTransactionVersionEncoder(): VariableSizeEncoder<NewTransactionVersion> {
     return createEncoder({
         getSizeFromValue: value => (value === 'legacy' ? 0 : 1),
         maxSize: 1,
@@ -31,7 +31,7 @@ export function getTransactionVersionEncoder(): VariableSizeEncoder<TransactionV
     });
 }
 
-export function getTransactionVersionDecoder(): VariableSizeDecoder<TransactionVersion> {
+export function getTransactionVersionDecoder(): VariableSizeDecoder<NewTransactionVersion> {
     return createDecoder({
         maxSize: 1,
         read: (bytes, offset) => {
@@ -40,13 +40,13 @@ export function getTransactionVersionDecoder(): VariableSizeDecoder<TransactionV
                 // No version flag set; it's a legacy (unversioned) transaction.
                 return ['legacy', offset];
             } else {
-                const version = (firstByte ^ VERSION_FLAG_MASK) as TransactionVersion;
+                const version = (firstByte ^ VERSION_FLAG_MASK) as NewTransactionVersion;
                 return [version, offset + 1];
             }
         },
     });
 }
 
-export function getTransactionVersionCodec(): VariableSizeCodec<TransactionVersion> {
+export function getTransactionVersionCodec(): VariableSizeCodec<NewTransactionVersion> {
     return combineCodec(getTransactionVersionEncoder(), getTransactionVersionDecoder());
 }

--- a/packages/transactions/src/serializers/message.ts
+++ b/packages/transactions/src/serializers/message.ts
@@ -22,10 +22,11 @@ import {
     getInstructionEncoder,
     getMessageHeaderDecoder,
     getMessageHeaderEncoder,
+    getTransactionVersionDecoder,
+    getTransactionVersionEncoder,
 } from '@solana/transaction-messages';
 
 import { CompiledMessage } from '../message';
-import { getTransactionVersionDecoder, getTransactionVersionEncoder } from './transaction-version';
 
 function getCompiledMessageLegacyEncoder(): VariableSizeEncoder<CompiledMessage> {
     return getStructEncoder(getPreludeStructEncoderTuple()) as VariableSizeEncoder<CompiledMessage>;


### PR DESCRIPTION
This is the last piece before we can move compileMessage over + its codec