### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: confidential transfer fee config

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1559,6 +1559,46 @@ describe('account', () => {
                     },
                 });
             });
+            it('confidential-transfer-fee-config', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplTokenExtensionConfidentialTransferFeeConfig {
+                                        authority {
+                                            address
+                                        }
+                                        extension
+                                        harvestToMintEnabled
+                                        withdrawWithheldAuthorityElgamalPubkey
+                                        withheldAmount
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    authority: {
+                                        address: expect.any(String),
+                                    },
+                                    extension: 'confidentialTransferFeeConfig',
+                                    harvestToMintEnabled: expect.any(Boolean),
+                                    withdrawWithheldAuthorityElgamalPubkey: expect.any(String),
+                                    withheldAmount: expect.any(String),
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -208,6 +208,9 @@ const resolveTokenExtensions = () => {
 };
 
 function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
+    if (extensionResult.extension === 'confidentialTransferFeeConfig') {
+        return 'SplTokenExtensionConfidentialTransferFeeConfig';
+    }
     if (extensionResult.extension === 'confidentialTransferMint') {
         return 'SplTokenExtensionConfidentialTransferMint';
     }
@@ -259,6 +262,9 @@ export const accountResolvers = {
     },
     SplTokenExtension: {
         __resolveType: resolveTokenExtensionType,
+    },
+    SplTokenExtensionConfidentialTransferFeeConfig: {
+        authority: resolveAccount('authority'),
     },
     SplTokenExtensionConfidentialTransferMint: {
         authority: resolveAccount('authority'),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -7,6 +7,17 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: Confidential Transfer Fee Config
+    """
+    type SplTokenExtensionConfidentialTransferFeeConfig implements SplTokenExtension {
+        extension: String
+        authority: Account
+        harvestToMintEnabled: Boolean
+        withdrawWithheldAuthorityElgamalPubkey: Address
+        withheldAmount: String
+    }
+
+    """
     Token-2022 Extension: Confidential Transfer Mint
     """
     type SplTokenExtensionConfidentialTransferMint implements SplTokenExtension {


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `ConfidentialTransferFeeConfig`.

Ref #2644.