### PR TITLE
Refactor signers sign-transaction to use transaction messages

### DIFF
--- a/packages/signers/src/__tests__/__setup__.ts
+++ b/packages/signers/src/__tests__/__setup__.ts
@@ -69,19 +69,19 @@ export function createMockMessageModifyingSigner(
 
 export function createMockTransactionPartialSigner(
     address: Address,
-): TransactionPartialSigner & { signTransactions: jest.Mock } {
+): TransactionPartialSigner & { newSignTransactions: jest.Mock; signTransactions: jest.Mock } {
     return { address, newSignTransactions: jest.fn(), signTransactions: jest.fn() };
 }
 
 export function createMockTransactionModifyingSigner(
     address: Address,
-): TransactionModifyingSigner & { modifyAndSignTransactions: jest.Mock } {
+): TransactionModifyingSigner & { modifyAndSignTransactions: jest.Mock; newModifyAndSignTransactions: jest.Mock } {
     return { address, modifyAndSignTransactions: jest.fn(), newModifyAndSignTransactions: jest.fn() };
 }
 
 export function createMockTransactionSendingSigner(
     address: Address,
-): TransactionSendingSigner & { signAndSendTransactions: jest.Mock } {
+): TransactionSendingSigner & { newSignAndSendTransactions: jest.Mock; signAndSendTransactions: jest.Mock } {
     return { address, newSignAndSendTransactions: jest.fn(), signAndSendTransactions: jest.fn() };
 }
 

--- a/packages/transactions/src/__tests__/new-compile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/new-compile-transaction-test.ts
@@ -1,13 +1,19 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
+import {
+    CompiledTransactionMessage,
+    getCompiledTransactionMessageEncoder,
+    newCompileTransactionMessage,
+} from '@solana/transaction-messages';
 
-import { CompiledMessage, compileTransactionMessage } from '../message';
 import { compileTransaction } from '../new-compile-transaction';
-import { getCompiledMessageEncoder } from '../serializers';
 
-jest.mock('../message');
-jest.mock('../serializers/message');
+jest.mock('@solana/transaction-messages', () => ({
+    ...jest.requireActual('@solana/transaction-messages'),
+    getCompiledTransactionMessageEncoder: jest.fn(),
+    newCompileTransactionMessage: jest.fn(),
+}));
 
 type TransactionMessage = Parameters<typeof compileTransaction>[0];
 
@@ -16,14 +22,19 @@ describe('compileTransactionMessage', () => {
     const mockAddressB = '1aaa' as Address;
     const mockCompiledMessage = {
         header: {
+            numReadonlyNonSignerAccounts: 0,
+            numReadonlySignerAccounts: 0,
             numSignerAccounts: 2,
         },
+        instructions: [],
+        lifetimeToken: 'a',
         staticAccounts: [mockAddressA, mockAddressB],
-    } as CompiledMessage;
+        version: 0,
+    } as CompiledTransactionMessage;
     const mockCompiledMessageBytes = new Uint8Array(Array(100)).fill(1);
     beforeEach(() => {
-        (compileTransactionMessage as jest.Mock).mockReturnValue(mockCompiledMessage);
-        (getCompiledMessageEncoder as jest.Mock).mockReturnValue({
+        (newCompileTransactionMessage as jest.Mock).mockReturnValue(mockCompiledMessage);
+        (getCompiledTransactionMessageEncoder as jest.Mock).mockReturnValue({
             encode: jest.fn().mockReturnValue(mockCompiledMessageBytes),
         });
     });

--- a/packages/transactions/src/new-compile-transaction.ts
+++ b/packages/transactions/src/new-compile-transaction.ts
@@ -1,15 +1,17 @@
 import { Address } from '@solana/addresses';
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 import { SignatureBytes } from '@solana/keys';
+import {
+    CompilableTransactionMessage,
+    getCompiledTransactionMessageEncoder,
+    newCompileTransactionMessage,
+} from '@solana/transaction-messages';
 
-import { CompilableTransaction } from './compilable-transaction';
-import { compileTransactionMessage } from './message';
-import { getCompiledMessageEncoder } from './serializers/message';
 import { NewTransaction, OrderedMap, TransactionMessageBytes } from './transaction';
 
-export function compileTransaction(transactionMessage: CompilableTransaction): NewTransaction {
-    const compiledMessage = compileTransactionMessage(transactionMessage);
-    const messageBytes = getCompiledMessageEncoder().encode(
+export function compileTransaction(transactionMessage: CompilableTransactionMessage): NewTransaction {
+    const compiledMessage = newCompileTransactionMessage(transactionMessage);
+    const messageBytes = getCompiledTransactionMessageEncoder().encode(
         compiledMessage,
     ) as ReadonlyUint8Array as TransactionMessageBytes;
 


### PR DESCRIPTION
The signers now all take a `NewTransaction` as input. So these functions take a transaction message (with signers) and compile it to a `NewTransaction` before sending it to the signers.

I think this PR will enable me to remove the old signer functions and clean up/rename things back, but I'll do that in a separate PR to make it easier to review. 