### PR TITLE
refactor(experimental): graphql: token-2022 extensions: InitializeInterestBearingConfig, UpdateInterestBearingConfig

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2040,10 +2040,40 @@ export const mockTransactionToken2022AllExtensions = {
                     parsed: {
                         info: {
                             mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
-                            rate: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
-                            rateAuthority: 20,
+                            rate: 20,
+                            rateAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
                         },
                         type: 'initializeInterestBearingConfig',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            newRate: 20,
+                            rateAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                        },
+                        type: 'updateInterestBearingConfigRate',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            multisigRateAuthority: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            newRate: 20,
+                            signers: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                        },
+                        type: 'updateInterestBearingConfigRate',
                     },
                     program: 'spl-token',
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',

--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2036,6 +2036,19 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            rate: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            rateAuthority: 20,
+                        },
+                        type: 'initializeInterestBearingConfig',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -2044,7 +2044,7 @@ describe('transaction', () => {
                                         newRate: expect.any(Number),
                                         programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                                         rateAuthority: null,
-                                        signers: expect.any([expect.any]),
+                                        signers: expect.any([expect.any(String)]),
                                     },
                                 ]),
                             },

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1944,6 +1944,51 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('initialize-interest-bearing-config', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenInitializeInterestBearingConfig {
+                                        mint {
+                                            address
+                                        }
+                                        rate {
+                                            address
+                                        }
+                                        rateAuthority
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        rate: {
+                                            address: expect.any(String),
+                                        },
+                                        rateAuthority: expect.any(Number),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1998,7 +1998,7 @@ describe('transaction', () => {
                             message {
                                 instructions {
                                     programId
-                                    ... on SplTokenUpdateInterestBearingConfig {
+                                    ... on SplTokenUpdateInterestBearingConfigRate {
                                         mint {
                                             address
                                         }
@@ -2044,7 +2044,7 @@ describe('transaction', () => {
                                         newRate: expect.any(Number),
                                         programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                                         rateAuthority: null,
-                                        signers: expect.any([expect.any(String)]),
+                                        signers: expect.arrayContaining([expect.any(String)]),
                                     },
                                 ]),
                             },

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1957,10 +1957,10 @@ describe('transaction', () => {
                                         mint {
                                             address
                                         }
-                                        rate {
+                                        rate
+                                        rateAuthority {
                                             address
                                         }
-                                        rateAuthority
                                     }
                                 }
                             }
@@ -1978,10 +1978,73 @@ describe('transaction', () => {
                                             address: expect.any(String),
                                         },
                                         programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-                                        rate: {
+                                        rate: expect.any(Number),
+                                        rateAuthority: {
                                             address: expect.any(String),
                                         },
-                                        rateAuthority: expect.any(Number),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+
+            it('update-interest-bearing-config', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenUpdateInterestBearingConfig {
+                                        mint {
+                                            address
+                                        }
+                                        multisigRateAuthority {
+                                            address
+                                        }
+                                        newRate
+                                        rateAuthority {
+                                            address
+                                        }
+                                        signers
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigRateAuthority: null,
+                                        newRate: expect.any(Number),
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        rateAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        signers: null,
+                                    },
+                                    {
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigRateAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        newRate: expect.any(Number),
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        rateAuthority: null,
+                                        signers: expect.any([expect.any]),
                                     },
                                 ]),
                             },

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -253,6 +253,10 @@ export const instructionResolvers = {
         groupAddress: resolveAccount('groupAddress'),
         mint: resolveAccount('mint'),
     },
+    SplTokenInitializeInterestBearingConfig: {
+        mint: resolveAccount('mint'),
+        rate: resolveAccount('rate'),
+    },
     SplTokenInitializeMetadataPointerInstruction: {
         authority: resolveAccount('authority'),
         metadataAddress: resolveAccount('metadataAddress'),
@@ -698,6 +702,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeConfidentialTransferMint') {
                         return 'SplTokenInitializeConfidentialTransferMint';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializeInterestBearingConfig') {
+                        return 'SplTokenInitializeInterestBearingConfig';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -255,7 +255,7 @@ export const instructionResolvers = {
     },
     SplTokenInitializeInterestBearingConfig: {
         mint: resolveAccount('mint'),
-        rate: resolveAccount('rate'),
+        rateAuthority: resolveAccount('rateAuthority'),
     },
     SplTokenInitializeMetadataPointerInstruction: {
         authority: resolveAccount('authority'),
@@ -370,6 +370,11 @@ export const instructionResolvers = {
         groupAddress: resolveAccount('groupAddress'),
         mint: resolveAccount('mint'),
         multisigAuthority: resolveAccount('multisigAuthority'),
+    },
+    SplTokenUpdateInterestBearingConfig: {
+        mint: resolveAccount('mint'),
+        multisigRateAuthority: resolveAccount('multisigRateAuthority'),
+        rateAuthority: resolveAccount('rateAuthority'),
     },
     SplTokenUpdateMetadataPointerInstruction: {
         authority: resolveAccount('authority'),
@@ -705,6 +710,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeInterestBearingConfig') {
                         return 'SplTokenInitializeInterestBearingConfig';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'updateInterestBearingConfigRate') {
+                        return 'SplTokenUpdateInterestBearingConfig';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -371,7 +371,7 @@ export const instructionResolvers = {
         mint: resolveAccount('mint'),
         multisigAuthority: resolveAccount('multisigAuthority'),
     },
-    SplTokenUpdateInterestBearingConfig: {
+    SplTokenUpdateInterestBearingConfigRate: {
         mint: resolveAccount('mint'),
         multisigRateAuthority: resolveAccount('multisigRateAuthority'),
         rateAuthority: resolveAccount('rateAuthority'),
@@ -712,7 +712,7 @@ export const instructionResolvers = {
                         return 'SplTokenInitializeInterestBearingConfig';
                     }
                     if (jsonParsedConfigs.instructionType === 'updateInterestBearingConfigRate') {
-                        return 'SplTokenUpdateInterestBearingConfig';
+                        return 'SplTokenUpdateInterestBearingConfigRate';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -763,9 +763,9 @@ export const instructionTypeDefs = /* GraphQL */ `
     }
 
     """
-    SplToken-2022: UpdateInterestBearingConfig instruction
+    SplToken-2022: UpdateInterestBearingConfigRate instruction
     """
-    type SplTokenUpdateInterestBearingConfig implements TransactionInstruction {
+    type SplTokenUpdateInterestBearingConfigRate implements TransactionInstruction {
         programId: Address
         mint: Account
         multisigRateAuthority: Account

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -758,8 +758,20 @@ export const instructionTypeDefs = /* GraphQL */ `
     type SplTokenInitializeInterestBearingConfig implements TransactionInstruction {
         programId: Address
         mint: Account
-        rate: Account
-        rateAuthority: Int
+        rate: Int
+        rateAuthority: Account
+    }
+
+    """
+    SplToken-2022: UpdateInterestBearingConfig instruction
+    """
+    type SplTokenUpdateInterestBearingConfig implements TransactionInstruction {
+        programId: Address
+        mint: Account
+        multisigRateAuthority: Account
+        newRate: Int
+        rateAuthority: Account
+        signers: [Address]
     }
 
     # TODO: Extensions!

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -752,6 +752,16 @@ export const instructionTypeDefs = /* GraphQL */ `
         mint: Account
     }
 
+    """
+    SplToken-2022: InitializeInterestBearingConfig instruction
+    """
+    type SplTokenInitializeInterestBearingConfig implements TransactionInstruction {
+        programId: Address
+        mint: Account
+        rate: Account
+        rateAuthority: Int
+    }
+
     # TODO: Extensions!
     # ...
 


### PR DESCRIPTION
This PR adds support for Token-2022's InitializeInterestBearingConfig,UpdateInterestBearingConfig instructions in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.