### PR TITLE
Export the new transaction codec from transactions

### DIFF
--- a/packages/transactions/src/codecs/index.ts
+++ b/packages/transactions/src/codecs/index.ts
@@ -1,0 +1,1 @@
+export * from './transaction-codec';

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -1,4 +1,5 @@
 export * from './blockhash';
+export * from './codecs';
 export * from './compilable-transaction';
 export * from './create-transaction';
 export * from './durable-nonce';


### PR DESCRIPTION
I forgot to export this codec which is quite important! I haven't exported the message encoder for now because I think that will only be used internally, but the transaction codec is definitely external-facing. 