### PR TITLE
graphql: token-2022 extensions: InitializeTransferFeeConfig

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1686,22 +1686,6 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
-                // Transfer Fee Instruction InitializeTransferFeeConfig
-                {
-                    parsed: {
-                        info: {
-                            maximumFee: 5000,
-                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
-                            transferFeeBasisPoints: 50,
-                            transferFeeConfigAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
-                            withdrawWithheldAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
-                        },
-                        type: 'initializeTransferFeeConfig',
-                    },
-                    program: 'spl-token',
-                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-                    stackHeight: null,
-                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1686,6 +1686,22 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                // Transfer Fee Instruction InitializeTransferFeeConfig
+                {
+                    parsed: {
+                        info: {
+                            maximumFee: 5000,
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            transferFeeBasisPoints: 50,
+                            transferFeeConfigAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            withdrawWithheldAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                        },
+                        type: 'initializeTransferFeeConfig',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -858,10 +858,10 @@ describe('transaction', () => {
                                         maximumFee
                                         transferFeeConfigAuthority {
                                             address
-                                       }
-                                       withdrawWithheldAuthority {
+                                        }
+                                        withdrawWithheldAuthority {
                                             address
-                                       } 
+                                        }
                                     }
                                 }
                             }
@@ -883,12 +883,11 @@ describe('transaction', () => {
                                         programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                                         transferFeeBasisPoints: expect.any(Number),
                                         transferFeeConfigAuthority: {
-                                            address: expect.any(String)
+                                            address: expect.any(String),
                                         },
                                         withdrawWithheldAuthority: {
-                                            address: expect.any(String)
+                                            address: expect.any(String),
                                         },
-
                                     },
                                 ]),
                             },

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -841,6 +841,61 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('initialize-transferFee-config', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenInitializeTransferFeeConfig {
+                                        mint {
+                                            address
+                                        }
+                                        transferFeeBasisPoints
+                                        maximumFee
+                                        transferFeeConfigAuthority {
+                                            address
+                                       }
+                                       withdrawWithheldAuthority {
+                                            address
+                                       } 
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        maximumFee: expect.any(Number),
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        transferFeeBasisPoints: expect.any(Number),
+                                        transferFeeConfigAuthority: {
+                                            address: expect.any(String)
+                                        },
+                                        withdrawWithheldAuthority: {
+                                            address: expect.any(String)
+                                        },
+
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -241,8 +241,8 @@ export const instructionResolvers = {
     },
     SplTokenInitializeTransferFeeConfig: {
         mint: resolveAccount('mint'),
-        transferFeeConfigAuthority: resolveAccount('account'),
-        withdrawWithheldAuthority: resolveAccount('account'),
+        transferFeeConfigAuthority: resolveAccount('transferFeeConfigAuthority'),
+        withdrawWithheldAuthority: resolveAccount('withdrawWithheldAuthority'),
     },
     SplTokenMintToCheckedInstruction: {
         account: resolveAccount('account'),

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -239,6 +239,11 @@ export const instructionResolvers = {
         delegate: resolveAccount('delegate'),
         mint: resolveAccount('mint'),
     },
+    SplTokenInitializeTransferFeeConfig: {
+        mint: resolveAccount('mint'),
+        transferFeeConfigAuthority: resolveAccount('account'),
+        withdrawWithheldAuthority: resolveAccount('account'),
+    },
     SplTokenMintToCheckedInstruction: {
         account: resolveAccount('account'),
         authority: resolveAccount('authority'),
@@ -546,6 +551,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'updateMetadataPointer') {
                         return 'SplTokenUpdateMetadataPointerInstruction';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializeTransferFeeConfig') {
+                        return 'SplTokenInitializeTransferFeeConfig';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -541,6 +541,18 @@ export const instructionTypeDefs = /* GraphQL */ `
         mint: Account
     }
 
+    """
+    SplToken-2022: InitializeTransferFeeConfig instruction
+    """
+    type SplTokenInitializeTransferFeeConfig implements TransactionInstruction {
+        programId: Address
+        mint: Account
+        transferFeeBasisPoints: Int
+        transferFeeConfigAuthority: Account
+        withdrawWithheldAuthority: Account
+        maximumFee: Int
+    }
+
     # TODO: Extensions!
     # ...
 


### PR DESCRIPTION
This PR adds support for Token-2022's TransferFeeExtension's InitializeTransferFeeConfig instruction
in the GraphQL schema.

Todo: 
Need to add test.