### PR TITLE
Rename new-wire-transaction

### DIFF
--- a/packages/library/src/__tests__/send-transaction-internal-test.ts
+++ b/packages/library/src/__tests__/send-transaction-internal-test.ts
@@ -4,7 +4,7 @@ import type { Commitment } from '@solana/rpc-types';
 import {
     Base64EncodedWireTransaction,
     FullySignedTransaction,
-    newGetBase64EncodedWireTransaction,
+    getBase64EncodedWireTransaction,
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
 } from '@solana/transactions';
@@ -34,7 +34,7 @@ describe('sendAndConfirmTransaction', () => {
         rpc = {
             sendTransaction: createPendingRequest,
         };
-        jest.mocked(newGetBase64EncodedWireTransaction).mockReturnValue(
+        jest.mocked(getBase64EncodedWireTransaction).mockReturnValue(
             'MOCK_WIRE_TRANSACTION' as Base64EncodedWireTransaction,
         );
     });
@@ -46,7 +46,7 @@ describe('sendAndConfirmTransaction', () => {
             rpc,
             transaction: MOCK_TRANSACTION,
         });
-        expect(newGetBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_TRANSACTION);
+        expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_TRANSACTION);
         expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', expect.anything());
     });
     it('calls `sendTransaction` with the expected inputs', () => {
@@ -64,7 +64,7 @@ describe('sendAndConfirmTransaction', () => {
             rpc,
             transaction: MOCK_TRANSACTION,
         });
-        expect(newGetBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_TRANSACTION);
+        expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_TRANSACTION);
         expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', {
             ...sendTransactionConfig,
             encoding: 'base64',
@@ -189,7 +189,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
         rpc = {
             sendTransaction: createPendingRequest,
         };
-        jest.mocked(newGetBase64EncodedWireTransaction).mockReturnValue(
+        jest.mocked(getBase64EncodedWireTransaction).mockReturnValue(
             'MOCK_WIRE_TRANSACTION' as Base64EncodedWireTransaction,
         );
     });
@@ -201,7 +201,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
             rpc,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
         });
-        expect(newGetBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_DURABLE_NONCE_TRANSACTION);
+        expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_DURABLE_NONCE_TRANSACTION);
         expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', expect.anything());
     });
     it('calls `sendTransaction` with the expected inputs', () => {
@@ -219,7 +219,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
             rpc,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
         });
-        expect(newGetBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_DURABLE_NONCE_TRANSACTION);
+        expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_DURABLE_NONCE_TRANSACTION);
         expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', {
             ...sendTransactionConfig,
             encoding: 'base64',

--- a/packages/library/src/send-transaction-internal.ts
+++ b/packages/library/src/send-transaction-internal.ts
@@ -7,7 +7,7 @@ import {
 } from '@solana/transaction-confirmation';
 import {
     FullySignedTransaction,
-    newGetBase64EncodedWireTransaction,
+    getBase64EncodedWireTransaction,
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
 } from '@solana/transactions';
@@ -77,7 +77,7 @@ export async function sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
     transaction,
     ...sendTransactionConfig
 }: SendTransactionBaseConfig): Promise<Signature> {
-    const base64EncodedWireTransaction = newGetBase64EncodedWireTransaction(transaction);
+    const base64EncodedWireTransaction = getBase64EncodedWireTransaction(transaction);
     return await rpc
         .sendTransaction(base64EncodedWireTransaction, {
             ...getSendTransactionConfigWithAdjustedPreflightCommitment(commitment, sendTransactionConfig),

--- a/packages/transactions/src/__tests__/wire-transaction-test.ts
+++ b/packages/transactions/src/__tests__/wire-transaction-test.ts
@@ -2,8 +2,8 @@ import { Address } from '@solana/addresses';
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 import { SignatureBytes } from '@solana/keys';
 
-import { newGetBase64EncodedWireTransaction } from '../new-wire-transaction';
 import { NewTransaction, TransactionMessageBytes } from '../transaction';
+import { getBase64EncodedWireTransaction } from '../wire-transaction';
 
 describe('getBase64EncodedWireTransaction', () => {
     it('serializes a transaction to wire format', () => {
@@ -62,7 +62,7 @@ describe('getBase64EncodedWireTransaction', () => {
             },
         };
 
-        expect(newGetBase64EncodedWireTransaction(transaction))
+        expect(getBase64EncodedWireTransaction(transaction))
             // Copy and paste this string into the Solana Explorer at https://explorer.solana.com/tx/inspector
             .toBe(
                 'AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlyfqJ5qvbi2J5r1hDgkimf7xAsjcGduDtpu9zfTn8MGyAgMBmLTJ6VrW508Eg1xWkND+TiiPuCPuCPuCPuCPugAIBAQMPHmsUIcBKBwQxJlwZxbvuGZK66K/RzQeO+K9wR9wR9y1bQTxlQN4VDJNzFE1RM8pMuDC6D3VnFqzqDlDXlDXlPHmsUIcBKBwQxJlwZxbvuGZK66K/RzQeO+K9wR9wR9wePNYoQ4CUDghiTLgzi3fcMyV10V+jmg8d8V7gj7gj7gECAQEAAA==',

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -2,5 +2,5 @@ export * from './codecs';
 export * from './lifetime';
 export * from './compile-transaction';
 export * from './signatures';
-export * from './new-wire-transaction';
+export * from './wire-transaction';
 export * from './transaction';

--- a/packages/transactions/src/wire-transaction.ts
+++ b/packages/transactions/src/wire-transaction.ts
@@ -7,7 +7,7 @@ export type Base64EncodedWireTransaction = string & {
     readonly __brand: unique symbol;
 };
 
-export function newGetBase64EncodedWireTransaction(transaction: NewTransaction): Base64EncodedWireTransaction {
+export function getBase64EncodedWireTransaction(transaction: NewTransaction): Base64EncodedWireTransaction {
     const wireTransactionBytes = getTransactionEncoder().encode(transaction);
     return getBase64Decoder().decode(wireTransactionBytes) as Base64EncodedWireTransaction;
 }


### PR DESCRIPTION
- rename the file to wire-transaction
- rename the function to remove `new` prefix