### PR TITLE
[refactor] [experimental] Use optimised base16 encode strategy

### DIFF
--- a/packages/codecs-strings/src/__benchmarks__/run.ts
+++ b/packages/codecs-strings/src/__benchmarks__/run.ts
@@ -1,9 +1,10 @@
-#!/usr/bin/env -S pnpx tsx
+#!/usr/bin/env -S  pnpm exec tsx
 
 import { webcrypto as crypto } from 'node:crypto';
 
 import { Bench } from 'tinybench';
 
+import { getBase16Codec } from '../base16';
 import { getBase58Codec } from '../base58';
 
 const bench = new Bench({
@@ -11,11 +12,15 @@ const bench = new Bench({
 });
 
 const bytes32 = new Uint8Array(32);
+const bytes16 = new Uint8Array(16);
 let base58EncodedString: string;
+let base16EncodedString: string;
 function randomizeBytes() {
     crypto.getRandomValues(bytes32);
+    crypto.getRandomValues(bytes16);
 }
 const base58Codec = getBase58Codec();
+const base16Codec = getBase16Codec();
 
 bench
     .add(
@@ -36,7 +41,17 @@ bench
                 base58EncodedString = base58Codec.decode(bytes32);
             },
         },
-    );
+    )
+    .add(
+        'Base16 encode',
+        () => {
+            base16Codec.encode(base16EncodedString);
+        }, {
+        beforeEach() {
+            randomizeBytes();
+            base16EncodedString = base16Codec.decode(bytes16);
+        }
+    });
 
 (async () => {
     await bench.warmup();

--- a/packages/codecs-strings/src/__benchmarks__/run.ts
+++ b/packages/codecs-strings/src/__benchmarks__/run.ts
@@ -46,12 +46,14 @@ bench
         'Base16 encode',
         () => {
             base16Codec.encode(base16EncodedString);
-        }, {
-        beforeEach() {
-            randomizeBytes();
-            base16EncodedString = base16Codec.decode(bytes16);
-        }
-    });
+        },
+        {
+            beforeEach() {
+                randomizeBytes();
+                base16EncodedString = base16Codec.decode(bytes16);
+            },
+        },
+    );
 
 (async () => {
     await bench.warmup();

--- a/packages/codecs-strings/src/__benchmarks__/run.ts
+++ b/packages/codecs-strings/src/__benchmarks__/run.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S  pnpm exec tsx
+#!/usr/bin/env -S pnpx tsx
 
 import { webcrypto as crypto } from 'node:crypto';
 

--- a/packages/codecs-strings/src/base16.ts
+++ b/packages/codecs-strings/src/base16.ts
@@ -6,18 +6,59 @@ import {
     VariableSizeDecoder,
     VariableSizeEncoder,
 } from '@solana/codecs-core';
+import { SOLANA_ERROR__CODECS__INVALID_STRING_FOR_BASE, SolanaError } from '@solana/errors';
 
-import { assertValidBaseString } from './assertions';
+const enum HexC {
+    ZERO = 48, // 0
+    NINE = 57, // 9
+    A_UP = 65, // A
+    F_UP = 70, // F
+    A_LO = 97, // a
+    F_LO = 102, // f
+}
 
+function charCodeToBase16(char: number) {
+    if (char >= HexC.ZERO && char <= HexC.NINE) return char - HexC.ZERO;
+    if (char >= HexC.A_UP && char <= HexC.F_UP) return char - (HexC.A_UP - 10);
+    if (char >= HexC.A_LO && char <= HexC.F_LO) return char - (HexC.A_LO - 10);
+}
 /** Encodes strings in base16. */
 export const getBase16Encoder = (): VariableSizeEncoder<string> =>
     createEncoder({
         getSizeFromValue: (value: string) => Math.ceil(value.length / 2),
         write(value: string, bytes, offset) {
-            const lowercaseValue = value.toLowerCase();
-            assertValidBaseString('0123456789abcdef', lowercaseValue, value);
-            const matches = lowercaseValue.match(/.{1,2}/g);
-            const hexBytes = matches ? matches.map((byte: string) => parseInt(byte, 16)) : [];
+            const len = value.length;
+            const al = len / 2;
+            if (len === 1) {
+                const c = value.charCodeAt(0);
+                const n = charCodeToBase16(c);
+                if (n === undefined) {
+                    throw new SolanaError(SOLANA_ERROR__CODECS__INVALID_STRING_FOR_BASE, {
+                        alphabet: '0123456789abcdef',
+                        base: 16,
+                        value,
+                    });
+                }
+                bytes.set([n], offset);
+                return 1 + offset;
+            }
+            const hexBytes = new Uint8Array(al);
+            for (let i = 0, j = 0; i < al; i++) {
+                const c1 = value.charCodeAt(j++);
+                const c2 = value.charCodeAt(j++);
+
+                const n1 = charCodeToBase16(c1);
+                const n2 = charCodeToBase16(c2);
+                if (n1 === undefined || (Number.isInteger(c2) && n2 === undefined)) {
+                    throw new SolanaError(SOLANA_ERROR__CODECS__INVALID_STRING_FOR_BASE, {
+                        alphabet: '0123456789abcdef',
+                        base: 16,
+                        value,
+                    });
+                }
+                hexBytes[i] = Number.isInteger(c2) ? n1 << 4 | (n2 ?? 0) : n1;
+            }
+
             bytes.set(hexBytes, offset);
             return hexBytes.length + offset;
         },


### PR DESCRIPTION
Quick PR addressing the issue #2527;
~@steveluscher it makes total sense to me that this approach is faster as we go through the input less times, also we check the errors inside the transform code instead of doing a iteration, but how shall i go about testing this?~

```shell
┌─────────┬─────────────────┬─────────────┬───────────────────┬──────────┬─────────┐
│ (index) │    Task Name    │   ops/sec   │ Average Time (ns) │  Margin  │ Samples │
├─────────┼─────────────────┼─────────────┼───────────────────┼──────────┼─────────┤
│    0    │ 'Base58 decode' │  '37,649'   │ 26561.11945194077 │ '±0.70%' │  18825  │
│    1    │ 'Base58 encode' │  '37,581'   │ 26608.59333410035 │ '±0.60%' │  18791  │
│    2    │ 'Base16 encode' │ '1,411,479' │ 708.4763073389463 │ '±5.45%' │ 705740  │
└─────────┴─────────────────┴─────────────┴───────────────────┴──────────┴─────────┘

┌─────────┬─────────────────────┬───────────┬────────────────────┬──────────┬─────────┐
│ (index) │      Task Name      │  ops/sec  │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼─────────────────────┼───────────┼────────────────────┼──────────┼─────────┤
│    0    │   'Base58 decode'   │ '38,357'  │ 26070.594277917186 │ '±0.58%' │  19179  │
│    1    │   'Base58 encode'   │ '38,289'  │ 26116.801952064176 │ '±0.65%' │  19145  │
│    2    │ 'Base16 encode old' │ '476,527' │ 2098.515199989724  │ '±2.82%' │ 238264  │
└─────────┴─────────────────────┴───────────┴────────────────────┴──────────┴─────────┘
```

Closes #2527.