### PR TITLE
Refactor compat to convert to new transaction type

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -68,14 +68,11 @@
     "dependencies": {
         "@solana/addresses": "workspace:*",
         "@solana/errors": "workspace:*",
-        "@solana/functional": "workspace:*",
-        "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
     "devDependencies": {
         "@solana/keys": "workspace:*",
-        "@solana/rpc-types": "workspace:*",
         "@solana/web3.js": "workspace:../library-legacy"
     },
     "bundlewatch": {

--- a/packages/compat/src/__tests__/transaction-test.ts
+++ b/packages/compat/src/__tests__/transaction-test.ts
@@ -1,1106 +1,234 @@
-import { Buffer } from 'node:buffer';
+import '@solana/test-matchers/toBeFrozenObject';
 
-import { Address } from '@solana/addresses';
-import {
-    SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_FIRST_INSTRUCTION_MUST_BE_ADVANCE_NONCE,
-    SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_INSTRUCTIONS_MISSING,
-    SolanaError,
-} from '@solana/errors';
-import { AccountRole, IInstruction } from '@solana/instructions';
-import { SignatureBytes } from '@solana/keys';
-import { ITransactionWithSignatures, Nonce } from '@solana/transactions';
-import { PublicKey, TransactionInstruction, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
+import { SOLANA_ERROR__TRANSACTION__MESSAGE_SIGNATURES_MISMATCH, SolanaError } from '@solana/errors';
+import { PublicKey, VersionedTransaction } from '@solana/web3.js';
 
-import { fromVersionedTransactionWithBlockhash, fromVersionedTransactionWithDurableNonce } from '../transaction';
+import { fromVersionedTransaction } from '../transaction';
 
-describe('fromVersionedTransactionWithBlockhash', () => {
-    const U64_MAX = 2n ** 64n - 1n;
-    const feePayerString = '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK';
-    const feePayerPublicKey = new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK');
-
-    const blockhashString = 'J4yED2jcMAHyQUg61DBmm4njmEydUr2WqrV9cdEcDDgL';
-
-    describe('for a transaction with `legacy` version', () => {
-        it('converts a transaction with no instructions', () => {
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToLegacyMessage(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction);
-
-            expect(transaction.version).toBe('legacy');
-            expect(transaction.feePayer).toEqual(feePayerString);
-            expect(transaction.lifetimeConstraint).toEqual({
-                blockhash: blockhashString,
-                lastValidBlockHeight: U64_MAX,
-            });
-        });
-
-        it('converts a transaction with one instruction with no accounts or data', () => {
-            const programId = new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf');
-
-            const instruction = new TransactionInstruction({
-                keys: [],
-                programId,
-            });
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [instruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToLegacyMessage(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction);
-
-            const expectedInstruction: IInstruction = {
-                programAddress: 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address,
-            };
-
-            expect(transaction.instructions).toStrictEqual([expectedInstruction]);
-        });
-
-        it('converts a transaction with one instruction with accounts and data', () => {
-            const programId = new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf');
-
-            const accountMetas = [
-                {
-                    isSigner: false,
-                    isWritable: false,
-                    pubkey: new PublicKey('8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e'),
+describe('fromVersionedTransaction', () => {
+    it('returns a transaction containing the serialized message bytes', () => {
+        const messageBytes = new Uint8Array([1, 2, 3, 4]);
+        const transaction = {
+            message: {
+                getAccountKeys() {
+                    return {
+                        staticAccountKeys: [],
+                    };
                 },
-                {
-                    isSigner: false,
-                    isWritable: true,
-                    pubkey: new PublicKey('3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd'),
+                header: {
+                    numRequiredSignatures: 0,
                 },
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: new PublicKey('G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V'),
+                serialize() {
+                    return messageBytes;
                 },
-                {
-                    isSigner: true,
-                    isWritable: true,
-                    pubkey: new PublicKey('H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x'),
+            },
+            signatures: [],
+        } as unknown as VersionedTransaction;
+
+        const converted = fromVersionedTransaction(transaction);
+        expect(converted.messageBytes).toStrictEqual(messageBytes);
+    });
+
+    it('freezes the signature map', () => {
+        const transaction = {
+            message: {
+                getAccountKeys() {
+                    return {
+                        staticAccountKeys: [],
+                    };
                 },
-            ];
-
-            const instructionData = Buffer.from([0, 1, 2, 3, 4]);
-
-            const instruction = new TransactionInstruction({
-                data: instructionData,
-                keys: accountMetas,
-                programId,
-            });
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [instruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToLegacyMessage(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction);
-
-            const expectedInstruction: IInstruction = {
-                accounts: [
-                    {
-                        address: '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Address,
-                        role: AccountRole.READONLY,
-                    },
-                    {
-                        address: '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Address,
-                        role: AccountRole.WRITABLE,
-                    },
-                    {
-                        address: 'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Address,
-                        role: AccountRole.READONLY_SIGNER,
-                    },
-                    {
-                        address: 'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address,
-                        role: AccountRole.WRITABLE_SIGNER,
-                    },
-                ],
-                data: instructionData,
-                programAddress: 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address,
-            };
-
-            expect(transaction.instructions).toStrictEqual([expectedInstruction]);
-        });
-
-        it('converts a transaction with multiple instructions', () => {
-            const instructions = [
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC'),
-                }),
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP'),
-                }),
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S'),
-                }),
-            ];
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions,
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToLegacyMessage(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction);
-
-            const expectedInstructions: IInstruction[] = [
-                {
-                    programAddress: 'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                header: {
+                    numRequiredSignatures: 0,
                 },
-                {
-                    programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                serialize() {
+                    return new Uint8Array();
                 },
-                {
-                    programAddress: 'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Address,
+            },
+            signatures: [],
+        } as unknown as VersionedTransaction;
+
+        const converted = fromVersionedTransaction(transaction);
+        expect(converted.signatures).toBeFrozenObject();
+    });
+
+    it('converts a transaction with a single signature', () => {
+        const signature = new Uint8Array([1, 2, 3, 4]);
+        const transaction = {
+            message: {
+                getAccountKeys() {
+                    return {
+                        staticAccountKeys: [new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK')],
+                    };
                 },
-            ];
-
-            expect(transaction.instructions).toStrictEqual(expectedInstructions);
-        });
-
-        it('converts a transaction with a single signer', () => {
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToLegacyMessage(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-
-            const transaction = fromVersionedTransactionWithBlockhash(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': feePayerSignature as SignatureBytes,
-            });
-        });
-
-        it('converts a transaction with multiple signers', () => {
-            const otherSigner1PublicKey = new PublicKey('8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e');
-            const otherSigner2PublicKey = new PublicKey('3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd');
-
-            const accountMetasSigners = [
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner1PublicKey,
+                header: {
+                    numRequiredSignatures: 1,
                 },
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner2PublicKey,
+                serialize() {
+                    return new Uint8Array();
                 },
-            ];
+            },
+            signatures: [signature],
+        } as unknown as VersionedTransaction;
 
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [
-                        new TransactionInstruction({
-                            keys: accountMetasSigners,
-                            programId: new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf'),
-                        }),
-                    ],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToLegacyMessage(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            const otherSignature1 = new Uint8Array(Array(64).fill(2));
-            const otherSignature2 = new Uint8Array(Array(64).fill(3));
-
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-            oldTransaction.addSignature(otherSigner1PublicKey, otherSignature1);
-            oldTransaction.addSignature(otherSigner2PublicKey, otherSignature2);
-
-            const transaction = fromVersionedTransactionWithBlockhash(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd': new Uint8Array(Array(64).fill(3)),
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': new Uint8Array(Array(64).fill(1)) as SignatureBytes,
-                '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e': new Uint8Array(Array(64).fill(2)) as SignatureBytes,
-            });
-        });
-
-        it('converts a partially signed transaction with multiple signers', () => {
-            const otherSigner1PublicKey = new PublicKey('8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e');
-            const otherSigner2PublicKey = new PublicKey('3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd');
-
-            const accountMetasSigners = [
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner1PublicKey,
-                },
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner2PublicKey,
-                },
-            ];
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [
-                        new TransactionInstruction({
-                            keys: accountMetasSigners,
-                            programId: new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf'),
-                        }),
-                    ],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToLegacyMessage(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            const otherSignature2 = new Uint8Array(Array(64).fill(3));
-
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-            oldTransaction.addSignature(otherSigner2PublicKey, otherSignature2);
-
-            const transaction = fromVersionedTransactionWithBlockhash(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd': new Uint8Array(Array(64).fill(3)),
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': new Uint8Array(Array(64).fill(1)),
-            });
-        });
-
-        it('converts a transaction with a given lastValidBlockHeight', () => {
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToLegacyMessage(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction, 100n);
-
-            expect(transaction.lifetimeConstraint).toEqual({
-                blockhash: blockhashString,
-                lastValidBlockHeight: 100n,
-            });
+        const converted = fromVersionedTransaction(transaction);
+        expect(converted.signatures).toStrictEqual({
+            '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': signature,
         });
     });
 
-    describe('for a transaction with `0` version', () => {
-        it('converts a transaction with no instructions', () => {
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToV0Message(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction);
-
-            expect(transaction.version).toBe(0);
-            expect(transaction.feePayer).toEqual(feePayerString);
-            expect(transaction.lifetimeConstraint).toEqual({
-                blockhash: blockhashString,
-                lastValidBlockHeight: U64_MAX,
-            });
-        });
-
-        it('converts a transaction with one instruction with no accounts or data', () => {
-            const programId = new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf');
-
-            const instruction = new TransactionInstruction({
-                keys: [],
-                programId,
-            });
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [instruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToV0Message(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction);
-
-            const expectedInstruction: IInstruction = {
-                programAddress: 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address,
-            };
-
-            expect(transaction.instructions).toStrictEqual([expectedInstruction]);
-        });
-
-        it('converts a transaction with one instruction with accounts and data', () => {
-            const programId = new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf');
-
-            const accountMetas = [
-                {
-                    isSigner: false,
-                    isWritable: false,
-                    pubkey: new PublicKey('8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e'),
+    it('converts an unsigned transaction with a single expected signer', () => {
+        const nullSignature = new Uint8Array(64).fill(0);
+        const transaction = {
+            message: {
+                getAccountKeys() {
+                    return {
+                        staticAccountKeys: [new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK')],
+                    };
                 },
-                {
-                    isSigner: false,
-                    isWritable: true,
-                    pubkey: new PublicKey('3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd'),
+                header: {
+                    numRequiredSignatures: 1,
                 },
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: new PublicKey('G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V'),
+                serialize() {
+                    return new Uint8Array();
                 },
-                {
-                    isSigner: true,
-                    isWritable: true,
-                    pubkey: new PublicKey('H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x'),
-                },
-            ];
-
-            const instructionData = Buffer.from([0, 1, 2, 3, 4]);
-
-            const instruction = new TransactionInstruction({
-                data: instructionData,
-                keys: accountMetas,
-                programId,
-            });
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [instruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToV0Message(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction);
-
-            const expectedInstruction: IInstruction = {
-                accounts: [
-                    {
-                        address: '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Address,
-                        role: AccountRole.READONLY,
-                    },
-                    {
-                        address: '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Address,
-                        role: AccountRole.WRITABLE,
-                    },
-                    {
-                        address: 'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Address,
-                        role: AccountRole.READONLY_SIGNER,
-                    },
-                    {
-                        address: 'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address,
-                        role: AccountRole.WRITABLE_SIGNER,
-                    },
-                ],
-                data: instructionData,
-                programAddress: 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address,
-            };
-
-            expect(transaction.instructions).toStrictEqual([expectedInstruction]);
-        });
-
-        it('converts a transaction with multiple instructions', () => {
-            const instructions = [
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC'),
-                }),
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP'),
-                }),
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S'),
-                }),
-            ];
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions,
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToV0Message(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction);
-
-            const expectedInstructions: IInstruction[] = [
-                {
-                    programAddress: 'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
-                },
-                {
-                    programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
-                },
-                {
-                    programAddress: 'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Address,
-                },
-            ];
-
-            expect(transaction.instructions).toStrictEqual(expectedInstructions);
-        });
-
-        it('converts a transaction with a single signer', () => {
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToV0Message(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-
-            const transaction = fromVersionedTransactionWithBlockhash(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': feePayerSignature as SignatureBytes,
-            });
-        });
-
-        it('converts a transaction with multiple signers', () => {
-            const otherSigner1PublicKey = new PublicKey('8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e');
-            const otherSigner2PublicKey = new PublicKey('3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd');
-
-            const accountMetasSigners = [
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner1PublicKey,
-                },
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner2PublicKey,
-                },
-            ];
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [
-                        new TransactionInstruction({
-                            keys: accountMetasSigners,
-                            programId: new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf'),
-                        }),
-                    ],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToV0Message(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            const otherSignature1 = new Uint8Array(Array(64).fill(2));
-            const otherSignature2 = new Uint8Array(Array(64).fill(3));
-
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-            oldTransaction.addSignature(otherSigner1PublicKey, otherSignature1);
-            oldTransaction.addSignature(otherSigner2PublicKey, otherSignature2);
-
-            const transaction = fromVersionedTransactionWithBlockhash(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd': new Uint8Array(Array(64).fill(3)),
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': new Uint8Array(Array(64).fill(1)) as SignatureBytes,
-                '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e': new Uint8Array(Array(64).fill(2)) as SignatureBytes,
-            });
-        });
-
-        it('converts a partially signed transaction with multiple signers', () => {
-            const otherSigner1PublicKey = new PublicKey('8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e');
-            const otherSigner2PublicKey = new PublicKey('3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd');
-
-            const accountMetasSigners = [
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner1PublicKey,
-                },
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner2PublicKey,
-                },
-            ];
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [
-                        new TransactionInstruction({
-                            keys: accountMetasSigners,
-                            programId: new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf'),
-                        }),
-                    ],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToV0Message(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            const otherSignature2 = new Uint8Array(Array(64).fill(3));
-
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-            oldTransaction.addSignature(otherSigner2PublicKey, otherSignature2);
-
-            const transaction = fromVersionedTransactionWithBlockhash(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd': new Uint8Array(Array(64).fill(3)),
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': new Uint8Array(Array(64).fill(1)),
-            });
-        });
-
-        it('converts a transaction with a given lastValidBlockHeight', () => {
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: blockhashString,
-                }).compileToV0Message(),
-            );
-
-            const transaction = fromVersionedTransactionWithBlockhash(oldTransaction, 100n);
-
-            expect(transaction.lifetimeConstraint).toEqual({
-                blockhash: blockhashString,
-                lastValidBlockHeight: 100n,
-            });
-        });
-    });
-});
-
-describe('fromVersionedTransactionWithDurableNonce', () => {
-    const nonce = '27kqzE1RifbyoFtibDRTjbnfZ894jsNpuR77JJkt3vgH' as Nonce;
-    const nonceAccountAddress = new PublicKey('DhezFECsqmzuDxeuitFChbghTrwKLdsKdVsGArYbFEtm');
-    const nonceAuthorityAddress = new PublicKey('2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM');
-
-    const feePayerPublicKey = new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK');
-
-    // /** An account's public key */
-    // pubkey: PublicKey;
-    // /** True if an instruction requires a transaction signature matching `pubkey` */
-    // isSigner: boolean;
-    // /** True if the `pubkey` can be loaded as a read-write account. */
-    // isWritable: boolean;
-
-    // A NonceAdvance instruction in old web3js TransactionInstruction form
-    function createNonceAdvanceInstruction(): TransactionInstruction {
-        return new TransactionInstruction({
-            data: Buffer.from([4, 0, 0, 0]),
-            keys: [
-                { isSigner: false, isWritable: true, pubkey: nonceAccountAddress },
-                {
-                    isSigner: false,
-                    isWritable: false,
-                    pubkey: new PublicKey('SysvarRecentB1ockHashes11111111111111111111'),
-                },
-                { isSigner: true, isWritable: false, pubkey: nonceAuthorityAddress },
-            ],
-            programId: new PublicKey('11111111111111111111111111111111'),
-        });
-    }
-
-    describe('for a transaction with `legacy` version', () => {
-        it('throws for a transaction with no instructions', () => {
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToLegacyMessage(),
-            );
-
-            expect(() => {
-                fromVersionedTransactionWithDurableNonce(oldTransaction);
-            }).toThrow(new SolanaError(SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_INSTRUCTIONS_MISSING));
-        });
-
-        it('throws for a transaction with one instruction which is not advance nonce', () => {
-            const programId = new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf');
-
-            const instruction = new TransactionInstruction({
-                keys: [],
-                programId,
-            });
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [instruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToLegacyMessage(),
-            );
-
-            expect(() => {
-                fromVersionedTransactionWithDurableNonce(oldTransaction);
-            }).toThrow(
-                new SolanaError(
-                    SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_FIRST_INSTRUCTION_MUST_BE_ADVANCE_NONCE,
-                ),
-            );
-        });
-
-        it('converts a transaction with one instruction which is advance nonce', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [nonceAdvanceInstruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToLegacyMessage(),
-            );
-
-            const transaction = fromVersionedTransactionWithDurableNonce(oldTransaction);
-
-            const expectedInstruction: IInstruction = {
-                accounts: [
-                    {
-                        address: 'DhezFECsqmzuDxeuitFChbghTrwKLdsKdVsGArYbFEtm' as Address,
-                        role: AccountRole.WRITABLE,
-                    },
-                    {
-                        address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
-                        role: AccountRole.READONLY,
-                    },
-                    {
-                        address: '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM' as Address,
-                        role: AccountRole.READONLY_SIGNER,
-                    },
-                ],
-                data: new Uint8Array([4, 0, 0, 0]),
-                programAddress: '11111111111111111111111111111111' as Address,
-            };
-
-            expect(transaction.instructions).toStrictEqual([expectedInstruction]);
-        });
-
-        it('converts a durable nonce transaction with multiple instructions', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
-
-            const instructions = [
-                nonceAdvanceInstruction,
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC'),
-                }),
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP'),
-                }),
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S'),
-                }),
-            ];
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions,
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToLegacyMessage(),
-            );
-
-            const transaction = fromVersionedTransactionWithDurableNonce(oldTransaction);
-
-            const expectedInstructions: IInstruction[] = [
-                {
-                    accounts: [
-                        {
-                            address: 'DhezFECsqmzuDxeuitFChbghTrwKLdsKdVsGArYbFEtm' as Address,
-                            role: AccountRole.WRITABLE,
-                        },
-                        {
-                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
-                            role: AccountRole.READONLY,
-                        },
-                        {
-                            address: '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM' as Address,
-                            role: AccountRole.READONLY_SIGNER,
-                        },
-                    ],
-                    data: new Uint8Array([4, 0, 0, 0]),
-                    programAddress: '11111111111111111111111111111111' as Address,
-                },
-                {
-                    programAddress: 'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
-                },
-                {
-                    programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
-                },
-                {
-                    programAddress: 'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Address,
-                },
-            ];
-
-            expect(transaction.instructions).toStrictEqual(expectedInstructions);
-        });
-
-        it('converts a durable nonce transaction with a single signer', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [nonceAdvanceInstruction],
-                    // Note there's a bug in legacy web3js where if the feepayer
-                    // is the same as authorizedPubkey, it gets the wrong role
-                    // in the advance nonce instruction
-                    // So for our test just use a different account as fee payer
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToLegacyMessage(),
-            );
-
-            const signature = new Uint8Array(Array(64).fill(1));
-            oldTransaction.addSignature(nonceAuthorityAddress, signature);
-
-            const transaction = fromVersionedTransactionWithDurableNonce(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM': signature as SignatureBytes,
-            });
-        });
-
-        it('converts a durable nonce transaction with multiple signers', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [nonceAdvanceInstruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToLegacyMessage(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-
-            const nonceAuthoritySignature = new Uint8Array(Array(64).fill(2));
-            oldTransaction.addSignature(nonceAuthorityAddress, nonceAuthoritySignature);
-
-            const transaction = fromVersionedTransactionWithDurableNonce(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM': nonceAuthoritySignature as SignatureBytes,
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': feePayerSignature as SignatureBytes,
-            });
-        });
-
-        it('converts a partially signed durable nonce transaction with multiple signers', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
-
-            const otherSigner1PublicKey = new PublicKey('BHPhpD7z7LqwDj2SFSWHoVWitXc9ycrgsftbAE1wpazj');
-
-            const accountMetasSigners = [
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner1PublicKey,
-                },
-            ];
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [
-                        nonceAdvanceInstruction,
-                        new TransactionInstruction({
-                            keys: accountMetasSigners,
-                            programId: new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf'),
-                        }),
-                    ],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToLegacyMessage(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            // No signature for nonceAuthorityAddress
-            const otherSignature1 = new Uint8Array(Array(64).fill(3));
-
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-            oldTransaction.addSignature(otherSigner1PublicKey, otherSignature1);
-
-            const transaction = fromVersionedTransactionWithDurableNonce(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': new Uint8Array(Array(64).fill(1)),
-                BHPhpD7z7LqwDj2SFSWHoVWitXc9ycrgsftbAE1wpazj: new Uint8Array(Array(64).fill(3)),
-            });
+            },
+            signatures: [nullSignature],
+        } as unknown as VersionedTransaction;
+
+        const converted = fromVersionedTransaction(transaction);
+        expect(converted.signatures).toStrictEqual({
+            '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': null,
         });
     });
 
-    describe('for a transaction with `0` version', () => {
-        it('throws for a transaction with no instructions', () => {
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToV0Message(),
-            );
+    it('converts a transaction with multiple signatures', () => {
+        const signature1 = new Uint8Array(64).fill(1);
+        const signature2 = new Uint8Array(64).fill(2);
+        const signature3 = new Uint8Array(64).fill(3);
+        const transaction = {
+            message: {
+                getAccountKeys() {
+                    return {
+                        staticAccountKeys: [
+                            new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+                            new PublicKey('9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw'),
+                            new PublicKey('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),
+                        ],
+                    };
+                },
+                header: {
+                    numRequiredSignatures: 3,
+                },
+                serialize() {
+                    return new Uint8Array();
+                },
+            },
+            signatures: [signature1, signature2, signature3],
+        } as unknown as VersionedTransaction;
 
-            expect(() => {
-                fromVersionedTransactionWithDurableNonce(oldTransaction);
-            }).toThrow(new SolanaError(SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_INSTRUCTIONS_MISSING));
+        const converted = fromVersionedTransaction(transaction);
+        expect(converted.signatures).toStrictEqual({
+            '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': signature1,
+            '9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw': signature2,
+            F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT: signature3,
         });
+    });
 
-        it('throws for a transaction with one instruction which is not advance nonce', () => {
-            const programId = new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf');
+    it('converts an unsigned transaction with multiple expected signers', () => {
+        const nullSignature = new Uint8Array(64).fill(0);
+        const transaction = {
+            message: {
+                getAccountKeys() {
+                    return {
+                        staticAccountKeys: [
+                            new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+                            new PublicKey('9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw'),
+                            new PublicKey('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),
+                        ],
+                    };
+                },
+                header: {
+                    numRequiredSignatures: 3,
+                },
+                serialize() {
+                    return new Uint8Array();
+                },
+            },
+            signatures: [nullSignature, nullSignature, nullSignature],
+        } as unknown as VersionedTransaction;
 
-            const instruction = new TransactionInstruction({
-                keys: [],
-                programId,
-            });
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [instruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToV0Message(),
-            );
-
-            expect(() => {
-                fromVersionedTransactionWithDurableNonce(oldTransaction);
-            }).toThrow(
-                new SolanaError(
-                    SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_FIRST_INSTRUCTION_MUST_BE_ADVANCE_NONCE,
-                ),
-            );
+        const converted = fromVersionedTransaction(transaction);
+        expect(converted.signatures).toStrictEqual({
+            '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': null,
+            '9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw': null,
+            F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT: null,
         });
+    });
 
-        it('converts a transaction with one instruction which is advance nonce', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
+    it('converts a partially signed transaction with multiple expected signers', () => {
+        const nullSignature = new Uint8Array(64).fill(0);
+        const signature1 = new Uint8Array(64).fill(1);
+        const signature3 = new Uint8Array(64).fill(3);
+        const transaction = {
+            message: {
+                getAccountKeys() {
+                    return {
+                        staticAccountKeys: [
+                            new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+                            new PublicKey('9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw'),
+                            new PublicKey('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),
+                        ],
+                    };
+                },
+                header: {
+                    numRequiredSignatures: 3,
+                },
+                serialize() {
+                    return new Uint8Array();
+                },
+            },
+            signatures: [signature1, nullSignature, signature3],
+        } as unknown as VersionedTransaction;
 
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [nonceAdvanceInstruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToV0Message(),
-            );
+        const converted = fromVersionedTransaction(transaction);
+        expect(converted.signatures).toStrictEqual({
+            '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': signature1,
+            '9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw': null,
+            F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT: signature3,
+        });
+    });
 
-            const transaction = fromVersionedTransactionWithDurableNonce(oldTransaction);
+    it('throws if the signatures are not the same length as the number of signers', () => {
+        const messageBytes = new Uint8Array([1, 2, 3, 4]);
+        const transaction = {
+            message: {
+                getAccountKeys() {
+                    return {
+                        staticAccountKeys: [
+                            new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+                            new PublicKey('9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw'),
+                        ],
+                    };
+                },
+                header: {
+                    numRequiredSignatures: 2,
+                },
+                serialize() {
+                    return messageBytes;
+                },
+            },
+            signatures: [new Uint8Array(64).fill(1)],
+        } as unknown as VersionedTransaction;
 
-            const expectedInstruction: IInstruction = {
-                accounts: [
-                    {
-                        address: 'DhezFECsqmzuDxeuitFChbghTrwKLdsKdVsGArYbFEtm' as Address,
-                        role: AccountRole.WRITABLE,
-                    },
-                    {
-                        address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
-                        role: AccountRole.READONLY,
-                    },
-                    {
-                        address: '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM' as Address,
-                        role: AccountRole.READONLY_SIGNER,
-                    },
+        expect(() => fromVersionedTransaction(transaction)).toThrow(
+            new SolanaError(SOLANA_ERROR__TRANSACTION__MESSAGE_SIGNATURES_MISMATCH, {
+                numRequiredSignatures: 2,
+                signaturesLength: 1,
+                signerAddresses: [
+                    '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK',
+                    '9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw',
                 ],
-                data: new Uint8Array([4, 0, 0, 0]),
-                programAddress: '11111111111111111111111111111111' as Address,
-            };
-
-            expect(transaction.instructions).toStrictEqual([expectedInstruction]);
-        });
-
-        it('converts a durable nonce transaction with multiple instructions', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
-
-            const instructions = [
-                nonceAdvanceInstruction,
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC'),
-                }),
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP'),
-                }),
-                new TransactionInstruction({
-                    keys: [],
-                    programId: new PublicKey('GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S'),
-                }),
-            ];
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions,
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToV0Message(),
-            );
-
-            const transaction = fromVersionedTransactionWithDurableNonce(oldTransaction);
-
-            const expectedInstructions: IInstruction[] = [
-                {
-                    accounts: [
-                        {
-                            address: 'DhezFECsqmzuDxeuitFChbghTrwKLdsKdVsGArYbFEtm' as Address,
-                            role: AccountRole.WRITABLE,
-                        },
-                        {
-                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
-                            role: AccountRole.READONLY,
-                        },
-                        {
-                            address: '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM' as Address,
-                            role: AccountRole.READONLY_SIGNER,
-                        },
-                    ],
-                    data: new Uint8Array([4, 0, 0, 0]),
-                    programAddress: '11111111111111111111111111111111' as Address,
-                },
-                {
-                    programAddress: 'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
-                },
-                {
-                    programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
-                },
-                {
-                    programAddress: 'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Address,
-                },
-            ];
-
-            expect(transaction.instructions).toStrictEqual(expectedInstructions);
-        });
-
-        it('converts a durable nonce transaction with a single signer', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [nonceAdvanceInstruction],
-                    // Note there's a bug in legacy web3js where if the feepayer
-                    // is the same as authorizedPubkey, it gets the wrong role
-                    // in the advance nonce instruction
-                    // So for our test just use a different account as fee payer
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToV0Message(),
-            );
-
-            const signature = new Uint8Array(Array(64).fill(1));
-            oldTransaction.addSignature(nonceAuthorityAddress, signature);
-
-            const transaction = fromVersionedTransactionWithDurableNonce(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM': signature as SignatureBytes,
-            });
-        });
-
-        it('converts a durable nonce transaction with multiple signers', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [nonceAdvanceInstruction],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToV0Message(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-
-            const nonceAuthoritySignature = new Uint8Array(Array(64).fill(2));
-            oldTransaction.addSignature(nonceAuthorityAddress, nonceAuthoritySignature);
-
-            const transaction = fromVersionedTransactionWithDurableNonce(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM': nonceAuthoritySignature as SignatureBytes,
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': feePayerSignature as SignatureBytes,
-            });
-        });
-
-        it('converts a partially signed durable nonce transaction with multiple signers', () => {
-            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
-
-            const otherSigner1PublicKey = new PublicKey('BHPhpD7z7LqwDj2SFSWHoVWitXc9ycrgsftbAE1wpazj');
-
-            const accountMetasSigners = [
-                {
-                    isSigner: true,
-                    isWritable: false,
-                    pubkey: otherSigner1PublicKey,
-                },
-            ];
-
-            const oldTransaction = new VersionedTransaction(
-                new TransactionMessage({
-                    instructions: [
-                        nonceAdvanceInstruction,
-                        new TransactionInstruction({
-                            keys: accountMetasSigners,
-                            programId: new PublicKey('HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf'),
-                        }),
-                    ],
-                    payerKey: feePayerPublicKey,
-                    recentBlockhash: nonce,
-                }).compileToV0Message(),
-            );
-
-            const feePayerSignature = new Uint8Array(Array(64).fill(1));
-            // No signature for nonceAuthorityAddress
-            const otherSignature1 = new Uint8Array(Array(64).fill(3));
-
-            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
-            oldTransaction.addSignature(otherSigner1PublicKey, otherSignature1);
-
-            const transaction = fromVersionedTransactionWithDurableNonce(
-                oldTransaction,
-            ) as unknown as ITransactionWithSignatures;
-
-            expect(transaction.signatures).toStrictEqual({
-                '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': new Uint8Array(Array(64).fill(1)),
-                BHPhpD7z7LqwDj2SFSWHoVWitXc9ycrgsftbAE1wpazj: new Uint8Array(Array(64).fill(3)),
-            });
-        });
+            }),
+        );
     });
 });

--- a/packages/compat/src/__typetests__/transaction-typetests.ts
+++ b/packages/compat/src/__typetests__/transaction-typetests.ts
@@ -1,23 +1,7 @@
-import {
-    IDurableNonceTransaction,
-    ITransactionWithBlockhashLifetime,
-    ITransactionWithFeePayer,
-    Transaction,
-} from '@solana/transactions';
+import { NewTransaction } from '@solana/transactions';
 import { VersionedTransaction } from '@solana/web3.js';
 
-import { fromVersionedTransactionWithBlockhash, fromVersionedTransactionWithDurableNonce } from '../transaction';
+import { fromVersionedTransaction } from '../transaction';
 
-// Blockhash
-{
-    const transaction = null as unknown as VersionedTransaction;
-    const returned = fromVersionedTransactionWithBlockhash(transaction);
-    returned satisfies ITransactionWithBlockhashLifetime & ITransactionWithFeePayer & Transaction;
-}
-
-// Durable nonce
-{
-    const transaction = null as unknown as VersionedTransaction;
-    const returned = fromVersionedTransactionWithDurableNonce(transaction);
-    returned satisfies IDurableNonceTransaction & ITransactionWithFeePayer & Transaction;
-}
+const transaction = null as unknown as VersionedTransaction;
+fromVersionedTransaction(transaction) satisfies NewTransaction;

--- a/packages/compat/src/transaction.ts
+++ b/packages/compat/src/transaction.ts
@@ -1,204 +1,42 @@
-import { type Address, assertIsAddress } from '@solana/addresses';
-import {
-    SOLANA_ERROR__TRANSACTION__ADDRESS_MISSING,
-    SOLANA_ERROR__TRANSACTION__FEE_PAYER_MISSING,
-    SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_FIRST_INSTRUCTION_MUST_BE_ADVANCE_NONCE,
-    SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_INSTRUCTIONS_MISSING,
-    SolanaError,
-} from '@solana/errors';
-import { pipe } from '@solana/functional';
-import type { IAccountMeta, IInstruction } from '@solana/instructions';
-import { AccountRole } from '@solana/instructions';
+import { SOLANA_ERROR__TRANSACTION__MESSAGE_SIGNATURES_MISMATCH, SolanaError } from '@solana/errors';
 import type { SignatureBytes } from '@solana/keys';
-import type { Blockhash } from '@solana/rpc-types';
-import {
-    appendTransactionInstruction,
-    createTransaction,
-    type IDurableNonceTransaction,
-    isAdvanceNonceAccountInstruction,
-    type ITransactionWithBlockhashLifetime,
-    type ITransactionWithFeePayer,
-    type ITransactionWithSignatures,
-    type Nonce,
-    setTransactionFeePayer,
-    setTransactionLifetimeUsingBlockhash,
-    setTransactionLifetimeUsingDurableNonce,
-    type Transaction,
-} from '@solana/transactions';
-import type {
-    MessageAccountKeys,
-    MessageCompiledInstruction,
-    PublicKey,
-    VersionedMessage,
-    VersionedTransaction,
-} from '@solana/web3.js';
+import { NewTransaction, type SignaturesMap, TransactionMessageBytes } from '@solana/transactions';
+import type { PublicKey, VersionedTransaction } from '@solana/web3.js';
 
-function convertAccount(
-    message: VersionedMessage,
-    accountKeys: MessageAccountKeys,
-    accountIndex: number,
-): IAccountMeta {
-    const accountPublicKey = accountKeys.get(accountIndex);
-    if (!accountPublicKey) {
-        throw new SolanaError(SOLANA_ERROR__TRANSACTION__ADDRESS_MISSING, {
-            index: accountIndex,
-        });
-    }
-    const isSigner = message.isAccountSigner(accountIndex);
-    const isWritable = message.isAccountWritable(accountIndex);
+import { ReadonlyUint8Array } from '../../codecs-core/dist/types';
 
-    const role = isSigner
-        ? isWritable
-            ? AccountRole.WRITABLE_SIGNER
-            : AccountRole.READONLY_SIGNER
-        : isWritable
-          ? AccountRole.WRITABLE
-          : AccountRole.READONLY;
-
-    return {
-        address: accountPublicKey.toBase58() as Address,
-        role,
-    };
+function convertSignatures(transaction: VersionedTransaction, staticAccountKeys: PublicKey[]): SignaturesMap {
+    return Object.fromEntries(
+        transaction.signatures.map((sig, index) => {
+            const address = staticAccountKeys[index];
+            if (sig.every(b => b === 0)) {
+                // all-0 signatures are stored as null
+                return [address, null];
+            } else {
+                return [address, sig as ReadonlyUint8Array as SignatureBytes];
+            }
+        }),
+    );
 }
 
-function convertInstruction(
-    message: VersionedMessage,
-    accountKeys: MessageAccountKeys,
-    instruction: MessageCompiledInstruction,
-): IInstruction {
-    const programAddressPublicKey = accountKeys.get(instruction.programIdIndex);
-    if (!programAddressPublicKey) {
-        throw new SolanaError(SOLANA_ERROR__TRANSACTION__ADDRESS_MISSING, {
-            index: instruction.programIdIndex,
+export function fromVersionedTransaction(transaction: VersionedTransaction): NewTransaction {
+    const { message } = transaction;
+    const { staticAccountKeys } = message.getAccountKeys();
+
+    const { numRequiredSignatures } = message.header;
+    if (numRequiredSignatures !== transaction.signatures.length) {
+        throw new SolanaError(SOLANA_ERROR__TRANSACTION__MESSAGE_SIGNATURES_MISMATCH, {
+            numRequiredSignatures: transaction.message.header.numRequiredSignatures,
+            signaturesLength: transaction.signatures.length,
+            signerAddresses: staticAccountKeys.slice(0, numRequiredSignatures).map(p => p.toBase58()),
         });
     }
 
-    const accounts = instruction.accountKeyIndexes.map(accountIndex =>
-        convertAccount(message, accountKeys, accountIndex),
-    );
+    const messageBytes = message.serialize() as ReadonlyUint8Array as TransactionMessageBytes;
+    const signatures = convertSignatures(transaction, staticAccountKeys);
 
     return {
-        programAddress: programAddressPublicKey.toBase58() as Address,
-        ...(accounts.length ? { accounts } : {}),
-        ...(instruction.data.length ? { data: instruction.data } : {}),
+        messageBytes,
+        signatures: Object.freeze(signatures),
     };
-}
-
-function convertSignatures(
-    transaction: VersionedTransaction,
-    staticAccountKeys: PublicKey[],
-): ITransactionWithSignatures['signatures'] {
-    return transaction.signatures.reduce((acc, sig, index) => {
-        // legacy web3js includes a fake all 0 signature if it hasn't been signed
-        // we don't do that for the new tx model. So just skip if it's all 0s
-        const allZeros = sig.every(byte => byte === 0);
-        if (allZeros) return acc;
-
-        const address = staticAccountKeys[index].toBase58() as Address;
-        return { ...acc, [address]: sig as SignatureBytes };
-    }, {});
-}
-
-export function fromVersionedTransactionWithBlockhash(
-    transaction: VersionedTransaction,
-    lastValidBlockHeight?: bigint,
-): ITransactionWithBlockhashLifetime & ITransactionWithFeePayer & Transaction {
-    // TODO: add support for address table lookups
-    // - will need to take `AddressLookupTableAccounts[]` as input
-    // - will need to convert account instructions to `IAccountLookupMeta` when appropriate
-    if (transaction.message.addressTableLookups.length > 0) {
-        // TODO coded error
-        // This should probably not be a `SolanaError`, since we need to add
-        // this functionality.
-        throw new Error('Cannot convert transaction with addressTableLookups');
-    }
-
-    const accountKeys = transaction.message.getAccountKeys();
-
-    // Fee payer is first account
-    const feePayer = accountKeys.staticAccountKeys[0];
-    if (!feePayer) throw new SolanaError(SOLANA_ERROR__TRANSACTION__FEE_PAYER_MISSING);
-
-    const blockhashLifetime = {
-        blockhash: transaction.message.recentBlockhash as Blockhash,
-        lastValidBlockHeight: lastValidBlockHeight ?? 2n ** 64n - 1n, // U64 MAX
-    };
-
-    const instructions = transaction.message.compiledInstructions.map(instruction =>
-        convertInstruction(transaction.message, accountKeys, instruction),
-    );
-
-    const signatures = convertSignatures(transaction, accountKeys.staticAccountKeys);
-
-    return pipe(
-        createTransaction({ version: transaction.version }),
-        tx => setTransactionFeePayer(feePayer.toBase58() as Address, tx),
-        tx => setTransactionLifetimeUsingBlockhash(blockhashLifetime, tx),
-        tx =>
-            instructions.reduce((acc, instruction) => {
-                return appendTransactionInstruction(instruction, acc);
-            }, tx),
-        tx => (transaction.signatures.length ? { ...tx, signatures } : tx),
-    );
-}
-
-export function fromVersionedTransactionWithDurableNonce(
-    transaction: VersionedTransaction,
-): IDurableNonceTransaction & ITransactionWithFeePayer & Transaction {
-    // TODO: add support for address table lookups
-    // - will need to take `AddressLookupTableAccounts[]` as input
-    // - will need to convert account instructions to `IAccountLookupMeta` when appropriate
-    if (transaction.message.addressTableLookups.length > 0) {
-        // TODO coded error
-        // This should probably not be a `SolanaError`, since we need to add
-        // this functionality.
-        throw new Error('Cannot convert transaction with addressTableLookups');
-    }
-
-    const accountKeys = transaction.message.getAccountKeys();
-
-    // Fee payer is first account
-    const feePayer = accountKeys.staticAccountKeys[0];
-    if (!feePayer) throw new SolanaError(SOLANA_ERROR__TRANSACTION__FEE_PAYER_MISSING);
-
-    const instructions = transaction.message.compiledInstructions.map(instruction =>
-        convertInstruction(transaction.message, accountKeys, instruction),
-    );
-
-    // Check first instruction is durable nonce + extract params
-    if (instructions.length === 0) {
-        throw new SolanaError(SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_INSTRUCTIONS_MISSING);
-    }
-
-    if (!isAdvanceNonceAccountInstruction(instructions[0])) {
-        throw new SolanaError(
-            SOLANA_ERROR__TRANSACTION__INVALID_NONCE_TRANSACTION_FIRST_INSTRUCTION_MUST_BE_ADVANCE_NONCE,
-        );
-    }
-
-    // We know these accounts are defined because we checked `isAdvanceNonceAccountInstruction`
-    const nonceAccountAddress = instructions[0].accounts![0].address;
-    assertIsAddress(nonceAccountAddress);
-
-    const nonceAuthorityAddress = instructions[0].accounts![2].address;
-    assertIsAddress(nonceAuthorityAddress);
-
-    const durableNonceLifetime = {
-        nonce: transaction.message.recentBlockhash as Nonce,
-        nonceAccountAddress,
-        nonceAuthorityAddress,
-    };
-
-    const signatures = convertSignatures(transaction, accountKeys.staticAccountKeys);
-
-    return pipe(
-        createTransaction({ version: transaction.version }),
-        tx => setTransactionFeePayer(feePayer.toBase58() as Address, tx),
-        tx => setTransactionLifetimeUsingDurableNonce(durableNonceLifetime, tx),
-        tx =>
-            instructions.slice(1).reduce((acc, instruction) => {
-                return appendTransactionInstruction(instruction, acc);
-            }, tx),
-        tx => (transaction.signatures.length ? { ...tx, signatures } : tx),
-    );
 }

--- a/packages/transactions/src/codecs/transaction-codec.ts
+++ b/packages/transactions/src/codecs/transaction-codec.ts
@@ -60,7 +60,7 @@ function decodePartiallyDecodedTransaction(transaction: PartiallyDecodedTransact
     - `numRequiredSignatures` (1 byte, we verify this matches the length of signatures)
     - `numReadOnlySignedAccounts` (1 byte, not used here)
     - `numReadOnlyUnsignedAccounts` (1 byte, not used here)
-    - static addresses, with signers first. This is an array of addresses, encoded with a short-u16 length
+    - static addresses, with signers first. This is an array of addresses, prefixed with a short-u16 length
     */
 
     const signerAddressesDecoder = getTupleDecoder([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,12 +242,6 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      '@solana/functional':
-        specifier: workspace:*
-        version: link:../functional
-      '@solana/instructions':
-        specifier: workspace:*
-        version: link:../instructions
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
@@ -255,9 +249,6 @@ importers:
         specifier: workspace:*
         version: link:../transactions
     devDependencies:
-      '@solana/rpc-types':
-        specifier: workspace:*
-        version: link:../rpc-types
       '@solana/web3.js':
         specifier: workspace:../library-legacy
         version: link:../library-legacy


### PR DESCRIPTION
This PR refactors the compat conversion from old web3js transactions to convert to the new Transaction type.

This is a massive simplification because it no longer needs to decompile the transaction - it just needs to include the serialized message bytes and convert the signatures. We already have helpers to decompile the transaction message if required, so there's no need to duplicate that here.