### PR TITLE
refactor(experimental): rpc scoping: `createBlockHeightExceedencePromiseFactory`

### DIFF
--- a/packages/transaction-confirmation/src/__typetests__/confirmation-strategy-blockheight-typetests.ts
+++ b/packages/transaction-confirmation/src/__typetests__/confirmation-strategy-blockheight-typetests.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { GetEpochInfoApi, Rpc, RpcDevnet, RpcMainnet, RpcTestnet } from '@solana/rpc';
+import {
+    RpcSubscriptions,
+    RpcSubscriptionsDevnet,
+    RpcSubscriptionsMainnet,
+    RpcSubscriptionsTestnet,
+    SlotNotificationsApi,
+} from '@solana/rpc-subscriptions';
+
+import { createBlockHeightExceedencePromiseFactory } from '../confirmation-strategy-blockheight';
+
+const rpc = null as unknown as Rpc<GetEpochInfoApi>;
+const rpcDevnet = null as unknown as RpcDevnet<GetEpochInfoApi>;
+const rpcTestnet = null as unknown as RpcTestnet<GetEpochInfoApi>;
+const rpcMainnet = null as unknown as RpcMainnet<GetEpochInfoApi>;
+
+const rpcSubscriptions = null as unknown as RpcSubscriptions<SlotNotificationsApi>;
+const rpcSubscriptionsDevnet = null as unknown as RpcSubscriptionsDevnet<SlotNotificationsApi>;
+const rpcSubscriptionsMainnet = null as unknown as RpcSubscriptionsMainnet<SlotNotificationsApi>;
+const rpcSubscriptionsTestnet = null as unknown as RpcSubscriptionsTestnet<SlotNotificationsApi>;
+
+// [DESCRIBE] createBlockHeightExceedencePromiseFactory
+{
+    {
+        // It typechecks when the RPC clusters match.
+        createBlockHeightExceedencePromiseFactory({ rpc, rpcSubscriptions });
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+    }
+    {
+        // It typechecks when either RPC is generic.
+        createBlockHeightExceedencePromiseFactory({ rpc, rpcSubscriptions });
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcDevnet, rpcSubscriptions });
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcTestnet, rpcSubscriptions });
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcMainnet, rpcSubscriptions });
+        createBlockHeightExceedencePromiseFactory({ rpc, rpcSubscriptions: rpcSubscriptionsDevnet });
+        createBlockHeightExceedencePromiseFactory({ rpc, rpcSubscriptions: rpcSubscriptionsTestnet });
+        createBlockHeightExceedencePromiseFactory({ rpc, rpcSubscriptions: rpcSubscriptionsMainnet });
+    }
+    {
+        // It fails to typecheck when explicit RPC clusters mismatch.
+        // @ts-expect-error
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+        // @ts-expect-error
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+        // @ts-expect-error
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+        // @ts-expect-error
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        // @ts-expect-error
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        // @ts-expect-error
+        createBlockHeightExceedencePromiseFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+    }
+}

--- a/packages/transaction-confirmation/src/confirmation-strategy-blockheight.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-blockheight.ts
@@ -9,13 +9,29 @@ type GetBlockHeightExceedencePromiseFn = (config: {
     lastValidBlockHeight: bigint;
 }) => Promise<void>;
 
+type CreateBlockHeightExceedencePromiseFactoryyConfig<TCluster> = {
+    rpc: Rpc<GetEpochInfoApi> & { '~cluster'?: TCluster };
+    rpcSubscriptions: RpcSubscriptions<SlotNotificationsApi> & { '~cluster'?: TCluster };
+};
+
 export function createBlockHeightExceedencePromiseFactory({
     rpc,
     rpcSubscriptions,
-}: Readonly<{
-    rpc: Rpc<GetEpochInfoApi>;
-    rpcSubscriptions: RpcSubscriptions<SlotNotificationsApi>;
-}>): GetBlockHeightExceedencePromiseFn {
+}: CreateBlockHeightExceedencePromiseFactoryyConfig<'devnet'>): GetBlockHeightExceedencePromiseFn;
+export function createBlockHeightExceedencePromiseFactory({
+    rpc,
+    rpcSubscriptions,
+}: CreateBlockHeightExceedencePromiseFactoryyConfig<'testnet'>): GetBlockHeightExceedencePromiseFn;
+export function createBlockHeightExceedencePromiseFactory({
+    rpc,
+    rpcSubscriptions,
+}: CreateBlockHeightExceedencePromiseFactoryyConfig<'mainnet'>): GetBlockHeightExceedencePromiseFn;
+export function createBlockHeightExceedencePromiseFactory<
+    TCluster extends 'devnet' | 'mainnet' | 'testnet' | void = void,
+>({
+    rpc,
+    rpcSubscriptions,
+}: CreateBlockHeightExceedencePromiseFactoryyConfig<TCluster>): GetBlockHeightExceedencePromiseFn {
     return async function getBlockHeightExceedencePromise({
         abortSignal: callerAbortSignal,
         commitment,


### PR DESCRIPTION
Following the effort to scope all `rpc` & `RpcSubscriptions` factories to specific clusters,
as outlined in #2534, this PR adds cluster scoping to
`createBlockHeightExceedencePromiseFactory `.