### PR TITLE
Rename ITransactionMessageWithBlockhashLifetime

### DIFF
--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -2,7 +2,7 @@ import { SignatureBytes } from '@solana/keys';
 import {
     CompilableTransactionMessage,
     IDurableNonceTransactionMessage,
-    ITransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithBlockhashLifetime,
 } from '@solana/transaction-messages';
 import { FullySignedTransaction, Transaction } from '@solana/transactions';
 import {
@@ -24,7 +24,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
 {
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with a blockhash lifetime
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
-        ITransactionMessageWithBlockhashLifetime;
+        TransactionMessageWithBlockhashLifetime;
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
         Readonly<Transaction & TransactionWithBlockhashLifetime>
     >;
@@ -50,7 +50,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
 {
     // [signTransactionMessageWithSigners]: returns a fully signed transaction with a blockhash lifetime
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
-        ITransactionMessageWithBlockhashLifetime;
+        TransactionMessageWithBlockhashLifetime;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
         Readonly<FullySignedTransaction & TransactionWithBlockhashLifetime>
     >;

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -3,7 +3,7 @@ import { SignatureBytes } from '@solana/keys';
 import {
     CompilableTransactionMessage,
     IDurableNonceTransactionMessage,
-    ITransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithBlockhashLifetime,
 } from '@solana/transaction-messages';
 import {
     assertTransactionIsFullySigned,
@@ -34,8 +34,8 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
  */
 export async function partiallySignTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners &
-        ITransactionMessageWithBlockhashLifetime = CompilableTransactionMessageWithSigners &
-        ITransactionMessageWithBlockhashLifetime,
+        TransactionMessageWithBlockhashLifetime = CompilableTransactionMessageWithSigners &
+        TransactionMessageWithBlockhashLifetime,
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },
@@ -83,8 +83,8 @@ export async function partiallySignTransactionMessageWithSigners<
  */
 export async function signTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners &
-        ITransactionMessageWithBlockhashLifetime = CompilableTransactionMessageWithSigners &
-        ITransactionMessageWithBlockhashLifetime,
+        TransactionMessageWithBlockhashLifetime = CompilableTransactionMessageWithSigners &
+        TransactionMessageWithBlockhashLifetime,
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },

--- a/packages/transaction-messages/src/__tests__/blockhash-test.ts
+++ b/packages/transaction-messages/src/__tests__/blockhash-test.ts
@@ -5,8 +5,8 @@ import type { Blockhash } from '@solana/rpc-types';
 
 import {
     assertIsTransactionMessageWithBlockhashLifetime,
-    ITransactionMessageWithBlockhashLifetime,
     setTransactionMessageLifetimeUsingBlockhash,
+    TransactionMessageWithBlockhashLifetime,
 } from '../blockhash';
 import { BaseTransactionMessage } from '../transaction-message';
 
@@ -108,7 +108,7 @@ describe('setTransactionMessageLifetimeUsingBlockhash', () => {
         expect(txWithBlockhashLifetimeConstraint).toHaveProperty('lifetimeConstraint', BLOCKHASH_CONSTRAINT_A);
     });
     describe('given a transaction with a blockhash lifetime already set', () => {
-        let txWithBlockhashLifetimeConstraint: BaseTransactionMessage & ITransactionMessageWithBlockhashLifetime;
+        let txWithBlockhashLifetimeConstraint: BaseTransactionMessage & TransactionMessageWithBlockhashLifetime;
         beforeEach(() => {
             txWithBlockhashLifetimeConstraint = {
                 ...baseTx,

--- a/packages/transaction-messages/src/__tests__/durable-nonce-test.ts
+++ b/packages/transaction-messages/src/__tests__/durable-nonce-test.ts
@@ -4,7 +4,7 @@ import { Address } from '@solana/addresses';
 import { AccountRole, IInstruction, ReadonlySignerAccount, WritableAccount } from '@solana/instructions';
 import type { Blockhash } from '@solana/rpc-types';
 
-import { ITransactionMessageWithBlockhashLifetime } from '../blockhash';
+import { TransactionMessageWithBlockhashLifetime } from '../blockhash';
 import {
     assertIsDurableNonceTransactionMessage,
     IDurableNonceTransactionMessage,
@@ -128,7 +128,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
                 lifetimeConstraint: {
                     blockhash: '123' as Blockhash,
                     lastValidBlockHeight: 123n,
-                } as ITransactionMessageWithBlockhashLifetime['lifetimeConstraint'],
+                } as TransactionMessageWithBlockhashLifetime['lifetimeConstraint'],
             } as BaseTransactionMessage);
         }).toThrow();
     });

--- a/packages/transaction-messages/src/__typetests__/transaction-message-typetests.ts
+++ b/packages/transaction-messages/src/__typetests__/transaction-message-typetests.ts
@@ -3,8 +3,8 @@ import { Blockhash } from '@solana/rpc-types';
 
 import {
     assertIsTransactionMessageWithBlockhashLifetime,
-    ITransactionMessageWithBlockhashLifetime,
     setTransactionMessageLifetimeUsingBlockhash,
+    TransactionMessageWithBlockhashLifetime,
 } from '../blockhash';
 import { CompilableTransactionMessage } from '../compilable-transaction-message';
 import { createTransactionMessage } from '../create-transaction-message';
@@ -47,27 +47,27 @@ createTransactionMessage({ version: 'legacy' }) satisfies Extract<TransactionMes
 setTransactionMessageLifetimeUsingBlockhash(
     mockBlockhashLifetime,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }>,
-) satisfies Extract<TransactionMessage, { version: 'legacy' }> & ITransactionMessageWithBlockhashLifetime;
+) satisfies Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithBlockhashLifetime;
 setTransactionMessageLifetimeUsingBlockhash(
     mockBlockhashLifetime,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }>,
     // @ts-expect-error Version should match
-) satisfies Extract<TransactionMessage, { version: 0 }> & ITransactionMessageWithBlockhashLifetime;
+) satisfies Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithBlockhashLifetime;
 setTransactionMessageLifetimeUsingBlockhash(
     mockBlockhashLifetime,
     null as unknown as Extract<TransactionMessage, { version: 0 }>,
-) satisfies Extract<TransactionMessage, { version: 0 }> & ITransactionMessageWithBlockhashLifetime;
+) satisfies Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithBlockhashLifetime;
 setTransactionMessageLifetimeUsingBlockhash(
     mockBlockhashLifetime,
     null as unknown as Extract<TransactionMessage, { version: 0 }>,
     // @ts-expect-error Version should match
-) satisfies Extract<TransactionMessage, { version: 'legacy' }> & ITransactionMessageWithBlockhashLifetime;
+) satisfies Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithBlockhashLifetime;
 
 {
     // assertIsTransactionMessageWithBlockhashLifetime
     const transaction = null as unknown as BaseTransactionMessage;
     // @ts-expect-error Should not be blockhash lifetime
-    transaction satisfies ITransactionMessageWithBlockhashLifetime;
+    transaction satisfies TransactionMessageWithBlockhashLifetime;
     // @ts-expect-error Should not satisfy has blockhash
     transaction satisfies {
         lifetimeConstraint: {
@@ -81,7 +81,7 @@ setTransactionMessageLifetimeUsingBlockhash(
         };
     };
     assertIsTransactionMessageWithBlockhashLifetime(transaction);
-    transaction satisfies ITransactionMessageWithBlockhashLifetime;
+    transaction satisfies TransactionMessageWithBlockhashLifetime;
     transaction satisfies {
         lifetimeConstraint: {
             blockhash: Blockhash;
@@ -139,31 +139,31 @@ setTransactionMessageFeePayer(
 // (blockhash)
 setTransactionMessageFeePayer(
     mockFeePayer,
-    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & ITransactionMessageWithBlockhashLifetime,
+    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithBlockhashLifetime,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    ITransactionMessageWithBlockhashLifetime &
-    ITransactionMessageWithFeePayer<'feePayer'>;
+    ITransactionMessageWithFeePayer<'feePayer'> &
+    TransactionMessageWithBlockhashLifetime;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }> &
-        ITransactionMessageWithBlockhashLifetime &
-        ITransactionMessageWithFeePayer<'NOTfeePayer'>,
+        ITransactionMessageWithFeePayer<'NOTfeePayer'> &
+        TransactionMessageWithBlockhashLifetime,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    ITransactionMessageWithBlockhashLifetime &
-    ITransactionMessageWithFeePayer<'feePayer'>;
+    ITransactionMessageWithFeePayer<'feePayer'> &
+    TransactionMessageWithBlockhashLifetime;
 setTransactionMessageFeePayer(
     mockFeePayer,
-    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & ITransactionMessageWithBlockhashLifetime,
+    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithBlockhashLifetime,
     // @ts-expect-error Version should match
 ) satisfies Extract<TransactionMessage, { version: 0 }> &
-    ITransactionMessageWithBlockhashLifetime &
-    ITransactionMessageWithFeePayer<'feePayer'>;
+    ITransactionMessageWithFeePayer<'feePayer'> &
+    TransactionMessageWithBlockhashLifetime;
 setTransactionMessageFeePayer(
     mockFeePayer,
-    null as unknown as Extract<TransactionMessage, { version: 0 }> & ITransactionMessageWithBlockhashLifetime,
+    null as unknown as Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithBlockhashLifetime,
 ) satisfies Extract<TransactionMessage, { version: 0 }> &
-    ITransactionMessageWithBlockhashLifetime &
-    ITransactionMessageWithFeePayer<'feePayer'>;
+    ITransactionMessageWithFeePayer<'feePayer'> &
+    TransactionMessageWithBlockhashLifetime;
 
 // (durable nonce)
 setTransactionMessageFeePayer(
@@ -231,12 +231,12 @@ null as unknown as BaseTransactionMessage satisfies CompilableTransactionMessage
 null as unknown as BaseTransactionMessage & ITransactionMessageWithFeePayer satisfies CompilableTransactionMessage;
 null as unknown as BaseTransactionMessage &
     // @ts-expect-error missing fee payer
-    ITransactionMessageWithBlockhashLifetime satisfies CompilableTransactionMessage;
+    TransactionMessageWithBlockhashLifetime satisfies CompilableTransactionMessage;
 // @ts-expect-error missing fee payer
 null as unknown as BaseTransactionMessage & IDurableNonceTransactionMessage satisfies CompilableTransactionMessage;
 null as unknown as BaseTransactionMessage &
-    ITransactionMessageWithBlockhashLifetime &
-    ITransactionMessageWithFeePayer satisfies CompilableTransactionMessage;
+    ITransactionMessageWithFeePayer &
+    TransactionMessageWithBlockhashLifetime satisfies CompilableTransactionMessage;
 null as unknown as BaseTransactionMessage &
     IDurableNonceTransactionMessage &
     ITransactionMessageWithFeePayer satisfies CompilableTransactionMessage;

--- a/packages/transaction-messages/src/blockhash.ts
+++ b/packages/transaction-messages/src/blockhash.ts
@@ -9,13 +9,13 @@ type BlockhashLifetimeConstraint = Readonly<{
     lastValidBlockHeight: bigint;
 }>;
 
-export interface ITransactionMessageWithBlockhashLifetime {
+export interface TransactionMessageWithBlockhashLifetime {
     readonly lifetimeConstraint: BlockhashLifetimeConstraint;
 }
 
 export function isTransactionMessageWithBlockhashLifetime(
-    transaction: BaseTransactionMessage | (BaseTransactionMessage & ITransactionMessageWithBlockhashLifetime),
-): transaction is BaseTransactionMessage & ITransactionMessageWithBlockhashLifetime {
+    transaction: BaseTransactionMessage | (BaseTransactionMessage & TransactionMessageWithBlockhashLifetime),
+): transaction is BaseTransactionMessage & TransactionMessageWithBlockhashLifetime {
     const lifetimeConstraintShapeMatches =
         'lifetimeConstraint' in transaction &&
         typeof transaction.lifetimeConstraint.blockhash === 'string' &&
@@ -30,8 +30,8 @@ export function isTransactionMessageWithBlockhashLifetime(
 }
 
 export function assertIsTransactionMessageWithBlockhashLifetime(
-    transaction: BaseTransactionMessage | (BaseTransactionMessage & ITransactionMessageWithBlockhashLifetime),
-): asserts transaction is BaseTransactionMessage & ITransactionMessageWithBlockhashLifetime {
+    transaction: BaseTransactionMessage | (BaseTransactionMessage & TransactionMessageWithBlockhashLifetime),
+): asserts transaction is BaseTransactionMessage & TransactionMessageWithBlockhashLifetime {
     if (!isTransactionMessageWithBlockhashLifetime(transaction)) {
         throw new SolanaError(SOLANA_ERROR__TRANSACTION__EXPECTED_BLOCKHASH_LIFETIME);
     }
@@ -42,18 +42,18 @@ export function setTransactionMessageLifetimeUsingBlockhash<
 >(
     blockhashLifetimeConstraint: BlockhashLifetimeConstraint,
     transaction: TTransaction,
-): ITransactionMessageWithBlockhashLifetime & Omit<TTransaction, 'lifetimeConstraint'>;
+): Omit<TTransaction, 'lifetimeConstraint'> & TransactionMessageWithBlockhashLifetime;
 
 export function setTransactionMessageLifetimeUsingBlockhash<
-    TTransaction extends BaseTransactionMessage | (BaseTransactionMessage & ITransactionMessageWithBlockhashLifetime),
+    TTransaction extends BaseTransactionMessage | (BaseTransactionMessage & TransactionMessageWithBlockhashLifetime),
 >(
     blockhashLifetimeConstraint: BlockhashLifetimeConstraint,
     transaction: TTransaction,
-): ITransactionMessageWithBlockhashLifetime & TTransaction;
+): TransactionMessageWithBlockhashLifetime & TTransaction;
 
 export function setTransactionMessageLifetimeUsingBlockhash(
     blockhashLifetimeConstraint: BlockhashLifetimeConstraint,
-    transaction: BaseTransactionMessage | (BaseTransactionMessage & ITransactionMessageWithBlockhashLifetime),
+    transaction: BaseTransactionMessage | (BaseTransactionMessage & TransactionMessageWithBlockhashLifetime),
 ) {
     if (
         'lifetimeConstraint' in transaction &&

--- a/packages/transaction-messages/src/compilable-transaction-message.ts
+++ b/packages/transaction-messages/src/compilable-transaction-message.ts
@@ -1,6 +1,6 @@
 import { IInstruction } from '@solana/instructions';
 
-import { ITransactionMessageWithBlockhashLifetime } from './blockhash';
+import { TransactionMessageWithBlockhashLifetime } from './blockhash';
 import { IDurableNonceTransactionMessage } from './durable-nonce';
 import { ITransactionMessageWithFeePayer } from './fee-payer';
 import { BaseTransactionMessage, NewTransactionVersion } from './transaction-message';
@@ -10,4 +10,4 @@ export type CompilableTransactionMessage<
     TInstruction extends IInstruction = IInstruction,
 > = BaseTransactionMessage<TVersion, TInstruction> &
     ITransactionMessageWithFeePayer &
-    (IDurableNonceTransactionMessage | ITransactionMessageWithBlockhashLifetime);
+    (IDurableNonceTransactionMessage | TransactionMessageWithBlockhashLifetime);

--- a/packages/transaction-messages/src/compile/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/message-test.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 
-import { ITransactionMessageWithBlockhashLifetime } from '../../blockhash';
+import { TransactionMessageWithBlockhashLifetime } from '../../blockhash';
 import { CompilableTransactionMessage } from '../../compilable-transaction-message';
 import { getCompiledAddressTableLookups } from '../address-table-lookups';
 import { getCompiledMessageHeader } from '../header';
@@ -16,7 +16,7 @@ jest.mock('../lifetime-token');
 jest.mock('../static-accounts');
 
 const MOCK_LIFETIME_CONSTRAINT =
-    'SOME_CONSTRAINT' as unknown as ITransactionMessageWithBlockhashLifetime['lifetimeConstraint'];
+    'SOME_CONSTRAINT' as unknown as TransactionMessageWithBlockhashLifetime['lifetimeConstraint'];
 
 describe('compileTransactionMessage', () => {
     let baseTx: CompilableTransactionMessage;

--- a/packages/transaction-messages/src/compile/lifetime-token.ts
+++ b/packages/transaction-messages/src/compile/lifetime-token.ts
@@ -1,9 +1,9 @@
-import { IDurableNonceTransactionMessage, ITransactionMessageWithBlockhashLifetime } from '../index';
+import { IDurableNonceTransactionMessage, TransactionMessageWithBlockhashLifetime } from '../index';
 
 export function getCompiledLifetimeToken(
     lifetimeConstraint: (
         | IDurableNonceTransactionMessage
-        | ITransactionMessageWithBlockhashLifetime
+        | TransactionMessageWithBlockhashLifetime
     )['lifetimeConstraint'],
 ): string {
     if ('nonce' in lifetimeConstraint) {

--- a/packages/transactions/src/__typetests__/compile-transaction-typetests.ts
+++ b/packages/transactions/src/__typetests__/compile-transaction-typetests.ts
@@ -3,9 +3,9 @@ import {
     BaseTransactionMessage,
     CompilableTransactionMessage,
     IDurableNonceTransactionMessage,
-    ITransactionMessageWithBlockhashLifetime,
     ITransactionMessageWithFeePayer,
     NewNonce,
+    TransactionMessageWithBlockhashLifetime,
 } from '@solana/transaction-messages';
 
 import { compileTransaction } from '../compile-transaction';
@@ -21,18 +21,18 @@ import { Transaction } from '../transaction';
 // transaction message with blockhash lifetime
 compileTransaction(
     null as unknown as BaseTransactionMessage &
-        ITransactionMessageWithBlockhashLifetime &
-        ITransactionMessageWithFeePayer,
+        ITransactionMessageWithFeePayer &
+        TransactionMessageWithBlockhashLifetime,
 ) satisfies Readonly<Transaction & TransactionWithLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage &
-        ITransactionMessageWithBlockhashLifetime &
-        ITransactionMessageWithFeePayer,
+        ITransactionMessageWithFeePayer &
+        TransactionMessageWithBlockhashLifetime,
 ) satisfies Readonly<Transaction & TransactionWithBlockhashLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage &
-        ITransactionMessageWithBlockhashLifetime &
-        ITransactionMessageWithFeePayer,
+        ITransactionMessageWithFeePayer &
+        TransactionMessageWithBlockhashLifetime,
 ).lifetimeConstraint.blockhash satisfies Blockhash;
 
 // transaction message with durable nonce lifetime

--- a/packages/transactions/src/compile-transaction.ts
+++ b/packages/transactions/src/compile-transaction.ts
@@ -5,7 +5,7 @@ import {
     getCompiledTransactionMessageEncoder,
     IDurableNonceTransactionMessage,
     isTransactionMessageWithBlockhashLifetime,
-    ITransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithBlockhashLifetime,
 } from '@solana/transaction-messages';
 
 import {
@@ -16,7 +16,7 @@ import {
 import { SignaturesMap, Transaction, TransactionMessageBytes } from './transaction';
 
 export function compileTransaction(
-    transactionMessage: CompilableTransactionMessage & ITransactionMessageWithBlockhashLifetime,
+    transactionMessage: CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime,
 ): Readonly<Transaction & TransactionWithBlockhashLifetime>;
 
 export function compileTransaction(


### PR DESCRIPTION
- Just removed the I so it's TransactionMessageWithBlockhashLifetime
- Mirrors the Transaction lifetime type