### PR TITLE
Export the message codec, rename to getCompiledTransactionMessageEncoder etc to avoid clash

### DIFF
--- a/packages/transaction-messages/src/codecs/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/message-test.ts
@@ -2,9 +2,13 @@ import { Address } from '@solana/addresses';
 import { Decoder, Encoder } from '@solana/codecs-core';
 
 import { CompiledTransactionMessage } from '../../compile/message';
-import { getCompiledMessageCodec, getCompiledMessageDecoder, getCompiledMessageEncoder } from '../message';
+import {
+    getCompiledTransactionMessageCodec,
+    getCompiledTransactionMessageDecoder,
+    getCompiledTransactionMessageEncoder,
+} from '../message';
 
-describe.each([getCompiledMessageCodec, getCompiledMessageEncoder])(
+describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessageEncoder])(
     'Transaction message serializer %p',
     serializerFactory => {
         let compiledMessage: Encoder<CompiledTransactionMessage>;
@@ -156,7 +160,7 @@ describe.each([getCompiledMessageCodec, getCompiledMessageEncoder])(
         });
         it('omits the address table lookups for `legacy` transactions', () => {
             expect(
-                getCompiledMessageCodec().encode({
+                getCompiledTransactionMessageCodec().encode({
                     header: {
                         numReadonlyNonSignerAccounts: 1,
                         numReadonlySignerAccounts: 2,
@@ -191,7 +195,7 @@ describe.each([getCompiledMessageCodec, getCompiledMessageEncoder])(
     },
 );
 
-describe.each([getCompiledMessageCodec, getCompiledMessageDecoder])(
+describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessageDecoder])(
     'Transaction message deserializer %p',
     serializerFactory => {
         let compiledMessage: Decoder<CompiledTransactionMessage>;

--- a/packages/transaction-messages/src/codecs/index.ts
+++ b/packages/transaction-messages/src/codecs/index.ts
@@ -4,4 +4,5 @@
 export * from './address-table-lookup';
 export * from './header';
 export * from './instruction';
+export * from './message';
 export * from './transaction-version';

--- a/packages/transaction-messages/src/codecs/message.ts
+++ b/packages/transaction-messages/src/codecs/message.ts
@@ -72,7 +72,7 @@ function getAddressTableLookupArrayDecoder() {
     return getArrayDecoder(getAddressTableLookupDecoder(), { size: getShortU16Decoder() });
 }
 
-export function getCompiledMessageEncoder(): VariableSizeEncoder<CompiledTransactionMessage> {
+export function getCompiledTransactionMessageEncoder(): VariableSizeEncoder<CompiledTransactionMessage> {
     return createEncoder({
         getSizeFromValue: (compiledMessage: CompiledTransactionMessage) => {
             if (compiledMessage.version === 'legacy') {
@@ -91,7 +91,7 @@ export function getCompiledMessageEncoder(): VariableSizeEncoder<CompiledTransac
     });
 }
 
-export function getCompiledMessageDecoder(): VariableSizeDecoder<CompiledTransactionMessage> {
+export function getCompiledTransactionMessageDecoder(): VariableSizeDecoder<CompiledTransactionMessage> {
     return transformDecoder(
         getStructDecoder(getPreludeStructDecoderTuple()) as VariableSizeDecoder<
             CompiledTransactionMessage & { addressTableLookups?: ReturnType<typeof getCompiledAddressTableLookups> }
@@ -108,6 +108,6 @@ export function getCompiledMessageDecoder(): VariableSizeDecoder<CompiledTransac
     );
 }
 
-export function getCompiledMessageCodec(): VariableSizeCodec<CompiledTransactionMessage> {
-    return combineCodec(getCompiledMessageEncoder(), getCompiledMessageDecoder());
+export function getCompiledTransactionMessageCodec(): VariableSizeCodec<CompiledTransactionMessage> {
+    return combineCodec(getCompiledTransactionMessageEncoder(), getCompiledTransactionMessageDecoder());
 }

--- a/packages/transaction-messages/src/index.ts
+++ b/packages/transaction-messages/src/index.ts
@@ -1,5 +1,6 @@
 export * from './blockhash';
 export * from './codecs';
+export * from './compilable-transaction-message';
 export * from './compile'; // TODO later: can probably delete this at the end
 export * from './create-transaction-message';
 export * from './decompile-message';


### PR DESCRIPTION
*he sighs*

I forgot to export the new compiled transaction message codec, which is quite unhelpful

But the function names (`getCompiledMessageEncoder` etc) clash with the transactions serializer. So I've renamed them `getCompiledTransactionMessageEncoder` etc, which is probably the right name for them anyway.