### PR TITLE
Replace uses of SerializedMessageBytesBase64 and TransactionVersion

### DIFF
--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -72,6 +72,7 @@
         "@solana/rpc-parsed-types": "workspace:*",
         "@solana/rpc-transformers": "workspace:*",
         "@solana/rpc-types": "workspace:*",
+        "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
     "devDependencies": {

--- a/packages/rpc-api/src/__tests__/get-fee-for-message-test.ts
+++ b/packages/rpc-api/src/__tests__/get-fee-for-message-test.ts
@@ -7,7 +7,7 @@ import {
 } from '@solana/errors';
 import type { Rpc } from '@solana/rpc-spec';
 import type { Blockhash, Commitment } from '@solana/rpc-types';
-import type { SerializedMessageBytesBase64 } from '@solana/transactions';
+import type { TransactionMessageBytesBase64 } from '@solana/transactions';
 
 import { GetFeeForMessageApi, GetLatestBlockhashApi } from '../index';
 import { createLocalhostSolanaRpc } from './__setup__';
@@ -56,7 +56,7 @@ function getMockTransactionMessage(blockhash: Blockhash) {
         /** ADDRESS TABLE LOOKUPS */
         0x00, // Number of address table lookups
     ]);
-    return getBase64Decoder().decode(message) as SerializedMessageBytesBase64;
+    return getBase64Decoder().decode(message) as TransactionMessageBytesBase64;
 }
 
 describe('getFeeForMessage', () => {
@@ -111,7 +111,7 @@ describe('getFeeForMessage', () => {
     describe('when called with an invalid message', () => {
         it('throws an error', async () => {
             expect.assertions(1);
-            const sendPromise = rpc.getFeeForMessage('someInvalidMessage' as SerializedMessageBytesBase64).send();
+            const sendPromise = rpc.getFeeForMessage('someInvalidMessage' as TransactionMessageBytesBase64).send();
             await expect(sendPromise).rejects.toThrow(
                 new SolanaError(SOLANA_ERROR__JSON_RPC__INVALID_PARAMS, {
                     __serverMessage: 'invalid base64 encoding: InvalidPadding',

--- a/packages/rpc-api/src/__typetests__/get-block-type-test.ts
+++ b/packages/rpc-api/src/__typetests__/get-block-type-test.ts
@@ -12,7 +12,7 @@ import type {
     TransactionStatus,
     U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-types';
-import { TransactionVersion } from '@solana/transactions';
+import { NewTransactionVersion } from '@solana/transaction-messages';
 
 import { GetBlockApi } from '../getBlock';
 
@@ -292,7 +292,7 @@ async () => {
             }>[];
             signatures: readonly Base58EncodedBytes[];
         };
-        version: TransactionVersion;
+        version: NewTransactionVersion;
     };
 
     // Fifth overload
@@ -543,7 +543,7 @@ async () => {
                   }>)
             | null;
         transaction: Base58EncodedDataResponse;
-        version: TransactionVersion;
+        version: NewTransactionVersion;
     };
 
     // Ninth overload
@@ -767,7 +767,7 @@ async () => {
                   }>)
             | null;
         transaction: Base64EncodedDataResponse;
-        version: TransactionVersion;
+        version: NewTransactionVersion;
     };
 
     // Thirteenth overload
@@ -991,7 +991,7 @@ async () => {
                 }>[];
             }>;
         };
-        version: TransactionVersion;
+        version: NewTransactionVersion;
     };
 
     // Seventeenth overload
@@ -1139,7 +1139,7 @@ async () => {
     type ExpectedTransactionForFullJsonVersioned = {
         meta: (ExpectedMetaForFullJsonBase & ExpectedMetaForFullJsonLoadedAddresses) | null;
         transaction: ExpectedTransactionForFullJsonBase;
-        version: TransactionVersion;
+        version: NewTransactionVersion;
     };
 
     // Twenty-first overload

--- a/packages/rpc-api/src/getBlock.ts
+++ b/packages/rpc-api/src/getBlock.ts
@@ -13,7 +13,7 @@ import type {
     U64UnsafeBeyond2Pow53Minus1,
     UnixTimestamp,
 } from '@solana/rpc-types';
-import type { TransactionVersion } from '@solana/transactions';
+import type { NewTransactionVersion } from '@solana/transaction-messages';
 
 // API response types
 
@@ -60,7 +60,7 @@ type GetBlockEncoding = 'base58' | 'base64' | 'json' | 'jsonParsed';
 // This will error if the block contains any transactions with a version greater than "legacy" (code -32015).
 // - Also, If `maxSupportedTransactionVersion` is not provided, the `version` field of each transaction is omitted.
 // - These rules apply to both "accounts" and "full" transaction details.
-type GetBlockMaxSupportedTransactionVersion = Exclude<TransactionVersion, 'legacy'>;
+type GetBlockMaxSupportedTransactionVersion = Exclude<NewTransactionVersion, 'legacy'>;
 
 export interface GetBlockApi extends RpcApiMethods {
     /**

--- a/packages/rpc-api/src/getFeeForMessage.ts
+++ b/packages/rpc-api/src/getFeeForMessage.ts
@@ -1,6 +1,6 @@
 import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot, SolanaRpcResponse, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
-import type { SerializedMessageBytesBase64 } from '@solana/transactions';
+import type { TransactionMessageBytesBase64 } from '@solana/transactions';
 
 /** Fee corresponding to the message at the specified blockhash */
 type GetFeeForMessageApiResponse = SolanaRpcResponse<U64UnsafeBeyond2Pow53Minus1 | null>;
@@ -10,7 +10,7 @@ export interface GetFeeForMessageApi extends RpcApiMethods {
      * Returns the fee the network will charge for a particular Message
      */
     getFeeForMessage(
-        message: SerializedMessageBytesBase64,
+        message: TransactionMessageBytesBase64,
         config?: Readonly<{
             commitment?: Commitment;
             minContextSlot?: Slot;

--- a/packages/rpc-api/src/getTransaction.ts
+++ b/packages/rpc-api/src/getTransaction.ts
@@ -16,7 +16,7 @@ import type {
     U64UnsafeBeyond2Pow53Minus1,
     UnixTimestamp,
 } from '@solana/rpc-types';
-import type { TransactionVersion } from '@solana/transactions';
+import type { NewTransactionVersion } from '@solana/transaction-messages';
 
 type ReturnData = {
     /** the return data itself */
@@ -162,7 +162,7 @@ export interface GetTransactionApi extends RpcApiMethods {
     /**
      * Returns transaction details for a confirmed transaction
      */
-    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | void = void>(
+    getTransaction<TMaxSupportedTransactionVersion extends NewTransactionVersion | void = void>(
         signature: Signature,
         config: GetTransactionCommonConfig<TMaxSupportedTransactionVersion> &
             Readonly<{
@@ -172,7 +172,7 @@ export interface GetTransactionApi extends RpcApiMethods {
         | (GetTransactionApiResponseBase &
               (TMaxSupportedTransactionVersion extends void
                   ? Record<string, never>
-                  : { version: TransactionVersion }) & {
+                  : { version: NewTransactionVersion }) & {
                   meta: (TransactionMetaBase & TransactionMetaInnerInstructionsParsed) | null;
                   transaction: TransactionJsonParsed &
                       (TMaxSupportedTransactionVersion extends void
@@ -180,7 +180,7 @@ export interface GetTransactionApi extends RpcApiMethods {
                           : TransactionAddressTableLookups);
               })
         | null;
-    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | void = void>(
+    getTransaction<TMaxSupportedTransactionVersion extends NewTransactionVersion | void = void>(
         signature: Signature,
         config: GetTransactionCommonConfig<TMaxSupportedTransactionVersion> &
             Readonly<{
@@ -190,7 +190,7 @@ export interface GetTransactionApi extends RpcApiMethods {
         | (GetTransactionApiResponseBase &
               (TMaxSupportedTransactionVersion extends void
                   ? Record<string, never>
-                  : { version: TransactionVersion }) & {
+                  : { version: NewTransactionVersion }) & {
                   meta:
                       | (TransactionMetaBase &
                             TransactionMetaInnerInstructionsNotParsed &
@@ -201,7 +201,7 @@ export interface GetTransactionApi extends RpcApiMethods {
                   transaction: Base64EncodedDataResponse;
               })
         | null;
-    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | void = void>(
+    getTransaction<TMaxSupportedTransactionVersion extends NewTransactionVersion | void = void>(
         signature: Signature,
         config: GetTransactionCommonConfig<TMaxSupportedTransactionVersion> &
             Readonly<{
@@ -211,7 +211,7 @@ export interface GetTransactionApi extends RpcApiMethods {
         | (GetTransactionApiResponseBase &
               (TMaxSupportedTransactionVersion extends void
                   ? Record<string, never>
-                  : { version: TransactionVersion }) & {
+                  : { version: NewTransactionVersion }) & {
                   meta:
                       | (TransactionMetaBase &
                             TransactionMetaInnerInstructionsNotParsed &
@@ -222,7 +222,7 @@ export interface GetTransactionApi extends RpcApiMethods {
                   transaction: Base58EncodedDataResponse;
               })
         | null;
-    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | void = void>(
+    getTransaction<TMaxSupportedTransactionVersion extends NewTransactionVersion | void = void>(
         signature: Signature,
         config?: GetTransactionCommonConfig<TMaxSupportedTransactionVersion> &
             Readonly<{
@@ -232,7 +232,7 @@ export interface GetTransactionApi extends RpcApiMethods {
         | (GetTransactionApiResponseBase &
               (TMaxSupportedTransactionVersion extends void
                   ? Record<string, never>
-                  : { version: TransactionVersion }) & {
+                  : { version: NewTransactionVersion }) & {
                   meta:
                       | (TransactionMetaBase &
                             TransactionMetaInnerInstructionsNotParsed &

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -68,6 +68,7 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/rpc-subscriptions-spec": "workspace:*",
         "@solana/rpc-transformers": "workspace:*",
+        "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
     "devDependencies": {

--- a/packages/rpc-subscriptions-api/src/__typetests__/block-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/block-notifications-type-test.ts
@@ -14,7 +14,7 @@ import type {
     TransactionStatus,
     U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-types';
-import type { TransactionVersion } from '@solana/transactions';
+import type { NewTransactionVersion } from '@solana/transaction-messages';
 
 import type { BlockNotificationsApi } from '../block-notifications';
 
@@ -447,7 +447,7 @@ type ExpectedTransactionForAccountsBaseVersioned = {
         }>[];
         signatures: readonly Base58EncodedBytes[];
     };
-    version: TransactionVersion;
+    version: NewTransactionVersion;
 };
 
 // Fifth overload
@@ -755,7 +755,7 @@ type ExpectedTransactionForFullBase58Versioned = {
               }>)
         | null;
     transaction: Base58EncodedDataResponse;
-    version: TransactionVersion;
+    version: NewTransactionVersion;
 };
 
 // Ninth overload
@@ -1021,7 +1021,7 @@ type ExpectedTransactionForFullBase64Versioned = {
               }>)
         | null;
     transaction: Base64EncodedDataResponse;
-    version: TransactionVersion;
+    version: NewTransactionVersion;
 };
 
 // Thirteenth overload
@@ -1276,7 +1276,7 @@ type ExpectedTransactionForFullJsonParsedVersioned = {
             }>[];
         }>;
     };
-    version: TransactionVersion;
+    version: NewTransactionVersion;
 };
 
 // Seventeenth overload
@@ -1443,7 +1443,7 @@ type ExpectedTransactionForFullJsonLegacy = {
 type ExpectedTransactionForFullJsonVersioned = {
     meta: (ExpectedMetaForFullJsonBase & ExpectedMetaForFullJsonLoadedAddresses) | null;
     transaction: ExpectedTransactionForFullJsonBase;
-    version: TransactionVersion;
+    version: NewTransactionVersion;
 };
 
 // Twenty-first overload

--- a/packages/rpc-subscriptions-api/src/block-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/block-notifications.ts
@@ -14,7 +14,7 @@ import type {
     U64UnsafeBeyond2Pow53Minus1,
     UnixTimestamp,
 } from '@solana/rpc-types';
-import type { TransactionVersion } from '@solana/transactions';
+import type { NewTransactionVersion } from '@solana/transaction-messages';
 
 // Subscription notification types
 
@@ -78,7 +78,7 @@ type BlockNotificationsEncoding = 'base58' | 'base64' | 'json' | 'jsonParsed';
 // This will error if the block contains any transactions with a version greater than "legacy" (code -32015).
 // - Also, If `maxSupportedTransactionVersion` is not provided, the `version` field of each transaction is omitted.
 // - These rules apply to both "accounts" and "full" transaction details.
-type BlockNotificationsMaxSupportedTransactionVersion = Exclude<TransactionVersion, 'legacy'>;
+type BlockNotificationsMaxSupportedTransactionVersion = Exclude<NewTransactionVersion, 'legacy'>;
 
 export interface BlockNotificationsApi extends RpcSubscriptionsApiMethods {
     /**

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -6,4 +6,3 @@ export * from './new-compile-transaction';
 export * from './new-signatures';
 export * from './new-wire-transaction';
 export * from './transaction';
-export * from './types'; // some uses to clean up before removing

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -3,6 +3,8 @@ import { ReadonlyUint8Array } from '@solana/codecs-core';
 import { SignatureBytes } from '@solana/keys';
 
 export type TransactionMessageBytes = ReadonlyUint8Array & { readonly __brand: unique symbol };
+export type TransactionMessageBytesBase64 = string & { readonly __serializedMessageBytesBase64: unique symbol };
+
 export type OrderedMap<K extends string, V> = Record<K, V>;
 export type SignaturesMap = OrderedMap<Address, SignatureBytes | null>;
 

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -1,9 +1,5 @@
 import { IAccountMeta, IInstruction } from '@solana/instructions';
 
-/** A string of bytes that are definitely a serialized message */
-export type SerializedMessageBytes = Uint8Array & { readonly __serializedMessageBytes: unique symbol };
-export type SerializedMessageBytesBase64 = string & { readonly __serializedMessageBytesBase64: unique symbol };
-
 export type BaseTransaction<
     TVersion extends TransactionVersion = TransactionVersion,
     TInstruction extends IInstruction = IInstruction,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,6 +649,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      '@solana/transaction-messages':
+        specifier: workspace:*
+        version: link:../transaction-messages
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
@@ -758,6 +761,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      '@solana/transaction-messages':
+        specifier: workspace:*
+        version: link:../transaction-messages
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions


### PR DESCRIPTION
- New type TransactionMessageBytesBase64 in Transactions
- Replace TransactionVersion with NewTransactionVersion

This removes the need to export this `types` file from Transactions. 