### PR TITLE
refactor(experimental): graphql: token-2022 extensions: ConfidentialTransferWithSplitProofs

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2385,6 +2385,29 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            source: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            destination: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            ciphertextCommitmentEqualityContext: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            batchedGroupedCiphertext2HandlesValidityContext:
+                                '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            batchedRangeProofContext: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            owner: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            newSourceDecryptableAvailableBalance: '57fZKMs9YqFhu6fENwKTe7mGZh+wJbIvYkQ3LI/FDnOdc2w7',
+                            noOpOnUninitializedSplitContextState: true,
+                            closeSplitContextStateOnExecution: true,
+                            lamportDestination: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            contextStateOwner: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                        },
+                        type: 'confidentialTransferWithSplitProofs',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -2810,6 +2810,97 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('confidential-transfer-with-split-proofs', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenConfidentialTransferWithSplitProofs {
+                                        batchedGroupedCiphertext2HandlesValidityContext {
+                                            address
+                                        }
+                                        batchedRangeProofContext {
+                                            address
+                                        }
+                                        ciphertextCommitmentEqualityContext {
+                                            address
+                                        }
+                                        closeSplitContextStateOnExecution
+                                        contextStateOwner {
+                                            address
+                                        }
+                                        destination {
+                                            address
+                                        }
+                                        lamportDestination {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                        newSourceDecryptableAvailableBalance
+                                        noOpOnUninitializedSplitContextState
+                                        owner {
+                                            address
+                                        }
+                                        source {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        batchedGroupedCiphertext2HandlesValidityContext: {
+                                            address: expect.any(String),
+                                        },
+                                        batchedRangeProofContext: {
+                                            address: expect.any(String),
+                                        },
+                                        ciphertextCommitmentEqualityContext: {
+                                            address: expect.any(String),
+                                        },
+                                        closeSplitContextStateOnExecution: expect.any(Boolean),
+                                        contextStateOwner: {
+                                            address: expect.any(String),
+                                        },
+                                        destination: {
+                                            address: expect.any(String),
+                                        },
+                                        lamportDestination: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        newSourceDecryptableAvailableBalance: expect.any(String),
+                                        noOpOnUninitializedSplitContextState: expect.any(Boolean),
+                                        owner: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        source: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -200,6 +200,19 @@ export const instructionResolvers = {
         owner: resolveAccount('owner'),
         source: resolveAccount('source'),
     },
+    SplTokenConfidentialTransferWithSplitProofs: {
+        batchedGroupedCiphertext2HandlesValidityContext: resolveAccount(
+            'batchedGroupedCiphertext2HandlesValidityContext',
+        ),
+        batchedRangeProofContext: resolveAccount('batchedRangeProofContext'),
+        ciphertextCommitmentEqualityContext: resolveAccount('ciphertextCommitmentEqualityContext'),
+        contextStateOwner: resolveAccount('contextStateOwner'),
+        destination: resolveAccount('destination'),
+        lamportDestination: resolveAccount('lamportDestination'),
+        mint: resolveAccount('mint'),
+        owner: resolveAccount('owner'),
+        source: resolveAccount('source'),
+    },
     SplTokenConfigureConfidentialTransferAccount: {
         account: resolveAccount('account'),
         mint: resolveAccount('mint'),
@@ -810,6 +823,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'confidentialTransfer') {
                         return 'SplTokenConfidentialTransfer';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'confidentialTransferWithSplitProofs') {
+                        return 'SplTokenConfidentialTransferWithSplitProofs';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -916,6 +916,25 @@ export const instructionTypeDefs = /* GraphQL */ `
         source: Account
     }
 
+    """
+    SplToken-2022: ConfidentialTransferWithSplitProofs instruction
+    """
+    type SplTokenConfidentialTransferWithSplitProofs implements TransactionInstruction {
+        programId: Address
+        batchedGroupedCiphertext2HandlesValidityContext: Account
+        batchedRangeProofContext: Account
+        ciphertextCommitmentEqualityContext: Account
+        closeSplitContextStateOnExecution: Boolean
+        contextStateOwner: Account
+        destination: Account
+        lamportDestination: Account
+        mint: Account
+        newSourceDecryptableAvailableBalance: String
+        noOpOnUninitializedSplitContextState: Boolean
+        owner: Account
+        source: Account
+    }
+
     # TODO: Extensions!
     # ...
 


### PR DESCRIPTION
This PR adds support for Token-2022's ConfidentialTransferWithSplitProofs instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.