### PR TITLE
Refactor send-transaction to use NewTransaction

### DIFF
--- a/packages/library/src/__tests__/send-transaction-internal-test.ts
+++ b/packages/library/src/__tests__/send-transaction-internal-test.ts
@@ -5,8 +5,8 @@ import {
     Base64EncodedWireTransaction,
     FullySignedTransaction,
     newGetBase64EncodedWireTransaction,
-    TransactionBlockhashLifetime,
-    TransactionDurableNonceLifetime,
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
 } from '@solana/transactions';
 
 import {
@@ -21,9 +21,7 @@ const FOREVER_PROMISE = new Promise(() => {
 });
 
 describe('sendAndConfirmTransaction', () => {
-    const MOCK_TRANSACTION = {} as unknown as FullySignedTransaction & {
-        lifetimeConstraint: TransactionBlockhashLifetime;
-    };
+    const MOCK_TRANSACTION = {} as FullySignedTransaction & TransactionWithBlockhashLifetime;
     let confirmRecentTransaction: jest.Mock;
     let createPendingRequest: jest.Mock;
     let rpc: Rpc<SendTransactionApi>;
@@ -177,9 +175,8 @@ describe('sendAndConfirmTransaction', () => {
 });
 
 describe('sendAndConfirmDurableNonceTransaction', () => {
-    const MOCK_DURABLE_NONCE_TRANSACTION = {} as unknown as FullySignedTransaction & {
-        lifetimeConstraint: TransactionDurableNonceLifetime;
-    };
+    const MOCK_DURABLE_NONCE_TRANSACTION = {} as unknown as FullySignedTransaction &
+        TransactionWithDurableNonceLifetime;
     let confirmDurableNonceTransaction: jest.Mock;
     let createPendingRequest: jest.Mock;
     let rpc: Rpc<SendTransactionApi>;

--- a/packages/library/src/send-transaction-internal.ts
+++ b/packages/library/src/send-transaction-internal.ts
@@ -6,18 +6,11 @@ import {
     waitForRecentTransactionConfirmation,
 } from '@solana/transaction-confirmation';
 import {
-    BaseTransaction,
     FullySignedTransaction,
-    IDurableNonceTransaction,
-    IFullySignedTransaction,
-    ITransactionWithBlockhashLifetime,
-    ITransactionWithFeePayer,
     newGetBase64EncodedWireTransaction,
-} from '@solana/transactions';
-import {
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
-} from '@solana/transactions/dist/types/lifetime';
+} from '@solana/transactions';
 
 interface SendAndConfirmDurableNonceTransactionConfig
     extends SendTransactionBaseConfig,
@@ -52,11 +45,6 @@ interface SendTransactionBaseConfig extends SendTransactionConfigWithoutEncoding
 
 interface SendTransactionConfigWithoutEncoding
     extends Omit<NonNullable<Parameters<SendTransactionApi['sendTransaction']>[1]>, 'encoding'> {}
-
-export type SendableTransaction = BaseTransaction &
-    IFullySignedTransaction &
-    ITransactionWithFeePayer &
-    (IDurableNonceTransaction | ITransactionWithBlockhashLifetime);
 
 function getSendTransactionConfigWithAdjustedPreflightCommitment(
     commitment: Commitment,


### PR DESCRIPTION
This PR replaces the helpers for sending transactions to send `NewTransaction` objects, and to use the lifetime helpers.

We replace `SendableTransaction` with `FullySignedTransaction`, and mix in the lifetime constraints when required. 