### PR TITLE
refactor(experimental): graphql: token-2022 extensions: metadata pointer

### DIFF
--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -745,6 +745,102 @@ describe('transaction', () => {
                     },
                 });
             });
+            it('initialize-metadata-pointer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenInitializeMetadataPointerInstruction {
+                                        authority {
+                                            address
+                                        }
+                                        metadataAddress {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        metadataAddress: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+            it('update-metadata-pointer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenUpdateMetadataPointerInstruction {
+                                        authority {
+                                            address
+                                        }
+                                        metadataAddress {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        metadataAddress: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -208,6 +208,11 @@ export const instructionResolvers = {
         owner: resolveAccount('owner'),
         rentSysvar: resolveAccount('rentSysvar'),
     },
+    SplTokenInitializeMetadataPointerInstruction: {
+        authority: resolveAccount('authority'),
+        metadataAddress: resolveAccount('metadataAddress'),
+        mint: resolveAccount('mint'),
+    },
     SplTokenInitializeMint2Instruction: {
         freezeAuthority: resolveAccount('freezeAuthority'),
         mint: resolveAccount('mint'),
@@ -281,6 +286,11 @@ export const instructionResolvers = {
         source: resolveAccount('source'),
     },
     SplTokenUiAmountToAmountInstruction: {
+        mint: resolveAccount('mint'),
+    },
+    SplTokenUpdateMetadataPointerInstruction: {
+        authority: resolveAccount('authority'),
+        metadataAddress: resolveAccount('metadataAddress'),
         mint: resolveAccount('mint'),
     },
     StakeAuthorizeCheckedInstruction: {
@@ -530,6 +540,12 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'initializePermanentDelegate') {
                         return 'SplTokenInitializePermanentDelegateInstruction';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializeMetadataPointer') {
+                        return 'SplTokenInitializeMetadataPointerInstruction';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'updateMetadataPointer') {
+                        return 'SplTokenUpdateMetadataPointerInstruction';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -521,6 +521,26 @@ export const instructionTypeDefs = /* GraphQL */ `
         mint: Account
     }
 
+    """
+    SplToken-2022: InitializeMetadataPointer instruction
+    """
+    type SplTokenInitializeMetadataPointerInstruction implements TransactionInstruction {
+        programId: Address
+        authority: Account
+        metadataAddress: Account
+        mint: Account
+    }
+
+    """
+    SplToken-2022: UpdateMetadataPointer instruction
+    """
+    type SplTokenUpdateMetadataPointerInstruction implements TransactionInstruction {
+        programId: Address
+        authority: Account
+        metadataAddress: Account
+        mint: Account
+    }
+
     # TODO: Extensions!
     # ...
 


### PR DESCRIPTION
This PR adds support for Token-2022's `MetadataPointer` extension
in the GraphQL schema.

cc @Hrushi20.

Continuing work on #2406.