### PR TITLE
Change gitignore of fast-stable-stringify to match other packages

### DIFF
--- a/packages/fast-stable-stringify/.gitignore
+++ b/packages/fast-stable-stringify/.gitignore
@@ -1,2 +1,1 @@
-node_modules
-.idea
+dist/


### PR DESCRIPTION
We need to gitignore the dist/ directory

I've removed everything else since all our other packages just use dist/ but LMK if anything else needs to be there specific to this package! 