### PR TITLE
refactor(experimental): add isProgramError helper function

### DIFF
--- a/.changeset/lovely-mice-promise.md
+++ b/.changeset/lovely-mice-promise.md
@@ -1,0 +1,5 @@
+---
+"@solana/programs": patch
+---
+
+Add `isProgramError` helper function to `@solana/programs`

--- a/packages/programs/README.md
+++ b/packages/programs/README.md
@@ -56,6 +56,29 @@ const myProgram: Program<'1234..5678'> & ProgramWithErrors<MyProgramErrorCode, M
 
 ## Functions
 
+### `isProgramError()`
+
+This function takes any error — typically caused by a transaction failure — and identifies whether it is a custom program error from the provided program address. It takes the following parameters:
+
+-   The `error` to identify.
+-   The `transactionMessage` object that failed to execute. Since the RPC response only provide the index of the failed instruction, we need the transaction message to access its program address.
+-   The `programAddress` of the program from which the error is expected.
+-   Optionally, the expected error `code` of the custom program error. When provided, the function will also check that the custom program error code matches the given value.
+
+```ts
+try {
+    // Send and confirm your transaction.
+} catch (error) {
+    if (isProgramError(error, transactionMessage, myProgramAddress, 42)) {
+        // Handle custom program error 42 from this program.
+    } else if (isProgramError(error, transactionMessage, myProgramAddress)) {
+        // Handle all other custom program errors from this program.
+    } else {
+        throw error;
+    }
+}
+```
+
 ### `resolveTransactionError()`
 
 This function takes a raw error caused by a transaction failure and attempts to resolve it into a custom program error.

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -64,8 +64,10 @@
     ],
     "devDependencies": {
         "@solana/addresses": "workspace:*",
+        "@solana/errors": "workspace:*",
         "@solana/functional": "workspace:*",
-        "@solana/transactions": "workspace:*"
+        "@solana/transactions": "workspace:*",
+        "@solana/transaction-messages": "workspace:*"
     },
     "bundlewatch": {
         "defaultCompression": "gzip",

--- a/packages/programs/src/__tests__/program-error-test.ts
+++ b/packages/programs/src/__tests__/program-error-test.ts
@@ -1,0 +1,103 @@
+import { Address } from '@solana/addresses';
+import { SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, SolanaError } from '@solana/errors';
+import { pipe } from '@solana/functional';
+import { appendTransactionMessageInstruction, createTransactionMessage } from '@solana/transaction-messages';
+
+import { isProgramError } from '../program-error';
+
+describe('isProgramError', () => {
+    it('identifies an error as a custom program error', () => {
+        // Given a transaction message with a single instruction.
+        const programAddress = '1111' as Address;
+        const tx = pipe(createTransactionMessage({ version: 0 }), tx =>
+            appendTransactionMessageInstruction({ programAddress }, tx),
+        );
+
+        // And a custom program error on the instruction.
+        const error = new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, {
+            code: 42,
+            index: 0,
+        });
+
+        // Then we expect the error to be identified as a program error.
+        expect(isProgramError(error, tx, programAddress)).toBe(true);
+    });
+
+    it('matches the provided custom program error code', () => {
+        // Given a transaction message with a single instruction.
+        const programAddress = '1111' as Address;
+        const tx = pipe(createTransactionMessage({ version: 0 }), tx =>
+            appendTransactionMessageInstruction({ programAddress }, tx),
+        );
+
+        // And a custom program error with code 42.
+        const error = new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, {
+            code: 42,
+            index: 0,
+        });
+
+        // When we specify the custom program error code 42.
+        const result = isProgramError(error, tx, programAddress, 42);
+
+        // Then we expect the result to be true.
+        expect(result).toBe(true);
+    });
+
+    it('returns false if the program address does not match', () => {
+        // Given a transaction message with a program A instruction.
+        const programA = '1111' as Address;
+        const tx = pipe(createTransactionMessage({ version: 0 }), tx =>
+            appendTransactionMessageInstruction({ programAddress: programA }, tx),
+        );
+
+        // And a custom program error on the instruction.
+        const error = new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, {
+            code: 42,
+            index: 0,
+        });
+
+        // When we try to identify the error as a program error for program B.
+        const programB = '2222' as Address;
+        const result = isProgramError(error, tx, programB);
+
+        // Then we expect the result to be false.
+        expect(result).toBe(false);
+    });
+
+    it('returns false if the instruction is missing', () => {
+        // Given a transaction message with a single instruction.
+        const programAddress = '1111' as Address;
+        const tx = pipe(createTransactionMessage({ version: 0 }), tx =>
+            appendTransactionMessageInstruction({ programAddress }, tx),
+        );
+
+        // And a custom program error pointing to a missing instruction.
+        const error = new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, {
+            code: 42,
+            index: 999,
+        });
+
+        // Then we expect the error not to be identified as a program error.
+        expect(isProgramError(error, tx, programAddress)).toBe(false);
+    });
+
+    it('returns false if the custom program error code does not match', () => {
+        // Given a transaction message with a single instruction.
+        const programAddress = '1111' as Address;
+        const tx = pipe(createTransactionMessage({ version: 0 }), tx =>
+            appendTransactionMessageInstruction({ programAddress }, tx),
+        );
+
+        // And a custom program error on the instruction with code 42.
+        const error = new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, {
+            code: 42,
+            index: 0,
+        });
+
+        // When we try to identify the error as a program error with code 43.
+        const result = isProgramError(error, tx, programAddress, 43);
+
+        // Then we expect the result to be false.
+        expect(result).toBe(false);
+    });
+});

--- a/packages/programs/src/__typetests__/program-error-typetest.ts
+++ b/packages/programs/src/__typetests__/program-error-typetest.ts
@@ -1,0 +1,32 @@
+import { Address } from '@solana/addresses';
+import { SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, SolanaError } from '@solana/errors';
+import { createTransactionMessage, TransactionMessage } from '@solana/transaction-messages';
+
+import { isProgramError } from '../program-error';
+
+const tx = {} as TransactionMessage;
+const programAddress = '1111' as Address;
+
+{
+    // [isProgramError]: It accepts a new TransactionMessage as a second argument.
+    const transactionMessage = createTransactionMessage({ version: 0 });
+    isProgramError(null, transactionMessage, programAddress);
+}
+
+{
+    // [isProgramError]: It narrow down the error type.
+    const error = {} as Error;
+    if (isProgramError(error, tx, programAddress)) {
+        error satisfies SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM>;
+    }
+}
+
+{
+    // [isProgramError]: It narrow down the error type and its custom program error code.
+    const error = {} as Error;
+    if (isProgramError(error, tx, programAddress, 42)) {
+        error satisfies SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & { context: { code: 42 } };
+        // @ts-expect-error Expected error to have code 42
+        error satisfies SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & { context: { code: 43 } };
+    }
+}

--- a/packages/programs/src/index.ts
+++ b/packages/programs/src/index.ts
@@ -1,2 +1,3 @@
 export * from './program';
+export * from './program-error';
 export * from './resolve-transaction-error';

--- a/packages/programs/src/program-error.ts
+++ b/packages/programs/src/program-error.ts
@@ -1,0 +1,18 @@
+import { Address } from '@solana/addresses';
+import { isSolanaError, SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, SolanaError } from '@solana/errors';
+
+export function isProgramError<TProgramErrorCode extends number>(
+    error: unknown,
+    transactionMessage: { instructions: Record<number, { programAddress: Address }> },
+    programAddress: Address,
+    code?: TProgramErrorCode,
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & { context: { code: TProgramErrorCode } } {
+    if (!isSolanaError(error, SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM)) {
+        return false;
+    }
+    const instructionProgramAddress = transactionMessage.instructions[error.context.index]?.programAddress;
+    if (!instructionProgramAddress || instructionProgramAddress !== programAddress) {
+        return false;
+    }
+    return typeof code === 'undefined' || error.context.code === code;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,9 +579,15 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/errors':
+        specifier: workspace:*
+        version: link:../errors
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional
+      '@solana/transaction-messages':
+        specifier: workspace:*
+        version: link:../transaction-messages
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions


### PR DESCRIPTION
This PR adds a new `isProgramError` helper function that checks whether any given error is a custom program error from a given program.

This PR — and recent changes to client generation to stay consistent with the new `@solana/errors` system — makes the rest of the `@solana/programs` package unnecessary (and subsequent PRs will remove the rest).

Now Kinobi generates the following constants for a given program:

```ts
export const MPL_TOKEN_AUTH_RULES_PROGRAM_ADDRESS =
  'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg' as Address<'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg'>;

/** NumericalOverflow: Numerical Overflow */
export const MPL_TOKEN_AUTH_RULES_ERROR__NUMERICAL_OVERFLOW = 0x0; // 0
/** DataTypeMismatch: Data type mismatch */
export const MPL_TOKEN_AUTH_RULES_ERROR__DATA_TYPE_MISMATCH = 0x1; // 1
/** IncorrectOwner: Incorrect account owner */
export const MPL_TOKEN_AUTH_RULES_ERROR__INCORRECT_OWNER = 0x2; // 2
/** PayloadVecIndexError: Could not index into PayloadVec */
export const MPL_TOKEN_AUTH_RULES_ERROR__PAYLOAD_VEC_INDEX_ERROR = 0x3; // 3
/** DerivedKeyInvalid: Derived key invalid */
export const MPL_TOKEN_AUTH_RULES_ERROR__DERIVED_KEY_INVALID = 0x4; // 4
/** AdditionalSignerCheckFailed: Additional Signer check failed */
export const MPL_TOKEN_AUTH_RULES_ERROR__ADDITIONAL_SIGNER_CHECK_FAILED = 0x5; // 5
// ...

export type MplTokenAuthRulesError =
  | typeof MPL_TOKEN_AUTH_RULES_ERROR__ADDITIONAL_SIGNER_CHECK_FAILED
  | typeof MPL_TOKEN_AUTH_RULES_ERROR__AMOUNT_CHECK_FAILED
  | typeof MPL_TOKEN_AUTH_RULES_ERROR__BORSH_SERIALIZATION_ERROR
  | typeof MPL_TOKEN_AUTH_RULES_ERROR__DATA_TYPE_MISMATCH
  | typeof MPL_TOKEN_AUTH_RULES_ERROR__DERIVED_KEY_INVALID
  | typeof MPL_TOKEN_AUTH_RULES_ERROR__DERIVED_KEY_MATCH_CHECK_FAILED
  | ...;
```

Meaning this `isProgramError` helper can be used as follows:

```ts
const tx = pipe(
  createTransactionMessage({ version: 0 }),
  tx => appendTransactionMessageInstruction(
    getSomeGeneratedInstruction({ ... }),
    tx
  )
);

try {
  // Compile, sign and send transaction.
} catch (e) {
  if (isProgramError(e, tx, MPL_TOKEN_AUTH_RULES_PROGRAM_ADDRESS, MPL_TOKEN_AUTH_RULES_ERROR__DERIVED_KEY_INVALID)) {
    // Handle specific errors.
  } else if (isProgramError(e, tx, MPL_TOKEN_AUTH_RULES_PROGRAM_ADDRESS)) {
    // Handle any other custom program errors from that program.
  } else {
    throw e;
  }
}
```

Side note: we could consider generating functions such as `isMplTokenAuthRulesProgramError()` — that would simply delegate to `isProgramError` with the right program address — if we think that would be useful.