### PR TITLE
refactor(experimental): graphql: sysvars: epoch schedule

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -949,6 +949,51 @@ describe('account', () => {
             });
             // TODO: Does not exist on-chain yet.
             it.todo('can get the epoch rewards sysvar');
+            it('can get the epoch schedule sysvar', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    address: 'SysvarEpochSchedu1e111111111111111111111111',
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            address
+                            lamports
+                            ownerProgram {
+                                address
+                            }
+                            rentEpoch
+                            space
+                            ... on SysvarEpochScheduleAccount {
+                                firstNormalEpoch
+                                firstNormalSlot
+                                leaderScheduleSlotOffset
+                                slotsPerEpoch
+                                warmup
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            address: 'SysvarEpochSchedu1e111111111111111111111111',
+                            firstNormalEpoch: expect.any(BigInt),
+                            firstNormalSlot: expect.any(BigInt),
+                            lamports: expect.any(BigInt),
+                            leaderScheduleSlotOffset: expect.any(BigInt),
+                            ownerProgram: {
+                                address: 'Sysvar1111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            slotsPerEpoch: expect.any(BigInt),
+                            space: expect.any(BigInt),
+                            warmup: expect.any(Boolean),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -150,6 +150,9 @@ function resolveAccountType(accountResult: AccountResult) {
             if (jsonParsedConfigs.accountType === 'epochRewards') {
                 return 'SysvarEpochRewardsAccount';
             }
+            if (jsonParsedConfigs.accountType === 'epochSchedule') {
+                return 'SysvarEpochScheduleAccount';
+            }
         }
     }
     return 'GenericAccount';
@@ -199,6 +202,10 @@ export const accountResolvers = {
         ownerProgram: resolveAccount('ownerProgram'),
     },
     SysvarEpochRewardsAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
+    },
+    SysvarEpochScheduleAccount: {
         data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -210,4 +210,22 @@ export const accountTypeDefs = /* GraphQL */ `
         distributionCompleteBlockHeight: BigInt
         totalRewards: BigInt
     }
+
+    """
+    Sysvar Epoch Schedule
+    """
+    type SysvarEpochScheduleAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        firstNormalEpoch: BigInt
+        firstNormalSlot: BigInt
+        leaderScheduleSlotOffset: BigInt
+        slotsPerEpoch: BigInt
+        warmup: Boolean
+    }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `EpochSchedule` to the GraphQL schema.

Ref: #2622.