### PR TITLE
refactor(experimental): rpc scoping: `sendAndConfirmTransactionFactory`

### DIFF
--- a/packages/library/src/__typetests__/send-and-confirm-transaction-typetests.ts
+++ b/packages/library/src/__typetests__/send-and-confirm-transaction-typetests.ts
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import {
+    GetEpochInfoApi,
+    GetSignatureStatusesApi,
+    Rpc,
+    RpcDevnet,
+    RpcMainnet,
+    RpcTestnet,
+    SendTransactionApi,
+} from '@solana/rpc';
+import {
+    RpcSubscriptions,
+    RpcSubscriptionsDevnet,
+    RpcSubscriptionsMainnet,
+    RpcSubscriptionsTestnet,
+    SignatureNotificationsApi,
+    SlotNotificationsApi,
+} from '@solana/rpc-subscriptions';
+
+import { sendAndConfirmTransactionFactory } from '../send-and-confirm-transaction';
+
+const rpc = null as unknown as Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
+const rpcDevnet = null as unknown as RpcDevnet<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
+const rpcTestnet = null as unknown as RpcTestnet<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
+const rpcMainnet = null as unknown as RpcMainnet<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
+
+const rpcSubscriptions = null as unknown as RpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>;
+const rpcSubscriptionsDevnet = null as unknown as RpcSubscriptionsDevnet<
+    SignatureNotificationsApi & SlotNotificationsApi
+>;
+const rpcSubscriptionsMainnet = null as unknown as RpcSubscriptionsMainnet<
+    SignatureNotificationsApi & SlotNotificationsApi
+>;
+const rpcSubscriptionsTestnet = null as unknown as RpcSubscriptionsTestnet<
+    SignatureNotificationsApi & SlotNotificationsApi
+>;
+
+// [DESCRIBE] sendAndConfirmTransactionFactory
+{
+    {
+        // It typechecks when the RPC clusters match.
+        sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
+        sendAndConfirmTransactionFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        sendAndConfirmTransactionFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+        sendAndConfirmTransactionFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+    }
+    {
+        // It typechecks when either RPC is generic.
+        sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
+        sendAndConfirmTransactionFactory({ rpc: rpcDevnet, rpcSubscriptions });
+        sendAndConfirmTransactionFactory({ rpc: rpcTestnet, rpcSubscriptions });
+        sendAndConfirmTransactionFactory({ rpc: rpcMainnet, rpcSubscriptions });
+    }
+    {
+        // It fails to typecheck when explicit RPC clusters mismatch.
+        // @ts-expect-error
+        sendAndConfirmTransactionFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+        // @ts-expect-error
+        sendAndConfirmTransactionFactory({ rpc: rpcDevnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+        // @ts-expect-error
+        sendAndConfirmTransactionFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsMainnet });
+        // @ts-expect-error
+        sendAndConfirmTransactionFactory({ rpc: rpcTestnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        // @ts-expect-error
+        sendAndConfirmTransactionFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsDevnet });
+        // @ts-expect-error
+        sendAndConfirmTransactionFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+    }
+}

--- a/packages/library/src/send-and-confirm-transaction.ts
+++ b/packages/library/src/send-and-confirm-transaction.ts
@@ -17,23 +17,35 @@ type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
     >,
 ) => Promise<void>;
 
-interface SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig {
-    rpc: Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
-    rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>;
-}
+type SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<TCluster> = {
+    rpc: Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi> & { '~cluster'?: TCluster };
+    rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi> & { '~cluster'?: TCluster };
+};
 
 export function sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,
-}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig): SendAndConfirmTransactionWithBlockhashLifetimeFunction {
+}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<'devnet'>): SendAndConfirmTransactionWithBlockhashLifetimeFunction;
+export function sendAndConfirmTransactionFactory({
+    rpc,
+    rpcSubscriptions,
+}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<'testnet'>): SendAndConfirmTransactionWithBlockhashLifetimeFunction;
+export function sendAndConfirmTransactionFactory({
+    rpc,
+    rpcSubscriptions,
+}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<'mainnet'>): SendAndConfirmTransactionWithBlockhashLifetimeFunction;
+export function sendAndConfirmTransactionFactory<TCluster extends 'devnet' | 'mainnet' | 'testnet' | void = void>({
+    rpc,
+    rpcSubscriptions,
+}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<TCluster>): SendAndConfirmTransactionWithBlockhashLifetimeFunction {
     const getBlockHeightExceedencePromise = createBlockHeightExceedencePromiseFactory({
         rpc,
         rpcSubscriptions,
-    });
+    } as Parameters<typeof createBlockHeightExceedencePromiseFactory>[0]);
     const getRecentSignatureConfirmationPromise = createRecentSignatureConfirmationPromiseFactory({
         rpc,
         rpcSubscriptions,
-    });
+    } as Parameters<typeof createRecentSignatureConfirmationPromiseFactory>[0]);
     async function confirmRecentTransaction(
         config: Omit<
             Parameters<typeof waitForRecentTransactionConfirmation>[0],


### PR DESCRIPTION
Following the effort to scope all `rpc` & `RpcSubscriptions` factories to specific clusters,
as outlined in #2534, this PR adds cluster scoping to
`sendAndConfirmTransactionFactory `.