### PR TITLE
refactor(experimental): graphql: token-2022 extensions: ApplyPendingConfidentialTransferBalance

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2124,6 +2124,38 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            account: '8wYAr4UKaHh35zFFbZW6iGgaBPJo1z9mvLwsdd3Mcpjo',
+                            expectedPendingBalanceCreditCounter: 1,
+                            newDecryptableAvailableBalance: '57fZKMs9YqFhu6fENwKTe7mGZh+wJbIvYkQ3LI/FDnOdc2w7',
+                            owner: 'B1diwnBSzuzbyzkKvd7nWfe4Et4hBbmBzvNY6HXB6mRV',
+                        },
+                        type: 'applyPendingConfidentialTransferBalance',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
+                            account: '8wYAr4UKaHh35zFFbZW6iGgaBPJo1z9mvLwsdd3Mcpjo',
+                            expectedPendingBalanceCreditCounter: 1,
+                            newDecryptableAvailableBalance: '57fZKMs9YqFhu6fENwKTe7mGZh+wJbIvYkQ3LI/FDnOdc2w7',
+                            multisigOwner: 'B1diwnBSzuzbyzkKvd7nWfe4Et4hBbmBzvNY6HXB6mRV',
+                            signers: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                        },
+                        type: 'applyPendingConfidentialTransferBalance',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -2228,6 +2228,72 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('apply-pending-confidential-transfer-balance', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenApplyPendingConfidentialTransferBalance {
+                                        account {
+                                            address
+                                        }
+                                        expectedPendingBalanceCreditCounter
+                                        multisigOwner {
+                                            address
+                                        }
+                                        newDecryptableAvailableBalance
+                                        owner {
+                                            address
+                                        }
+                                        signers
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        account: {
+                                            address: expect.any(String),
+                                        },
+                                        expectedPendingBalanceCreditCounter: expect.any(BigInt),
+                                        multisigOwner: null,
+                                        newDecryptableAvailableBalance: expect.any(String),
+                                        owner: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: null,
+                                    },
+                                    {
+                                        account: {
+                                            address: expect.any(String),
+                                        },
+                                        expectedPendingBalanceCreditCounter: expect.any(BigInt),
+                                        multisigOwner: {
+                                            address: expect.any(String),
+                                        },
+                                        newDecryptableAvailableBalance: expect.any(String),
+                                        owner: null,
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: expect.arrayContaining([expect.any(String)]),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -151,6 +151,11 @@ export const instructionResolvers = {
     SplTokenAmountToUiAmountInstruction: {
         mint: resolveAccount('mint'),
     },
+    SplTokenApplyPendingConfidentialTransferBalance: {
+        account: resolveAccount('account'),
+        multisigOwner: resolveAccount('multisigOwner'),
+        owner: resolveAccount('owner'),
+    },
     SplTokenApproveCheckedInstruction: {
         delegate: resolveAccount('delegate'),
         mint: resolveAccount('mint'),
@@ -738,6 +743,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'configureConfidentialTransferAccount') {
                         return 'SplTokenConfigureConfidentialTransferAccount';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'applyPendingConfidentialTransferBalance') {
+                        return 'SplTokenApplyPendingConfidentialTransferBalance';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -810,6 +810,19 @@ export const instructionTypeDefs = /* GraphQL */ `
         signers: [Address]
     }
 
+    """
+    SplToken-2022: ApplyPendingConfidentialTransferBalance instruction
+    """
+    type SplTokenApplyPendingConfidentialTransferBalance implements TransactionInstruction {
+        programId: Address
+        account: Account
+        expectedPendingBalanceCreditCounter: BigInt
+        multisigOwner: Account
+        newDecryptableAvailableBalance: String
+        owner: Account
+        signers: [Address]
+    }
+
     # TODO: Extensions!
     # ...
 


### PR DESCRIPTION
This PR adds support for Token-2022's ApplyPendingConfidentialTransferBalance instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.