### PR TITLE
 refactor(experimental): graphql: token-2022 extensions: TransferCheckedWithFee

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1950,6 +1950,36 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            destination: "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB",
+                            feeAmount: {
+                                amount: "5",
+                                decimals: 2,
+                                uiAmount: 0.05,
+                                uiAmountString: "0.05"
+                            },
+                            mint: "FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ",
+                            multisigAuthority: "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB",
+                            signers: [
+                                "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB",
+                                "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB"
+                            ],
+                            source: "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB",
+                            tokenAmount: {
+                                amount: "55",
+                                decimals: 2,
+                                uiAmount: 0.55,
+                                uiAmountString: "0.55"
+                            }
+                        },
+                        type: 'transferCheckedWithFee',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                }
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1924,6 +1924,32 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            authority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            destination: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            feeAmount: {
+                                amount: '5000',
+                                decimals: 9,
+                                uiAmount: 0.000005,
+                                uiAmountString: '0.000005',
+                            },
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            source: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            tokenAmount: {
+                                amount: '1000000000000000',
+                                decimals: 9,
+                                uiAmount: 1000000,
+                                uiAmountString: '1000000',
+                            },
+                        },
+                        type: 'transferCheckedWithFee',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1953,33 +1953,33 @@ export const mockTransactionToken2022AllExtensions = {
                 {
                     parsed: {
                         info: {
-                            destination: "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB",
+                            destination: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
                             feeAmount: {
-                                amount: "5",
+                                amount: '5',
                                 decimals: 2,
                                 uiAmount: 0.05,
-                                uiAmountString: "0.05"
+                                uiAmountString: '0.05',
                             },
-                            mint: "FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ",
-                            multisigAuthority: "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB",
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            multisigAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
                             signers: [
-                                "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB",
-                                "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB"
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
                             ],
-                            source: "2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB",
+                            source: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
                             tokenAmount: {
-                                amount: "55",
+                                amount: '55',
                                 decimals: 2,
                                 uiAmount: 0.55,
-                                uiAmountString: "0.55"
-                            }
+                                uiAmountString: '0.55',
+                            },
                         },
                         type: 'transferCheckedWithFee',
                     },
                     program: 'spl-token',
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
-                }
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1662,7 +1662,7 @@ describe('transaction', () => {
                 });
             });
 
-            it('transfer-checked-with-fee', async () => {
+            it('transfer-checked-with-fee-with-authority', async () => {
                 expect.assertions(1);
                 const source = /* GraphQL */ `
                     query testQuery($signature: Signature!) {
@@ -1732,6 +1732,88 @@ describe('transaction', () => {
                                             amount: expect.any(String),
                                             decimals: expect.any(Number),
                                             uiAmount: expect.any(BigInt),
+                                            uiAmountString: expect.any(String),
+                                        },
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+
+            it('transfer-checked-with-fee-with-multisigAuthority', async () => {
+                // expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenTransferCheckedWithFee {
+                                        mint {
+                                            address
+                                        }
+                                        source {
+                                            address
+                                        }
+                                        destination {
+                                            address
+                                        }
+                                        feeAmount {
+                                            amount
+                                            decimals
+                                            uiAmount
+                                            uiAmountString
+                                        }
+                                        tokenAmount {
+                                            amount
+                                            decimals
+                                            uiAmount
+                                            uiAmountString
+                                        }
+                                        multisigAuthority {
+                                            address
+                                        }
+                                        signers
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        destination: {
+                                            address: expect.any(String),
+                                        },
+                                        feeAmount: {
+                                            amount: expect.any(String),
+                                            decimals: expect.any(Number),
+                                            uiAmount: null, // can't convert decimal to BigInt
+                                            uiAmountString: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: [expect.any(String),expect.any(String)],
+                                        source: {
+                                            address: expect.any(String),
+                                        },
+                                        tokenAmount: {
+                                            amount: expect.any(String),
+                                            decimals: expect.any(Number),
+                                            uiAmount: null,  // Can't convert decimal to BigInt
                                             uiAmountString: expect.any(String),
                                         },
                                     },

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1806,14 +1806,14 @@ describe('transaction', () => {
                                             address: expect.any(String),
                                         },
                                         programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-                                        signers: [expect.any(String),expect.any(String)],
+                                        signers: [expect.any(String), expect.any(String)],
                                         source: {
                                             address: expect.any(String),
                                         },
                                         tokenAmount: {
                                             amount: expect.any(String),
                                             decimals: expect.any(Number),
-                                            uiAmount: null,  // Can't convert decimal to BigInt
+                                            uiAmount: null, // Can't convert decimal to BigInt
                                             uiAmountString: expect.any(String),
                                         },
                                     },

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1759,7 +1759,7 @@ describe('transaction', () => {
                                             address: expect.any(String),
                                         },
                                         programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-                                        signers: [expect.any(String), expect.any(String)],
+                                        signers: expect.arrayContaining([expect.any(String)]),
                                         source: {
                                             address: expect.any(String),
                                         },

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1662,7 +1662,7 @@ describe('transaction', () => {
                 });
             });
 
-            it('transfer-checked-with-fee-with-authority', async () => {
+            it('transfer-checked-with-fee', async () => {
                 expect.assertions(1);
                 const source = /* GraphQL */ `
                     query testQuery($signature: Signature!) {
@@ -1675,83 +1675,6 @@ describe('transaction', () => {
                                             address
                                         }
                                         authority {
-                                            address
-                                        }
-                                        source {
-                                            address
-                                        }
-                                        destination {
-                                            address
-                                        }
-                                        feeAmount {
-                                            amount
-                                            decimals
-                                            uiAmount
-                                            uiAmountString
-                                        }
-                                        tokenAmount {
-                                            amount
-                                            decimals
-                                            uiAmount
-                                            uiAmountString
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                `;
-
-                const result = await rpcGraphQL.query(source, { signature });
-                expect(result).toMatchObject({
-                    data: {
-                        transaction: {
-                            message: {
-                                instructions: expect.arrayContaining([
-                                    {
-                                        authority: {
-                                            address: expect.any(String),
-                                        },
-                                        destination: {
-                                            address: expect.any(String),
-                                        },
-                                        feeAmount: {
-                                            amount: expect.any(String),
-                                            decimals: expect.any(Number),
-                                            uiAmount: null, // can't convert decimal to BigInt
-                                            uiAmountString: expect.any(String),
-                                        },
-                                        mint: {
-                                            address: expect.any(String),
-                                        },
-                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-                                        source: {
-                                            address: expect.any(String),
-                                        },
-                                        tokenAmount: {
-                                            amount: expect.any(String),
-                                            decimals: expect.any(Number),
-                                            uiAmount: expect.any(BigInt),
-                                            uiAmountString: expect.any(String),
-                                        },
-                                    },
-                                ]),
-                            },
-                        },
-                    },
-                });
-            });
-
-            it('transfer-checked-with-fee-with-multisigAuthority', async () => {
-                // expect.assertions(1);
-                const source = /* GraphQL */ `
-                    query testQuery($signature: Signature!) {
-                        transaction(signature: $signature) {
-                            message {
-                                instructions {
-                                    programId
-                                    ... on SplTokenTransferCheckedWithFee {
-                                        mint {
                                             address
                                         }
                                         source {
@@ -1790,6 +1713,36 @@ describe('transaction', () => {
                             message: {
                                 instructions: expect.arrayContaining([
                                     {
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        destination: {
+                                            address: expect.any(String),
+                                        },
+                                        feeAmount: {
+                                            amount: expect.any(String),
+                                            decimals: expect.any(Number),
+                                            uiAmount: null, // can't convert decimal to BigInt
+                                            uiAmountString: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigAuthority: null,
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: null,
+                                        source: {
+                                            address: expect.any(String),
+                                        },
+                                        tokenAmount: {
+                                            amount: expect.any(String),
+                                            decimals: expect.any(Number),
+                                            uiAmount: expect.any(BigInt),
+                                            uiAmountString: expect.any(String),
+                                        },
+                                    },
+                                    {
+                                        authority: null,
                                         destination: {
                                             address: expect.any(String),
                                         },

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1661,6 +1661,86 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('transfer-checked-with-fee', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenTransferCheckedWithFee {
+                                        mint {
+                                            address
+                                        }
+                                        authority {
+                                            address
+                                        }
+                                        source {
+                                            address
+                                        }
+                                        destination {
+                                            address
+                                        }
+                                        feeAmount {
+                                            amount
+                                            decimals
+                                            uiAmount
+                                            uiAmountString
+                                        }
+                                        tokenAmount {
+                                            amount
+                                            decimals
+                                            uiAmount
+                                            uiAmountString
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        destination: {
+                                            address: expect.any(String),
+                                        },
+                                        feeAmount: {
+                                            amount: expect.any(String),
+                                            decimals: expect.any(Number),
+                                            uiAmount: null, // can't convert decimal to BigInt
+                                            uiAmountString: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        source: {
+                                            address: expect.any(String),
+                                        },
+                                        tokenAmount: {
+                                            amount: expect.any(String),
+                                            decimals: expect.any(Number),
+                                            uiAmount: expect.any(BigInt),
+                                            uiAmountString: expect.any(String),
+                                        },
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -320,6 +320,12 @@ export const instructionResolvers = {
         multisigAuthority: resolveAccount('multisigAuthority'),
         source: resolveAccount('source'),
     },
+    SplTokenTransferCheckedWithFee: {
+        authority: resolveAccount('authority'),
+        destination: resolveAccount('destination'),
+        mint: resolveAccount('mint'),
+        source: resolveAccount('source'),
+    },
     SplTokenTransferInstruction: {
         authority: resolveAccount('authority'),
         destination: resolveAccount('destination'),
@@ -638,6 +644,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeTransferFeeConfig') {
                         return 'SplTokenInitializeTransferFeeConfig';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'transferCheckedWithFee') {
+                        return 'SplTokenTransferCheckedWithFee';
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeTransferHook') {
                         return 'SplTokenInitializeTransferHookInstruction';

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -325,7 +325,7 @@ export const instructionResolvers = {
         destination: resolveAccount('destination'),
         mint: resolveAccount('mint'),
         multisigAuthority: resolveAccount('multisigAuthority'),
-        source: resolveAccount('source')
+        source: resolveAccount('source'),
     },
     SplTokenTransferInstruction: {
         authority: resolveAccount('authority'),

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -324,7 +324,8 @@ export const instructionResolvers = {
         authority: resolveAccount('authority'),
         destination: resolveAccount('destination'),
         mint: resolveAccount('mint'),
-        source: resolveAccount('source'),
+        multisigAuthority: resolveAccount('multisigAuthority'),
+        source: resolveAccount('source')
     },
     SplTokenTransferInstruction: {
         authority: resolveAccount('authority'),

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -715,6 +715,8 @@ export const instructionTypeDefs = /* GraphQL */ `
         mint: Account
         source: Account
         tokenAmount: TokenAmount
+        multisigAuthority: Account
+        signers: [Account]
     }
 
     # TODO: Extensions!

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -704,6 +704,19 @@ export const instructionTypeDefs = /* GraphQL */ `
         signers: [Address]
     }
 
+    """
+    SplToken-2022: TransferCheckedWithFee instruction
+    """
+    type SplTokenTransferCheckedWithFee implements TransactionInstruction {
+        programId: Address
+        authority: Account
+        destination: Account
+        feeAmount: TokenAmount
+        mint: Account
+        source: Account
+        tokenAmount: TokenAmount
+    }
+
     # TODO: Extensions!
     # ...
 

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -716,7 +716,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         source: Account
         tokenAmount: TokenAmount
         multisigAuthority: Account
-        signers: [Account]
+        signers: [Address]
     }
 
     # TODO: Extensions!


### PR DESCRIPTION
This PR adds support for Token-2022's TransferFeeExtension's TransferCheckedWithFee instruction
in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.