### PR TITLE
refactor(experimental): graphql: sysvars: clock

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -901,5 +901,52 @@ describe('account', () => {
                 },
             });
         });
+        describe('sysvars', () => {
+            it('can get the clock sysvar', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    address: 'SysvarC1ock11111111111111111111111111111111',
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            address
+                            lamports
+                            ownerProgram {
+                                address
+                            }
+                            rentEpoch
+                            space
+                            ... on SysvarClockAccount {
+                                epoch
+                                epochStartTimestamp
+                                leaderScheduleEpoch
+                                slot
+                                unixTimestamp
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            address: 'SysvarC1ock11111111111111111111111111111111',
+                            epoch: expect.any(BigInt),
+                            epochStartTimestamp: expect.any(BigInt),
+                            lamports: expect.any(BigInt),
+                            leaderScheduleEpoch: expect.any(BigInt),
+                            ownerProgram: {
+                                address: 'Sysvar1111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            slot: expect.any(BigInt),
+                            space: expect.any(BigInt),
+                            unixTimestamp: expect.any(BigInt),
+                        },
+                    },
+                });
+            });
+        });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -143,6 +143,11 @@ function resolveAccountType(accountResult: AccountResult) {
         ) {
             return 'LookupTableAccount';
         }
+        if (jsonParsedConfigs.programName === 'sysvar') {
+            if (jsonParsedConfigs.accountType === 'clock') {
+                return 'SysvarClockAccount';
+            }
+        }
     }
     return 'GenericAccount';
 }
@@ -185,6 +190,10 @@ export const accountResolvers = {
     },
     StakeAccountDataStakeDelegation: {
         voter: resolveAccount('voter'),
+    },
+    SysvarClockAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
     },
     TokenAccount: {
         data: resolveAccountData(),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -176,4 +176,22 @@ export const accountTypeDefs = /* GraphQL */ `
         rootSlot: BigInt
         votes: [VoteAccountDataVote]
     }
+
+    """
+    Sysvar Clock
+    """
+    type SysvarClockAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        epoch: BigInt
+        epochStartTimestamp: BigInt
+        leaderScheduleEpoch: BigInt
+        slot: BigInt
+        unixTimestamp: BigInt
+    }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `Clock` to the GraphQL schema.

Ref: #2622.