### PR TITLE
refactor(experimental): fix mixed changeset error on CI

### DIFF
--- a/.changeset/strong-pandas-marry.md
+++ b/.changeset/strong-pandas-marry.md
@@ -1,5 +1,4 @@
 ---
-"@solana/web3.js": patch
 "@solana/web3.js-experimental": patch
 "@solana/rpc-subscriptions": patch
 "@solana/rpc": patch


### PR DESCRIPTION
CI fails right now because one of our changesets refers to the legacy library when it is excluded from the packages changeset supports.

![CleanShot 2024-04-17 at 12 03 39@2x](https://github.com/solana-labs/solana-web3.js/assets/3642397/db207e3b-d98f-4f17-94fe-e6e0e622c1bf)

