### PR TITLE
Restore original author to license file for `@solana/fast-stable-stringify`

### DIFF
--- a/packages/fast-stable-stringify/LICENSE
+++ b/packages/fast-stable-stringify/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2023 Solana Labs, Inc
+Copyright (c) 2017 Nicolaas Johannes Out
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
I'm pretty sure we are supposed to add a copyright notice for us, but retain the existing one.