### PR TITLE
refactor(experimental): graphql: sysvars: rent

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1121,6 +1121,47 @@ describe('account', () => {
                     },
                 });
             });
+            it('can get the rent sysvar', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    address: 'SysvarRent111111111111111111111111111111111',
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            address
+                            lamports
+                            ownerProgram {
+                                address
+                            }
+                            rentEpoch
+                            space
+                            ... on SysvarRentAccount {
+                                burnPercent
+                                exemptionThreshold
+                                lamportsPerByteYear
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            address: 'SysvarRent111111111111111111111111111111111',
+                            burnPercent: expect.any(Number),
+                            exemptionThreshold: expect.any(Number),
+                            lamports: expect.any(BigInt),
+                            lamportsPerByteYear: expect.any(BigInt),
+                            ownerProgram: {
+                                address: 'Sysvar1111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: expect.any(BigInt),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -168,6 +168,9 @@ function resolveAccountType(accountResult: AccountResult) {
             if (jsonParsedConfigs.accountType === 'recentBlockhashes') {
                 return 'SysvarRecentBlockhashesAccount';
             }
+            if (jsonParsedConfigs.accountType === 'rent') {
+                return 'SysvarRentAccount';
+            }
         }
     }
     return 'GenericAccount';
@@ -233,6 +236,10 @@ export const accountResolvers = {
         ownerProgram: resolveAccount('ownerProgram'),
     },
     SysvarRecentBlockhashesAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
+    },
+    SysvarRentAccount: {
         data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -278,4 +278,20 @@ export const accountTypeDefs = /* GraphQL */ `
         rentEpoch: BigInt
         entries: [SysvarRecentBlockhashesEntry]
     }
+
+    """
+    Sysvar Rent
+    """
+    type SysvarRentAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        burnPercent: Int
+        exemptionThreshold: Int
+        lamportsPerByteYear: BigInt
+    }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `Rent` to the GraphQL schema.

Ref: #2622.