### PR TITLE
Apply default input dependencies to every Turbo step

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,12 +18,12 @@
         },
         "compile:js": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["tsconfig.*", "src/**"],
+            "inputs": ["$TURBO_DEFAULT$", "tsconfig.*", "src/**"],
             "outputs": ["dist/**"]
         },
         "compile:typedefs": {
             "dependsOn": ["^compile:typedefs"],
-            "inputs": ["tsconfig.*", "src/**"],
+            "inputs": ["$TURBO_DEFAULT$", "tsconfig.*", "src/**"],
             "outputs": ["dist/**/*.d.ts"]
         },
         "publish-packages": {
@@ -55,32 +55,32 @@
             ]
         },
         "style:fix": {
-            "inputs": ["*"],
+            "inputs": ["$TURBO_DEFAULT$", "*"],
             "outputs": ["*"]
         },
         "test:lint": {
             "dependsOn": ["^compile:typedefs"],
-            "inputs": ["src/**", "test/**"],
+            "inputs": ["$TURBO_DEFAULT$", "src/**", "test/**"],
             "outputs": []
         },
         "test:live-with-test-validator": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**"]
+            "inputs": ["$TURBO_DEFAULT$", "src/**"]
         },
         "test:prettier": {
-            "inputs": ["*"]
+            "inputs": ["$TURBO_DEFAULT$", "*"]
         },
         "test:typecheck": {
             "dependsOn": ["^compile:typedefs"],
-            "inputs": ["tsconfig.*", "src/**"]
+            "inputs": ["$TURBO_DEFAULT$", "tsconfig.*", "src/**"]
         },
         "test:unit:browser": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**"]
+            "inputs": ["$TURBO_DEFAULT$", "src/**"]
         },
         "test:unit:node": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**"]
+            "inputs": ["$TURBO_DEFAULT$", "src/**"]
         },
         "test:treeshakability:browser": {
             "dependsOn": ["compile:js"]
@@ -110,17 +110,18 @@
         },
         "@solana/web3.js#compile:docs": {
             "dependsOn": ["clean"],
-            "inputs": ["src/**"],
+            "inputs": ["$TURBO_DEFAULT$", "src/**"],
             "outputs": ["doc/**"]
         },
         "@solana/web3.js#compile:js": {
             "dependsOn": ["clean", "^compile:js"],
-            "inputs": ["babel.config.json", "rollup.config.mjs", "tsconfig.*", "src/**"],
+            "inputs": ["$TURBO_DEFAULT$", "babel.config.json", "rollup.config.mjs", "tsconfig.*", "src/**"],
             "outputs": ["lib/**"]
         },
         "@solana/web3.js#compile:typedefs": {
             "dependsOn": ["clean", "^compile:typedefs"],
             "inputs": [
+                "$TURBO_DEFAULT$",
                 "rollup.config.types.mjs",
                 "scripts/typegen.sh",
                 "src/**",
@@ -130,19 +131,19 @@
             "outputs": ["declarations/**", "lib/**/*.d.ts"]
         },
         "@solana/web3.js#test:lint": {
-            "inputs": ["src/**", "test/**"]
+            "inputs": ["$TURBO_DEFAULT$", "src/**", "test/**"]
         },
         "@solana/web3.js#test:live-with-test-validator": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**", "test/**"]
+            "inputs": ["$TURBO_DEFAULT$", "src/**", "test/**"]
         },
         "@solana/web3.js#test:typecheck": {
             "dependsOn": ["^compile:typedefs"],
-            "inputs": ["src/**", "test/**", "tsconfig.*"]
+            "inputs": ["$TURBO_DEFAULT$", "src/**", "test/**", "tsconfig.*"]
         },
         "@solana/web3.js#test:unit:node": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**", "test/**"]
+            "inputs": ["$TURBO_DEFAULT$", "src/**", "test/**"]
         }
     },
     "remoteCache": {


### PR DESCRIPTION
TIL that specifying an `input` clears unsets the defaults. You have to put them back.
