### PR TITLE
refactor(experimental): graphql: token-2022 extensions: WithdrawConfidentialTransfer

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2304,6 +2304,49 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+
+                {
+                    parsed: {
+                        info: {
+                            source: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            destination: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            instructionsSysvar: 'SysvarRent111111111111111111111111111111111',
+                            amount: 1,
+                            decimals: 10,
+                            newDecryptableAvailableBalance: '57fZKMs9YqFhu6fENwKTe7mGZh+wJbIvYkQ3LI/FDnOdc2w7',
+                            owner: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            proofInstructionOffset: 1,
+                        },
+                        type: 'withdrawConfidentialTransfer',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
+                            source: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            destination: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            instructionsSysvar: 'SysvarRent111111111111111111111111111111111',
+                            amount: 1,
+                            decimals: 10,
+                            newDecryptableAvailableBalance: '57fZKMs9YqFhu6fENwKTe7mGZh+wJbIvYkQ3LI/FDnOdc2w7',
+                            proofInstructionOffset: 1,
+                            multisigOwner: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            signers: [
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ],
+                        },
+                        type: 'withdrawConfidentialTransfer',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -2618,6 +2618,105 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('withdraw-confidential-transfer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenWithdrawConfidentialTransfer {
+                                        amount
+                                        decimals
+                                        destination {
+                                            address
+                                        }
+                                        instructionsSysvar {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                        multisigOwner {
+                                            address
+                                        }
+                                        newDecryptableAvailableBalance
+                                        owner {
+                                            address
+                                        }
+                                        proofInstructionOffset
+                                        signers
+                                        source {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        amount: expect.any(BigInt),
+                                        decimals: expect.any(BigInt),
+                                        destination: {
+                                            address: expect.any(String),
+                                        },
+                                        instructionsSysvar: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigOwner: null,
+                                        newDecryptableAvailableBalance: expect.any(String),
+                                        owner: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        proofInstructionOffset: expect.any(Number),
+                                        signers: null,
+                                        source: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                    {
+                                        amount: expect.any(BigInt),
+                                        decimals: expect.any(BigInt),
+                                        destination: {
+                                            address: expect.any(String),
+                                        },
+                                        instructionsSysvar: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        multisigOwner: {
+                                            address: expect.any(String),
+                                        },
+                                        newDecryptableAvailableBalance: expect.any(String),
+                                        owner: null,
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        proofInstructionOffset: expect.any(Number),
+                                        signers: expect.arrayContaining([expect.any(String)]),
+                                        source: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -436,6 +436,14 @@ export const instructionResolvers = {
         mint: resolveAccount('mint'),
         multisigAuthority: resolveAccount('multisigAuthority'),
     },
+    SplTokenWithdrawConfidentialTransfer: {
+        destination: resolveAccount('destination'),
+        instructionsSysvar: resolveAccount('instructionsSysvar'),
+        mint: resolveAccount('mint'),
+        multisigOwner: resolveAccount('multisigOwner'),
+        owner: resolveAccount('owner'),
+        source: resolveAccount('source'),
+    },
     SplTokenWithdrawWithheldTokensFromAccounts: {
         feeRecipient: resolveAccount('feeRecipient'),
         mint: resolveAccount('mint'),
@@ -788,6 +796,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'depositConfidentialTransfer') {
                         return 'SplTokenDepositConfidentialTransfer';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'withdrawConfidentialTransfer') {
+                        return 'SplTokenWithdrawConfidentialTransfer';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -882,6 +882,22 @@ export const instructionTypeDefs = /* GraphQL */ `
         source: Account
     }
 
+    """
+    SplToken-2022: WithdrawConfidentialTransfer instruction
+    """
+    type SplTokenWithdrawConfidentialTransfer implements TransactionInstruction {
+        programId: Address
+        amount: BigInt
+        decimals: BigInt # FIXME:*
+        destination: Account
+        instructionsSysvar: Account
+        mint: Account
+        multisigOwner: Account
+        owner: Account
+        signers: [Address]
+        source: Account
+    }
+
     # TODO: Extensions!
     # ...
 

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -891,9 +891,11 @@ export const instructionTypeDefs = /* GraphQL */ `
         decimals: BigInt # FIXME:*
         destination: Account
         instructionsSysvar: Account
+        newDecryptableAvailableBalance: String
         mint: Account
         multisigOwner: Account
         owner: Account
+        proofInstructionOffset: Int
         signers: [Address]
         source: Account
     }


### PR DESCRIPTION
This PR adds support for Token-2022's WithdrawConfidentialTransfer instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.