### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: metadata pointer

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1639,6 +1639,46 @@ describe('account', () => {
                     },
                 });
             });
+            it('metadata-pointer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplTokenExtensionMetadataPointer {
+                                        authority {
+                                            address
+                                        }
+                                        extension
+                                        metadataAddress {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    authority: {
+                                        address: expect.any(String),
+                                    },
+                                    extension: 'metadataPointer',
+                                    metadataAddress: {
+                                        address: expect.any(String),
+                                    },
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -220,6 +220,9 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'interestBearingConfig') {
         return 'SplTokenExtensionInterestBearingConfig';
     }
+    if (extensionResult.extension === 'metadataPointer') {
+        return 'SplTokenExtensionMetadataPointer';
+    }
     if (extensionResult.extension === 'mintCloseAuthority') {
         return 'SplTokenExtensionMintCloseAuthority';
     }
@@ -274,6 +277,10 @@ export const accountResolvers = {
     },
     SplTokenExtensionInterestBearingConfig: {
         rateAuthority: resolveAccount('rateAuthority'),
+    },
+    SplTokenExtensionMetadataPointer: {
+        authority: resolveAccount('authority'),
+        metadataAddress: resolveAccount('metadataAddress'),
     },
     SplTokenExtensionMintCloseAuthority: {
         closeAuthority: resolveAccount('closeAuthority'),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -48,6 +48,15 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: Metadata Pointer
+    """
+    type SplTokenExtensionMetadataPointer implements SplTokenExtension {
+        extension: String
+        authority: Account
+        metadataAddress: Account
+    }
+
+    """
     Token-2022 Extension: Mint Close Authority
     """
     type SplTokenExtensionMintCloseAuthority implements SplTokenExtension {


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `MetadataPointer`.

Ref #2644.