### PR TITLE
refactor(experimental): rpc scoping: `createNonceInvalidationPromiseFactory`

### DIFF
--- a/.changeset/poor-dogs-crash.md
+++ b/.changeset/poor-dogs-crash.md
@@ -1,0 +1,5 @@
+---
+"@solana/transaction-confirmation": patch
+---
+
+Changes `createNonceInvalidationPromiseFactory` to enforce `rpc` and `rpcSubscriptions` to have matching clusters, changing the function signature to accept an object rather than two parameters.

--- a/packages/library/src/send-transaction.ts
+++ b/packages/library/src/send-transaction.ts
@@ -75,7 +75,7 @@ export function sendAndConfirmDurableNonceTransactionFactory({
     rpc,
     rpcSubscriptions,
 }: SendAndConfirmDurableNonceTransactionFactoryConfig): SendAndConfirmDurableNonceTransactionFunction {
-    const getNonceInvalidationPromise = createNonceInvalidationPromiseFactory(rpc, rpcSubscriptions);
+    const getNonceInvalidationPromise = createNonceInvalidationPromiseFactory({ rpc, rpcSubscriptions });
     const getRecentSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory({
         rpc,
         rpcSubscriptions,

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
@@ -48,7 +48,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
         const rpcSubscriptions = {
             accountNotifications: createPendingSubscription,
         };
-        getNonceInvalidationPromise = createNonceInvalidationPromiseFactory(rpc, rpcSubscriptions);
+        getNonceInvalidationPromise = createNonceInvalidationPromiseFactory({ rpc, rpcSubscriptions });
     });
     it('calls the abort signal passed to the account info query when aborted', async () => {
         expect.assertions(2);

--- a/packages/transaction-confirmation/src/__typetests__/confirmation-strategy-nonce-typetests.ts
+++ b/packages/transaction-confirmation/src/__typetests__/confirmation-strategy-nonce-typetests.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { GetAccountInfoApi, Rpc, RpcDevnet, RpcMainnet, RpcTestnet } from '@solana/rpc';
+import {
+    AccountNotificationsApi,
+    RpcSubscriptions,
+    RpcSubscriptionsDevnet,
+    RpcSubscriptionsMainnet,
+    RpcSubscriptionsTestnet,
+} from '@solana/rpc-subscriptions';
+
+import { createNonceInvalidationPromiseFactory } from '../confirmation-strategy-nonce';
+
+const rpc = null as unknown as Rpc<GetAccountInfoApi>;
+const rpcDevnet = null as unknown as RpcDevnet<GetAccountInfoApi>;
+const rpcTestnet = null as unknown as RpcTestnet<GetAccountInfoApi>;
+const rpcMainnet = null as unknown as RpcMainnet<GetAccountInfoApi>;
+
+const rpcSubscriptions = null as unknown as RpcSubscriptions<AccountNotificationsApi>;
+const rpcSubscriptionsDevnet = null as unknown as RpcSubscriptionsDevnet<AccountNotificationsApi>;
+const rpcSubscriptionsMainnet = null as unknown as RpcSubscriptionsMainnet<AccountNotificationsApi>;
+const rpcSubscriptionsTestnet = null as unknown as RpcSubscriptionsTestnet<AccountNotificationsApi>;
+
+// [DESCRIBE] createNonceInvalidationPromiseFactory
+{
+    {
+        // It typechecks when the RPC clusters match.
+        createNonceInvalidationPromiseFactory({ rpc, rpcSubscriptions });
+        createNonceInvalidationPromiseFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        createNonceInvalidationPromiseFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+        createNonceInvalidationPromiseFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+    }
+    {
+        // It typechecks when either RPC is generic.
+        createNonceInvalidationPromiseFactory({ rpc, rpcSubscriptions });
+        createNonceInvalidationPromiseFactory({ rpc: rpcDevnet, rpcSubscriptions });
+        createNonceInvalidationPromiseFactory({ rpc: rpcTestnet, rpcSubscriptions });
+        createNonceInvalidationPromiseFactory({ rpc: rpcMainnet, rpcSubscriptions });
+        createNonceInvalidationPromiseFactory({ rpc, rpcSubscriptions: rpcSubscriptionsDevnet });
+        createNonceInvalidationPromiseFactory({ rpc, rpcSubscriptions: rpcSubscriptionsTestnet });
+        createNonceInvalidationPromiseFactory({ rpc, rpcSubscriptions: rpcSubscriptionsMainnet });
+    }
+    {
+        // It fails to typecheck when explicit RPC clusters mismatch.
+        // @ts-expect-error
+        createNonceInvalidationPromiseFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+        // @ts-expect-error
+        createNonceInvalidationPromiseFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+        // @ts-expect-error
+        createNonceInvalidationPromiseFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+        // @ts-expect-error
+        createNonceInvalidationPromiseFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        // @ts-expect-error
+        createNonceInvalidationPromiseFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        // @ts-expect-error
+        createNonceInvalidationPromiseFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+    }
+}

--- a/packages/transaction-confirmation/src/confirmation-strategy-nonce.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-nonce.ts
@@ -13,16 +13,33 @@ type GetNonceInvalidationPromiseFn = (config: {
     nonceAccountAddress: Address;
 }) => Promise<void>;
 
+type CreateNonceInvalidationPromiseFactoryConfig<TCluster> = {
+    rpc: Rpc<GetAccountInfoApi> & { '~cluster'?: TCluster };
+    rpcSubscriptions: RpcSubscriptions<AccountNotificationsApi> & { '~cluster'?: TCluster };
+};
+
 const NONCE_VALUE_OFFSET =
     4 + // version(u32)
     4 + // state(u32)
     32; // nonce authority(pubkey)
 // Then comes the nonce value.
 
-export function createNonceInvalidationPromiseFactory(
-    rpc: Rpc<GetAccountInfoApi>,
-    rpcSubscriptions: RpcSubscriptions<AccountNotificationsApi>,
-): GetNonceInvalidationPromiseFn {
+export function createNonceInvalidationPromiseFactory({
+    rpc,
+    rpcSubscriptions,
+}: CreateNonceInvalidationPromiseFactoryConfig<'devnet'>): GetNonceInvalidationPromiseFn;
+export function createNonceInvalidationPromiseFactory({
+    rpc,
+    rpcSubscriptions,
+}: CreateNonceInvalidationPromiseFactoryConfig<'testnet'>): GetNonceInvalidationPromiseFn;
+export function createNonceInvalidationPromiseFactory({
+    rpc,
+    rpcSubscriptions,
+}: CreateNonceInvalidationPromiseFactoryConfig<'mainnet'>): GetNonceInvalidationPromiseFn;
+export function createNonceInvalidationPromiseFactory<TCluster extends 'devnet' | 'mainnet' | 'testnet' | void = void>({
+    rpc,
+    rpcSubscriptions,
+}: CreateNonceInvalidationPromiseFactoryConfig<TCluster>): GetNonceInvalidationPromiseFn {
     return async function getNonceInvalidationPromise({
         abortSignal: callerAbortSignal,
         commitment,


### PR DESCRIPTION
Following the effort to scope all `rpc` & `RpcSubscriptions` factories to specific clusters,
as outlined in #2534, this PR adds cluster scoping to
`createNonceInvalidationPromiseFactory `.