### PR TITLE
refactor(experimental): Use ReadonlyUint8Array on PDA seeds

### DIFF
--- a/packages/addresses/src/program-derived-address.ts
+++ b/packages/addresses/src/program-derived-address.ts
@@ -1,4 +1,5 @@
 import { assertDigestCapabilityIsAvailable } from '@solana/assertions';
+import type { ReadonlyUint8Array } from '@solana/codecs-core';
 import {
     isSolanaError,
     SOLANA_ERROR__ADDRESSES__FAILED_TO_FIND_VIABLE_PDA_BUMP_SEED,
@@ -77,7 +78,7 @@ type SeedInput = Readonly<{
     seed: Seed;
 }>;
 
-type Seed = Uint8Array | string;
+type Seed = ReadonlyUint8Array | string;
 
 const MAX_SEED_LENGTH = 32;
 const MAX_SEEDS = 16;


### PR DESCRIPTION
I'm getting the following error when updating Kinobi with the latest version of the new web3.js:

![CleanShot 2024-04-12 at 11 47 35@2x](https://github.com/solana-labs/solana-web3.js/assets/3642397/62af3648-7b29-4ae6-84c2-62a3041690f7)

This is because we've updated everything to use `ReadonlyUint8Arrays` but not the PDA seeds so there is a type mismatch. This PR fixes this.