### PR TITLE
Refactor fee-payer-signer to use TransactionMessage

### DIFF
--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -70,6 +70,7 @@
         "@solana/errors": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
+        "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
     "devDependencies": {

--- a/packages/signers/src/__tests__/fee-payer-signer-test.ts
+++ b/packages/signers/src/__tests__/fee-payer-signer-test.ts
@@ -1,16 +1,16 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
-import { BaseTransaction, ITransactionWithFeePayer, ITransactionWithSignatures } from '@solana/transactions';
+import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { ITransactionWithFeePayerSigner, setTransactionFeePayerSigner } from '../fee-payer-signer';
+import { ITransactionMessageWithFeePayerSigner, setTransactionFeePayerSigner } from '../fee-payer-signer';
 import { TransactionSigner } from '../transaction-signer';
 import { createMockTransactionPartialSigner } from './__setup__';
 
 describe('setTransactionFeePayerSigner', () => {
     let feePayerSignerA: TransactionSigner;
     let feePayerSignerB: TransactionSigner;
-    let baseTx: BaseTransaction;
+    let baseTx: BaseTransactionMessage;
     beforeEach(() => {
         baseTx = { instructions: [], version: 0 };
         feePayerSignerA = createMockTransactionPartialSigner('1111' as Address);
@@ -22,7 +22,7 @@ describe('setTransactionFeePayerSigner', () => {
         expect(txWithFeePayerA).toHaveProperty('feePayerSigner', feePayerSignerA);
     });
     describe('given a transaction with a fee payer signer already set', () => {
-        let txWithFeePayerA: BaseTransaction & ITransactionWithFeePayerSigner;
+        let txWithFeePayerA: BaseTransactionMessage & ITransactionMessageWithFeePayerSigner;
         beforeEach(() => {
             txWithFeePayerA = {
                 ...baseTx,
@@ -39,29 +39,9 @@ describe('setTransactionFeePayerSigner', () => {
             const txWithSameFeePayer = setTransactionFeePayerSigner(feePayerSignerA, txWithFeePayerA);
             expect(txWithFeePayerA).toBe(txWithSameFeePayer);
         });
-        describe('given that transaction also has signatures', () => {
-            let txWithFeePayerAndSignatures: BaseTransaction & ITransactionWithFeePayer & ITransactionWithSignatures;
-            beforeEach(() => {
-                txWithFeePayerAndSignatures = {
-                    ...txWithFeePayerA,
-                    signatures: {},
-                };
-            });
-            it('does not clear the signatures when the fee payer is the same as the current one', () => {
-                expect(setTransactionFeePayerSigner(feePayerSignerA, txWithFeePayerAndSignatures)).toHaveProperty(
-                    'signatures',
-                    txWithFeePayerAndSignatures.signatures,
-                );
-            });
-            it('clears the signatures when the fee payer is different than the current one', () => {
-                expect(setTransactionFeePayerSigner(feePayerSignerB, txWithFeePayerAndSignatures)).not.toHaveProperty(
-                    'signatures',
-                );
-            });
-        });
     });
     describe('given a transaction with a non-signer fee payer already set', () => {
-        let txWithFeePayerA: BaseTransaction & ITransactionWithFeePayer;
+        let txWithFeePayerA: BaseTransactionMessage & ITransactionMessageWithFeePayer;
         beforeEach(() => {
             txWithFeePayerA = {
                 ...baseTx,
@@ -78,26 +58,6 @@ describe('setTransactionFeePayerSigner', () => {
             expect(txWithSameFeePayer).toHaveProperty('feePayer', feePayerSignerA.address);
             expect(txWithSameFeePayer).toHaveProperty('feePayerSigner', feePayerSignerA);
             expect(txWithFeePayerA).not.toBe(txWithSameFeePayer);
-        });
-        describe('given that transaction also has signatures', () => {
-            let txWithFeePayerAndSignatures: BaseTransaction & ITransactionWithFeePayer & ITransactionWithSignatures;
-            beforeEach(() => {
-                txWithFeePayerAndSignatures = {
-                    ...txWithFeePayerA,
-                    signatures: {},
-                };
-            });
-            it('does not clear the signatures when the fee payer is the same as the current one', () => {
-                expect(setTransactionFeePayerSigner(feePayerSignerA, txWithFeePayerAndSignatures)).toHaveProperty(
-                    'signatures',
-                    txWithFeePayerAndSignatures.signatures,
-                );
-            });
-            it('clears the signatures when the fee payer is different than the current one', () => {
-                expect(setTransactionFeePayerSigner(feePayerSignerB, txWithFeePayerAndSignatures)).not.toHaveProperty(
-                    'signatures',
-                );
-            });
         });
     });
     it('freezes the object', () => {

--- a/packages/signers/src/fee-payer-signer.ts
+++ b/packages/signers/src/fee-payer-signer.ts
@@ -1,14 +1,9 @@
 import { Address } from '@solana/addresses';
-import {
-    BaseTransaction,
-    getUnsignedTransaction,
-    ITransactionWithFeePayer,
-    ITransactionWithSignatures,
-} from '@solana/transactions';
+import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { TransactionSigner } from './transaction-signer';
 
-export interface ITransactionWithFeePayerSigner<
+export interface ITransactionMessageWithFeePayerSigner<
     TAddress extends string = string,
     TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
 > {
@@ -16,35 +11,22 @@ export interface ITransactionWithFeePayerSigner<
     readonly feePayerSigner: TSigner;
 }
 
-export function setTransactionFeePayerSigner<TFeePayerAddress extends string, TTransaction extends BaseTransaction>(
+export function setTransactionFeePayerSigner<
+    TFeePayerAddress extends string,
+    TTransactionMessage extends BaseTransactionMessage,
+>(
     feePayerSigner: TransactionSigner<TFeePayerAddress>,
-    transaction:
-        | (ITransactionWithFeePayer<string> & ITransactionWithSignatures & TTransaction)
-        | (ITransactionWithSignatures & TTransaction),
-): ITransactionWithFeePayerSigner<TFeePayerAddress> & Omit<TTransaction, keyof ITransactionWithSignatures>;
-
-export function setTransactionFeePayerSigner<TFeePayerAddress extends string, TTransaction extends BaseTransaction>(
-    feePayerSigner: TransactionSigner<TFeePayerAddress>,
-    transaction: TTransaction | (ITransactionWithFeePayer<string> & TTransaction),
-): ITransactionWithFeePayerSigner<TFeePayerAddress> & TTransaction;
-
-export function setTransactionFeePayerSigner<TFeePayerAddress extends string, TTransaction extends BaseTransaction>(
-    feePayerSigner: TransactionSigner<TFeePayerAddress>,
-    transaction:
-        | TTransaction
-        | (ITransactionWithFeePayer<string> & ITransactionWithSignatures & TTransaction)
-        | (ITransactionWithFeePayer<string> & TTransaction)
-        | (ITransactionWithSignatures & TTransaction),
-) {
-    if ('feePayer' in transaction && feePayerSigner.address === transaction.feePayer) {
-        if ('feePayerSigner' in transaction) return transaction;
-        const out = { ...transaction, feePayerSigner };
+    transactionMessage: TTransactionMessage | (ITransactionMessageWithFeePayer<string> & TTransactionMessage),
+): ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & TTransactionMessage {
+    if ('feePayer' in transactionMessage && feePayerSigner.address === transactionMessage.feePayer) {
+        if ('feePayerSigner' in transactionMessage)
+            return transactionMessage as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & TTransactionMessage;
+        const out = { ...transactionMessage, feePayerSigner };
         Object.freeze(out);
-        return out;
+        return out as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & TTransactionMessage;
     }
     const out = {
-        // A change in fee payer implies that any existing signatures are invalid.
-        ...getUnsignedTransaction(transaction),
+        ...transactionMessage,
         feePayer: feePayerSigner.address,
         feePayerSigner,
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,6 +854,9 @@ importers:
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
+      '@solana/transaction-messages':
+        specifier: workspace:*
+        version: link:../transaction-messages
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions


### PR DESCRIPTION
This PR refactors the `setTransactionFeePayerSigner` function to operate on a `TransactionMessage` instead of an old transaction type.

One thing I want to flag is that I'm not sure why I needed to add these casts on the outputs to satisfy the type checker - but you can see that the tests behave exactly the same. 