### PR TITLE
Add glyphs to fix Hash collision with bigint and string

### DIFF
--- a/packages/fast-stable-stringify/src/__tests__/json_test.ts
+++ b/packages/fast-stable-stringify/src/__tests__/json_test.ts
@@ -3,7 +3,7 @@ import stringify from '..';
 describe('test_fast_stable_stringify', function () {
     it('big int', function () {
         const obj = { age: 23, bigint: BigInt('200'), name: 'ABCD' };
-        expect(stringify(obj)).toMatch('{"age":23,"bigint":"200n‽","name":"ABCD"}');
+        expect(stringify(obj)).toMatch('{"age":23,"bigint":"200n‽¶","name":"ABCD"}');
     });
 
     it('only string', function () {

--- a/packages/fast-stable-stringify/src/__tests__/json_test.ts
+++ b/packages/fast-stable-stringify/src/__tests__/json_test.ts
@@ -3,7 +3,7 @@ import stringify from '..';
 describe('test_fast_stable_stringify', function () {
     it('big int', function () {
         const obj = { age: 23, bigint: BigInt('200'), name: 'ABCD' };
-        expect(stringify(obj)).toMatch('{"age":23,"bigint":"200n","name":"ABCD"}');
+        expect(stringify(obj)).toMatch('{"age":23,"bigint":"200n‽","name":"ABCD"}');
     });
 
     it('only string', function () {

--- a/packages/fast-stable-stringify/src/index.ts
+++ b/packages/fast-stable-stringify/src/index.ts
@@ -61,7 +61,7 @@ function stringify(val, isArrayProp) {
         case 'undefined':
             return isArrayProp ? null : undefined;
         case 'bigint':
-            return JSON.stringify(val.toString() + 'n‽');
+            return JSON.stringify(val.toString() + 'n‽¶');
         case 'string':
             return JSON.stringify(val);
         default:

--- a/packages/fast-stable-stringify/src/index.ts
+++ b/packages/fast-stable-stringify/src/index.ts
@@ -61,7 +61,7 @@ function stringify(val, isArrayProp) {
         case 'undefined':
             return isArrayProp ? null : undefined;
         case 'bigint':
-            return JSON.stringify(val.toString() + 'n');
+            return JSON.stringify(val.toString() + 'n‽');
         case 'string':
             return JSON.stringify(val);
         default:


### PR DESCRIPTION
Added `‽` and `¶` which is a mix of question mark and exclamation. These glyphs are rarely used. Added two glyphs to reduce the possibility of collision.

Closes #2496.