### PR TITLE
Add an encoder for the new transaction type

### DIFF
--- a/packages/transactions/src/codecs/__tests__/signatures-encoder-test.ts
+++ b/packages/transactions/src/codecs/__tests__/signatures-encoder-test.ts
@@ -2,10 +2,8 @@ import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__TRANSACTION__CANNOT_ENCODE_WITH_EMPTY_SIGNATURES, SolanaError } from '@solana/errors';
 import { SignatureBytes } from '@solana/keys';
 
-import { NewTransaction } from '../../transaction';
+import { SignaturesMap } from '../../transaction';
 import { getSignaturesEncoder } from '../signatures-encoder';
-
-type SignaturesMap = NewTransaction['signatures'];
 
 describe('getSignaturesEncoder', () => {
     const encoder = getSignaturesEncoder();

--- a/packages/transactions/src/codecs/__tests__/transaction-codec-test.ts
+++ b/packages/transactions/src/codecs/__tests__/transaction-codec-test.ts
@@ -1,0 +1,40 @@
+import { ReadonlyUint8Array, VariableSizeEncoder } from '@solana/codecs-core';
+
+import { NewTransaction, TransactionMessageBytes } from '../../transaction';
+import { getSignaturesEncoder } from '../signatures-encoder';
+import { getNewTransactionEncoder } from '../transaction-codec';
+
+jest.mock('../signatures-encoder');
+
+describe('getNewTransactionEncoder', () => {
+    const mockEncodedSignatures = new Uint8Array([1, 2, 3]);
+    let encoder: VariableSizeEncoder<NewTransaction>;
+    beforeEach(() => {
+        (getSignaturesEncoder as jest.Mock).mockReturnValue({
+            getSizeFromValue: jest.fn().mockReturnValue(mockEncodedSignatures.length),
+            write: jest.fn().mockImplementation((_value, bytes: Uint8Array, offset: number) => {
+                bytes.set(mockEncodedSignatures, offset);
+                return offset + mockEncodedSignatures.length;
+            }),
+        });
+        encoder = getNewTransactionEncoder();
+    });
+
+    it('should encode the transaction correctly', () => {
+        const messageBytes = new Uint8Array([4, 5, 6]) as ReadonlyUint8Array as TransactionMessageBytes;
+
+        const transaction: NewTransaction = {
+            messageBytes,
+            signatures: {},
+        };
+
+        expect(encoder.encode(transaction)).toStrictEqual(
+            new Uint8Array([
+                /* signatures */
+                ...mockEncodedSignatures,
+                /* message bytes */
+                ...messageBytes,
+            ]),
+        );
+    });
+});

--- a/packages/transactions/src/codecs/signatures-encoder.ts
+++ b/packages/transactions/src/codecs/signatures-encoder.ts
@@ -1,12 +1,10 @@
-import { Encoder, fixEncoderSize, transformEncoder } from '@solana/codecs-core';
+import { fixEncoderSize, transformEncoder, VariableSizeEncoder } from '@solana/codecs-core';
 import { getArrayEncoder, getBytesEncoder } from '@solana/codecs-data-structures';
 import { getShortU16Encoder } from '@solana/codecs-numbers';
 import { SOLANA_ERROR__TRANSACTION__CANNOT_ENCODE_WITH_EMPTY_SIGNATURES, SolanaError } from '@solana/errors';
 import { SignatureBytes } from '@solana/keys';
 
-import { NewTransaction } from '../transaction';
-
-type SignaturesMap = NewTransaction['signatures'];
+import { SignaturesMap } from '../transaction';
 
 function getSignaturesToEncode(signaturesMap: SignaturesMap): SignatureBytes[] {
     const signatures = Object.values(signaturesMap);
@@ -22,7 +20,7 @@ function getSignaturesToEncode(signaturesMap: SignaturesMap): SignatureBytes[] {
     });
 }
 
-export function getSignaturesEncoder(): Encoder<NewTransaction['signatures']> {
+export function getSignaturesEncoder(): VariableSizeEncoder<SignaturesMap> {
     return transformEncoder(
         getArrayEncoder(fixEncoderSize(getBytesEncoder(), 64), { size: getShortU16Encoder() }),
         getSignaturesToEncode,

--- a/packages/transactions/src/codecs/transaction-codec.ts
+++ b/packages/transactions/src/codecs/transaction-codec.ts
@@ -1,0 +1,12 @@
+import { VariableSizeEncoder } from '@solana/codecs-core';
+import { getBytesEncoder, getStructEncoder } from '@solana/codecs-data-structures';
+
+import { NewTransaction } from '../transaction';
+import { getSignaturesEncoder } from './signatures-encoder';
+
+export function getNewTransactionEncoder(): VariableSizeEncoder<NewTransaction> {
+    return getStructEncoder([
+        ['signatures', getSignaturesEncoder()],
+        ['messageBytes', getBytesEncoder()],
+    ]);
+}

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -4,8 +4,9 @@ import { SignatureBytes } from '@solana/keys';
 
 export type TransactionMessageBytes = ReadonlyUint8Array & { readonly __brand: unique symbol };
 export type OrderedMap<K extends string, V> = Record<K, V>;
+export type SignaturesMap = OrderedMap<Address, SignatureBytes | null>;
 
 export type NewTransaction = Readonly<{
     messageBytes: TransactionMessageBytes;
-    signatures: OrderedMap<Address, SignatureBytes | null>;
+    signatures: SignaturesMap;
 }>;


### PR DESCRIPTION
This PR adds an encoder for the `NewTransaction` type. It concatenates the signatures (encoder added in parent PR) and the message bytes.

A future PR will add a decoder. 