### PR TITLE
refactor(experimental): graphql: sysvars: epoch rewards

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -947,6 +947,8 @@ describe('account', () => {
                     },
                 });
             });
+            // TODO: Does not exist on-chain yet.
+            it.todo('can get the epoch rewards sysvar');
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -147,6 +147,9 @@ function resolveAccountType(accountResult: AccountResult) {
             if (jsonParsedConfigs.accountType === 'clock') {
                 return 'SysvarClockAccount';
             }
+            if (jsonParsedConfigs.accountType === 'epochRewards') {
+                return 'SysvarEpochRewardsAccount';
+            }
         }
     }
     return 'GenericAccount';
@@ -192,6 +195,10 @@ export const accountResolvers = {
         voter: resolveAccount('voter'),
     },
     SysvarClockAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
+    },
+    SysvarEpochRewardsAccount: {
         data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -194,4 +194,20 @@ export const accountTypeDefs = /* GraphQL */ `
         slot: BigInt
         unixTimestamp: BigInt
     }
+
+    """
+    Sysvar Epoch Rewards
+    """
+    type SysvarEpochRewardsAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        distributedRewards: BigInt
+        distributionCompleteBlockHeight: BigInt
+        totalRewards: BigInt
+    }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `EpochRewards` to the GraphQL schema.

Ref: #2622.