### PR TITLE
Add transaction message functions to transaction-with-single-sending-signer

### DIFF
--- a/packages/signers/src/__tests__/__setup__.ts
+++ b/packages/signers/src/__tests__/__setup__.ts
@@ -1,6 +1,7 @@
 import { Address } from '@solana/addresses';
 import { AccountRole, IInstruction } from '@solana/instructions';
 import type { Blockhash } from '@solana/rpc-types';
+import { CompilableTransactionMessage } from '@solana/transaction-messages';
 import {
     appendTransactionInstruction,
     CompilableTransaction,
@@ -9,7 +10,12 @@ import {
     setTransactionLifetimeUsingBlockhash,
 } from '@solana/transactions';
 
-import { IAccountSignerMeta, IInstructionWithSigners, ITransactionWithSigners } from '../account-signer-meta';
+import {
+    IAccountSignerMeta,
+    IInstructionWithSigners,
+    ITransactionMessageWithSigners,
+    ITransactionWithSigners,
+} from '../account-signer-meta';
 import { MessageModifyingSigner } from '../message-modifying-signer';
 import { MessagePartialSigner } from '../message-partial-signer';
 import { TransactionModifyingSigner } from '../transaction-modifying-signer';
@@ -30,6 +36,18 @@ export function createMockInstructionWithSigners(signers: TransactionSigner[]): 
 export function createMockTransactionWithSigners(
     signers: TransactionSigner[],
 ): CompilableTransaction & ITransactionWithSigners {
+    const transaction = createTransaction({ version: 0 });
+    const transactionWithFeePayer = setTransactionFeePayer(signers[0]?.address ?? '1111', transaction);
+    const compilableTransaction = setTransactionLifetimeUsingBlockhash(
+        { blockhash: 'dummy_blockhash' as Blockhash, lastValidBlockHeight: 42n },
+        transactionWithFeePayer,
+    );
+    return appendTransactionInstruction(createMockInstructionWithSigners(signers), compilableTransaction);
+}
+
+export function createMockTransactionMessageWithSigners(
+    signers: TransactionSigner[],
+): CompilableTransactionMessage & ITransactionMessageWithSigners {
     const transaction = createTransaction({ version: 0 });
     const transactionWithFeePayer = setTransactionFeePayer(signers[0]?.address ?? '1111', transaction);
     const compilableTransaction = setTransactionLifetimeUsingBlockhash(

--- a/packages/signers/src/__tests__/account-signer-meta-test.ts
+++ b/packages/signers/src/__tests__/account-signer-meta-test.ts
@@ -1,10 +1,16 @@
 import { Address } from '@solana/addresses';
+import { createTransactionMessage } from '@solana/transaction-messages';
 import { createTransaction } from '@solana/transactions';
 
-import { getSignersFromInstruction, getSignersFromTransaction } from '../account-signer-meta';
+import {
+    getSignersFromInstruction,
+    getSignersFromTransaction,
+    getSignersFromTransactionMessage,
+} from '../account-signer-meta';
 import { setTransactionFeePayerSigner } from '../fee-payer-signer';
 import {
     createMockInstructionWithSigners,
+    createMockTransactionMessageWithSigners,
     createMockTransactionModifyingSigner,
     createMockTransactionPartialSigner,
     createMockTransactionWithSigners,
@@ -78,6 +84,50 @@ describe('getSignersFromTransaction', () => {
 
         // When we extract the signers from the transaction's account metas.
         const extractedSigners = getSignersFromTransaction(transaction);
+
+        // Then we expect the extracted signers to be deduplicated.
+        expect(extractedSigners).toHaveLength(2);
+        expect(extractedSigners.map(signer => signer.address).sort()).toStrictEqual(['1111', '2222']);
+    });
+});
+
+describe('getSignersFromTransactionMessage', () => {
+    it('extracts signers from the account meta of the provided transaction', () => {
+        // Given a transaction with two signers A and B.
+        const signerA = createMockTransactionPartialSigner('1111' as Address);
+        const signerB = createMockTransactionModifyingSigner('2222' as Address);
+        const transaction = createMockTransactionMessageWithSigners([signerA, signerB]);
+
+        // When we extract the signers from the transaction's account metas.
+        const extractedSigners = getSignersFromTransactionMessage(transaction);
+
+        // Then we expect signer A and B to be part of the extracted signers.
+        expect(extractedSigners).toHaveLength(2);
+        expect(extractedSigners[0]).toBe(signerA);
+        expect(extractedSigners[1]).toBe(signerB);
+    });
+
+    it('extracts the fee payer signer of the provided transaction', () => {
+        // Given a transaction with a signer fee payer.
+        const feePayerSigner = createMockTransactionPartialSigner('1111' as Address);
+        const transaction = setTransactionFeePayerSigner(feePayerSigner, createTransactionMessage({ version: 0 }));
+
+        // When we extract the signers from the transaction.
+        const extractedSigners = getSignersFromTransactionMessage(transaction);
+
+        // Then we expect the extracted signers to contain the fee payer signer.
+        expect(extractedSigners).toHaveLength(1);
+        expect(extractedSigners[0]).toBe(feePayerSigner);
+    });
+
+    it('removes duplicated signers', () => {
+        // Given a transaction with duplicated signers using the same reference.
+        const signerA = createMockTransactionPartialSigner('1111' as Address);
+        const signerB = createMockTransactionModifyingSigner('2222' as Address);
+        const transaction = createMockTransactionMessageWithSigners([signerA, signerB, signerA, signerA]);
+
+        // When we extract the signers from the transaction's account metas.
+        const extractedSigners = getSignersFromTransactionMessage(transaction);
 
         // Then we expect the extracted signers to be deduplicated.
         expect(extractedSigners).toHaveLength(2);

--- a/packages/signers/src/__tests__/transaction-with-single-sending-signer.ts
+++ b/packages/signers/src/__tests__/transaction-with-single-sending-signer.ts
@@ -6,56 +6,104 @@ import {
 } from '@solana/errors';
 
 import {
+    assertIsTransactionMessageWithSingleSendingSigner,
     assertIsTransactionWithSingleSendingSigner,
-    isTransactionWithSingleSendingSigner,
+    isTransactionMessageWithSingleSendingSigner,
 } from '../transaction-with-single-sending-signer';
 import {
     createMockTransactionCompositeSigner,
+    createMockTransactionMessageWithSigners,
     createMockTransactionModifyingSigner,
     createMockTransactionPartialSigner,
     createMockTransactionSendingSigner,
     createMockTransactionWithSigners,
 } from './__setup__';
 
-describe('isTransactionWithSingleSendingSigner', () => {
-    it('returns true if a transaction contains a single sending only signer', () => {
-        // Given a transaction with a single sending signer.
+describe('isTransactionMessageWithSingleSendingSigner', () => {
+    it('returns true if a transaction message contains a single sending only signer', () => {
+        // Given a transaction message with a single sending signer.
         const signer = createMockTransactionSendingSigner('2222' as Address);
-        const transaction = createMockTransactionWithSigners([signer]);
+        const transaction = createMockTransactionMessageWithSigners([signer]);
 
         // Then we expect it to be a valid `TransactionWithSingleSendingSigner`.
-        expect(isTransactionWithSingleSendingSigner(transaction)).toBe(true);
+        expect(isTransactionMessageWithSingleSendingSigner(transaction)).toBe(true);
     });
 
-    it('returns true if a transaction contains multiple sending signer composites', () => {
-        // Given a transaction with a two sending signers that can also be used as other signer interfaces.
+    it('returns true if a transaction message contains multiple sending signer composites', () => {
+        // Given a transaction message with two sending signers that can also be used as other signer interfaces.
         const signerA = createMockTransactionCompositeSigner('1111' as Address);
         const signerB = createMockTransactionCompositeSigner('2222' as Address);
-        const transaction = createMockTransactionWithSigners([signerA, signerB]);
+        const transaction = createMockTransactionMessageWithSigners([signerA, signerB]);
 
-        // Then we expect it to be a valid `TransactionWithSingleSendingSigner` because we can use
+        // Then we expect it to be a valid `TransactionMessageWithSingleSendingSigner` because we can use
         // one of them as a sending signer and the other as a modifying or partial signer.
-        expect(isTransactionWithSingleSendingSigner(transaction)).toBe(true);
+        expect(isTransactionMessageWithSingleSendingSigner(transaction)).toBe(true);
     });
 
-    it('returns false if a transaction contains multiple sending only signer', () => {
-        // Given a transaction with a two sending only signers.
+    it('returns false if a transaction message contains multiple sending only signers', () => {
+        // Given a transaction message with two sending only signers.
         const signerA = createMockTransactionSendingSigner('1111' as Address);
         const signerB = createMockTransactionSendingSigner('2222' as Address);
-        const transaction = createMockTransactionWithSigners([signerA, signerB]);
+        const transaction = createMockTransactionMessageWithSigners([signerA, signerB]);
 
-        // Then we expect it not to be a valid `TransactionWithSingleSendingSigner`.
-        expect(isTransactionWithSingleSendingSigner(transaction)).toBe(false);
+        // Then we expect it not to be a valid `TransactionMessageWithSingleSendingSigner`.
+        expect(isTransactionMessageWithSingleSendingSigner(transaction)).toBe(false);
     });
 
-    it('returns false if a transaction contains no sending signer at all', () => {
-        // Given a transaction with no sending signer.
+    it('returns false if a transaction message contains no sending signer at all', () => {
+        // Given a transaction message with no sending signer.
         const signerA = createMockTransactionPartialSigner('1111' as Address);
         const signerB = createMockTransactionModifyingSigner('2222' as Address);
-        const transaction = createMockTransactionWithSigners([signerA, signerB]);
+        const transaction = createMockTransactionMessageWithSigners([signerA, signerB]);
 
-        // Then we expect it not to be a valid `TransactionWithSingleSendingSigner`.
-        expect(isTransactionWithSingleSendingSigner(transaction)).toBe(false);
+        // Then we expect it not to be a valid `TransactionMessageWithSingleSendingSigner`.
+        expect(isTransactionMessageWithSingleSendingSigner(transaction)).toBe(false);
+    });
+});
+
+describe('assertIsTransactionMessageWithSingleSendingSigner', () => {
+    it('succeeds if a transaction message contains a single sending only signer', () => {
+        // Given a transaction message with a single sending signer.
+        const signer = createMockTransactionSendingSigner('2222' as Address);
+        const transaction = createMockTransactionMessageWithSigners([signer]);
+
+        // Then we expect the assertion to succeed.
+        expect(() => assertIsTransactionMessageWithSingleSendingSigner(transaction)).not.toThrow();
+    });
+
+    it('succeeds if a transaction contains multiple sending signer composites', () => {
+        // Given a transaction message with two sending signers that can also be used as other signer interfaces.
+        const signerA = createMockTransactionCompositeSigner('1111' as Address);
+        const signerB = createMockTransactionCompositeSigner('2222' as Address);
+        const transaction = createMockTransactionMessageWithSigners([signerA, signerB]);
+
+        // Then we expect the assertion to succeed because we can use one of them
+        // as a sending signer and the other as a modifying or partial signer.
+        expect(() => assertIsTransactionMessageWithSingleSendingSigner(transaction)).not.toThrow();
+    });
+
+    it('fails if a transaction message contains multiple sending only signers', () => {
+        // Given a transaction message with a two sending only signers.
+        const signerA = createMockTransactionSendingSigner('1111' as Address);
+        const signerB = createMockTransactionSendingSigner('2222' as Address);
+        const transaction = createMockTransactionMessageWithSigners([signerA, signerB]);
+
+        // Then we expect the assertion to fail.
+        expect(() => assertIsTransactionMessageWithSingleSendingSigner(transaction)).toThrow(
+            new SolanaError(SOLANA_ERROR__SIGNER__TRANSACTION_CANNOT_HAVE_MULTIPLE_SENDING_SIGNERS),
+        );
+    });
+
+    it('fails if a transaction message contains no sending signer at all', () => {
+        // Given a transaction message with no sending signer.
+        const signerA = createMockTransactionPartialSigner('1111' as Address);
+        const signerB = createMockTransactionModifyingSigner('2222' as Address);
+        const transaction = createMockTransactionMessageWithSigners([signerA, signerB]);
+
+        // Then we expect the assertion to fail.
+        expect(() => assertIsTransactionMessageWithSingleSendingSigner(transaction)).toThrow(
+            new SolanaError(SOLANA_ERROR__SIGNER__TRANSACTION_SENDING_SIGNER_MISSING),
+        );
     });
 });
 

--- a/packages/signers/src/account-signer-meta.ts
+++ b/packages/signers/src/account-signer-meta.ts
@@ -62,3 +62,14 @@ export function getSignersFromTransaction<
         ...transaction.instructions.flatMap(getSignersFromInstruction),
     ]);
 }
+
+/** Extract all signers from a transaction message that may contain IAccountSignerMeta accounts. */
+export function getSignersFromTransactionMessage<
+    TSigner extends TransactionSigner = TransactionSigner,
+    TTransactionMessage extends ITransactionMessageWithSigners<TSigner> = ITransactionMessageWithSigners<TSigner>,
+>(transaction: TTransactionMessage): readonly TSigner[] {
+    return deduplicateSigners([
+        ...(transaction.feePayerSigner ? [transaction.feePayerSigner] : []),
+        ...transaction.instructions.flatMap(getSignersFromInstruction),
+    ]);
+}

--- a/packages/signers/src/transaction-with-single-sending-signer.ts
+++ b/packages/signers/src/transaction-with-single-sending-signer.ts
@@ -3,12 +3,60 @@ import {
     SOLANA_ERROR__SIGNER__TRANSACTION_SENDING_SIGNER_MISSING,
     SolanaError,
 } from '@solana/errors';
+import { CompilableTransactionMessage } from '@solana/transaction-messages';
 import { CompilableTransaction } from '@solana/transactions';
 
-import { getSignersFromTransaction, ITransactionWithSigners } from './account-signer-meta';
+import {
+    getSignersFromTransaction,
+    getSignersFromTransactionMessage,
+    ITransactionMessageWithSigners,
+    ITransactionWithSigners,
+} from './account-signer-meta';
 import { isTransactionModifyingSigner } from './transaction-modifying-signer';
 import { isTransactionPartialSigner } from './transaction-partial-signer';
 import { isTransactionSendingSigner } from './transaction-sending-signer';
+
+/** Defines a transaction message with exactly one {@link TransactionSendingSigner}. */
+export type ITransactionMessageWithSingleSendingSigner = ITransactionMessageWithSigners & {
+    readonly __transactionWithSingleSendingSigner: unique symbol;
+};
+
+/** Checks whether the provided transaction has exactly one {@link TransactionSendingSigner}. */
+export function isTransactionMessageWithSingleSendingSigner<TTransactionMessage extends CompilableTransactionMessage>(
+    transaction: TTransactionMessage,
+): transaction is ITransactionMessageWithSingleSendingSigner & TTransactionMessage {
+    try {
+        assertIsTransactionMessageWithSingleSendingSigner(transaction);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Asserts that the provided transaction has exactly one {@link TransactionSendingSigner}. */
+export function assertIsTransactionMessageWithSingleSendingSigner<
+    TTransactionMessage extends CompilableTransactionMessage,
+>(
+    transaction: TTransactionMessage,
+): asserts transaction is ITransactionMessageWithSingleSendingSigner & TTransactionMessage {
+    const signers = getSignersFromTransactionMessage(transaction);
+    const sendingSigners = signers.filter(isTransactionSendingSigner);
+
+    if (sendingSigners.length === 0) {
+        throw new SolanaError(SOLANA_ERROR__SIGNER__TRANSACTION_SENDING_SIGNER_MISSING);
+    }
+
+    // When identifying if there are multiple sending signers, we only need to check for
+    // sending signers that do not implement other transaction signer interfaces as
+    // they will be used as these other signer interfaces in case of a conflict.
+    const sendingOnlySigners = sendingSigners.filter(
+        signer => !isTransactionPartialSigner(signer) && !isTransactionModifyingSigner(signer),
+    );
+
+    if (sendingOnlySigners.length > 1) {
+        throw new SolanaError(SOLANA_ERROR__SIGNER__TRANSACTION_CANNOT_HAVE_MULTIPLE_SENDING_SIGNERS);
+    }
+}
 
 /** Defines a transaction with exactly one {@link TransactionSendingSigner}. */
 export type ITransactionWithSingleSendingSigner = ITransactionWithSigners & {
@@ -16,7 +64,7 @@ export type ITransactionWithSingleSendingSigner = ITransactionWithSigners & {
 };
 
 /** Checks whether the provided transaction has exactly one {@link TransactionSendingSigner}. */
-export function isTransactionWithSingleSendingSigner<TTransaction extends CompilableTransaction>(
+export function _isTransactionWithSingleSendingSigner<TTransaction extends CompilableTransaction>(
     transaction: TTransaction,
 ): transaction is ITransactionWithSingleSendingSigner & TTransaction {
     try {


### PR DESCRIPTION
- The existing assert function is used by other code, so the existing version is kept for now
