### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: interest bearing config

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1355,6 +1355,46 @@ describe('account', () => {
                     },
                 });
             });
+            it('interest-bearing-config', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplToken2022ExtensionInterestBearingConfig {
+                                        currentRate
+                                        initializationTimestamp
+                                        lastUpdateTimestamp
+                                        preUpdateAverageRate
+                                        rateAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    currentRate: expect.any(Number),
+                                    initializationTimestamp: expect.any(BigInt),
+                                    lastUpdateTimestamp: expect.any(BigInt),
+                                    preUpdateAverageRate: expect.any(Number),
+                                    rateAuthority: {
+                                        address: expect.any(String),
+                                    },
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -208,6 +208,9 @@ const resolveToken2022Extensions = () => {
 };
 
 function resolveToken2022ExtensionType(extensionResult: Token2022ExtensionResult) {
+    if (extensionResult.extension === 'interestBearingConfig') {
+        return 'SplToken2022ExtensionInterestBearingConfig';
+    }
     if (extensionResult.extension === 'mintCloseAuthority') {
         return 'SplToken2022ExtensionMintCloseAuthority';
     }
@@ -244,6 +247,9 @@ export const accountResolvers = {
     },
     SplToken2022Extension: {
         __resolveType: resolveToken2022ExtensionType,
+    },
+    SplToken2022ExtensionInterestBearingConfig: {
+        rateAuthority: resolveAccount('rateAuthority'),
     },
     SplToken2022ExtensionMintCloseAuthority: {
         closeAuthority: resolveAccount('closeAuthority'),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -23,6 +23,18 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: Interest-Bearing Config
+    """
+    type SplToken2022ExtensionInterestBearingConfig implements SplToken2022Extension {
+        extension: String
+        currentRate: Int
+        initializationTimestamp: BigInt
+        lastUpdateTimestamp: BigInt
+        preUpdateAverageRate: Int
+        rateAuthority: Account
+    }
+
+    """
     Account interface
     """
     interface Account {


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `InterestBearingConfig`.

Ref #2644.