### PR TITLE
refactor(experimental): rpc scoping: `createRecentSignatureConfirmationPromiseFactory`

### DIFF
--- a/.changeset/nine-pots-notice.md
+++ b/.changeset/nine-pots-notice.md
@@ -1,0 +1,5 @@
+---
+"@solana/transaction-confirmation": patch
+---
+
+Changes `createRecentSignatureConfirmationPromiseFactory` to enforce `rpc` and `rpcSubscriptions` to have matching clusters, changing the function signature to accept an object rather than two parameters.

--- a/packages/library/src/airdrop.ts
+++ b/packages/library/src/airdrop.ts
@@ -28,10 +28,10 @@ export function airdropFactory<TCluster extends 'devnet' | 'mainnet' | 'testnet'
     rpc,
     rpcSubscriptions,
 }: AirdropFactoryConfig<TCluster>): AirdropFunction {
-    const getRecentSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory(
+    const getRecentSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory({
         rpc,
         rpcSubscriptions,
-    );
+    } as Parameters<typeof createRecentSignatureConfirmationPromiseFactory>[0]);
     async function confirmSignatureOnlyTransaction(
         config: Omit<
             Parameters<typeof waitForRecentTransactionConfirmationUntilTimeout>[0],

--- a/packages/library/src/send-transaction.ts
+++ b/packages/library/src/send-transaction.ts
@@ -76,10 +76,10 @@ export function sendAndConfirmDurableNonceTransactionFactory({
     rpcSubscriptions,
 }: SendAndConfirmDurableNonceTransactionFactoryConfig): SendAndConfirmDurableNonceTransactionFunction {
     const getNonceInvalidationPromise = createNonceInvalidationPromiseFactory(rpc, rpcSubscriptions);
-    const getRecentSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory(
+    const getRecentSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory({
         rpc,
         rpcSubscriptions,
-    );
+    });
     async function confirmDurableNonceTransaction(
         config: Omit<
             Parameters<typeof waitForDurableNonceTransactionConfirmation>[0],
@@ -110,10 +110,10 @@ export function sendAndConfirmTransactionFactory({
         rpc,
         rpcSubscriptions,
     });
-    const getRecentSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory(
+    const getRecentSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory({
         rpc,
         rpcSubscriptions,
-    );
+    });
     async function confirmRecentTransaction(
         config: Omit<
             Parameters<typeof waitForRecentTransactionConfirmation>[0],

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
@@ -31,7 +31,7 @@ describe('createSignatureConfirmationPromiseFactory', () => {
         const rpcSubscriptions = {
             signatureNotifications: createPendingSubscription,
         };
-        getSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory(rpc, rpcSubscriptions);
+        getSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory({ rpc, rpcSubscriptions });
     });
     it('sets up a subscription for notifications about signature changes', async () => {
         expect.assertions(2);

--- a/packages/transaction-confirmation/src/__typetests__/confirmation-strategy-recent-signature-typetests.ts
+++ b/packages/transaction-confirmation/src/__typetests__/confirmation-strategy-recent-signature-typetests.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { GetSignatureStatusesApi, Rpc, RpcDevnet, RpcMainnet, RpcTestnet } from '@solana/rpc';
+import {
+    RpcSubscriptions,
+    RpcSubscriptionsDevnet,
+    RpcSubscriptionsMainnet,
+    RpcSubscriptionsTestnet,
+    SignatureNotificationsApi,
+} from '@solana/rpc-subscriptions';
+
+import { createRecentSignatureConfirmationPromiseFactory } from '../confirmation-strategy-recent-signature';
+
+const rpc = null as unknown as Rpc<GetSignatureStatusesApi>;
+const rpcDevnet = null as unknown as RpcDevnet<GetSignatureStatusesApi>;
+const rpcTestnet = null as unknown as RpcTestnet<GetSignatureStatusesApi>;
+const rpcMainnet = null as unknown as RpcMainnet<GetSignatureStatusesApi>;
+
+const rpcSubscriptions = null as unknown as RpcSubscriptions<SignatureNotificationsApi>;
+const rpcSubscriptionsDevnet = null as unknown as RpcSubscriptionsDevnet<SignatureNotificationsApi>;
+const rpcSubscriptionsMainnet = null as unknown as RpcSubscriptionsMainnet<SignatureNotificationsApi>;
+const rpcSubscriptionsTestnet = null as unknown as RpcSubscriptionsTestnet<SignatureNotificationsApi>;
+
+// [DESCRIBE] createRecentSignatureConfirmationPromiseFactory
+{
+    {
+        // It typechecks when the RPC clusters match.
+        createRecentSignatureConfirmationPromiseFactory({ rpc, rpcSubscriptions });
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+    }
+    {
+        // It typechecks when either RPC is generic.
+        createRecentSignatureConfirmationPromiseFactory({ rpc, rpcSubscriptions });
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcDevnet, rpcSubscriptions });
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcTestnet, rpcSubscriptions });
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcMainnet, rpcSubscriptions });
+        createRecentSignatureConfirmationPromiseFactory({ rpc, rpcSubscriptions: rpcSubscriptionsDevnet });
+        createRecentSignatureConfirmationPromiseFactory({ rpc, rpcSubscriptions: rpcSubscriptionsTestnet });
+        createRecentSignatureConfirmationPromiseFactory({ rpc, rpcSubscriptions: rpcSubscriptionsMainnet });
+    }
+    {
+        // It fails to typecheck when explicit RPC clusters mismatch.
+        // @ts-expect-error
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+        // @ts-expect-error
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+        // @ts-expect-error
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+        // @ts-expect-error
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        // @ts-expect-error
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        // @ts-expect-error
+        createRecentSignatureConfirmationPromiseFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+    }
+}

--- a/packages/transaction-confirmation/src/confirmation-strategy-recent-signature.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-recent-signature.ts
@@ -10,10 +10,29 @@ type GetRecentSignatureConfirmationPromiseFn = (config: {
     signature: Signature;
 }) => Promise<void>;
 
-export function createRecentSignatureConfirmationPromiseFactory(
-    rpc: Rpc<GetSignatureStatusesApi>,
-    rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi>,
-): GetRecentSignatureConfirmationPromiseFn {
+type CreateRecentSignatureConfirmationPromiseFactoryConfig<TCluster> = {
+    rpc: Rpc<GetSignatureStatusesApi> & { '~cluster'?: TCluster };
+    rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi> & { '~cluster'?: TCluster };
+};
+
+export function createRecentSignatureConfirmationPromiseFactory({
+    rpc,
+    rpcSubscriptions,
+}: CreateRecentSignatureConfirmationPromiseFactoryConfig<'devnet'>): GetRecentSignatureConfirmationPromiseFn;
+export function createRecentSignatureConfirmationPromiseFactory({
+    rpc,
+    rpcSubscriptions,
+}: CreateRecentSignatureConfirmationPromiseFactoryConfig<'testnet'>): GetRecentSignatureConfirmationPromiseFn;
+export function createRecentSignatureConfirmationPromiseFactory({
+    rpc,
+    rpcSubscriptions,
+}: CreateRecentSignatureConfirmationPromiseFactoryConfig<'mainnet'>): GetRecentSignatureConfirmationPromiseFn;
+export function createRecentSignatureConfirmationPromiseFactory<
+    TCluster extends 'devnet' | 'mainnet' | 'testnet' | void = void,
+>({
+    rpc,
+    rpcSubscriptions,
+}: CreateRecentSignatureConfirmationPromiseFactoryConfig<TCluster>): GetRecentSignatureConfirmationPromiseFn {
     return async function getRecentSignatureConfirmationPromise({
         abortSignal: callerAbortSignal,
         commitment,


### PR DESCRIPTION
Following the effort to scope all `rpc` & `RpcSubscriptions` factories to specific clusters,
as outlined in #2534, this PR adds cluster scoping to
`createRecentSignatureConfirmationPromiseFactory`.