### PR TITLE
refactor(experimental): graphql: token-2022 extensions: initialize-permanent-delegate

### DIFF
--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -17,6 +17,7 @@ import {
     mockTransactionMemo,
     mockTransactionSystem,
     mockTransactionToken,
+    mockTransactionToken2022AllExtensions,
     mockTransactionVote,
 } from './__setup__';
 
@@ -648,6 +649,95 @@ describe('transaction', () => {
                                                 },
                                             },
                                         ]),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+        });
+        describe('token-2022 extensions', () => {
+            beforeEach(() => {
+                mockRpcTransport.mockResolvedValueOnce(mockTransactionToken2022AllExtensions);
+            });
+            it('initialize-mint-close-authority', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenInitializeMintCloseAuthorityInstruction {
+                                        mint {
+                                            address
+                                        }
+                                        newAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        newAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+            it('initialize-permanent-delegate', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenInitializePermanentDelegateInstruction {
+                                        delegate {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        delegate: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                                     },
                                 ]),
                             },

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -230,6 +230,10 @@ export const instructionResolvers = {
         multisig: resolveAccount('multisig'),
         rentSysvar: resolveAccount('rentSysvar'),
     },
+    SplTokenInitializePermanentDelegateInstruction: {
+        delegate: resolveAccount('delegate'),
+        mint: resolveAccount('mint'),
+    },
     SplTokenMintToCheckedInstruction: {
         account: resolveAccount('account'),
         authority: resolveAccount('authority'),
@@ -523,6 +527,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeMintCloseAuthority') {
                         return 'SplTokenInitializeMintCloseAuthorityInstruction';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializePermanentDelegate') {
+                        return 'SplTokenInitializePermanentDelegateInstruction';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -504,7 +504,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     }
 
     """
-    SplToken: InitializeMintCloseAuthority instruction
+    SplToken-2022: InitializeMintCloseAuthority instruction
     """
     type SplTokenInitializeMintCloseAuthorityInstruction implements TransactionInstruction {
         programId: Address
@@ -512,21 +512,17 @@ export const instructionTypeDefs = /* GraphQL */ `
         newAuthority: Account
     }
 
+    """
+    SplToken-2022: InitializePermanentDelegate instruction
+    """
+    type SplTokenInitializePermanentDelegateInstruction implements TransactionInstruction {
+        programId: Address
+        delegate: Account
+        mint: Account
+    }
+
     # TODO: Extensions!
-    # - TransferFeeExtension
-    # - ConfidentialTransferFeeExtension
-    # - DefaultAccountStateExtension
-    # - Reallocate
-    # - MemoTransferExtension
-    # - CreateNativeMint
-    # - InitializeNonTransferableMint
-    # - InterestBearingMintExtension
-    # - CpiGuardExtension
-    # - InitializePermanentDelegate
-    # - TransferHookExtension
-    # - ConfidentialTransferFeeExtension
-    # - WithdrawExcessLamports
-    # - MetadataPointerExtension
+    # ...
 
     type Lockup {
         custodian: Account


### PR DESCRIPTION
This PR adds support for Token-2022's `InitializePermanentDelegate` extension
in the GraphQL schema.

cc @Hrushi20.

Continuing work on #2406.