### PR TITLE
refactor(experimental): graphql: token-2022 extensions: group member pointer

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1668,6 +1668,23 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            memberAddress: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            multisigAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            signers: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                        },
+                        type: 'updateGroupMemberPointer',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // Initializing Account Extensions.
                 {
                     parsed: {

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -861,6 +861,122 @@ describe('transaction', () => {
                     },
                 });
             });
+            it('initialize-group-member-pointer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenInitializeGroupMemberPointerInstruction {
+                                        authority {
+                                            address
+                                        }
+                                        memberAddress {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        memberAddress: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+            it('update-group-member-pointer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenUpdateGroupMemberPointerInstruction {
+                                        authority {
+                                            address
+                                        }
+                                        memberAddress {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                        multisigAuthority {
+                                            address
+                                        }
+                                        signers
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        memberAddress: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigAuthority: null,
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: null,
+                                    },
+                                    {
+                                        authority: null,
+                                        memberAddress: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: expect.arrayContaining([expect.any(String)]),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
             it('initialize-metadata-pointer', async () => {
                 expect.assertions(1);
                 const source = /* GraphQL */ `

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -208,6 +208,11 @@ export const instructionResolvers = {
         owner: resolveAccount('owner'),
         rentSysvar: resolveAccount('rentSysvar'),
     },
+    SplTokenInitializeGroupMemberPointerInstruction: {
+        authority: resolveAccount('authority'),
+        memberAddress: resolveAccount('memberAddress'),
+        mint: resolveAccount('mint'),
+    },
     SplTokenInitializeGroupPointerInstruction: {
         authority: resolveAccount('authority'),
         groupAddress: resolveAccount('groupAddress'),
@@ -297,6 +302,12 @@ export const instructionResolvers = {
     },
     SplTokenUiAmountToAmountInstruction: {
         mint: resolveAccount('mint'),
+    },
+    SplTokenUpdateGroupMemberPointerInstruction: {
+        authority: resolveAccount('authority'),
+        memberAddress: resolveAccount('memberAddress'),
+        mint: resolveAccount('mint'),
+        multisigAuthority: resolveAccount('multisigAuthority'),
     },
     SplTokenUpdateGroupPointerInstruction: {
         authority: resolveAccount('authority'),
@@ -563,6 +574,12 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'updateGroupPointer') {
                         return 'SplTokenUpdateGroupPointerInstruction';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializeGroupMemberPointer') {
+                        return 'SplTokenInitializeGroupMemberPointerInstruction';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'updateGroupMemberPointer') {
+                        return 'SplTokenUpdateGroupMemberPointerInstruction';
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeMetadataPointer') {
                         return 'SplTokenInitializeMetadataPointerInstruction';

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -544,6 +544,28 @@ export const instructionTypeDefs = /* GraphQL */ `
     }
 
     """
+    SplToken-2022: InitializeGroupMemberPointer instruction
+    """
+    type SplTokenInitializeGroupMemberPointerInstruction implements TransactionInstruction {
+        programId: Address
+        authority: Account
+        memberAddress: Account
+        mint: Account
+    }
+
+    """
+    SplToken-2022: UpdateGroupMemberPointer instruction
+    """
+    type SplTokenUpdateGroupMemberPointerInstruction implements TransactionInstruction {
+        programId: Address
+        authority: Account
+        memberAddress: Account
+        mint: Account
+        multisigAuthority: Account
+        signers: [Address]
+    }
+
+    """
     SplToken-2022: InitializeMetadataPointer instruction
     """
     type SplTokenInitializeMetadataPointerInstruction implements TransactionInstruction {


### PR DESCRIPTION
This PR adds support for Token-2022's `GroupMemberPointer` extension
in the GraphQL schema.

cc @Hrushi20.

Continuing work on #2406.