### PR TITLE
refactor(experimental): graphql: sysvars: fees

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -994,6 +994,47 @@ describe('account', () => {
                     },
                 });
             });
+            it('can get the fees sysvar', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    address: 'SysvarFees111111111111111111111111111111111',
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            address
+                            lamports
+                            ownerProgram {
+                                address
+                            }
+                            rentEpoch
+                            space
+                            ... on SysvarFeesAccount {
+                                feeCalculator {
+                                    lamportsPerSignature
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            address: 'SysvarFees111111111111111111111111111111111',
+                            feeCalculator: {
+                                lamportsPerSignature: expect.any(BigInt),
+                            },
+                            lamports: expect.any(BigInt),
+                            ownerProgram: {
+                                address: 'Sysvar1111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: expect.any(BigInt),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -153,6 +153,9 @@ function resolveAccountType(accountResult: AccountResult) {
             if (jsonParsedConfigs.accountType === 'epochSchedule') {
                 return 'SysvarEpochScheduleAccount';
             }
+            if (jsonParsedConfigs.accountType === 'fees') {
+                return 'SysvarFeesAccount';
+            }
         }
     }
     return 'GenericAccount';
@@ -206,6 +209,10 @@ export const accountResolvers = {
         ownerProgram: resolveAccount('ownerProgram'),
     },
     SysvarEpochScheduleAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
+    },
+    SysvarFeesAccount: {
         data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -228,4 +228,21 @@ export const accountTypeDefs = /* GraphQL */ `
         slotsPerEpoch: BigInt
         warmup: Boolean
     }
+
+    type SysvarFeesFeeCalculator {
+        lamportsPerSignature: BigInt
+    }
+    """
+    Sysvar Fees
+    """
+    type SysvarFeesAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        feeCalculator: SysvarFeesFeeCalculator
+    }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `Fees` to the GraphQL schema.

Ref: #2622.