### PR TITLE
add TransactionWithXLifetime types

### DIFF
--- a/packages/library/src/send-transaction-internal.ts
+++ b/packages/library/src/send-transaction-internal.ts
@@ -15,8 +15,8 @@ import {
     newGetBase64EncodedWireTransaction,
 } from '@solana/transactions';
 import {
-    TransactionBlockhashLifetime,
-    TransactionDurableNonceLifetime,
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
 } from '@solana/transactions/dist/types/lifetime';
 
 interface SendAndConfirmDurableNonceTransactionConfig
@@ -28,7 +28,7 @@ interface SendAndConfirmDurableNonceTransactionConfig
             'getNonceInvalidationPromise' | 'getRecentSignatureConfirmationPromise'
         >,
     ) => Promise<void>;
-    transaction: FullySignedTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime };
+    transaction: FullySignedTransaction & TransactionWithDurableNonceLifetime;
 }
 
 interface SendAndConfirmTransactionWithBlockhashLifetimeConfig
@@ -40,7 +40,7 @@ interface SendAndConfirmTransactionWithBlockhashLifetimeConfig
             'getBlockHeightExceedencePromise' | 'getRecentSignatureConfirmationPromise'
         >,
     ) => Promise<void>;
-    transaction: FullySignedTransaction & { lifetimeConstraint: TransactionBlockhashLifetime };
+    transaction: FullySignedTransaction & TransactionWithBlockhashLifetime;
 }
 
 interface SendTransactionBaseConfig extends SendTransactionConfigWithoutEncoding {

--- a/packages/library/src/send-transaction.ts
+++ b/packages/library/src/send-transaction.ts
@@ -14,8 +14,8 @@ import {
 } from '@solana/transaction-confirmation';
 import {
     FullySignedTransaction,
-    TransactionBlockhashLifetime,
-    TransactionDurableNonceLifetime,
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
 } from '@solana/transactions';
 
 import {
@@ -39,7 +39,7 @@ interface SendTransactionWithoutConfirmingFactoryConfig {
 }
 
 type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
-    transaction: FullySignedTransaction & { lifetimeConstraint: TransactionBlockhashLifetime },
+    transaction: FullySignedTransaction & TransactionWithBlockhashLifetime,
     config: Omit<
         Parameters<typeof sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'confirmRecentTransaction' | 'rpc' | 'transaction'
@@ -47,7 +47,7 @@ type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
 ) => Promise<void>;
 
 type SendAndConfirmDurableNonceTransactionFunction = (
-    transaction: FullySignedTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime },
+    transaction: FullySignedTransaction & TransactionWithDurableNonceLifetime,
     config: Omit<
         Parameters<typeof sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'confirmDurableNonceTransaction' | 'rpc' | 'transaction'

--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -6,8 +6,8 @@ import {
 } from '@solana/transaction-messages';
 import { FullySignedTransaction, NewTransaction } from '@solana/transactions';
 import {
-    TransactionBlockhashLifetime,
-    TransactionDurableNonceLifetime,
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
     TransactionWithLifetime,
 } from '@solana/transactions/dist/types/lifetime';
 
@@ -26,7 +26,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
         ITransactionMessageWithBlockhashLifetime;
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        NewTransaction & { lifetimeConstraint: TransactionBlockhashLifetime }
+        Readonly<NewTransaction & TransactionWithBlockhashLifetime>
     >;
 }
 
@@ -35,7 +35,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
         IDurableNonceTransactionMessage;
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        NewTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime }
+        Readonly<NewTransaction & TransactionWithDurableNonceLifetime>
     >;
 }
 
@@ -43,7 +43,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with an unknown lifetime
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners;
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        NewTransaction & TransactionWithLifetime
+        Readonly<NewTransaction & TransactionWithLifetime>
     >;
 }
 
@@ -52,7 +52,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
         ITransactionMessageWithBlockhashLifetime;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        FullySignedTransaction & { lifetimeConstraint: TransactionBlockhashLifetime }
+        Readonly<FullySignedTransaction & TransactionWithBlockhashLifetime>
     >;
 }
 
@@ -61,7 +61,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
         IDurableNonceTransactionMessage;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        FullySignedTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime }
+        Readonly<FullySignedTransaction & TransactionWithDurableNonceLifetime>
     >;
 }
 
@@ -69,7 +69,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
     // [signTransactionMessageWithSigners]: returns a fully signed transaction with an unknown lifetime
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        FullySignedTransaction & TransactionWithLifetime
+        Readonly<FullySignedTransaction & TransactionWithLifetime>
     >;
 }
 

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -12,8 +12,8 @@ import {
     NewTransaction,
 } from '@solana/transactions';
 import {
-    TransactionBlockhashLifetime,
-    TransactionDurableNonceLifetime,
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
     TransactionWithLifetime,
 } from '@solana/transactions/dist/types/lifetime';
 
@@ -39,7 +39,7 @@ export async function partiallySignTransactionMessageWithSigners<
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },
-): Promise<NewTransaction & { lifetimeConstraint: TransactionBlockhashLifetime }>;
+): Promise<NewTransaction & TransactionWithBlockhashLifetime>;
 
 export async function partiallySignTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners &
@@ -47,21 +47,21 @@ export async function partiallySignTransactionMessageWithSigners<
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },
-): Promise<NewTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime }>;
+): Promise<Readonly<NewTransaction & TransactionWithDurableNonceLifetime>>;
 
 export async function partiallySignTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners = CompilableTransactionMessageWithSigners,
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },
-): Promise<NewTransaction & TransactionWithLifetime>;
+): Promise<Readonly<NewTransaction & TransactionWithLifetime>>;
 
 export async function partiallySignTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners = CompilableTransactionMessageWithSigners,
 >(
     transactionMessage: TTransactionMessage,
     config: { abortSignal?: AbortSignal } = {},
-): Promise<NewTransaction & TransactionWithLifetime> {
+): Promise<Readonly<NewTransaction & TransactionWithLifetime>> {
     const { partialSigners, modifyingSigners } = categorizeTransactionSigners(
         deduplicateSigners(getSignersFromTransactionMessage(transactionMessage).filter(isTransactionSigner)),
         { identifySendingSigner: false },
@@ -88,7 +88,7 @@ export async function signTransactionMessageWithSigners<
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },
-): Promise<FullySignedTransaction & { lifetimeConstraint: TransactionBlockhashLifetime }>;
+): Promise<Readonly<FullySignedTransaction & TransactionWithBlockhashLifetime>>;
 
 export async function signTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners &
@@ -96,21 +96,21 @@ export async function signTransactionMessageWithSigners<
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },
-): Promise<FullySignedTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime }>;
+): Promise<Readonly<FullySignedTransaction & TransactionWithDurableNonceLifetime>>;
 
 export async function signTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners = CompilableTransactionMessageWithSigners,
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },
-): Promise<FullySignedTransaction & TransactionWithLifetime>;
+): Promise<Readonly<FullySignedTransaction & TransactionWithLifetime>>;
 
 export async function signTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners = CompilableTransactionMessageWithSigners,
 >(
     transactionMessage: TTransactionMessage,
     config: { abortSignal?: AbortSignal } = {},
-): Promise<FullySignedTransaction & TransactionWithLifetime> {
+): Promise<Readonly<FullySignedTransaction & TransactionWithLifetime>> {
     const signedTransaction = await partiallySignTransactionMessageWithSigners(transactionMessage, config);
     newAssertTransactionIsFullySigned(signedTransaction);
     return signedTransaction;
@@ -235,7 +235,7 @@ async function signModifyingAndPartialTransactionSigners<
     modifyingSigners: readonly TransactionModifyingSigner[] = [],
     partialSigners: readonly TransactionPartialSigner[] = [],
     abortSignal?: AbortSignal,
-): Promise<NewTransaction & TransactionWithLifetime> {
+): Promise<Readonly<NewTransaction & TransactionWithLifetime>> {
     // serialize the transaction
     const transaction = compileTransaction(transactionMessage);
 
@@ -246,7 +246,7 @@ async function signModifyingAndPartialTransactionSigners<
             const [tx] = await modifyingSigner.modifyAndSignTransactions([await transaction], { abortSignal });
             return Object.freeze(tx);
         },
-        Promise.resolve(transaction) as Promise<NewTransaction & TransactionWithLifetime>,
+        Promise.resolve(transaction) as Promise<Readonly<NewTransaction & TransactionWithLifetime>>,
     );
 
     // Handle partial signers in parallel.
@@ -257,7 +257,7 @@ async function signModifyingAndPartialTransactionSigners<
             return signatures;
         }),
     );
-    const signedTransaction: NewTransaction & TransactionWithLifetime = {
+    const signedTransaction: Readonly<NewTransaction & TransactionWithLifetime> = {
         ...modifiedTransaction,
         signatures: Object.freeze(
             signatureDictionaries.reduce((signatures, signatureDictionary) => {

--- a/packages/transaction-confirmation/src/__tests__/waiters-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/waiters-test.ts
@@ -5,8 +5,8 @@ import type { Blockhash } from '@solana/rpc-types';
 import { NewNonce } from '@solana/transaction-messages';
 import { NewTransaction, TransactionMessageBytes } from '@solana/transactions';
 import {
-    TransactionBlockhashLifetime,
-    TransactionDurableNonceLifetime,
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
 } from '@solana/transactions/dist/types/lifetime';
 
 import { ReadonlyUint8Array } from '../../../codecs-core/dist/types';
@@ -21,7 +21,7 @@ const FOREVER_PROMISE = new Promise(() => {
 });
 
 describe('waitForDurableNonceTransactionConfirmation', () => {
-    const MOCK_DURABLE_NONCE_TRANSACTION: NewTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime } = {
+    const MOCK_DURABLE_NONCE_TRANSACTION: NewTransaction & TransactionWithDurableNonceLifetime = {
         lifetimeConstraint: { nonce: 'xyz' as NewNonce, nonceAccountAddress: '5'.repeat(44) as Address },
         messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
         signatures: {
@@ -170,7 +170,7 @@ describe('waitForDurableNonceTransactionConfirmation', () => {
 });
 
 describe('waitForRecentTransactionConfirmation', () => {
-    const MOCK_TRANSACTION: NewTransaction & { lifetimeConstraint: TransactionBlockhashLifetime } = {
+    const MOCK_TRANSACTION: NewTransaction & TransactionWithBlockhashLifetime = {
         lifetimeConstraint: { blockhash: '4'.repeat(44) as Blockhash, lastValidBlockHeight: 123n },
         messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
         signatures: {

--- a/packages/transaction-confirmation/src/waiters.ts
+++ b/packages/transaction-confirmation/src/waiters.ts
@@ -1,8 +1,8 @@
 import { Signature } from '@solana/keys';
 import { newGetSignatureFromTransaction, NewTransaction } from '@solana/transactions';
 import {
-    TransactionBlockhashLifetime,
-    TransactionDurableNonceLifetime,
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
 } from '@solana/transactions/dist/types/lifetime';
 
 import { createBlockHeightExceedencePromiseFactory } from './confirmation-strategy-blockheight';
@@ -12,13 +12,13 @@ import { getTimeoutPromise } from './confirmation-strategy-timeout';
 
 interface WaitForDurableNonceTransactionConfirmationConfig extends BaseTransactionConfirmationStrategyConfig {
     getNonceInvalidationPromise: ReturnType<typeof createNonceInvalidationPromiseFactory>;
-    transaction: NewTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime };
+    transaction: Readonly<NewTransaction & TransactionWithDurableNonceLifetime>;
 }
 
 interface WaitForRecentTransactionWithBlockhashLifetimeConfirmationConfig
     extends BaseTransactionConfirmationStrategyConfig {
     getBlockHeightExceedencePromise: ReturnType<typeof createBlockHeightExceedencePromiseFactory>;
-    transaction: NewTransaction & { lifetimeConstraint: TransactionBlockhashLifetime };
+    transaction: Readonly<NewTransaction & TransactionWithBlockhashLifetime>;
 }
 
 interface WaitForRecentTransactionWithTimeBasedLifetimeConfirmationConfig

--- a/packages/transactions/src/__typetests__/compile-transaction-typetests.ts
+++ b/packages/transactions/src/__typetests__/compile-transaction-typetests.ts
@@ -8,7 +8,13 @@ import {
     NewNonce,
 } from '@solana/transaction-messages';
 
-import { TransactionBlockhashLifetime, TransactionDurableNonceLifetime, TransactionWithLifetime } from '../lifetime';
+import {
+    TransactionBlockhashLifetime,
+    TransactionDurableNonceLifetime,
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
+    TransactionWithLifetime,
+} from '../lifetime';
 import { compileTransaction } from '../new-compile-transaction';
 import { NewTransaction } from '../transaction';
 
@@ -17,12 +23,12 @@ compileTransaction(
     null as unknown as BaseTransactionMessage &
         ITransactionMessageWithBlockhashLifetime &
         ITransactionMessageWithFeePayer,
-) satisfies NewTransaction & TransactionWithLifetime;
+) satisfies Readonly<NewTransaction & TransactionWithLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage &
         ITransactionMessageWithBlockhashLifetime &
         ITransactionMessageWithFeePayer,
-) satisfies NewTransaction & { lifetimeConstraint: TransactionBlockhashLifetime };
+) satisfies Readonly<NewTransaction & TransactionWithBlockhashLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage &
         ITransactionMessageWithBlockhashLifetime &
@@ -32,22 +38,26 @@ compileTransaction(
 // transaction message with durable nonce lifetime
 compileTransaction(
     null as unknown as BaseTransactionMessage & IDurableNonceTransactionMessage & ITransactionMessageWithFeePayer,
-) satisfies NewTransaction & TransactionWithLifetime;
+) satisfies Readonly<NewTransaction & TransactionWithLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage & IDurableNonceTransactionMessage & ITransactionMessageWithFeePayer,
-) satisfies NewTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime };
+) satisfies Readonly<NewTransaction & TransactionWithDurableNonceLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage & IDurableNonceTransactionMessage & ITransactionMessageWithFeePayer,
 ).lifetimeConstraint.nonce satisfies NewNonce;
 
 // transaction message with unknown lifetime
-compileTransaction(null as unknown as CompilableTransactionMessage) satisfies NewTransaction & TransactionWithLifetime;
+compileTransaction(null as unknown as CompilableTransactionMessage) satisfies Readonly<
+    NewTransaction & TransactionWithLifetime
+>;
 // @ts-expect-error not known to have blockhash lifetime
-compileTransaction(null as unknown as CompilableTransactionMessage) satisfies NewTransaction &
-    TransactionBlockhashLifetime;
+compileTransaction(null as unknown as CompilableTransactionMessage) satisfies Readonly<
+    NewTransaction & TransactionBlockhashLifetime
+>;
 // @ts-expect-error not known to have durable nonce lifetime
-compileTransaction(null as unknown as CompilableTransactionMessage) satisfies NewTransaction &
-    TransactionDurableNonceLifetime;
+compileTransaction(null as unknown as CompilableTransactionMessage) satisfies Readonly<
+    NewTransaction & TransactionDurableNonceLifetime
+>;
 compileTransaction(null as unknown as CompilableTransactionMessage).lifetimeConstraint satisfies
     | { blockhash: Blockhash }
     | { nonce: NewNonce };

--- a/packages/transactions/src/lifetime.ts
+++ b/packages/transactions/src/lifetime.ts
@@ -16,6 +16,14 @@ export type TransactionWithLifetime = {
     readonly lifetimeConstraint: TransactionBlockhashLifetime | TransactionDurableNonceLifetime;
 };
 
+export type TransactionWithBlockhashLifetime = {
+    readonly lifetimeConstraint: TransactionBlockhashLifetime;
+};
+
+export type TransactionWithDurableNonceLifetime = {
+    readonly lifetimeConstraint: TransactionDurableNonceLifetime;
+};
+
 export function isTransactionBlockhashLifetime(
     lifetime: TransactionWithLifetime['lifetimeConstraint'],
 ): lifetime is TransactionBlockhashLifetime {

--- a/packages/transactions/src/new-compile-transaction.ts
+++ b/packages/transactions/src/new-compile-transaction.ts
@@ -10,24 +10,28 @@ import {
     newCompileTransactionMessage,
 } from '@solana/transaction-messages';
 
-import { TransactionBlockhashLifetime, TransactionDurableNonceLifetime, TransactionWithLifetime } from './lifetime';
+import {
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
+    TransactionWithLifetime,
+} from './lifetime';
 import { NewTransaction, OrderedMap, TransactionMessageBytes } from './transaction';
 
 export function compileTransaction(
     transactionMessage: CompilableTransactionMessage & ITransactionMessageWithBlockhashLifetime,
-): NewTransaction & { lifetimeConstraint: TransactionBlockhashLifetime };
+): Readonly<NewTransaction & TransactionWithBlockhashLifetime>;
 
 export function compileTransaction(
     transactionMessage: CompilableTransactionMessage & IDurableNonceTransactionMessage,
-): NewTransaction & { lifetimeConstraint: TransactionDurableNonceLifetime };
+): Readonly<NewTransaction & TransactionWithDurableNonceLifetime>;
 
 export function compileTransaction(
     transactionMessage: CompilableTransactionMessage,
-): NewTransaction & TransactionWithLifetime;
+): Readonly<NewTransaction & TransactionWithLifetime>;
 
 export function compileTransaction(
     transactionMessage: CompilableTransactionMessage,
-): NewTransaction & TransactionWithLifetime {
+): Readonly<NewTransaction & TransactionWithLifetime> {
     const compiledMessage = newCompileTransactionMessage(transactionMessage);
     const messageBytes = getCompiledTransactionMessageEncoder().encode(
         compiledMessage,


### PR DESCRIPTION
I was repeating `NewTransaction & { lifetimeConstraint: X }` way too often

This PR adds helper types so we can include the lifetime constraints in types easier. 