### PR TITLE
refactor(experimental): graphql: sysvars: last restart slot

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1035,6 +1035,43 @@ describe('account', () => {
                     },
                 });
             });
+            it('can get the last restart slot sysvar', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    address: 'SysvarLastRestartS1ot1111111111111111111111',
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            address
+                            lamports
+                            ownerProgram {
+                                address
+                            }
+                            rentEpoch
+                            space
+                            ... on SysvarLastRestartSlotAccount {
+                                lastRestartSlot
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            address: 'SysvarLastRestartS1ot1111111111111111111111',
+                            lamports: expect.any(BigInt),
+                            lastRestartSlot: expect.any(BigInt),
+                            ownerProgram: {
+                                address: 'Sysvar1111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: expect.any(BigInt),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -156,6 +156,9 @@ function resolveAccountType(accountResult: AccountResult) {
             if (jsonParsedConfigs.accountType === 'fees') {
                 return 'SysvarFeesAccount';
             }
+            if (jsonParsedConfigs.accountType === 'lastRestartSlot') {
+                return 'SysvarLastRestartSlotAccount';
+            }
         }
     }
     return 'GenericAccount';
@@ -213,6 +216,10 @@ export const accountResolvers = {
         ownerProgram: resolveAccount('ownerProgram'),
     },
     SysvarFeesAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
+    },
+    SysvarLastRestartSlotAccount: {
         data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -245,4 +245,18 @@ export const accountTypeDefs = /* GraphQL */ `
         rentEpoch: BigInt
         feeCalculator: SysvarFeesFeeCalculator
     }
+
+    """
+    Sysvar Last Restart Slot
+    """
+    type SysvarLastRestartSlotAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        lastRestartSlot: BigInt
+    }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `LastRestartSlot` to the GraphQL schema.

Ref: #2622.