### PR TITLE
refactor(experimental): graphql: token-2022 extensions: UpdateConfidentialTransferMint

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2408,6 +2408,22 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            confidentialTransferMintAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            newConfidentialTransferMintAuthority: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            auditorElgamalPubkey: null,
+                            authority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            autoApproveNewAccounts: true,
+                        },
+                        type: 'updateConfidentialTransferMint',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -2901,6 +2901,65 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('update-confidential-transfer-mint', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenUpdateConfidentialTransferMint {
+                                        auditorElgamalPubkey
+                                        authority {
+                                            address
+                                        }
+                                        autoApproveNewAccounts
+                                        confidentialTransferMintAuthority {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                        newConfidentialTransferMintAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        auditorElgamalPubkey: null,
+                                        authority: {
+                                            address: expect.any(String),
+                                        },
+                                        autoApproveNewAccounts: expect.any(Boolean),
+                                        confidentialTransferMintAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        newConfidentialTransferMintAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -423,6 +423,12 @@ export const instructionResolvers = {
     SplTokenUiAmountToAmountInstruction: {
         mint: resolveAccount('mint'),
     },
+    SplTokenUpdateConfidentialTransferMint: {
+        authority: resolveAccount('authority'),
+        confidentialTransferMintAuthority: resolveAccount('confidentialTransferMintAuthority'),
+        mint: resolveAccount('mint'),
+        newConfidentialTransferMintAuthority: resolveAccount('newConfidentialTransferMintAuthority'),
+    },
     SplTokenUpdateDefaultAccountStateInstruction: {
         freezeAuthority: resolveAccount('freezeAuthority'),
         mint: resolveAccount('mint'),
@@ -826,6 +832,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'confidentialTransferWithSplitProofs') {
                         return 'SplTokenConfidentialTransferWithSplitProofs';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'updateConfidentialTransferMint') {
+                        return 'SplTokenUpdateConfidentialTransferMint';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -935,6 +935,19 @@ export const instructionTypeDefs = /* GraphQL */ `
         source: Account
     }
 
+    """
+    SplToken-2022: UpdateConfidentialTransferMint instruction
+    """
+    type SplTokenUpdateConfidentialTransferMint implements TransactionInstruction {
+        programId: Address
+        auditorElgamalPubkey: Address
+        authority: Account
+        autoApproveNewAccounts: Boolean
+        confidentialTransferMintAuthority: Account
+        mint: Account
+        newConfidentialTransferMintAuthority: Account
+    }
+
     # TODO: Extensions!
     # ...
 


### PR DESCRIPTION
This PR adds support for Token-2022's UpdateConfidentialTransferMint instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.