### PR TITLE
Refactor transaction-sending-signer to add newSignAndSendTransactions

### DIFF
--- a/packages/signers/src/__tests__/__setup__.ts
+++ b/packages/signers/src/__tests__/__setup__.ts
@@ -64,7 +64,7 @@ export function createMockTransactionModifyingSigner(
 export function createMockTransactionSendingSigner(
     address: Address,
 ): TransactionSendingSigner & { signAndSendTransactions: jest.Mock } {
-    return { address, signAndSendTransactions: jest.fn() };
+    return { address, newSignAndSendTransactions: jest.fn(), signAndSendTransactions: jest.fn() };
 }
 
 export function createMockTransactionCompositeSigner(address: Address) {

--- a/packages/signers/src/__tests__/transaction-sending-signer-test.ts
+++ b/packages/signers/src/__tests__/transaction-sending-signer-test.ts
@@ -12,6 +12,7 @@ describe('isTransactionSendingSigner', () => {
         const myAddress = address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
         const mySigner = {
             address: myAddress,
+            newSignAndSendTransactions: () => Promise.resolve([]),
             signAndSendTransactions: () => Promise.resolve([]),
         } satisfies TransactionSendingSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
 
@@ -26,6 +27,7 @@ describe('assertIsTransactionSendingSigner', () => {
         const myAddress = address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
         const mySigner = {
             address: myAddress,
+            newSignAndSendTransactions: () => Promise.resolve([]),
             signAndSendTransactions: () => Promise.resolve([]),
         } satisfies TransactionSendingSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
 

--- a/packages/signers/src/__tests__/transaction-signer-test.ts
+++ b/packages/signers/src/__tests__/transaction-signer-test.ts
@@ -18,6 +18,7 @@ describe('isTransactionSigner', () => {
         } satisfies TransactionSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
         const mySendingSigner = {
             address: myAddress,
+            newSignAndSendTransactions: () => Promise.resolve([]),
             signAndSendTransactions: () => Promise.resolve([]),
         } satisfies TransactionSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
 
@@ -50,6 +51,7 @@ describe('assertIsTransactionSigner', () => {
         } satisfies TransactionSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
         const mySendingSigner = {
             address: myAddress,
+            newSignAndSendTransactions: () => Promise.resolve([]),
             signAndSendTransactions: () => Promise.resolve([]),
         } satisfies TransactionSigner<'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'>;
 

--- a/packages/signers/src/transaction-sending-signer.ts
+++ b/packages/signers/src/transaction-sending-signer.ts
@@ -1,7 +1,7 @@
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_SENDING_SIGNER, SolanaError } from '@solana/errors';
 import { SignatureBytes } from '@solana/keys';
-import { CompilableTransaction } from '@solana/transactions';
+import { CompilableTransaction, NewTransaction } from '@solana/transactions';
 
 import { BaseSignerConfig } from './types';
 
@@ -10,6 +10,10 @@ export type TransactionSendingSignerConfig = BaseSignerConfig;
 /** Defines a signer capable of signing and sending transactions simultaneously. */
 export type TransactionSendingSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
+    newSignAndSendTransactions(
+        transactions: readonly NewTransaction[],
+        config?: TransactionSendingSignerConfig,
+    ): Promise<readonly SignatureBytes[]>;
     signAndSendTransactions(
         transactions: readonly CompilableTransaction[],
         config?: TransactionSendingSignerConfig,


### PR DESCRIPTION
- Similar to with partial signers, this adds a new function for now for sending NewTransaction objects
- Will in future replace the existing signAndSendTransactions function

It's nice (from a web3js perspective at least...) that the signers package doesn't actually have the implementation of these types! 