### PR TITLE
refactor(experimental): graphql: sysvars: slot history

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1207,6 +1207,45 @@ describe('account', () => {
                     },
                 });
             });
+            it('can get the slot history sysvar', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    address: 'SysvarS1otHistory11111111111111111111111111',
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            address
+                            lamports
+                            ownerProgram {
+                                address
+                            }
+                            rentEpoch
+                            space
+                            ... on SysvarSlotHistoryAccount {
+                                bits
+                                nextSlot
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            address: 'SysvarS1otHistory11111111111111111111111111',
+                            bits: expect.any(String),
+                            lamports: expect.any(BigInt),
+                            nextSlot: expect.any(BigInt),
+                            ownerProgram: {
+                                address: 'Sysvar1111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: expect.any(BigInt),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -174,6 +174,9 @@ function resolveAccountType(accountResult: AccountResult) {
             if (jsonParsedConfigs.accountType === 'slotHashes') {
                 return 'SysvarSlotHashesAccount';
             }
+            if (jsonParsedConfigs.accountType === 'slotHistory') {
+                return 'SysvarSlotHistoryAccount';
+            }
         }
     }
     return 'GenericAccount';
@@ -247,6 +250,10 @@ export const accountResolvers = {
         ownerProgram: resolveAccount('ownerProgram'),
     },
     SysvarSlotHashesAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
+    },
+    SysvarSlotHistoryAccount: {
         data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -313,4 +313,19 @@ export const accountTypeDefs = /* GraphQL */ `
         rentEpoch: BigInt
         entries: [SlotHashEntry]
     }
+
+    """
+    Sysvar Slot History
+    """
+    type SysvarSlotHistoryAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        bits: String
+        nextSlot: BigInt
+    }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `SlotHistory` to the GraphQL schema.

Ref: #2622.