### PR TITLE
refactor(experimental): graphql: token-2022 extensions: harvestWithheldTokensToMint and WithdrawWithheldTokensFromAccounts

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1841,6 +1841,59 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            sourceAccounts: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                        },
+                        type: 'harvestWithheldTokensToMint',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
+                            feeRecipient: '6muXBR8kTs1UEbATDkFzEf61HPeEHrCvdBNciVoxic8d',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            sourceAccounts: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                            withdrawWithheldAuthority: '6muXBR8kTs1UEbATDkFzEf61HPeEHrCvdBNciVoxic8d',
+                        },
+                        type: 'withdrawWithheldTokensFromAccounts',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
+                            feeRecipient: '6muXBR8kTs1UEbATDkFzEf61HPeEHrCvdBNciVoxic8d',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            sourceAccounts: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                            multisigWithdrawWithheldAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            signers: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                        },
+                        type: 'withdrawWithheldTokensFromAccounts',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1480,6 +1480,117 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('harvest-withheld-tokens-to-mint', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenHarvestWithheldTokensToMint {
+                                        mint {
+                                            address
+                                        }
+                                        sourceAccounts
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        sourceAccounts: expect.arrayContaining([expect.any(String)]),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+
+            it('withdraw-withheld-tokens-from-accounts', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenWithdrawWithheldTokensFromAccounts {
+                                        feeRecipient {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                        multisigWithdrawWithheldAuthority {
+                                            address
+                                        }
+                                        signers
+                                        sourceAccounts
+                                        withdrawWithheldAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        feeRecipient: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigWithdrawWithheldAuthority: null,
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: null,
+                                        sourceAccounts: expect.arrayContaining([expect.any(String)]),
+                                        withdrawWithheldAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                    {
+                                        feeRecipient: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigWithdrawWithheldAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: expect.arrayContaining([expect.any(String)]),
+                                        sourceAccounts: expect.arrayContaining([expect.any(String)]),
+                                        withdrawWithheldAuthority: null,
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -206,6 +206,9 @@ export const instructionResolvers = {
     SplTokenGetAccountDataSizeInstruction: {
         mint: resolveAccount('mint'),
     },
+    SplTokenHarvestWithheldTokensToMint: {
+        mint: resolveAccount('mint'),
+    },
     SplTokenInitializeAccount2Instruction: {
         account: resolveAccount('account'),
         mint: resolveAccount('mint'),
@@ -354,6 +357,12 @@ export const instructionResolvers = {
         hookProgramId: resolveAccount('programId'),
         mint: resolveAccount('mint'),
         multisigAuthority: resolveAccount('multisigAuthority'),
+    },
+    SplTokenWithdrawWithheldTokensFromAccounts: {
+        feeRecipient: resolveAccount('feeRecipient'),
+        mint: resolveAccount('mint'),
+        multisigWithdrawWithheldAuthority: resolveAccount('multisigWithdrawWithheldAuthority'),
+        withdrawWithheldAuthority: resolveAccount('withdrawWithheldAuthority'),
     },
     StakeAuthorizeCheckedInstruction: {
         authority: resolveAccount('authority'),
@@ -641,6 +650,12 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'enableCpiGuard') {
                         return 'SplTokenEnableCpiGuardInstruction';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'harvestWithheldTokensToMint') {
+                        return 'SplTokenHarvestWithheldTokensToMint';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'withdrawWithheldTokensFromAccounts') {
+                        return 'SplTokenWithdrawWithheldTokensFromAccounts';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -684,12 +684,12 @@ export const instructionTypeDefs = /* GraphQL */ `
     """
     type SplTokenWithdrawWithheldTokensFromAccounts implements TransactionInstruction {
         programId: Address
-        mint: Account
-        sourceAccounts: [Address]
-        withdrawWithheldAuthority: Account
         feeRecipient: Account
+        mint: Account
         multisigWithdrawWithheldAuthority: Account
         signers: [Address]
+        sourceAccounts: [Address]
+        withdrawWithheldAuthority: Account
     }
 
     # TODO: Extensions!

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -670,6 +670,28 @@ export const instructionTypeDefs = /* GraphQL */ `
         signers: [Address]
     }
 
+    """
+    SplToken-2022: HarvestWithheldTokensToMint instruction
+    """
+    type SplTokenHarvestWithheldTokensToMint implements TransactionInstruction {
+        programId: Address
+        mint: Account
+        sourceAccounts: [Address]
+    }
+
+    """
+    SplToken-2022: HarvestWithheldTokensToMint instruction
+    """
+    type SplTokenWithdrawWithheldTokensFromAccounts implements TransactionInstruction {
+        programId: Address
+        mint: Account
+        sourceAccounts: [Address]
+        withdrawWithheldAuthority: Account
+        feeRecipient: Account
+        multisigWithdrawWithheldAuthority: Account
+        signers: [Address]
+    }
+
     # TODO: Extensions!
     # ...
 

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -680,7 +680,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     }
 
     """
-    SplToken-2022: HarvestWithheldTokensToMint instruction
+    SplToken-2022: WithdrawWithheldTokensFromAccounts instruction
     """
     type SplTokenWithdrawWithheldTokensFromAccounts implements TransactionInstruction {
         programId: Address


### PR DESCRIPTION
This PR adds support for Token-2022's TransferFeeExtension's harvestWithheldTokensToMint and withdrawWithheldTokensFromAccounts instructions in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.