### PR TITLE
Rename setTransactionFeePayerSigner to setTransactionMessageFeePayerSigner

### DIFF
--- a/packages/signers/src/__tests__/account-signer-meta-test.ts
+++ b/packages/signers/src/__tests__/account-signer-meta-test.ts
@@ -2,7 +2,7 @@ import { Address } from '@solana/addresses';
 import { createTransactionMessage } from '@solana/transaction-messages';
 
 import { getSignersFromInstruction, getSignersFromTransactionMessage } from '../account-signer-meta';
-import { setTransactionFeePayerSigner } from '../fee-payer-signer';
+import { setTransactionMessageFeePayerSigner } from '../fee-payer-signer';
 import {
     createMockInstructionWithSigners,
     createMockTransactionMessageWithSigners,
@@ -60,7 +60,10 @@ describe('getSignersFromTransactionMessage', () => {
     it('extracts the fee payer signer of the provided transaction', () => {
         // Given a transaction with a signer fee payer.
         const feePayerSigner = createMockTransactionPartialSigner('1111' as Address);
-        const transaction = setTransactionFeePayerSigner(feePayerSigner, createTransactionMessage({ version: 0 }));
+        const transaction = setTransactionMessageFeePayerSigner(
+            feePayerSigner,
+            createTransactionMessage({ version: 0 }),
+        );
 
         // When we extract the signers from the transaction.
         const extractedSigners = getSignersFromTransactionMessage(transaction);

--- a/packages/signers/src/__tests__/fee-payer-signer-test.ts
+++ b/packages/signers/src/__tests__/fee-payer-signer-test.ts
@@ -3,11 +3,11 @@ import '@solana/test-matchers/toBeFrozenObject';
 import { Address } from '@solana/addresses';
 import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { ITransactionMessageWithFeePayerSigner, setTransactionFeePayerSigner } from '../fee-payer-signer';
+import { ITransactionMessageWithFeePayerSigner, setTransactionMessageFeePayerSigner } from '../fee-payer-signer';
 import { TransactionSigner } from '../transaction-signer';
 import { createMockTransactionPartialSigner } from './__setup__';
 
-describe('setTransactionFeePayerSigner', () => {
+describe('setTransactionMessageFeePayerSigner', () => {
     let feePayerSignerA: TransactionSigner;
     let feePayerSignerB: TransactionSigner;
     let baseTx: BaseTransactionMessage;
@@ -17,7 +17,7 @@ describe('setTransactionFeePayerSigner', () => {
         feePayerSignerB = createMockTransactionPartialSigner('2222' as Address);
     });
     it('sets the fee payer signer on the transaction', () => {
-        const txWithFeePayerA = setTransactionFeePayerSigner(feePayerSignerA, baseTx);
+        const txWithFeePayerA = setTransactionMessageFeePayerSigner(feePayerSignerA, baseTx);
         expect(txWithFeePayerA).toHaveProperty('feePayer', feePayerSignerA.address);
         expect(txWithFeePayerA).toHaveProperty('feePayerSigner', feePayerSignerA);
     });
@@ -31,12 +31,12 @@ describe('setTransactionFeePayerSigner', () => {
             };
         });
         it('sets the new fee payer on the transaction when it differs from the existing one', () => {
-            const txWithFeePayerB = setTransactionFeePayerSigner(feePayerSignerB, txWithFeePayerA);
+            const txWithFeePayerB = setTransactionMessageFeePayerSigner(feePayerSignerB, txWithFeePayerA);
             expect(txWithFeePayerB).toHaveProperty('feePayer', feePayerSignerB.address);
             expect(txWithFeePayerB).toHaveProperty('feePayerSigner', feePayerSignerB);
         });
         it('returns the original transaction when trying to set the same fee payer again', () => {
-            const txWithSameFeePayer = setTransactionFeePayerSigner(feePayerSignerA, txWithFeePayerA);
+            const txWithSameFeePayer = setTransactionMessageFeePayerSigner(feePayerSignerA, txWithFeePayerA);
             expect(txWithFeePayerA).toBe(txWithSameFeePayer);
         });
     });
@@ -49,19 +49,19 @@ describe('setTransactionFeePayerSigner', () => {
             };
         });
         it('sets the new fee payer on the transaction when it differs from the existing one', () => {
-            const txWithFeePayerB = setTransactionFeePayerSigner(feePayerSignerB, txWithFeePayerA);
+            const txWithFeePayerB = setTransactionMessageFeePayerSigner(feePayerSignerB, txWithFeePayerA);
             expect(txWithFeePayerB).toHaveProperty('feePayer', feePayerSignerB.address);
             expect(txWithFeePayerB).toHaveProperty('feePayerSigner', feePayerSignerB);
         });
         it('returns a new transaction instance when setting the same fee payer but as a signer this time', () => {
-            const txWithSameFeePayer = setTransactionFeePayerSigner(feePayerSignerA, txWithFeePayerA);
+            const txWithSameFeePayer = setTransactionMessageFeePayerSigner(feePayerSignerA, txWithFeePayerA);
             expect(txWithSameFeePayer).toHaveProperty('feePayer', feePayerSignerA.address);
             expect(txWithSameFeePayer).toHaveProperty('feePayerSigner', feePayerSignerA);
             expect(txWithFeePayerA).not.toBe(txWithSameFeePayer);
         });
     });
     it('freezes the object', () => {
-        const txWithFeePayer = setTransactionFeePayerSigner(feePayerSignerA, baseTx);
+        const txWithFeePayer = setTransactionMessageFeePayerSigner(feePayerSignerA, baseTx);
         expect(txWithFeePayer).toBeFrozenObject();
     });
 });

--- a/packages/signers/src/__tests__/sign-transaction-test.ts
+++ b/packages/signers/src/__tests__/sign-transaction-test.ts
@@ -7,8 +7,13 @@ import {
     SolanaError,
 } from '@solana/errors';
 import { Blockhash } from '@solana/rpc-types';
-import { compileTransaction, FullySignedTransaction, Transaction, TransactionMessageBytes } from '@solana/transactions';
-import { TransactionWithLifetime } from '@solana/transactions/dist/types/lifetime';
+import {
+    compileTransaction,
+    FullySignedTransaction,
+    Transaction,
+    TransactionMessageBytes,
+    TransactionWithLifetime,
+} from '@solana/transactions';
 
 import { ReadonlyUint8Array } from '../../../codecs-core/dist/types';
 import {

--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -4,12 +4,13 @@ import {
     TransactionMessageWithBlockhashLifetime,
     TransactionMessageWithDurableNonceLifetime,
 } from '@solana/transaction-messages';
-import { FullySignedTransaction, Transaction } from '@solana/transactions';
 import {
+    FullySignedTransaction,
+    Transaction,
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
     TransactionWithLifetime,
-} from '@solana/transactions/dist/types/lifetime';
+} from '@solana/transactions';
 
 import { ITransactionMessageWithSigners } from '../account-signer-meta';
 import {

--- a/packages/signers/src/fee-payer-signer.ts
+++ b/packages/signers/src/fee-payer-signer.ts
@@ -11,7 +11,7 @@ export interface ITransactionMessageWithFeePayerSigner<
     readonly feePayerSigner: TSigner;
 }
 
-export function setTransactionFeePayerSigner<
+export function setTransactionMessageFeePayerSigner<
     TFeePayerAddress extends string,
     TTransactionMessage extends BaseTransactionMessage,
 >(

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -10,12 +10,10 @@ import {
     compileTransaction,
     FullySignedTransaction,
     Transaction,
-} from '@solana/transactions';
-import {
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
     TransactionWithLifetime,
-} from '@solana/transactions/dist/types/lifetime';
+} from '@solana/transactions';
 
 import { getSignersFromTransactionMessage, ITransactionMessageWithSigners } from './account-signer-meta';
 import { deduplicateSigners } from './deduplicate-signers';


### PR DESCRIPTION
Clean up imports of `@solana/transactions` in signers, there were some leftover imports from `dist/types`. 

Rename `setTransactionFeePayerSigner` to `setTransactionMessageFeePayerSigner` to match the rest of the API