### PR TITLE
Add glyphs to fix Hash collision with bigint and string 

### DIFF
--- a/packages/fast-stable-stringify/src/__tests__/index-test.ts
+++ b/packages/fast-stable-stringify/src/__tests__/index-test.ts
@@ -196,6 +196,9 @@ describe('fastStableStringify', function () {
         expect(stringify(value)).toBe(jsonStableStringify(value));
     });
     it('hashes bigints', function () {
-        expect(stringify(200n)).toMatch('"200n"');
+        expect(stringify(200n)).toMatch('"200"n');
+        expect(stringify({'foo':100n})).toMatch('{"foo":"100"n}');
+        expect(stringify({'age':BigInt(100n),'name':'Hrushi'})).toMatch('{"age":"100"n,"name":"Hrushi"}');
+        expect(stringify({'age':[BigInt(100n), BigInt(200n), BigInt(300n)]})).toMatch('{"age":["100"n,"200"n,"300"n]}');
     });
 });

--- a/packages/fast-stable-stringify/src/__tests__/index-test.ts
+++ b/packages/fast-stable-stringify/src/__tests__/index-test.ts
@@ -196,11 +196,9 @@ describe('fastStableStringify', function () {
         expect(stringify(value)).toBe(jsonStableStringify(value));
     });
     it('hashes bigints', function () {
-        expect(stringify(200n)).toMatch('"200"n');
-        expect(stringify({ foo: 100n })).toMatch('{"foo":"100"n}');
-        expect(stringify({ age: BigInt(100n), name: 'Hrushi' })).toMatch('{"age":"100"n,"name":"Hrushi"}');
-        expect(stringify({ age: [BigInt(100n), BigInt(200n), BigInt(300n)] })).toMatch(
-            '{"age":["100"n,"200"n,"300"n]}',
-        );
+        expect(stringify(200n)).toMatch('200n');
+        expect(stringify({ foo: 100n, goo: '100n' })).toMatch('{"foo":100n,"goo":"100n"}');
+        expect(stringify({ age: BigInt(100n), name: 'Hrushi' })).toMatch('{"age":100n,"name":"Hrushi"}');
+        expect(stringify({ age: [BigInt(100n), BigInt(200n), BigInt(300n)] })).toMatch('{"age":[100n,200n,300n]}');
     });
 });

--- a/packages/fast-stable-stringify/src/__tests__/index-test.ts
+++ b/packages/fast-stable-stringify/src/__tests__/index-test.ts
@@ -197,8 +197,10 @@ describe('fastStableStringify', function () {
     });
     it('hashes bigints', function () {
         expect(stringify(200n)).toMatch('"200"n');
-        expect(stringify({'foo':100n})).toMatch('{"foo":"100"n}');
-        expect(stringify({'age':BigInt(100n),'name':'Hrushi'})).toMatch('{"age":"100"n,"name":"Hrushi"}');
-        expect(stringify({'age':[BigInt(100n), BigInt(200n), BigInt(300n)]})).toMatch('{"age":["100"n,"200"n,"300"n]}');
+        expect(stringify({ foo: 100n })).toMatch('{"foo":"100"n}');
+        expect(stringify({ age: BigInt(100n), name: 'Hrushi' })).toMatch('{"age":"100"n,"name":"Hrushi"}');
+        expect(stringify({ age: [BigInt(100n), BigInt(200n), BigInt(300n)] })).toMatch(
+            '{"age":["100"n,"200"n,"300"n]}',
+        );
     });
 });

--- a/packages/fast-stable-stringify/src/index.ts
+++ b/packages/fast-stable-stringify/src/index.ts
@@ -61,7 +61,7 @@ function stringify(val: unknown, isArrayProp: boolean) {
         case 'undefined':
             return isArrayProp ? null : undefined;
         case 'bigint':
-            return (JSON.stringify(val.toString()) + 'n');
+            return JSON.stringify(val.toString()) + 'n';
         case 'string':
             return JSON.stringify(val);
         default:

--- a/packages/fast-stable-stringify/src/index.ts
+++ b/packages/fast-stable-stringify/src/index.ts
@@ -61,7 +61,7 @@ function stringify(val: unknown, isArrayProp: boolean) {
         case 'undefined':
             return isArrayProp ? null : undefined;
         case 'bigint':
-            return JSON.stringify(val.toString() + 'n');
+            return (JSON.stringify(val.toString()) + 'n');
         case 'string':
             return JSON.stringify(val);
         default:

--- a/packages/fast-stable-stringify/src/index.ts
+++ b/packages/fast-stable-stringify/src/index.ts
@@ -61,7 +61,7 @@ function stringify(val: unknown, isArrayProp: boolean) {
         case 'undefined':
             return isArrayProp ? null : undefined;
         case 'bigint':
-            return JSON.stringify(val.toString()) + 'n';
+            return `${val.toString()}n`;
         case 'string':
             return JSON.stringify(val);
         default:


### PR DESCRIPTION
Support BigInt and added more tests. Putting Glyph outside the quote avoid collisions. 

```
s(100n) // "100"n
s({foo: 100n}) // {"foo":"100"n}
```

Closes #2496.