### PR TITLE
Freeze instructions and lifetime in transaction message objects

### DIFF
--- a/.changeset/thick-radios-appear.md
+++ b/.changeset/thick-radios-appear.md
@@ -1,0 +1,5 @@
+---
+"@solana/transaction-messages": patch
+---
+
+Freeze the instructions and lifetimeConstraint fields within transaction messages

--- a/packages/transaction-messages/src/__tests__/blockhash-test.ts
+++ b/packages/transaction-messages/src/__tests__/blockhash-test.ts
@@ -137,4 +137,11 @@ describe('setTransactionMessageLifetimeUsingBlockhash', () => {
         );
         expect(txWithBlockhashLifetimeConstraint).toBeFrozenObject();
     });
+    it('freezes the blockhash constraint', () => {
+        const txWithBlockhashLifetimeConstraint = setTransactionMessageLifetimeUsingBlockhash(
+            BLOCKHASH_CONSTRAINT_A,
+            baseTx,
+        );
+        expect(txWithBlockhashLifetimeConstraint.lifetimeConstraint).toBeFrozenObject();
+    });
 });

--- a/packages/transaction-messages/src/__tests__/create-transaction-message-test.ts
+++ b/packages/transaction-messages/src/__tests__/create-transaction-message-test.ts
@@ -19,4 +19,8 @@ describe('createTransactionMessage', () => {
         const tx = createTransactionMessage({ version: 0 });
         expect(tx).toBeFrozenObject();
     });
+    it('freezes the instructions array', () => {
+        const tx = createTransactionMessage({ version: 0 });
+        expect(tx.instructions).toBeFrozenObject();
+    });
 });

--- a/packages/transaction-messages/src/__tests__/instructions-test.ts
+++ b/packages/transaction-messages/src/__tests__/instructions-test.ts
@@ -47,6 +47,10 @@ describe('Transaction instruction helpers', () => {
             const txWithAddedInstruction = appendTransactionMessageInstruction(exampleInstruction, baseTx);
             expect(txWithAddedInstruction).toBeFrozenObject();
         });
+        it('freezes the instructions array', () => {
+            const txWithAddedInstruction = appendTransactionMessageInstruction(exampleInstruction, baseTx);
+            expect(txWithAddedInstruction.instructions).toBeFrozenObject();
+        });
     });
     describe('appendTransactionMessageInstructions', () => {
         it('adds the instructions to the end of the list', () => {
@@ -67,6 +71,13 @@ describe('Transaction instruction helpers', () => {
             );
             expect(txWithAddedInstruction).toBeFrozenObject();
         });
+        it('freezes the instructions array', () => {
+            const txWithAddedInstruction = appendTransactionMessageInstructions(
+                [exampleInstruction, secondExampleInstruction],
+                baseTx,
+            );
+            expect(txWithAddedInstruction.instructions).toBeFrozenObject();
+        });
     });
     describe('prependTransactionMessageInstruction', () => {
         it('adds the instruction to the beginning of the list', () => {
@@ -76,6 +87,10 @@ describe('Transaction instruction helpers', () => {
         it('freezes the object', () => {
             const txWithAddedInstruction = prependTransactionMessageInstruction(exampleInstruction, baseTx);
             expect(txWithAddedInstruction).toBeFrozenObject();
+        });
+        it('freezes the instructions array', () => {
+            const txWithAddedInstruction = prependTransactionMessageInstruction(exampleInstruction, baseTx);
+            expect(txWithAddedInstruction.instructions).toBeFrozenObject();
         });
     });
     describe('prependTransactionMessageInstructions', () => {
@@ -96,6 +111,13 @@ describe('Transaction instruction helpers', () => {
                 baseTx,
             );
             expect(txWithAddedInstruction).toBeFrozenObject();
+        });
+        it('freezes the instructions array', () => {
+            const txWithAddedInstruction = prependTransactionMessageInstructions(
+                [exampleInstruction, secondExampleInstruction],
+                baseTx,
+            );
+            expect(txWithAddedInstruction.instructions).toBeFrozenObject();
         });
     });
 });

--- a/packages/transaction-messages/src/blockhash.ts
+++ b/packages/transaction-messages/src/blockhash.ts
@@ -64,7 +64,7 @@ export function setTransactionMessageLifetimeUsingBlockhash(
     }
     const out = {
         ...transaction,
-        lifetimeConstraint: blockhashLifetimeConstraint,
+        lifetimeConstraint: Object.freeze(blockhashLifetimeConstraint),
     };
     Object.freeze(out);
     return out;

--- a/packages/transaction-messages/src/create-transaction-message.ts
+++ b/packages/transaction-messages/src/create-transaction-message.ts
@@ -10,10 +10,8 @@ export function createTransactionMessage<TVersion extends TransactionVersion>(
 export function createTransactionMessage<TVersion extends TransactionVersion>({
     version,
 }: TransactionConfig<TVersion>): TransactionMessage {
-    const out: TransactionMessage = {
-        instructions: [],
+    return Object.freeze({
+        instructions: Object.freeze([]),
         version,
-    };
-    Object.freeze(out);
-    return out;
+    }) as TransactionMessage;
 }

--- a/packages/transaction-messages/src/decompile-message.ts
+++ b/packages/transaction-messages/src/decompile-message.ts
@@ -136,11 +136,11 @@ function convertInstruction(
     const accounts = instruction.accountIndices?.map(accountIndex => accountMetas[accountIndex]);
     const { data } = instruction;
 
-    return {
+    return Object.freeze({
         programAddress,
-        ...(accounts && accounts.length ? { accounts } : {}),
+        ...(accounts && accounts.length ? { accounts: Object.freeze(accounts) } : {}),
         ...(data && data.length ? { data } : {}),
-    };
+    });
 }
 
 type LifetimeConstraint =

--- a/packages/transaction-messages/src/durable-nonce.ts
+++ b/packages/transaction-messages/src/durable-nonce.ts
@@ -177,26 +177,24 @@ export function setTransactionMessageLifetimeUsingDurableNonce<
         } else {
             // we have a different advance nonce instruction as the first instruction, replace it
             newInstructions = [
-                createAdvanceNonceAccountInstruction(nonceAccountAddress, nonceAuthorityAddress),
+                Object.freeze(createAdvanceNonceAccountInstruction(nonceAccountAddress, nonceAuthorityAddress)),
                 ...transaction.instructions.slice(1),
             ];
         }
     } else {
         // we don't have an existing advance nonce instruction as the first instruction, prepend one
         newInstructions = [
-            createAdvanceNonceAccountInstruction(nonceAccountAddress, nonceAuthorityAddress),
+            Object.freeze(createAdvanceNonceAccountInstruction(nonceAccountAddress, nonceAuthorityAddress)),
             ...transaction.instructions,
         ];
     }
 
-    const out = {
+    return Object.freeze({
         ...transaction,
-        instructions: newInstructions,
-        lifetimeConstraint: {
+        instructions: Object.freeze(newInstructions),
+        lifetimeConstraint: Object.freeze({
             nonce,
-        },
-    } as TransactionMessageWithDurableNonceLifetime<TNonceAccountAddress, TNonceAuthorityAddress, TNonceValue> &
+        }),
+    }) as TransactionMessageWithDurableNonceLifetime<TNonceAccountAddress, TNonceAuthorityAddress, TNonceValue> &
         TTransaction;
-    Object.freeze(out);
-    return out;
 }

--- a/packages/transaction-messages/src/instructions.ts
+++ b/packages/transaction-messages/src/instructions.ts
@@ -11,12 +11,10 @@ export function appendTransactionMessageInstructions<TTransaction extends BaseTr
     instructions: ReadonlyArray<TTransaction['instructions'][number]>,
     transaction: TTransaction,
 ): TTransaction {
-    const out = {
+    return Object.freeze({
         ...transaction,
-        instructions: [...transaction.instructions, ...instructions],
-    };
-    Object.freeze(out);
-    return out;
+        instructions: Object.freeze([...transaction.instructions, ...instructions]),
+    });
 }
 
 export function prependTransactionMessageInstruction<TTransaction extends BaseTransactionMessage>(
@@ -30,10 +28,8 @@ export function prependTransactionMessageInstructions<TTransaction extends BaseT
     instructions: ReadonlyArray<TTransaction['instructions'][number]>,
     transaction: TTransaction,
 ): TTransaction {
-    const out = {
+    return Object.freeze({
         ...transaction,
-        instructions: [...instructions, ...transaction.instructions],
-    };
-    Object.freeze(out);
-    return out;
+        instructions: Object.freeze([...instructions, ...transaction.instructions]),
+    });
 }


### PR DESCRIPTION
- Freeze the instructions array when we append/prepend instructions
- Freeze the instructions array when we create a transaction message
- Freeze the instructions array and lifetime when adding a durable nonce
- Freeze the lifetime constraint when adding a blockhash
- Freeze instructions when decompiling a transaction message