### PR TITLE
Maintain transaction lifetime on transactions

### DIFF
--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -1,0 +1,81 @@
+import { SignatureBytes } from '@solana/keys';
+import {
+    CompilableTransactionMessage,
+    IDurableNonceTransactionMessage,
+    ITransactionMessageWithBlockhashLifetime,
+} from '@solana/transaction-messages';
+import { FullySignedTransaction, NewTransaction } from '@solana/transactions';
+import {
+    TransactionBlockhashLifetime,
+    TransactionDurableNonceLifetime,
+    TransactionWithLifetime,
+} from '@solana/transactions/dist/types/lifetime';
+
+import { ITransactionMessageWithSigners } from '../account-signer-meta';
+import {
+    partiallySignTransactionMessageWithSigners,
+    signAndSendTransactionMessageWithSigners,
+    signTransactionMessageWithSigners,
+} from '../sign-transaction';
+import { ITransactionMessageWithSingleSendingSigner } from '../transaction-with-single-sending-signer';
+
+type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & ITransactionMessageWithSigners;
+
+{
+    // [partiallySignTransactionMessageWithSigners]: returns a transaction with a blockhash lifetime
+    const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
+        ITransactionMessageWithBlockhashLifetime;
+    partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        NewTransaction & { lifetimeConstraint: TransactionBlockhashLifetime }
+    >;
+}
+
+{
+    // [partiallySignTransactionMessageWithSigners]: returns a transaction with a durable nonce lifetime
+    const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
+        IDurableNonceTransactionMessage;
+    partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        NewTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime }
+    >;
+}
+
+{
+    // [partiallySignTransactionMessageWithSigners]: returns a transaction with an unknown lifetime
+    const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners;
+    partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        NewTransaction & TransactionWithLifetime
+    >;
+}
+
+{
+    // [signTransactionMessageWithSigners]: returns a fully signed transaction with a blockhash lifetime
+    const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
+        ITransactionMessageWithBlockhashLifetime;
+    signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        FullySignedTransaction & { lifetimeConstraint: TransactionBlockhashLifetime }
+    >;
+}
+
+{
+    // [signTransactionMessageWithSigners]: returns a fully signed transaction with a durable nonce lifetime
+    const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
+        IDurableNonceTransactionMessage;
+    signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        FullySignedTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime }
+    >;
+}
+
+{
+    // [signTransactionMessageWithSigners]: returns a fully signed transaction with an unknown lifetime
+    const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners;
+    signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        FullySignedTransaction & TransactionWithLifetime
+    >;
+}
+
+{
+    // [signAndSendTransactionMessageWithSigners]: returns a signature
+    const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
+        ITransactionMessageWithSingleSendingSigner;
+    signAndSendTransactionMessageWithSigners(transactionMessage) satisfies Promise<SignatureBytes>;
+}

--- a/packages/signers/src/transaction-modifying-signer.ts
+++ b/packages/signers/src/transaction-modifying-signer.ts
@@ -9,10 +9,10 @@ export type TransactionModifyingSignerConfig = BaseSignerConfig;
 /** Defines a signer capable of signing transactions. */
 export type TransactionModifyingSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
-    modifyAndSignTransactions(
-        transactions: readonly NewTransaction[],
+    modifyAndSignTransactions<T extends NewTransaction>(
+        transactions: readonly T[],
         config?: TransactionModifyingSignerConfig,
-    ): Promise<readonly NewTransaction[]>;
+    ): Promise<readonly T[]>;
 }>;
 
 /** Checks whether the provided value implements the {@link TransactionModifyingSigner} interface. */

--- a/packages/transactions/src/__typetests__/signatures-typetests.ts
+++ b/packages/transactions/src/__typetests__/signatures-typetests.ts
@@ -1,0 +1,35 @@
+import { Signature } from '@solana/keys';
+
+import {
+    FullySignedTransaction,
+    newAssertTransactionIsFullySigned,
+    newGetSignatureFromTransaction,
+    newPartiallySignTransaction,
+    newSignTransaction,
+} from '..';
+import { NewTransaction } from '../transaction';
+
+// getSignatureFromTransaction
+{
+    const transaction = null as unknown as NewTransaction & { some: 1 };
+    newGetSignatureFromTransaction(transaction) satisfies Signature;
+}
+
+// partiallySignTransaction
+{
+    const transaction = null as unknown as NewTransaction & { some: 1 };
+    newPartiallySignTransaction([], transaction) satisfies Promise<NewTransaction & { some: 1 }>;
+}
+
+// signTransaction
+{
+    const transaction = null as unknown as NewTransaction & { some: 1 };
+    newSignTransaction([], transaction) satisfies Promise<FullySignedTransaction & { some: 1 }>;
+}
+
+// assertTransactionIsFullySigned
+{
+    const transaction = null as unknown as NewTransaction & { some: 1 };
+    newAssertTransactionIsFullySigned(transaction);
+    transaction satisfies FullySignedTransaction & { some: 1 };
+}

--- a/packages/transactions/src/new-signatures.ts
+++ b/packages/transactions/src/new-signatures.ts
@@ -34,10 +34,10 @@ function uint8ArraysEqual(arr1: Uint8Array, arr2: Uint8Array) {
     return arr1.length === arr2.length && arr1.every((value, index) => value === arr2[index]);
 }
 
-export async function newPartiallySignTransaction(
+export async function newPartiallySignTransaction<T extends NewTransaction>(
     keyPairs: CryptoKeyPair[],
-    transaction: NewTransaction,
-): Promise<NewTransaction> {
+    transaction: T,
+): Promise<T> {
     let newSignatures: Record<Address, SignatureBytes> | undefined;
     let unexpectedSigners: Set<Address> | undefined;
 
@@ -92,10 +92,10 @@ export async function newPartiallySignTransaction(
     });
 }
 
-export async function newSignTransaction(
+export async function newSignTransaction<T extends NewTransaction>(
     keyPairs: CryptoKeyPair[],
-    transaction: NewTransaction,
-): Promise<FullySignedTransaction> {
+    transaction: T,
+): Promise<FullySignedTransaction & T> {
     const out = await newPartiallySignTransaction(keyPairs, transaction);
     newAssertTransactionIsFullySigned(out);
     Object.freeze(out);


### PR DESCRIPTION
This PR updates the usages of `NewTransaction` to maintain the transaction lifetime. I should have realised we'd have to extend it!

- The sign functions in the `transactions` package now take a `T extends NewTransaction` and maintain the type T. This means that if you input a transaction with a lifetime, the output transaction will have the same lifetime.

- The signers now return `NewTransaction & TransactionWithLifetime`. I haven't calculated the diff here because they take a transaction message as input and call `compileTransactionMessage`, so their output isn't based on the transaction message input. 