### PR TITLE
Use native `WebSocket` in server runtimes that support it

### DIFF
--- a/.changeset/witty-camels-remember.md
+++ b/.changeset/witty-camels-remember.md
@@ -1,0 +1,5 @@
+---
+"@solana/ws-impl": patch
+---
+
+Use native `WebSocket` for compatibility with server runtimes that support it, like Deno

--- a/packages/ws-impl/src/index.node.ts
+++ b/packages/ws-impl/src/index.node.ts
@@ -1,4 +1,6 @@
 // When building the browser bundle, this import gets replaced by `globalThis.WebSocket`.
 import WebSocketImpl from 'ws';
 
-export default WebSocketImpl;
+export default globalThis.WebSocket
+    ? globalThis.WebSocket // Use native `WebSocket` in runtimes that support it (eg. Deno)
+    : WebSocketImpl;


### PR DESCRIPTION
Test Plan: run repro in #2461.

Closes #2461.
