### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: default account state

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1429,6 +1429,36 @@ describe('account', () => {
                     },
                 });
             });
+            it('default-account-state', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplTokenExtensionDefaultAccountState {
+                                        accountState
+                                        extension
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    accountState: expect.any(String),
+                                    extension: 'defaultAccountState',
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -208,6 +208,9 @@ const resolveTokenExtensions = () => {
 };
 
 function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
+    if (extensionResult.extension === 'defaultAccountState') {
+        return 'SplTokenExtensionDefaultAccountState';
+    }
     if (extensionResult.extension === 'interestBearingConfig') {
         return 'SplTokenExtensionInterestBearingConfig';
     }

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -7,6 +7,14 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: Default Account State
+    """
+    type SplTokenExtensionDefaultAccountState implements SplTokenExtension {
+        extension: String
+        accountState: SplTokenDefaultAccountState
+    }
+
+    """
     Token-2022 Extension: Interest-Bearing Config
     """
     type SplTokenExtensionInterestBearingConfig implements SplTokenExtension {


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `DefaultAccountState`.

Ref #2644.