### PR TITLE
refactor(experimental): graphql: sysvars: slot hashes

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1162,6 +1162,51 @@ describe('account', () => {
                     },
                 });
             });
+            it('can get the slot hashes sysvar', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    address: 'SysvarS1otHashes111111111111111111111111111',
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            address
+                            lamports
+                            ownerProgram {
+                                address
+                            }
+                            rentEpoch
+                            space
+                            ... on SysvarSlotHashesAccount {
+                                entries {
+                                    hash
+                                    slot
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            address: 'SysvarS1otHashes111111111111111111111111111',
+                            entries: expect.arrayContaining([
+                                {
+                                    hash: expect.any(String),
+                                    slot: expect.any(BigInt),
+                                },
+                            ]),
+                            lamports: expect.any(BigInt),
+                            ownerProgram: {
+                                address: 'Sysvar1111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: expect.any(BigInt),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -171,6 +171,9 @@ function resolveAccountType(accountResult: AccountResult) {
             if (jsonParsedConfigs.accountType === 'rent') {
                 return 'SysvarRentAccount';
             }
+            if (jsonParsedConfigs.accountType === 'slotHashes') {
+                return 'SysvarSlotHashesAccount';
+            }
         }
     }
     return 'GenericAccount';
@@ -240,6 +243,10 @@ export const accountResolvers = {
         ownerProgram: resolveAccount('ownerProgram'),
     },
     SysvarRentAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
+    },
+    SysvarSlotHashesAccount: {
         data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -294,4 +294,23 @@ export const accountTypeDefs = /* GraphQL */ `
         exemptionThreshold: Int
         lamportsPerByteYear: BigInt
     }
+
+    type SlotHashEntry {
+        hash: String
+        slot: BigInt
+    }
+
+    """
+    Sysvar Slot Hashes
+    """
+    type SysvarSlotHashesAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        entries: [SlotHashEntry]
+    }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `SlotHashes` to the GraphQL schema.

Ref: #2622.