### PR TITLE
refactor(experimental): graphql: sysvars: recent blockhashes

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1072,6 +1072,55 @@ describe('account', () => {
                     },
                 });
             });
+            it('can get the recent blockhashes sysvar', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    address: 'SysvarRecentB1ockHashes11111111111111111111',
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            address
+                            lamports
+                            ownerProgram {
+                                address
+                            }
+                            rentEpoch
+                            space
+                            ... on SysvarRecentBlockhashesAccount {
+                                entries {
+                                    blockhash
+                                    feeCalculator {
+                                        lamportsPerSignature
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            address: 'SysvarRecentB1ockHashes11111111111111111111',
+                            entries: expect.arrayContaining([
+                                {
+                                    blockhash: expect.any(String),
+                                    feeCalculator: {
+                                        lamportsPerSignature: expect.any(BigInt),
+                                    },
+                                },
+                            ]),
+                            lamports: expect.any(BigInt),
+                            ownerProgram: {
+                                address: 'Sysvar1111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: expect.any(BigInt),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -104,10 +104,16 @@ export const resolveAccount = (fieldName?: string) => {
                             programId,
                             programName,
                         };
-                        result = {
-                            ...result,
-                            ...(parsedData as object),
-                        };
+                        if (Array.isArray(parsedData)) {
+                            // If the `jsonParsed` data is an array, put it
+                            // into a field called `entries`.
+                            Object.assign(result, { entries: parsedData });
+                        } else {
+                            result = {
+                                ...result,
+                                ...(parsedData as object),
+                            };
+                        }
                     }
                 }
             });
@@ -158,6 +164,9 @@ function resolveAccountType(accountResult: AccountResult) {
             }
             if (jsonParsedConfigs.accountType === 'lastRestartSlot') {
                 return 'SysvarLastRestartSlotAccount';
+            }
+            if (jsonParsedConfigs.accountType === 'recentBlockhashes') {
+                return 'SysvarRecentBlockhashesAccount';
             }
         }
     }
@@ -220,6 +229,10 @@ export const accountResolvers = {
         ownerProgram: resolveAccount('ownerProgram'),
     },
     SysvarLastRestartSlotAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
+    },
+    SysvarRecentBlockhashesAccount: {
         data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -229,9 +229,10 @@ export const accountTypeDefs = /* GraphQL */ `
         warmup: Boolean
     }
 
-    type SysvarFeesFeeCalculator {
+    type FeeCalculator {
         lamportsPerSignature: BigInt
     }
+
     """
     Sysvar Fees
     """
@@ -243,7 +244,7 @@ export const accountTypeDefs = /* GraphQL */ `
         ownerProgram: Account
         space: BigInt
         rentEpoch: BigInt
-        feeCalculator: SysvarFeesFeeCalculator
+        feeCalculator: FeeCalculator
     }
 
     """
@@ -258,5 +259,23 @@ export const accountTypeDefs = /* GraphQL */ `
         space: BigInt
         rentEpoch: BigInt
         lastRestartSlot: BigInt
+    }
+
+    type SysvarRecentBlockhashesEntry {
+        blockhash: String
+        feeCalculator: FeeCalculator
+    }
+    """
+    Sysvar Recent Blockhashes
+    """
+    type SysvarRecentBlockhashesAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        entries: [SysvarRecentBlockhashesEntry]
     }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `RecentBlockhashes` to the GraphQL schema.

Ref: #2622.