### PR TITLE
refactor(experimental): graphql: token-2022 extensions: DepositConfidentialTransfer

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2268,6 +2268,42 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            source: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            destination: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            amount: 1,
+                            decimals: 10,
+                            owner: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                        },
+                        type: 'depositConfidentialTransfer',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
+                            source: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            destination: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            amount: 1,
+                            decimals: 10,
+                            multisigOwner: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            signers: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                        },
+                        type: 'depositConfidentialTransfer',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -2534,6 +2534,90 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('deposit-confidential-transfer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenDepositConfidentialTransfer {
+                                        amount
+                                        decimals
+                                        destination {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                        multisigOwner {
+                                            address
+                                        }
+                                        owner {
+                                            address
+                                        }
+                                        signers
+                                        source {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        amount: expect.any(BigInt),
+                                        decimals: expect.any(BigInt),
+                                        destination: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigOwner: null,
+                                        owner: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: null,
+                                        source: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                    {
+                                        amount: expect.any(BigInt),
+                                        decimals: expect.any(BigInt),
+                                        destination: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigOwner: {
+                                            address: expect.any(String),
+                                        },
+                                        owner: null,
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        signers: expect.arrayContaining([expect.any(String)]),
+                                        source: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -2576,7 +2576,7 @@ describe('transaction', () => {
                                 instructions: expect.arrayContaining([
                                     {
                                         amount: expect.any(BigInt),
-                                        decimals: expect.any(BigInt),
+                                        decimals: expect.any(Number),
                                         destination: {
                                             address: expect.any(String),
                                         },
@@ -2595,7 +2595,7 @@ describe('transaction', () => {
                                     },
                                     {
                                         amount: expect.any(BigInt),
-                                        decimals: expect.any(BigInt),
+                                        decimals: expect.any(Number),
                                         destination: {
                                             address: expect.any(String),
                                         },

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -2576,7 +2576,7 @@ describe('transaction', () => {
                                 instructions: expect.arrayContaining([
                                     {
                                         amount: expect.any(BigInt),
-                                        decimals: expect.any(Number),
+                                        decimals: expect.any(BigInt),
                                         destination: {
                                             address: expect.any(String),
                                         },
@@ -2595,7 +2595,7 @@ describe('transaction', () => {
                                     },
                                     {
                                         amount: expect.any(BigInt),
-                                        decimals: expect.any(Number),
+                                        decimals: expect.any(BigInt),
                                         destination: {
                                             address: expect.any(String),
                                         },

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -202,6 +202,13 @@ export const instructionResolvers = {
         INITIALIZED: 'initialized',
         UNINITIALIZED: 'uninitialized',
     },
+    SplTokenDepositConfidentialTransfer: {
+        destination: resolveAccount('destination'),
+        mint: resolveAccount('mint'),
+        multisigOwner: resolveAccount('multisigOwner'),
+        owner: resolveAccount('owner'),
+        source: resolveAccount('source'),
+    },
     SplTokenDisableConfidentialTransferConfidentialCredits: {
         account: resolveAccount('account'),
         multisigOwner: resolveAccount('multisigOwner'),
@@ -778,6 +785,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'disableNonConfidentialTransferConfidentialCredits') {
                         return 'SplTokenDisableConfidentialTransferNonConfidentialCredits';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'depositConfidentialTransfer') {
+                        return 'SplTokenDepositConfidentialTransfer';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -873,7 +873,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     type SplTokenDepositConfidentialTransfer implements TransactionInstruction {
         programId: Address
         amount: BigInt
-        decimals: Int
+        decimals: BigInt # FIXME:*
         destination: Account
         mint: Account
         multisigOwner: Account

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -873,7 +873,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     type SplTokenDepositConfidentialTransfer implements TransactionInstruction {
         programId: Address
         amount: BigInt
-        decimals: BigInt
+        decimals: Int
         destination: Account
         mint: Account
         multisigOwner: Account

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -855,6 +855,7 @@ export const instructionTypeDefs = /* GraphQL */ `
         owner: Account
         signers: [Address]
     }
+
     """
     SplToken-2022: DisableConfidentialTransferNonConfidentialCredits instruction
     """
@@ -864,6 +865,21 @@ export const instructionTypeDefs = /* GraphQL */ `
         multisigOwner: Account
         owner: Account
         signers: [Address]
+    }
+
+    """
+    SplToken-2022: DepositConfidentialTransfer instruction
+    """
+    type SplTokenDepositConfidentialTransfer implements TransactionInstruction {
+        programId: Address
+        amount: BigInt
+        decimals: BigInt
+        destination: Account
+        mint: Account
+        multisigOwner: Account
+        owner: Account
+        signers: [Address]
+        source: Account
     }
 
     # TODO: Extensions!


### PR DESCRIPTION
This PR adds support for Token-2022's DepositConfidentialTransfer  instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.