### PR TITLE
chore: bump `@solana/spl-token` to `^0.4.6`

### DIFF
--- a/packages/library-legacy/package.json
+++ b/packages/library-legacy/package.json
@@ -88,7 +88,7 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
-    "@solana/spl-token": "^0.4.5",
+    "@solana/spl-token": "^0.4.6",
     "@types/bn.js": "^5.1.5",
     "@types/bs58": "^4.0.1",
     "@types/chai-as-promised": "^7.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,7 +502,7 @@ importers:
         specifier: ^0.4.4
         version: 0.4.4(rollup@4.16.4)
       '@solana/spl-token':
-        specifier: ^0.4.5
+        specifier: ^0.4.6
         version: 0.4.6(@solana/web3.js@1.91.6)(fastestsmallesttextencoderdecoder@1.0.22)
       '@types/bn.js':
         specifier: ^5.1.5


### PR DESCRIPTION
`0.4.4` and `0.4.5` had broken CJS exports, so we should not be recommending them here.
