### PR TITLE
Add newModifyAndSignTransactions to modifying signer

### DIFF
--- a/packages/signers/src/__tests__/__setup__.ts
+++ b/packages/signers/src/__tests__/__setup__.ts
@@ -58,7 +58,7 @@ export function createMockTransactionPartialSigner(
 export function createMockTransactionModifyingSigner(
     address: Address,
 ): TransactionModifyingSigner & { modifyAndSignTransactions: jest.Mock } {
-    return { address, modifyAndSignTransactions: jest.fn() };
+    return { address, modifyAndSignTransactions: jest.fn(), newModifyAndSignTransactions: jest.fn() };
 }
 
 export function createMockTransactionSendingSigner(

--- a/packages/signers/src/__tests__/transaction-modifying-signer-test.ts
+++ b/packages/signers/src/__tests__/transaction-modifying-signer-test.ts
@@ -13,6 +13,7 @@ describe('isTransactionModifyingSigner', () => {
         const mySigner = {
             address: myAddress,
             modifyAndSignTransactions: () => Promise.resolve([]),
+            newModifyAndSignTransactions: () => Promise.resolve([]),
         } satisfies TransactionModifyingSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
 
         expect(isTransactionModifyingSigner(mySigner)).toBe(true);
@@ -27,6 +28,7 @@ describe('assertIsTransactionModifyingSigner', () => {
         const mySigner = {
             address: myAddress,
             modifyAndSignTransactions: () => Promise.resolve([]),
+            newModifyAndSignTransactions: () => Promise.resolve([]),
         } satisfies TransactionModifyingSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
 
         const expectedError = new SolanaError(SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_MODIFYING_SIGNER, {

--- a/packages/signers/src/__tests__/transaction-signer-test.ts
+++ b/packages/signers/src/__tests__/transaction-signer-test.ts
@@ -14,6 +14,7 @@ describe('isTransactionSigner', () => {
         const myModifyingSigner = {
             address: myAddress,
             modifyAndSignTransactions: () => Promise.resolve([]),
+            newModifyAndSignTransactions: () => Promise.resolve([]),
         } satisfies TransactionSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
         const mySendingSigner = {
             address: myAddress,
@@ -45,6 +46,7 @@ describe('assertIsTransactionSigner', () => {
         const myModifyingSigner = {
             address: myAddress,
             modifyAndSignTransactions: () => Promise.resolve([]),
+            newModifyAndSignTransactions: () => Promise.resolve([]),
         } satisfies TransactionSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
         const mySendingSigner = {
             address: myAddress,

--- a/packages/signers/src/transaction-modifying-signer.ts
+++ b/packages/signers/src/transaction-modifying-signer.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_MODIFYING_SIGNER, SolanaError } from '@solana/errors';
-import { CompilableTransaction } from '@solana/transactions';
+import { CompilableTransaction, NewTransaction } from '@solana/transactions';
 
 import { BaseSignerConfig } from './types';
 
@@ -13,6 +13,10 @@ export type TransactionModifyingSigner<TAddress extends string = string> = Reado
         transactions: readonly TTransaction[],
         config?: TransactionModifyingSignerConfig,
     ): Promise<readonly TTransaction[]>;
+    newModifyAndSignTransactions(
+        transactions: readonly NewTransaction[],
+        config?: TransactionModifyingSignerConfig,
+    ): Promise<readonly NewTransaction[]>;
 }>;
 
 /** Checks whether the provided value implements the {@link TransactionModifyingSigner} interface. */


### PR DESCRIPTION
Again I've left the existing `modifyAndSignTransactions` for now because of code that uses it and hasn't yet been refactored, though this time it'll just be deleted and the new function has the correct name already. 

This is required to have the signature `NewTransaction -> NewTransaction` because of logic handling multiple modifying signers. 