### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: confidential transfer mint

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1521,6 +1521,44 @@ describe('account', () => {
                     },
                 });
             });
+            it('confidential-transfer-mint', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplTokenExtensionConfidentialTransferMint {
+                                        auditorElgamalPubkey
+                                        authority {
+                                            address
+                                        }
+                                        autoApproveNewAccounts
+                                        extension
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    auditorElgamalPubkey: null,
+                                    authority: {
+                                        address: expect.any(String),
+                                    },
+                                    autoApproveNewAccounts: expect.any(Boolean),
+                                    extension: 'confidentialTransferMint',
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -208,6 +208,9 @@ const resolveTokenExtensions = () => {
 };
 
 function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
+    if (extensionResult.extension === 'confidentialTransferMint') {
+        return 'SplTokenExtensionConfidentialTransferMint';
+    }
     if (extensionResult.extension === 'defaultAccountState') {
         return 'SplTokenExtensionDefaultAccountState';
     }
@@ -256,6 +259,9 @@ export const accountResolvers = {
     },
     SplTokenExtension: {
         __resolveType: resolveTokenExtensionType,
+    },
+    SplTokenExtensionConfidentialTransferMint: {
+        authority: resolveAccount('authority'),
     },
     SplTokenExtensionInterestBearingConfig: {
         rateAuthority: resolveAccount('rateAuthority'),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -7,6 +7,16 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: Confidential Transfer Mint
+    """
+    type SplTokenExtensionConfidentialTransferMint implements SplTokenExtension {
+        extension: String
+        auditorElgamalPubkey: Address
+        authority: Account
+        autoApproveNewAccounts: Boolean
+    }
+
+    """
     Token-2022 Extension: Default Account State
     """
     type SplTokenExtensionDefaultAccountState implements SplTokenExtension {


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `ConfidentialTransferMint`.

Ref #2644.