### PR TITLE
refactor(experimental): graphql: token-2022 extensions: group pointer

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1641,6 +1641,23 @@ export const mockTransactionToken2022AllExtensions = {
                 {
                     parsed: {
                         info: {
+                            groupAddress: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            multisigAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            signers: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                        },
+                        type: 'updateGroupPointer',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
                             authority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
                             memberAddress: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
                             mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -745,6 +745,122 @@ describe('transaction', () => {
                     },
                 });
             });
+            it('initialize-group-pointer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenInitializeGroupPointerInstruction {
+                                        authority {
+                                            address
+                                        }
+                                        groupAddress {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        groupAddress: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+            it('update-group-pointer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenUpdateGroupPointerInstruction {
+                                        authority {
+                                            address
+                                        }
+                                        groupAddress {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                        multisigAuthority {
+                                            address
+                                        }
+                                        signers
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        groupAddress: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigAuthority: null,
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: null,
+                                    },
+                                    {
+                                        authority: null,
+                                        groupAddress: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: expect.arrayContaining([expect.any(String)]),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
             it('initialize-metadata-pointer', async () => {
                 expect.assertions(1);
                 const source = /* GraphQL */ `
@@ -861,7 +977,6 @@ describe('transaction', () => {
                     },
                 });
             });
-
             it('initialize-transferFee-config', async () => {
                 expect.assertions(1);
                 const source = /* GraphQL */ `

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -208,6 +208,11 @@ export const instructionResolvers = {
         owner: resolveAccount('owner'),
         rentSysvar: resolveAccount('rentSysvar'),
     },
+    SplTokenInitializeGroupPointerInstruction: {
+        authority: resolveAccount('authority'),
+        groupAddress: resolveAccount('groupAddress'),
+        mint: resolveAccount('mint'),
+    },
     SplTokenInitializeMetadataPointerInstruction: {
         authority: resolveAccount('authority'),
         metadataAddress: resolveAccount('metadataAddress'),
@@ -292,6 +297,12 @@ export const instructionResolvers = {
     },
     SplTokenUiAmountToAmountInstruction: {
         mint: resolveAccount('mint'),
+    },
+    SplTokenUpdateGroupPointerInstruction: {
+        authority: resolveAccount('authority'),
+        groupAddress: resolveAccount('groupAddress'),
+        mint: resolveAccount('mint'),
+        multisigAuthority: resolveAccount('multisigAuthority'),
     },
     SplTokenUpdateMetadataPointerInstruction: {
         authority: resolveAccount('authority'),
@@ -546,6 +557,12 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'initializePermanentDelegate') {
                         return 'SplTokenInitializePermanentDelegateInstruction';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializeGroupPointer') {
+                        return 'SplTokenInitializeGroupPointerInstruction';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'updateGroupPointer') {
+                        return 'SplTokenUpdateGroupPointerInstruction';
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeMetadataPointer') {
                         return 'SplTokenInitializeMetadataPointerInstruction';

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -522,6 +522,28 @@ export const instructionTypeDefs = /* GraphQL */ `
     }
 
     """
+    SplToken-2022: InitializeGroupPointer instruction
+    """
+    type SplTokenInitializeGroupPointerInstruction implements TransactionInstruction {
+        programId: Address
+        authority: Account
+        groupAddress: Account
+        mint: Account
+    }
+
+    """
+    SplToken-2022: UpdateGroupPointer instruction
+    """
+    type SplTokenUpdateGroupPointerInstruction implements TransactionInstruction {
+        programId: Address
+        authority: Account
+        groupAddress: Account
+        mint: Account
+        multisigAuthority: Account
+        signers: [Address]
+    }
+
+    """
     SplToken-2022: InitializeMetadataPointer instruction
     """
     type SplTokenInitializeMetadataPointerInstruction implements TransactionInstruction {


### PR DESCRIPTION
This PR adds support for Token-2022's `GroupPointer` extension
in the GraphQL schema.

cc @Hrushi20.

Continuing work on #2406.