### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: permanent delegate

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1323,6 +1323,38 @@ describe('account', () => {
                     },
                 });
             });
+            it('permanent-delegate', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplToken2022ExtensionPermanentDelegate {
+                                        delegate {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    delegate: {
+                                        address: expect.any(String),
+                                    },
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -211,6 +211,9 @@ function resolveToken2022ExtensionType(extensionResult: Token2022ExtensionResult
     if (extensionResult.extension === 'mintCloseAuthority') {
         return 'SplToken2022ExtensionMintCloseAuthority';
     }
+    if (extensionResult.extension === 'permanentDelegate') {
+        return 'SplToken2022ExtensionPermanentDelegate';
+    }
 }
 
 export const accountResolvers = {
@@ -244,6 +247,9 @@ export const accountResolvers = {
     },
     SplToken2022ExtensionMintCloseAuthority: {
         closeAuthority: resolveAccount('closeAuthority'),
+    },
+    SplToken2022ExtensionPermanentDelegate: {
+        delegate: resolveAccount('delegate'),
     },
     StakeAccount: {
         data: resolveAccountData(),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -15,6 +15,14 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: Permanent Delegate
+    """
+    type SplToken2022ExtensionPermanentDelegate implements SplToken2022Extension {
+        extension: String
+        delegate: Account
+    }
+
+    """
     Account interface
     """
     interface Account {


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `PermanentDelegate`.

Ref #2644.