### PR TITLE
Refactor transaction-partial-signer to add newSignTransactions

### DIFF
--- a/packages/signers/src/__tests__/__setup__.ts
+++ b/packages/signers/src/__tests__/__setup__.ts
@@ -52,7 +52,7 @@ export function createMockMessageModifyingSigner(
 export function createMockTransactionPartialSigner(
     address: Address,
 ): TransactionPartialSigner & { signTransactions: jest.Mock } {
-    return { address, signTransactions: jest.fn() };
+    return { address, newSignTransactions: jest.fn(), signTransactions: jest.fn() };
 }
 
 export function createMockTransactionModifyingSigner(

--- a/packages/signers/src/__tests__/noop-signer-test.ts
+++ b/packages/signers/src/__tests__/noop-signer-test.ts
@@ -1,7 +1,7 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { address } from '@solana/addresses';
-import { CompilableTransaction } from '@solana/transactions';
+import { CompilableTransaction, NewTransaction } from '@solana/transactions';
 
 import { createNoopSigner, NoopSigner } from '../noop-signer';
 import { createSignableMessage } from '../signable-message';
@@ -37,6 +37,25 @@ describe('createNoopSigner', () => {
         // When we sign two messages using that signer.
         const messages = [createSignableMessage('hello'), createSignableMessage('world')];
         const signatureDictionaries = await mySigner.signMessages(messages);
+
+        // Then the signature directories are empty and frozen.
+        expect(signatureDictionaries[0]).toStrictEqual({});
+        expect(signatureDictionaries[1]).toStrictEqual({});
+        expect(signatureDictionaries[0]).toBeFrozenObject();
+        expect(signatureDictionaries[1]).toBeFrozenObject();
+    });
+
+    it('returns an empty signature directory when signing new transactions', async () => {
+        expect.assertions(4);
+
+        // Given a NoopSigner.
+        const mySigner = createNoopSigner(address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'));
+
+        // And given we have a couple of mock transactions to sign.
+        const mockTransactions = [{} as NewTransaction, {} as NewTransaction];
+
+        // When we sign both transactions using that signer.
+        const signatureDictionaries = await mySigner.newSignTransactions(mockTransactions);
 
         // Then the signature directories are empty and frozen.
         expect(signatureDictionaries[0]).toStrictEqual({});

--- a/packages/signers/src/__tests__/transaction-partial-signer-test.ts
+++ b/packages/signers/src/__tests__/transaction-partial-signer-test.ts
@@ -12,6 +12,7 @@ describe('isTransactionPartialSigner', () => {
         const myAddress = address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
         const mySigner = {
             address: myAddress,
+            newSignTransactions: () => Promise.resolve([]),
             signTransactions: () => Promise.resolve([]),
         } satisfies TransactionPartialSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
 
@@ -26,6 +27,7 @@ describe('assertIsTransactionPartialSigner', () => {
         const myAddress = address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
         const mySigner = {
             address: myAddress,
+            newSignTransactions: () => Promise.resolve([]),
             signTransactions: () => Promise.resolve([]),
         } satisfies TransactionPartialSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
 

--- a/packages/signers/src/__tests__/transaction-signer-test.ts
+++ b/packages/signers/src/__tests__/transaction-signer-test.ts
@@ -8,6 +8,7 @@ describe('isTransactionSigner', () => {
         const myAddress = address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
         const myPartialSigner = {
             address: myAddress,
+            newSignTransactions: () => Promise.resolve([]),
             signTransactions: () => Promise.resolve([]),
         } satisfies TransactionSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
         const myModifyingSigner = {
@@ -38,6 +39,7 @@ describe('assertIsTransactionSigner', () => {
         const myAddress = address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
         const myPartialSigner = {
             address: myAddress,
+            newSignTransactions: () => Promise.resolve([]),
             signTransactions: () => Promise.resolve([]),
         } satisfies TransactionSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
         const myModifyingSigner = {

--- a/packages/signers/src/keypair-signer.ts
+++ b/packages/signers/src/keypair-signer.ts
@@ -1,7 +1,7 @@
 import { Address, getAddressFromPublicKey } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__EXPECTED_KEY_PAIR_SIGNER, SolanaError } from '@solana/errors';
 import { createKeyPairFromBytes, generateKeyPair, signBytes } from '@solana/keys';
-import { partiallySignTransaction } from '@solana/transactions';
+import { newPartiallySignTransaction, partiallySignTransaction } from '@solana/transactions';
 
 import { isMessagePartialSigner, MessagePartialSigner } from './message-partial-signer';
 import { isTransactionPartialSigner, TransactionPartialSigner } from './transaction-partial-signer';
@@ -41,6 +41,14 @@ export async function createSignerFromKeyPair(keyPair: CryptoKeyPair): Promise<K
     const out: KeyPairSigner = {
         address,
         keyPair,
+        newSignTransactions: transactions =>
+            Promise.all(
+                transactions.map(async transaction => {
+                    const signedTransaction = await newPartiallySignTransaction([keyPair], transaction);
+                    // we know that the address has signed `signedTransaction` because it comes from the keypair
+                    return Object.freeze({ [address]: signedTransaction.signatures[address]! });
+                }),
+            ),
         signMessages: messages =>
             Promise.all(
                 messages.map(async message =>

--- a/packages/signers/src/noop-signer.ts
+++ b/packages/signers/src/noop-signer.ts
@@ -11,6 +11,7 @@ export type NoopSigner<TAddress extends string = string> = MessagePartialSigner<
 export function createNoopSigner(address: Address): NoopSigner {
     const out: NoopSigner = {
         address,
+        newSignTransactions: transactions => Promise.resolve(transactions.map(() => Object.freeze({}))),
         signMessages: messages => Promise.resolve(messages.map(() => Object.freeze({}))),
         signTransactions: transactions => Promise.resolve(transactions.map(() => Object.freeze({}))),
     };

--- a/packages/signers/src/transaction-partial-signer.ts
+++ b/packages/signers/src/transaction-partial-signer.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_PARTIAL_SIGNER, SolanaError } from '@solana/errors';
-import { CompilableTransaction } from '@solana/transactions';
+import { CompilableTransaction, NewTransaction } from '@solana/transactions';
 
 import { BaseSignerConfig, SignatureDictionary } from './types';
 
@@ -9,6 +9,10 @@ export type TransactionPartialSignerConfig = BaseSignerConfig;
 /** Defines a signer capable of signing transactions. */
 export type TransactionPartialSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
+    newSignTransactions(
+        transactions: readonly NewTransaction[],
+        config?: TransactionPartialSignerConfig,
+    ): Promise<readonly SignatureDictionary[]>;
     signTransactions(
         transactions: readonly CompilableTransaction[],
         config?: TransactionPartialSignerConfig,


### PR DESCRIPTION
This PR updates the `TransactionPartialSigner` type to also be able to sign `NewTransaction` objects. I've kept the current `signTransactions` function unchanged for now because it's used by yet to be refactored signer code. So this is just additive here, but will eventually replace `signTransactions`. 