### PR TITLE
refactor(experimental): graphql: sysvars: stake history

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1246,6 +1246,47 @@ describe('account', () => {
                     },
                 });
             });
+            it('can get the stake history sysvar', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    address: 'SysvarStakeHistory1111111111111111111111111',
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            address
+                            lamports
+                            ownerProgram {
+                                address
+                            }
+                            rentEpoch
+                            space
+                            ... on SysvarStakeHistoryAccount {
+                                entries {
+                                    effective
+                                    activating
+                                    deactivating
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            address: 'SysvarStakeHistory1111111111111111111111111',
+                            entries: expect.any(Array), // Not always populated on test validator
+                            lamports: expect.any(BigInt),
+                            ownerProgram: {
+                                address: 'Sysvar1111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: expect.any(BigInt),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -177,6 +177,9 @@ function resolveAccountType(accountResult: AccountResult) {
             if (jsonParsedConfigs.accountType === 'slotHistory') {
                 return 'SysvarSlotHistoryAccount';
             }
+            if (jsonParsedConfigs.accountType === 'stakeHistory') {
+                return 'SysvarStakeHistoryAccount';
+            }
         }
     }
     return 'GenericAccount';
@@ -254,6 +257,10 @@ export const accountResolvers = {
         ownerProgram: resolveAccount('ownerProgram'),
     },
     SysvarSlotHistoryAccount: {
+        data: resolveAccountData(),
+        ownerProgram: resolveAccount('ownerProgram'),
+    },
+    SysvarStakeHistoryAccount: {
         data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -328,4 +328,24 @@ export const accountTypeDefs = /* GraphQL */ `
         bits: String
         nextSlot: BigInt
     }
+
+    type StakeHistoryEntry {
+        activating: BigInt
+        deactivating: BigInt
+        effective: BigInt
+    }
+
+    """
+    Sysvar Stake History
+    """
+    type SysvarStakeHistoryAccount implements Account {
+        address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
+        executable: Boolean
+        lamports: BigInt
+        ownerProgram: Account
+        space: BigInt
+        rentEpoch: BigInt
+        entries: [StakeHistoryEntry]
+    }
 `;


### PR DESCRIPTION
This PR adds support for parsed sysvar account `StakeHistory` to the GraphQL schema.

Ref: #2622.