### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: transfer fee config

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1459,6 +1459,68 @@ describe('account', () => {
                     },
                 });
             });
+            it('transfer-fee-config', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplTokenExtensionTransferFeeConfig {
+                                        extension
+                                        newerTransferFee {
+                                            epoch
+                                            maximumFee
+                                            transferFeeBasisPoints
+                                        }
+                                        olderTransferFee {
+                                            epoch
+                                            maximumFee
+                                            transferFeeBasisPoints
+                                        }
+                                        transferFeeConfigAuthority {
+                                            address
+                                        }
+                                        withdrawWithheldAuthority {
+                                            address
+                                        }
+                                        withheldAmount
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'transferFeeConfig',
+                                    newerTransferFee: {
+                                        epoch: expect.any(BigInt),
+                                        maximumFee: expect.any(BigInt),
+                                        transferFeeBasisPoints: expect.any(Number),
+                                    },
+                                    olderTransferFee: {
+                                        epoch: expect.any(BigInt),
+                                        maximumFee: expect.any(BigInt),
+                                        transferFeeBasisPoints: expect.any(Number),
+                                    },
+                                    transferFeeConfigAuthority: {
+                                        address: expect.any(String),
+                                    },
+                                    withdrawWithheldAuthority: {
+                                        address: expect.any(String),
+                                    },
+                                    withheldAmount: expect.any(BigInt),
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -223,6 +223,9 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'permanentDelegate') {
         return 'SplTokenExtensionPermanentDelegate';
     }
+    if (extensionResult.extension === 'transferFeeConfig') {
+        return 'SplTokenExtensionTransferFeeConfig';
+    }
 }
 
 export const accountResolvers = {
@@ -262,6 +265,10 @@ export const accountResolvers = {
     },
     SplTokenExtensionPermanentDelegate: {
         delegate: resolveAccount('delegate'),
+    },
+    SplTokenExtensionTransferFeeConfig: {
+        transferFeeConfigAuthority: resolveAccount('transferFeeConfigAuthority'),
+        withdrawWithheldAuthority: resolveAccount('withdrawWithheldAuthority'),
     },
     StakeAccount: {
         data: resolveAccountData(),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -49,6 +49,23 @@ export const accountTypeDefs = /* GraphQL */ `
         delegate: Account
     }
 
+    type SplTokenTransferFeeConfig {
+        epoch: Epoch
+        maximumFee: BigInt
+        transferFeeBasisPoints: Int
+    }
+    """
+    Token-2022 Extension: Transfer Fee Config
+    """
+    type SplTokenExtensionTransferFeeConfig implements SplTokenExtension {
+        extension: String
+        newerTransferFee: SplTokenTransferFeeConfig
+        olderTransferFee: SplTokenTransferFeeConfig
+        transferFeeConfigAuthority: Account
+        withdrawWithheldAuthority: Account
+        withheldAmount: BigInt
+    }
+
     """
     Account interface
     """


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `TransferFeeConfig`.

Ref #2644.