### PR TITLE
refactor(experimental): graphql: token-2022 extensions: ConfigureConfidentialTransferAccount Instruction #2611

### DIFF
--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -2173,6 +2173,61 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('configure-confidential-transfer-account', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenConfigureConfidentialTransferAccount {
+                                        account {
+                                            address
+                                        }
+                                        decryptableZeroBalance
+                                        maximumPendingBalanceCreditCounter
+                                        mint {
+                                            address
+                                        }
+                                        multisigOwner {
+                                            address
+                                        }
+                                        signers
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        account: {
+                                            address: expect.any(String),
+                                        },
+                                        decryptableZeroBalance: expect.any(String),
+                                        maximumPendingBalanceCreditCounter: expect.any(BigInt),
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigOwner: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: expect.arrayContaining([expect.any(String)]),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -187,6 +187,11 @@ export const instructionResolvers = {
         multisigOwner: resolveAccount('multisigOwner'),
         owner: resolveAccount('owner'),
     },
+    SplTokenConfigureConfidentialTransferAccount: {
+        account: resolveAccount('account'),
+        mint: resolveAccount('mint'),
+        multisigOwner: resolveAccount('multisigOwner'),
+    },
     SplTokenDefaultAccountState: {
         FROZEN: 'frozen',
         INITIALIZED: 'initialized',
@@ -730,6 +735,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'emptyConfidentialTransferAccount') {
                         return 'SplTokenEmptyConfidentialTransferAccount';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'configureConfidentialTransferAccount') {
+                        return 'SplTokenConfigureConfidentialTransferAccount';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -797,6 +797,19 @@ export const instructionTypeDefs = /* GraphQL */ `
         signers: [Address]
     }
 
+    """
+    SplToken-2022: ConfigureConfidentialTransferAccount instruction
+    """
+    type SplTokenConfigureConfidentialTransferAccount implements TransactionInstruction {
+        programId: Address
+        account: Account
+        decryptableZeroBalance: String
+        maximumPendingBalanceCreditCounter: BigInt
+        mint: Account
+        multisigOwner: Account
+        signers: [Address]
+    }
+
     # TODO: Extensions!
     # ...
 


### PR DESCRIPTION
This PR adds support for Token-2022's ConfigureConfidentialTransferAccount instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.