### PR TITLE
Rename durable-nonce

### DIFF
--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -1,8 +1,8 @@
 import { SignatureBytes } from '@solana/keys';
 import {
     CompilableTransactionMessage,
-    IDurableNonceTransactionMessage,
     TransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithDurableNonceLifetime,
 } from '@solana/transaction-messages';
 import { FullySignedTransaction, Transaction } from '@solana/transactions';
 import {
@@ -33,7 +33,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
 {
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with a durable nonce lifetime
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
-        IDurableNonceTransactionMessage;
+        TransactionMessageWithDurableNonceLifetime;
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
         Readonly<Transaction & TransactionWithDurableNonceLifetime>
     >;
@@ -59,7 +59,7 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
 {
     // [signTransactionMessageWithSigners]: returns a fully signed transaction with a durable nonce lifetime
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
-        IDurableNonceTransactionMessage;
+        TransactionMessageWithDurableNonceLifetime;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
         Readonly<FullySignedTransaction & TransactionWithDurableNonceLifetime>
     >;

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -2,8 +2,8 @@ import { SOLANA_ERROR__SIGNER__TRANSACTION_SENDING_SIGNER_MISSING, SolanaError }
 import { SignatureBytes } from '@solana/keys';
 import {
     CompilableTransactionMessage,
-    IDurableNonceTransactionMessage,
     TransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithDurableNonceLifetime,
 } from '@solana/transaction-messages';
 import {
     assertTransactionIsFullySigned,
@@ -43,7 +43,8 @@ export async function partiallySignTransactionMessageWithSigners<
 
 export async function partiallySignTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners &
-        IDurableNonceTransactionMessage = CompilableTransactionMessageWithSigners & IDurableNonceTransactionMessage,
+        TransactionMessageWithDurableNonceLifetime = CompilableTransactionMessageWithSigners &
+        TransactionMessageWithDurableNonceLifetime,
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },
@@ -92,7 +93,8 @@ export async function signTransactionMessageWithSigners<
 
 export async function signTransactionMessageWithSigners<
     TTransactionMessage extends CompilableTransactionMessageWithSigners &
-        IDurableNonceTransactionMessage = CompilableTransactionMessageWithSigners & IDurableNonceTransactionMessage,
+        TransactionMessageWithDurableNonceLifetime = CompilableTransactionMessageWithSigners &
+        TransactionMessageWithDurableNonceLifetime,
 >(
     transactionMessage: TTransactionMessage,
     config?: { abortSignal?: AbortSignal },

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
@@ -1,7 +1,7 @@
 import { Address } from '@solana/addresses';
 import { getBase58Encoder, getBase64Decoder } from '@solana/codecs-strings';
 import { SOLANA_ERROR__INVALID_NONCE, SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND, SolanaError } from '@solana/errors';
-import { NewNonce } from '@solana/transaction-messages';
+import { Nonce } from '@solana/transaction-messages';
 
 import { createNonceInvalidationPromiseFactory } from '../confirmation-strategy-nonce';
 
@@ -10,7 +10,7 @@ const FOREVER_PROMISE = new Promise(() => {
 });
 
 describe('createNonceInvalidationPromiseFactory', () => {
-    function getBase64EncodedNonceAccountData(nonceValue: NewNonce) {
+    function getBase64EncodedNonceAccountData(nonceValue: Nonce) {
         // This is mostly fake; we just put the nonce value in the correct spot in the byte buffer
         // without actually implementing the rest.
         const NONCE_VALUE_OFFSET =
@@ -56,7 +56,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         getNonceInvalidationPromise({
             abortSignal: abortController.signal,
             commitment: 'finalized',
-            currentNonceValue: '4'.repeat(44) as NewNonce,
+            currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
         });
         await jest.runAllTimersAsync();
@@ -73,7 +73,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         getNonceInvalidationPromise({
             abortSignal: abortController.signal,
             commitment: 'finalized',
-            currentNonceValue: '4'.repeat(44) as NewNonce,
+            currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
         });
         expect(createSubscriptionIterable).toHaveBeenCalledWith({
@@ -89,7 +89,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         getNonceInvalidationPromise({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
-            currentNonceValue: '4'.repeat(44) as NewNonce,
+            currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
         });
         await jest.runAllTimersAsync();
@@ -110,7 +110,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         getNonceInvalidationPromise({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
-            currentNonceValue: '4'.repeat(44) as NewNonce,
+            currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
         });
         await jest.runAllTimersAsync();
@@ -134,7 +134,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         const invalidationPromise = getNonceInvalidationPromise({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
-            currentNonceValue: '4'.repeat(44) as NewNonce,
+            currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
         });
         await jest.runAllTimersAsync();
@@ -146,7 +146,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         const invalidationPromise = getNonceInvalidationPromise({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
-            currentNonceValue: '4'.repeat(44) as NewNonce,
+            currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
         });
         await expect(invalidationPromise).rejects.toThrow(
@@ -165,7 +165,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         const invalidationPromise = getNonceInvalidationPromise({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
-            currentNonceValue: '4'.repeat(44) as NewNonce,
+            currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
         });
         await expect(invalidationPromise).rejects.toThrow(
@@ -180,7 +180,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         accountNotificationGenerator.mockImplementation(async function* () {
             yield {
                 value: {
-                    data: getBase64EncodedNonceAccountData('4'.repeat(44) as NewNonce),
+                    data: getBase64EncodedNonceAccountData('4'.repeat(44) as Nonce),
                 },
             };
             yield FOREVER_PROMISE;
@@ -188,7 +188,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         const invalidationPromise = getNonceInvalidationPromise({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
-            currentNonceValue: '4'.repeat(44) as NewNonce,
+            currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
         });
         await jest.runAllTimersAsync();
@@ -197,13 +197,13 @@ describe('createNonceInvalidationPromiseFactory', () => {
     it('fatals when the nonce value returned by the account subscription is different than the expected one', async () => {
         expect.assertions(1);
         accountNotificationGenerator.mockImplementation(async function* () {
-            yield { value: { data: getBase64EncodedNonceAccountData('5'.repeat(44) as NewNonce) } };
+            yield { value: { data: getBase64EncodedNonceAccountData('5'.repeat(44) as Nonce) } };
             yield FOREVER_PROMISE;
         });
         const invalidationPromise = getNonceInvalidationPromise({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
-            currentNonceValue: '4'.repeat(44) as NewNonce,
+            currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
         });
         await expect(invalidationPromise).rejects.toThrow(

--- a/packages/transaction-confirmation/src/__tests__/waiters-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/waiters-test.ts
@@ -2,7 +2,7 @@ import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING, SolanaError } from '@solana/errors';
 import { Signature, SignatureBytes } from '@solana/keys';
 import type { Blockhash } from '@solana/rpc-types';
-import { NewNonce } from '@solana/transaction-messages';
+import { Nonce } from '@solana/transaction-messages';
 import { Transaction, TransactionMessageBytes } from '@solana/transactions';
 import {
     TransactionWithBlockhashLifetime,
@@ -22,7 +22,7 @@ const FOREVER_PROMISE = new Promise(() => {
 
 describe('waitForDurableNonceTransactionConfirmation', () => {
     const MOCK_DURABLE_NONCE_TRANSACTION: Transaction & TransactionWithDurableNonceLifetime = {
-        lifetimeConstraint: { nonce: 'xyz' as NewNonce, nonceAccountAddress: '5'.repeat(44) as Address },
+        lifetimeConstraint: { nonce: 'xyz' as Nonce, nonceAccountAddress: '5'.repeat(44) as Address },
         messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
         signatures: {
             ['9'.repeat(44) as Address]: new Uint8Array(new Array(64).fill(0)) as SignatureBytes,

--- a/packages/transaction-confirmation/src/confirmation-strategy-nonce.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-nonce.ts
@@ -4,12 +4,12 @@ import { SOLANA_ERROR__INVALID_NONCE, SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND, Sol
 import type { GetAccountInfoApi, Rpc } from '@solana/rpc';
 import type { AccountNotificationsApi, RpcSubscriptions } from '@solana/rpc-subscriptions';
 import type { Base64EncodedDataResponse, Commitment } from '@solana/rpc-types';
-import { NewNonce } from '@solana/transaction-messages';
+import { Nonce } from '@solana/transaction-messages';
 
 type GetNonceInvalidationPromiseFn = (config: {
     abortSignal: AbortSignal;
     commitment: Commitment;
-    currentNonceValue: NewNonce;
+    currentNonceValue: Nonce;
     nonceAccountAddress: Address;
 }) => Promise<void>;
 
@@ -42,10 +42,10 @@ export function createNonceInvalidationPromiseFactory(
             .subscribe({ abortSignal: abortController.signal });
         const base58Decoder = getBase58Decoder();
         const base64Encoder = getBase64Encoder();
-        function getNonceFromAccountData([base64EncodedBytes]: Base64EncodedDataResponse): NewNonce {
+        function getNonceFromAccountData([base64EncodedBytes]: Base64EncodedDataResponse): Nonce {
             const data = base64Encoder.encode(base64EncodedBytes);
             const nonceValueBytes = data.slice(NONCE_VALUE_OFFSET, NONCE_VALUE_OFFSET + 32);
-            return base58Decoder.decode(nonceValueBytes) as NewNonce;
+            return base58Decoder.decode(nonceValueBytes) as Nonce;
         }
         const nonceAccountDidAdvancePromise = (async () => {
             for await (const accountNotification of accountNotifications) {
@@ -78,7 +78,7 @@ export function createNonceInvalidationPromiseFactory(
             const nonceValue =
                 // This works because we asked for the exact slice of data representing the nonce
                 // value, and furthermore asked for it in `base58` encoding.
-                nonceAccount.data[0] as unknown as NewNonce;
+                nonceAccount.data[0] as unknown as Nonce;
             if (nonceValue !== expectedNonceValue) {
                 throw new SolanaError(SOLANA_ERROR__INVALID_NONCE, {
                     actualNonceValue: nonceValue,

--- a/packages/transaction-messages/src/__tests__/decompile-message-test.ts
+++ b/packages/transaction-messages/src/__tests__/decompile-message-test.ts
@@ -8,7 +8,7 @@ import { AccountRole, IAccountLookupMeta, IAccountMeta, IInstruction } from '@so
 
 import { CompiledTransactionMessage } from '../compile';
 import { decompileTransactionMessage } from '../decompile-message';
-import { NewNonce } from '../durable-nonce';
+import { Nonce } from '../durable-nonce';
 
 describe('decompileTransactionMessage', () => {
     const U64_MAX = 2n ** 64n - 1n;
@@ -197,7 +197,7 @@ describe('decompileTransactionMessage', () => {
     });
 
     describe('for a transaction with a durable nonce lifetime', () => {
-        const nonce = '27kqzE1RifbyoFtibDRTjbnfZ894jsNpuR77JJkt3vgH' as NewNonce;
+        const nonce = '27kqzE1RifbyoFtibDRTjbnfZ894jsNpuR77JJkt3vgH' as Nonce;
 
         // added as writable non-signer in the durable nonce instruction
         const nonceAccountAddress = 'DhezFECsqmzuDxeuitFChbghTrwKLdsKdVsGArYbFEtm' as Address;

--- a/packages/transaction-messages/src/__tests__/durable-nonce-test.ts
+++ b/packages/transaction-messages/src/__tests__/durable-nonce-test.ts
@@ -7,9 +7,9 @@ import type { Blockhash } from '@solana/rpc-types';
 import { TransactionMessageWithBlockhashLifetime } from '../blockhash';
 import {
     assertIsDurableNonceTransactionMessage,
-    IDurableNonceTransactionMessage,
-    NewNonce,
+    Nonce,
     setTransactionMessageLifetimeUsingDurableNonce,
+    TransactionMessageWithDurableNonceLifetime,
 } from '../durable-nonce';
 import { BaseTransactionMessage } from '../transaction-message';
 
@@ -22,7 +22,7 @@ function createMockAdvanceNonceAccountInstruction<
 }: {
     nonceAccountAddress: Address<TNonceAccountAddress>;
     nonceAuthorityAddress: Address<TNonceAuthorityAddress>;
-}): IDurableNonceTransactionMessage['instructions'][0] {
+}): TransactionMessageWithDurableNonceLifetime['instructions'][0] {
     return {
         accounts: [
             { address: nonceAccountAddress, role: AccountRole.WRITABLE } as WritableAccount<TNonceAccountAddress>,
@@ -36,15 +36,15 @@ function createMockAdvanceNonceAccountInstruction<
                 role: AccountRole.READONLY_SIGNER,
             } as ReadonlySignerAccount<TNonceAuthorityAddress>,
         ],
-        data: new Uint8Array([4, 0, 0, 0]) as IDurableNonceTransactionMessage['instructions'][0]['data'],
+        data: new Uint8Array([4, 0, 0, 0]) as TransactionMessageWithDurableNonceLifetime['instructions'][0]['data'],
         programAddress: '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>,
     };
 }
 
 describe('assertIsDurableNonceTransactionMessage()', () => {
-    let durableNonceTx: BaseTransactionMessage & IDurableNonceTransactionMessage;
+    let durableNonceTx: BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime;
     const NONCE_CONSTRAINT = {
-        nonce: '123' as NewNonce,
+        nonce: '123' as Nonce,
         nonceAccountAddress: '123' as Address,
         nonceAuthorityAddress: '123' as Address,
     };
@@ -53,7 +53,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
             instructions: [createMockAdvanceNonceAccountInstruction(NONCE_CONSTRAINT)],
             lifetimeConstraint: {
                 nonce: NONCE_CONSTRAINT.nonce,
-            } as IDurableNonceTransactionMessage['lifetimeConstraint'],
+            } as TransactionMessageWithDurableNonceLifetime['lifetimeConstraint'],
             version: 0,
         } as const;
     });
@@ -77,7 +77,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
                 ],
                 lifetimeConstraint: {
                     nonce: NONCE_CONSTRAINT.nonce,
-                } as IDurableNonceTransactionMessage['lifetimeConstraint'],
+                } as TransactionMessageWithDurableNonceLifetime['lifetimeConstraint'],
             });
         }).toThrow();
     });
@@ -93,7 +93,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
                 ],
                 lifetimeConstraint: {
                     nonce: NONCE_CONSTRAINT.nonce,
-                } as IDurableNonceTransactionMessage['lifetimeConstraint'],
+                } as TransactionMessageWithDurableNonceLifetime['lifetimeConstraint'],
             });
         }).toThrow();
     });
@@ -109,7 +109,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
                 ],
                 lifetimeConstraint: {
                     nonce: NONCE_CONSTRAINT.nonce,
-                } as IDurableNonceTransactionMessage['lifetimeConstraint'],
+                } as TransactionMessageWithDurableNonceLifetime['lifetimeConstraint'],
             });
         }).toThrow();
     });
@@ -155,7 +155,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
             instructions: [updatedInstruction],
             lifetimeConstraint: {
                 nonce: NONCE_CONSTRAINT.nonce,
-            } as IDurableNonceTransactionMessage['lifetimeConstraint'],
+            } as TransactionMessageWithDurableNonceLifetime['lifetimeConstraint'],
             version: 0,
         } as const;
         expect(() => {
@@ -167,12 +167,12 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
 describe('setTransactionMessageLifetimeUsingDurableNonce', () => {
     let baseTx: BaseTransactionMessage;
     const NONCE_CONSTRAINT_A = {
-        nonce: '123' as NewNonce,
+        nonce: '123' as Nonce,
         nonceAccountAddress: '123' as Address,
         nonceAuthorityAddress: '123' as Address,
     };
     const NONCE_CONSTRAINT_B = {
-        nonce: '456' as NewNonce,
+        nonce: '456' as Nonce,
         nonceAccountAddress: '456' as Address,
         nonceAuthorityAddress: '456' as Address,
     };
@@ -229,7 +229,7 @@ describe('setTransactionMessageLifetimeUsingDurableNonce', () => {
         });
     });
     describe('given a durable nonce transaction', () => {
-        let durableNonceTxWithConstraintA: BaseTransactionMessage & IDurableNonceTransactionMessage;
+        let durableNonceTxWithConstraintA: BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime;
         beforeEach(() => {
             durableNonceTxWithConstraintA = {
                 ...baseTx,

--- a/packages/transaction-messages/src/__typetests__/transaction-message-typetests.ts
+++ b/packages/transaction-messages/src/__typetests__/transaction-message-typetests.ts
@@ -9,9 +9,9 @@ import {
 import { CompilableTransactionMessage } from '../compilable-transaction-message';
 import { createTransactionMessage } from '../create-transaction-message';
 import {
-    IDurableNonceTransactionMessage,
-    NewNonce,
+    Nonce,
     setTransactionMessageLifetimeUsingDurableNonce,
+    TransactionMessageWithDurableNonceLifetime,
 } from '../durable-nonce';
 import { ITransactionMessageWithFeePayer, setTransactionMessageFeePayer } from '../fee-payer';
 import { appendTransactionMessageInstruction, prependTransactionMessageInstruction } from '../instructions';
@@ -24,7 +24,7 @@ const mockBlockhashLifetime = {
     lastValidBlockHeight: 0n,
 };
 const mockNonceConfig = {
-    nonce: null as unknown as NewNonce<'nonce'>,
+    nonce: null as unknown as Nonce<'nonce'>,
     nonceAccountAddress: null as unknown as Address<'nonce'>,
     nonceAuthorityAddress: null as unknown as Address<'nonceAuthority'>,
 };
@@ -98,21 +98,21 @@ setTransactionMessageLifetimeUsingBlockhash(
 setTransactionMessageLifetimeUsingDurableNonce(
     mockNonceConfig,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }>,
-) satisfies Extract<TransactionMessage, { version: 'legacy' }> & IDurableNonceTransactionMessage;
+) satisfies Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithDurableNonceLifetime;
 setTransactionMessageLifetimeUsingDurableNonce(
     mockNonceConfig,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }>,
     // @ts-expect-error Version should match
-) satisfies Extract<TransactionMessage, { version: 0 }> & IDurableNonceTransactionMessage;
+) satisfies Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithDurableNonceLifetime;
 setTransactionMessageLifetimeUsingDurableNonce(
     mockNonceConfig,
     null as unknown as Extract<TransactionMessage, { version: 0 }>,
-) satisfies Extract<TransactionMessage, { version: 0 }> & IDurableNonceTransactionMessage;
+) satisfies Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithDurableNonceLifetime;
 setTransactionMessageLifetimeUsingDurableNonce(
     mockNonceConfig,
     null as unknown as Extract<TransactionMessage, { version: 0 }>,
     // @ts-expect-error Version should match
-) satisfies Extract<TransactionMessage, { version: 'legacy' }> & IDurableNonceTransactionMessage;
+) satisfies Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithDurableNonceLifetime;
 
 // setTransactionMessageFeePayer
 
@@ -168,31 +168,31 @@ setTransactionMessageFeePayer(
 // (durable nonce)
 setTransactionMessageFeePayer(
     mockFeePayer,
-    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & IDurableNonceTransactionMessage,
+    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithDurableNonceLifetime,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    IDurableNonceTransactionMessage &
-    ITransactionMessageWithFeePayer<'feePayer'>;
+    ITransactionMessageWithFeePayer<'feePayer'> &
+    TransactionMessageWithDurableNonceLifetime;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }> &
-        IDurableNonceTransactionMessage &
-        ITransactionMessageWithFeePayer<'NOTfeePayer'>,
+        ITransactionMessageWithFeePayer<'NOTfeePayer'> &
+        TransactionMessageWithDurableNonceLifetime,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    IDurableNonceTransactionMessage &
-    ITransactionMessageWithFeePayer<'feePayer'>;
+    ITransactionMessageWithFeePayer<'feePayer'> &
+    TransactionMessageWithDurableNonceLifetime;
 setTransactionMessageFeePayer(
     mockFeePayer,
-    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & IDurableNonceTransactionMessage,
+    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithDurableNonceLifetime,
     // @ts-expect-error Version should match
 ) satisfies Extract<TransactionMessage, { version: 0 }> &
-    IDurableNonceTransactionMessage &
-    ITransactionMessageWithFeePayer<'feePayer'>;
+    ITransactionMessageWithFeePayer<'feePayer'> &
+    TransactionMessageWithDurableNonceLifetime;
 setTransactionMessageFeePayer(
     mockFeePayer,
-    null as unknown as Extract<TransactionMessage, { version: 0 }> & IDurableNonceTransactionMessage,
+    null as unknown as Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithDurableNonceLifetime,
 ) satisfies Extract<TransactionMessage, { version: 0 }> &
-    IDurableNonceTransactionMessage &
-    ITransactionMessageWithFeePayer<'feePayer'>;
+    ITransactionMessageWithFeePayer<'feePayer'> &
+    TransactionMessageWithDurableNonceLifetime;
 
 // appendTransactionMessageInstruction
 appendTransactionMessageInstruction(
@@ -232,11 +232,14 @@ null as unknown as BaseTransactionMessage & ITransactionMessageWithFeePayer sati
 null as unknown as BaseTransactionMessage &
     // @ts-expect-error missing fee payer
     TransactionMessageWithBlockhashLifetime satisfies CompilableTransactionMessage;
-// @ts-expect-error missing fee payer
-null as unknown as BaseTransactionMessage & IDurableNonceTransactionMessage satisfies CompilableTransactionMessage;
+{
+    const transaction = null as unknown as BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    // @ts-expect-error missing fee payer
+    transaction satisfies CompilableTransactionMessage;
+}
 null as unknown as BaseTransactionMessage &
     ITransactionMessageWithFeePayer &
     TransactionMessageWithBlockhashLifetime satisfies CompilableTransactionMessage;
 null as unknown as BaseTransactionMessage &
-    IDurableNonceTransactionMessage &
-    ITransactionMessageWithFeePayer satisfies CompilableTransactionMessage;
+    ITransactionMessageWithFeePayer &
+    TransactionMessageWithDurableNonceLifetime satisfies CompilableTransactionMessage;

--- a/packages/transaction-messages/src/blockhash.ts
+++ b/packages/transaction-messages/src/blockhash.ts
@@ -1,7 +1,7 @@
 import { SOLANA_ERROR__TRANSACTION__EXPECTED_BLOCKHASH_LIFETIME, SolanaError } from '@solana/errors';
 import { assertIsBlockhash, type Blockhash } from '@solana/rpc-types';
 
-import { IDurableNonceTransactionMessage } from './durable-nonce';
+import { TransactionMessageWithDurableNonceLifetime } from './durable-nonce';
 import { BaseTransactionMessage } from './transaction-message';
 
 type BlockhashLifetimeConstraint = Readonly<{
@@ -38,7 +38,7 @@ export function assertIsTransactionMessageWithBlockhashLifetime(
 }
 
 export function setTransactionMessageLifetimeUsingBlockhash<
-    TTransaction extends BaseTransactionMessage & IDurableNonceTransactionMessage,
+    TTransaction extends BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime,
 >(
     blockhashLifetimeConstraint: BlockhashLifetimeConstraint,
     transaction: TTransaction,

--- a/packages/transaction-messages/src/compilable-transaction-message.ts
+++ b/packages/transaction-messages/src/compilable-transaction-message.ts
@@ -1,7 +1,7 @@
 import { IInstruction } from '@solana/instructions';
 
 import { TransactionMessageWithBlockhashLifetime } from './blockhash';
-import { IDurableNonceTransactionMessage } from './durable-nonce';
+import { TransactionMessageWithDurableNonceLifetime } from './durable-nonce';
 import { ITransactionMessageWithFeePayer } from './fee-payer';
 import { BaseTransactionMessage, NewTransactionVersion } from './transaction-message';
 
@@ -10,4 +10,4 @@ export type CompilableTransactionMessage<
     TInstruction extends IInstruction = IInstruction,
 > = BaseTransactionMessage<TVersion, TInstruction> &
     ITransactionMessageWithFeePayer &
-    (IDurableNonceTransactionMessage | TransactionMessageWithBlockhashLifetime);
+    (TransactionMessageWithBlockhashLifetime | TransactionMessageWithDurableNonceLifetime);

--- a/packages/transaction-messages/src/compile/__tests__/lifetime-token-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/lifetime-token-test.ts
@@ -1,7 +1,7 @@
 import type { Blockhash } from '@solana/rpc-types';
 
 import { getCompiledLifetimeToken } from '../../compile/lifetime-token';
-import { NewNonce } from '../../durable-nonce';
+import { Nonce } from '../../durable-nonce';
 
 describe('getCompiledLifetimeToken', () => {
     it('compiles a recent blockhash lifetime constraint', () => {
@@ -13,7 +13,7 @@ describe('getCompiledLifetimeToken', () => {
     });
     it('compiles a nonce lifetime constraint', () => {
         const token = getCompiledLifetimeToken({
-            nonce: 'abc' as NewNonce,
+            nonce: 'abc' as Nonce,
         });
         expect(token).toBe('abc');
     });

--- a/packages/transaction-messages/src/compile/lifetime-token.ts
+++ b/packages/transaction-messages/src/compile/lifetime-token.ts
@@ -1,9 +1,9 @@
-import { IDurableNonceTransactionMessage, TransactionMessageWithBlockhashLifetime } from '../index';
+import { TransactionMessageWithBlockhashLifetime, TransactionMessageWithDurableNonceLifetime } from '../index';
 
 export function getCompiledLifetimeToken(
     lifetimeConstraint: (
-        | IDurableNonceTransactionMessage
         | TransactionMessageWithBlockhashLifetime
+        | TransactionMessageWithDurableNonceLifetime
     )['lifetimeConstraint'],
 ): string {
     if ('nonce' in lifetimeConstraint) {

--- a/packages/transaction-messages/src/decompile-message.ts
+++ b/packages/transaction-messages/src/decompile-message.ts
@@ -16,8 +16,8 @@ import { CompiledTransactionMessage } from './compile';
 import type { getCompiledAddressTableLookups } from './compile/address-table-lookups';
 import { createTransactionMessage } from './create-transaction-message';
 import {
-    newIsAdvanceNonceAccountInstruction,
-    NewNonce,
+    isAdvanceNonceAccountInstruction,
+    Nonce,
     setTransactionMessageLifetimeUsingDurableNonce,
 } from './durable-nonce';
 import { setTransactionMessageFeePayer } from './fee-payer';
@@ -149,7 +149,7 @@ type LifetimeConstraint =
           lastValidBlockHeight: bigint;
       }
     | {
-          nonce: NewNonce;
+          nonce: Nonce;
           nonceAccountAddress: Address;
           nonceAuthorityAddress: Address;
       };
@@ -159,7 +159,7 @@ function getLifetimeConstraint(
     firstInstruction?: IInstruction,
     lastValidBlockHeight?: bigint,
 ): LifetimeConstraint {
-    if (!firstInstruction || !newIsAdvanceNonceAccountInstruction(firstInstruction)) {
+    if (!firstInstruction || !isAdvanceNonceAccountInstruction(firstInstruction)) {
         // first instruction is not advance durable nonce, so use blockhash lifetime constraint
         return {
             blockhash: messageLifetimeToken as Blockhash,
@@ -174,7 +174,7 @@ function getLifetimeConstraint(
         assertIsAddress(nonceAuthorityAddress);
 
         return {
-            nonce: messageLifetimeToken as NewNonce,
+            nonce: messageLifetimeToken as Nonce,
             nonceAccountAddress,
             nonceAuthorityAddress,
         };

--- a/packages/transactions/src/__tests__/compile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/compile-transaction-test.ts
@@ -6,7 +6,7 @@ import {
     CompiledTransactionMessage,
     compileTransactionMessage,
     getCompiledTransactionMessageEncoder,
-    NewNonce,
+    Nonce,
 } from '@solana/transaction-messages';
 
 import { compileTransaction } from '../compile-transaction';
@@ -99,12 +99,12 @@ describe('compileTransactionMessage', () => {
                 },
             ],
             lifetimeConstraint: {
-                nonce: 'b' as NewNonce,
+                nonce: 'b' as Nonce,
             },
         } as unknown as TransactionMessage;
         const transaction = compileTransaction(transactionMessage);
         expect(transaction.lifetimeConstraint).toStrictEqual({
-            nonce: 'b' as NewNonce,
+            nonce: 'b' as Nonce,
             nonceAccountAddress: 'nonceAddress',
         });
     });

--- a/packages/transactions/src/__typetests__/compile-transaction-typetests.ts
+++ b/packages/transactions/src/__typetests__/compile-transaction-typetests.ts
@@ -2,10 +2,10 @@ import { Blockhash } from '@solana/rpc-types';
 import {
     BaseTransactionMessage,
     CompilableTransactionMessage,
-    IDurableNonceTransactionMessage,
     ITransactionMessageWithFeePayer,
-    NewNonce,
+    Nonce,
     TransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithDurableNonceLifetime,
 } from '@solana/transaction-messages';
 
 import { compileTransaction } from '../compile-transaction';
@@ -37,14 +37,20 @@ compileTransaction(
 
 // transaction message with durable nonce lifetime
 compileTransaction(
-    null as unknown as BaseTransactionMessage & IDurableNonceTransactionMessage & ITransactionMessageWithFeePayer,
+    null as unknown as BaseTransactionMessage &
+        ITransactionMessageWithFeePayer &
+        TransactionMessageWithDurableNonceLifetime,
 ) satisfies Readonly<Transaction & TransactionWithLifetime>;
 compileTransaction(
-    null as unknown as BaseTransactionMessage & IDurableNonceTransactionMessage & ITransactionMessageWithFeePayer,
+    null as unknown as BaseTransactionMessage &
+        ITransactionMessageWithFeePayer &
+        TransactionMessageWithDurableNonceLifetime,
 ) satisfies Readonly<Transaction & TransactionWithDurableNonceLifetime>;
 compileTransaction(
-    null as unknown as BaseTransactionMessage & IDurableNonceTransactionMessage & ITransactionMessageWithFeePayer,
-).lifetimeConstraint.nonce satisfies NewNonce;
+    null as unknown as BaseTransactionMessage &
+        ITransactionMessageWithFeePayer &
+        TransactionMessageWithDurableNonceLifetime,
+).lifetimeConstraint.nonce satisfies Nonce;
 
 // transaction message with unknown lifetime
 compileTransaction(null as unknown as CompilableTransactionMessage) satisfies Readonly<
@@ -60,10 +66,10 @@ compileTransaction(null as unknown as CompilableTransactionMessage) satisfies Re
 >;
 compileTransaction(null as unknown as CompilableTransactionMessage).lifetimeConstraint satisfies
     | { blockhash: Blockhash }
-    | { nonce: NewNonce };
+    | { nonce: Nonce };
 // @ts-expect-error not known to have blockhash lifetime
 compileTransaction(null as unknown as CompilableTransactionMessage).lifetimeConstraint satisfies {
     blockhash: Blockhash;
 };
 // @ts-expect-error not known to have durable nonce lifetime
-compileTransaction(null as unknown as CompilableTransactionMessage).lifetimeConstraint satisfies { nonce: NewNonce };
+compileTransaction(null as unknown as CompilableTransactionMessage).lifetimeConstraint satisfies { nonce: Nonce };

--- a/packages/transactions/src/compile-transaction.ts
+++ b/packages/transactions/src/compile-transaction.ts
@@ -3,9 +3,9 @@ import {
     CompilableTransactionMessage,
     compileTransactionMessage,
     getCompiledTransactionMessageEncoder,
-    IDurableNonceTransactionMessage,
     isTransactionMessageWithBlockhashLifetime,
     TransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithDurableNonceLifetime,
 } from '@solana/transaction-messages';
 
 import {
@@ -20,7 +20,7 @@ export function compileTransaction(
 ): Readonly<Transaction & TransactionWithBlockhashLifetime>;
 
 export function compileTransaction(
-    transactionMessage: CompilableTransactionMessage & IDurableNonceTransactionMessage,
+    transactionMessage: CompilableTransactionMessage & TransactionMessageWithDurableNonceLifetime,
 ): Readonly<Transaction & TransactionWithDurableNonceLifetime>;
 
 export function compileTransaction(

--- a/packages/transactions/src/lifetime.ts
+++ b/packages/transactions/src/lifetime.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 import { Blockhash, Slot } from '@solana/rpc-types';
-import { NewNonce } from '@solana/transaction-messages';
+import { Nonce } from '@solana/transaction-messages';
 
 export type TransactionBlockhashLifetime = {
     blockhash: Blockhash;
@@ -8,7 +8,7 @@ export type TransactionBlockhashLifetime = {
 };
 
 export type TransactionDurableNonceLifetime = {
-    nonce: NewNonce;
+    nonce: Nonce;
     nonceAccountAddress: Address;
 };
 


### PR DESCRIPTION
- Rename NewNonce to Nonce
- Rename IDurableNonceTransactionMessage to TransactionMessageWithDurableNonceLifetime to mirror Transaction lifetime
- Remove the `new` prefix from functions