### PR TITLE
refactor(experimental): graphql: token-2022 extensions: InitializeConfidentialTransferMint 

### DIFF
--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1896,6 +1896,54 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('initialize-confidential-transfer-mint', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenInitializeConfidentialTransferMint {
+                                        mint {
+                                            address
+                                        }
+                                        authority {
+                                            address
+                                        }
+                                        auditorElgamalPubkey
+                                        autoApproveNewAccounts
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        auditorElgamalPubkey: null,
+                                        autoApproveNewAccounts: expect.any(Boolean),
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -1928,14 +1928,14 @@ describe('transaction', () => {
                             message: {
                                 instructions: expect.arrayContaining([
                                     {
-                                        mint: {
-                                            address: expect.any(String),
-                                        },
+                                        auditorElgamalPubkey: null,
                                         authority: {
                                             address: expect.any(String),
                                         },
-                                        auditorElgamalPubkey: null,
                                         autoApproveNewAccounts: expect.any(Boolean),
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
                                         programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                                     },
                                 ]),

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -387,6 +387,10 @@ export const instructionResolvers = {
         multisigWithdrawWithheldAuthority: resolveAccount('multisigWithdrawWithheldAuthority'),
         withdrawWithheldAuthority: resolveAccount('withdrawWithheldAuthority'),
     },
+    SplTokenInitializeConfidentialTransferMint: {
+        mint: resolveAccount('mint'),
+        authority: resolveAccount('authority'),
+    },
     StakeAuthorizeCheckedInstruction: {
         authority: resolveAccount('authority'),
         clockSysvar: resolveAccount('clockSysvar'),
@@ -691,6 +695,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'disableRequiredMemoTransfers') {
                         return 'SplTokenDisableRequiredMemoTransfers';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializeConfidentialTransferMint') {
+                        return 'SplTokenInitializeConfidentialTransferMint';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -236,6 +236,10 @@ export const instructionResolvers = {
         owner: resolveAccount('owner'),
         rentSysvar: resolveAccount('rentSysvar'),
     },
+    SplTokenInitializeConfidentialTransferMint: {
+        authority: resolveAccount('authority'),
+        mint: resolveAccount('mint'),
+    },
     SplTokenInitializeDefaultAccountStateInstruction: {
         mint: resolveAccount('mint'),
     },
@@ -386,10 +390,6 @@ export const instructionResolvers = {
         mint: resolveAccount('mint'),
         multisigWithdrawWithheldAuthority: resolveAccount('multisigWithdrawWithheldAuthority'),
         withdrawWithheldAuthority: resolveAccount('withdrawWithheldAuthority'),
-    },
-    SplTokenInitializeConfidentialTransferMint: {
-        authority: resolveAccount('authority'),
-        mint: resolveAccount('mint'),
     },
     StakeAuthorizeCheckedInstruction: {
         authority: resolveAccount('authority'),

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -388,8 +388,8 @@ export const instructionResolvers = {
         withdrawWithheldAuthority: resolveAccount('withdrawWithheldAuthority'),
     },
     SplTokenInitializeConfidentialTransferMint: {
-        mint: resolveAccount('mint'),
         authority: resolveAccount('authority'),
+        mint: resolveAccount('mint'),
     },
     StakeAuthorizeCheckedInstruction: {
         authority: resolveAccount('authority'),

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -741,6 +741,17 @@ export const instructionTypeDefs = /* GraphQL */ `
         signers: [Address]
     }
 
+    """
+    SplToken-2022: InitializeConfidentialTransferMint instruction
+    """
+    type SplTokenInitializeConfidentialTransferMint implements TransactionInstruction {
+        programId: Address
+        auditorElgamalPubkey: Address
+        authority: Account
+        mint: Account
+        autoApproveNewAccounts: Boolean
+    }
+
     # TODO: Extensions!
     # ...
 

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -748,8 +748,8 @@ export const instructionTypeDefs = /* GraphQL */ `
         programId: Address
         auditorElgamalPubkey: Address
         authority: Account
-        mint: Account
         autoApproveNewAccounts: Boolean
+        mint: Account
     }
 
     # TODO: Extensions!


### PR DESCRIPTION
This PR adds support for Token-2022's InitializeConfidentialTransferMint instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.