### PR TITLE
 refactor(experimental): graphql: token-2022 extensions: withdrawWithheldTokensFromMint

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1894,6 +1894,36 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            feeRecipient: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            withdrawWithheldAuthority: '6muXBR8kTs1UEbATDkFzEf61HPeEHrCvdBNciVoxic8d',
+                        },
+                        type: 'withdrawWithheldTokensFromMint',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
+                            feeRecipient: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            multisigWithdrawWithheldAuthority: '6muXBR8kTs1UEbATDkFzEf61HPeEHrCvdBNciVoxic8d',
+                            signers: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                        },
+                        type: 'withdrawWithheldTokensFromMint',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1652,7 +1652,7 @@ describe('transaction', () => {
                                             address: expect.any(String),
                                         },
                                         programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-                                        signers: [expect.any(String), expect.any(String)],
+                                        signers: expect.arrayContaining([expect.any(String)]),
                                         withdrawWithheldAuthority: null,
                                     },
                                 ]),

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1643,7 +1643,7 @@ describe('transaction', () => {
             });
 
             it('withdraw-withheld-tokens-from-mint-with-multisigWithdrawWithheldAuthority', async () => {
-                // expect.assertions(1);
+                expect.assertions(1);
                 const source = /* GraphQL */ `
                     query testQuery($signature: Signature!) {
                         transaction(signature: $signature) {
@@ -1669,7 +1669,6 @@ describe('transaction', () => {
                 `;
 
                 const result = await rpcGraphQL.query(source, { signature });
-                console.log(result.data);
                 expect(result).toMatchObject({
                     data: {
                         transaction: {

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1591,6 +1591,109 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('withdraw-withheld-tokens-from-mint', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenWithdrawWithheldTokensFromMint {
+                                        mint {
+                                            address
+                                        }
+                                        feeRecipient {
+                                            address
+                                        }
+                                        withdrawWithheldAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        feeRecipient: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        withdrawWithheldAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+
+            it('withdraw-withheld-tokens-from-mint-with-multisigWithdrawWithheldAuthority', async () => {
+                // expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenWithdrawWithheldTokensFromMint {
+                                        mint {
+                                            address
+                                        }
+                                        feeRecipient {
+                                            address
+                                        }
+                                        multisigWithdrawWithheldAuthority {
+                                            address
+                                        }
+                                        signers
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { signature });
+                console.log(result.data);
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        feeRecipient: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigWithdrawWithheldAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: [expect.any(String), expect.any(String)],
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1610,53 +1610,6 @@ describe('transaction', () => {
                                         withdrawWithheldAuthority {
                                             address
                                         }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                `;
-
-                const result = await rpcGraphQL.query(source, { signature });
-                expect(result).toMatchObject({
-                    data: {
-                        transaction: {
-                            message: {
-                                instructions: expect.arrayContaining([
-                                    {
-                                        feeRecipient: {
-                                            address: expect.any(String),
-                                        },
-                                        mint: {
-                                            address: expect.any(String),
-                                        },
-                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-                                        withdrawWithheldAuthority: {
-                                            address: expect.any(String),
-                                        },
-                                    },
-                                ]),
-                            },
-                        },
-                    },
-                });
-            });
-
-            it('withdraw-withheld-tokens-from-mint-with-multisigWithdrawWithheldAuthority', async () => {
-                expect.assertions(1);
-                const source = /* GraphQL */ `
-                    query testQuery($signature: Signature!) {
-                        transaction(signature: $signature) {
-                            message {
-                                instructions {
-                                    programId
-                                    ... on SplTokenWithdrawWithheldTokensFromMint {
-                                        mint {
-                                            address
-                                        }
-                                        feeRecipient {
-                                            address
-                                        }
                                         multisigWithdrawWithheldAuthority {
                                             address
                                         }
@@ -1681,11 +1634,26 @@ describe('transaction', () => {
                                         mint: {
                                             address: expect.any(String),
                                         },
+                                        multisigWithdrawWithheldAuthority: null,
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: null,
+                                        withdrawWithheldAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                    {
+                                        feeRecipient: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
                                         multisigWithdrawWithheldAuthority: {
                                             address: expect.any(String),
                                         },
                                         programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                                         signers: [expect.any(String), expect.any(String)],
+                                        withdrawWithheldAuthority: null,
                                     },
                                 ]),
                             },

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -364,6 +364,12 @@ export const instructionResolvers = {
         multisigWithdrawWithheldAuthority: resolveAccount('multisigWithdrawWithheldAuthority'),
         withdrawWithheldAuthority: resolveAccount('withdrawWithheldAuthority'),
     },
+    SplTokenWithdrawWithheldTokensFromMint: {
+        feeRecipient: resolveAccount('feeRecipient'),
+        mint: resolveAccount('mint'),
+        multisigWithdrawWithheldAuthority: resolveAccount('multisigWithdrawWithheldAuthority'),
+        withdrawWithheldAuthority: resolveAccount('withdrawWithheldAuthority'),
+    },
     StakeAuthorizeCheckedInstruction: {
         authority: resolveAccount('authority'),
         clockSysvar: resolveAccount('clockSysvar'),
@@ -656,6 +662,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'withdrawWithheldTokensFromAccounts') {
                         return 'SplTokenWithdrawWithheldTokensFromAccounts';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'withdrawWithheldTokensFromMint') {
+                        return 'SplTokenWithdrawWithheldTokensFromMint';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -692,6 +692,18 @@ export const instructionTypeDefs = /* GraphQL */ `
         withdrawWithheldAuthority: Account
     }
 
+    """
+    SplToken-2022: WithdrawWithheldTokensFromMint instruction
+    """
+    type SplTokenWithdrawWithheldTokensFromMint implements TransactionInstruction {
+        programId: Address
+        feeRecipient: Account
+        mint: Account
+        withdrawWithheldAuthority: Account
+        multisigWithdrawWithheldAuthority: Account
+        signers: [Address]
+    }
+
     # TODO: Extensions!
     # ...
 


### PR DESCRIPTION
This PR adds support for Token-2022's TransferFeeExtension's withdrawWithheldTokensFromMint instruction
in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.