### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: group pointer

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1679,6 +1679,46 @@ describe('account', () => {
                     },
                 });
             });
+            it('group-pointer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplTokenExtensionGroupPointer {
+                                        authority {
+                                            address
+                                        }
+                                        extension
+                                        groupAddress {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    authority: {
+                                        address: expect.any(String),
+                                    },
+                                    extension: 'groupPointer',
+                                    groupAddress: {
+                                        address: expect.any(String),
+                                    },
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -217,6 +217,9 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'defaultAccountState') {
         return 'SplTokenExtensionDefaultAccountState';
     }
+    if (extensionResult.extension === 'groupPointer') {
+        return 'SplTokenExtensionGroupPointer';
+    }
     if (extensionResult.extension === 'interestBearingConfig') {
         return 'SplTokenExtensionInterestBearingConfig';
     }
@@ -274,6 +277,10 @@ export const accountResolvers = {
     },
     SplTokenExtensionConfidentialTransferMint: {
         authority: resolveAccount('authority'),
+    },
+    SplTokenExtensionGroupPointer: {
+        authority: resolveAccount('authority'),
+        groupAddress: resolveAccount('groupAddress'),
     },
     SplTokenExtensionInterestBearingConfig: {
         rateAuthority: resolveAccount('rateAuthority'),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -36,6 +36,15 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: Group Pointer
+    """
+    type SplTokenExtensionGroupPointer implements SplTokenExtension {
+        extension: String
+        authority: Account
+        groupAddress: Account
+    }
+
+    """
     Token-2022 Extension: Interest-Bearing Config
     """
     type SplTokenExtensionInterestBearingConfig implements SplTokenExtension {


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `GroupPointer`.

Ref #2644.