### PR TITLE
Enforce TypeScript >=5 via `peerDependencies`

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -70,6 +70,9 @@
         "@solana/rpc-spec": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -71,6 +71,9 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -68,6 +68,9 @@
     "dependencies": {
         "@solana/errors": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -68,6 +68,9 @@
     "dependencies": {
         "@solana/errors": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -73,6 +73,9 @@
     "devDependencies": {
         "@solana/codecs-strings": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -69,6 +69,9 @@
         "@solana/codecs-core": "workspace:*",
         "@solana/errors": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -76,7 +76,8 @@
         "tinybench": "^2.8.0"
     },
     "peerDependencies": {
-        "fastestsmallesttextencoderdecoder": "^1.0.22"
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
     },
     "bundlewatch": {
         "defaultCompression": "gzip",

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -67,6 +67,9 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/options": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -75,6 +75,9 @@
         "@solana/keys": "workspace:*",
         "@solana/web3.js": "workspace:../library-legacy"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -70,6 +70,9 @@
         "commander": "^12.0.0",
         "chalk": "^5.3.0"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/fast-stable-stringify/package.json
+++ b/packages/fast-stable-stringify/package.json
@@ -69,6 +69,9 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -62,6 +62,9 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -68,6 +68,9 @@
     "devDependencies": {
         "@solana/addresses": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -72,6 +72,9 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -83,6 +83,9 @@
         "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -72,6 +72,9 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -70,6 +70,9 @@
         "@solana/functional": "workspace:*",
         "@solana/transaction-messages": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -79,6 +79,9 @@
         "@solana/rpc-spec-types": "workspace:*",
         "@solana/rpc-transport-http": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -76,6 +76,9 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -64,6 +64,9 @@
         "@solana/addresses": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -62,6 +62,9 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -66,6 +66,9 @@
         "@solana/errors": "workspace:*",
         "@solana/rpc-spec-types": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -74,6 +74,9 @@
     "devDependencies": {
         "@solana/rpc-subscriptions-transport-websocket": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -66,6 +66,9 @@
         "@solana/errors": "workspace:*",
         "@solana/rpc-spec-types": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-subscriptions-transport-websocket/package.json
+++ b/packages/rpc-subscriptions-transport-websocket/package.json
@@ -71,6 +71,7 @@
         "jest-websocket-mock": "^2.5.0"
     },
     "peerDependencies": {
+        "typescript": ">=5",
         "ws": "^8.14.0"
     },
     "bundlewatch": {

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -72,6 +72,9 @@
         "@solana/rpc-transformers": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -68,6 +68,9 @@
         "@solana/rpc-spec": "workspace:*",
         "@solana/rpc-subscriptions-spec": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -73,6 +73,9 @@
         "undici": "^6.14.0",
         "zx": "^7.2.3"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -69,6 +69,9 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -72,6 +72,9 @@
         "@solana/rpc-transport-http": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -77,6 +77,9 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/text-encoding-impl": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -78,6 +78,9 @@
         "@solana/rpc-spec": "workspace:*",
         "@solana/rpc-transport-http": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -78,6 +78,9 @@
     "devDependencies": {
         "@solana/instructions": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -75,6 +75,9 @@
     "devDependencies": {
         "@solana/codecs-strings": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -75,6 +75,9 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/transaction-messages": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -68,6 +68,9 @@
     "devDependencies": {
         "@solana/crypto-impl": "workspace:*"
     },
+    "peerDependencies": {
+        "typescript": ">=5"
+    },
     "bundlewatch": {
         "defaultCompression": "gzip",
         "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   jsdom: ^22
   mock-socket: ^9.3.1
@@ -131,6 +135,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/addresses:
     dependencies:
@@ -146,12 +153,18 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/assertions:
     dependencies:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/build-scripts:
     devDependencies:
@@ -176,12 +189,18 @@ importers:
       '@solana/options':
         specifier: workspace:*
         version: link:../options
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/codecs-core:
     dependencies:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/codecs-data-structures:
     dependencies:
@@ -194,6 +213,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/codecs-strings':
         specifier: workspace:*
@@ -207,6 +229,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/codecs-strings:
     dependencies:
@@ -222,6 +247,9 @@ importers:
       fastestsmallesttextencoderdecoder:
         specifier: ^1.0.22
         version: 1.0.22
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/text-encoding-impl':
         specifier: workspace:*
@@ -244,6 +272,9 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/web3.js':
         specifier: workspace:../library-legacy
@@ -259,8 +290,15 @@ importers:
       commander:
         specifier: ^12.0.0
         version: 12.0.0
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/fast-stable-stringify:
+    dependencies:
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@types/json-stable-stringify':
         specifier: ^1.0.36
@@ -269,13 +307,20 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
 
-  packages/functional: {}
+  packages/functional:
+    dependencies:
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/instructions:
     dependencies:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -295,6 +340,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       tinybench:
         specifier: ^2.8.0
@@ -350,6 +398,9 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/library-legacy:
     dependencies:
@@ -576,6 +627,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/programs:
     dependencies:
@@ -585,6 +639,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/functional':
         specifier: workspace:*
@@ -619,6 +676,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/rpc-api:
     dependencies:
@@ -655,6 +715,9 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/rpc-spec-types':
         specifier: workspace:*
@@ -680,6 +743,9 @@ importers:
       graphql:
         specifier: ^16.8.0
         version: 16.8.1
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -698,6 +764,10 @@ importers:
         version: link:../transactions
 
   packages/rpc-parsed-types:
+    dependencies:
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -714,8 +784,15 @@ importers:
       '@solana/rpc-spec-types':
         specifier: workspace:*
         version: link:../rpc-spec-types
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
-  packages/rpc-spec-types: {}
+  packages/rpc-spec-types:
+    dependencies:
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/rpc-subscriptions:
     dependencies:
@@ -743,6 +820,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/rpc-subscriptions-api:
     dependencies:
@@ -767,6 +847,9 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/rpc-subscriptions-transport-websocket':
         specifier: workspace:*
@@ -780,6 +863,9 @@ importers:
       '@solana/rpc-spec-types':
         specifier: workspace:*
         version: link:../rpc-spec-types
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/rpc-subscriptions-transport-websocket:
     dependencies:
@@ -789,6 +875,9 @@ importers:
       '@solana/rpc-subscriptions-spec':
         specifier: workspace:*
         version: link:../rpc-subscriptions-spec
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
       ws:
         specifier: ^8.14.0
         version: 8.14.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -814,6 +903,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/rpc-transport-http:
     dependencies:
@@ -823,6 +915,9 @@ importers:
       '@solana/rpc-spec':
         specifier: workspace:*
         version: link:../rpc-spec
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
       undici-types:
         specifier: ^6.13.0
         version: 6.13.0
@@ -854,6 +949,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/signers:
     dependencies:
@@ -875,6 +973,9 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/rpc-types':
         specifier: workspace:*
@@ -897,6 +998,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -971,6 +1075,9 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/instructions':
         specifier: workspace:*
@@ -1002,6 +1109,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/codecs-strings':
         specifier: workspace:*
@@ -1042,6 +1152,9 @@ importers:
       '@solana/transaction-messages':
         specifier: workspace:*
         version: link:../transaction-messages
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
 
   packages/tsconfig: {}
 
@@ -1050,6 +1163,9 @@ importers:
       '@noble/ed25519':
         specifier: ^2.0.0
         version: 2.1.0
+      typescript:
+        specifier: '>=5'
+        version: 5.4.5
     devDependencies:
       '@solana/crypto-impl':
         specifier: workspace:*
@@ -3238,7 +3354,7 @@ packages:
     engines: {node: ^16.10.0 || ^18.12.0 || >=20.0.0}
     peerDependencies:
       canvas: ^2.5.0
-      jsdom: '*'
+      jsdom: ^22
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -12823,7 +12939,6 @@ packages:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
@@ -13435,7 +13550,3 @@ packages:
       which: 3.0.1
       yaml: 2.3.1
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
# Summary

I'm seeing quite a few people struggle with type errors in Technology Preview 3. We need to telegraph, through `package.json` that this package requires TypeScript 5 or higher. This is mostly due to our use of const type parameters, which were [introduced in TypeScript 5](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#const-type-parameters).

# Test Plan

I didn't.
