### PR TITLE
Remove console.error

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -1635,9 +1635,6 @@ function createRpcClient(
         if (too_many_requests_retries === 0) {
           break;
         }
-        console.error(
-          `Server responded with ${res.status} ${res.statusText}.  Retrying after ${waitTime}ms delay...`,
-        );
         await sleep(waitTime);
         waitTime *= 2;
       }


### PR DESCRIPTION
Remove console.error on 429, not to log error on client side even if the errors are handled.