### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: group member pointer

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1719,6 +1719,46 @@ describe('account', () => {
                     },
                 });
             });
+            it('group-member-pointer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplTokenExtensionGroupMemberPointer {
+                                        authority {
+                                            address
+                                        }
+                                        extension
+                                        memberAddress {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    authority: {
+                                        address: expect.any(String),
+                                    },
+                                    extension: 'groupMemberPointer',
+                                    memberAddress: {
+                                        address: expect.any(String),
+                                    },
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -220,6 +220,9 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'groupPointer') {
         return 'SplTokenExtensionGroupPointer';
     }
+    if (extensionResult.extension === 'groupMemberPointer') {
+        return 'SplTokenExtensionGroupMemberPointer';
+    }
     if (extensionResult.extension === 'interestBearingConfig') {
         return 'SplTokenExtensionInterestBearingConfig';
     }
@@ -277,6 +280,10 @@ export const accountResolvers = {
     },
     SplTokenExtensionConfidentialTransferMint: {
         authority: resolveAccount('authority'),
+    },
+    SplTokenExtensionGroupMemberPointer: {
+        authority: resolveAccount('authority'),
+        memberAddress: resolveAccount('memberAddress'),
     },
     SplTokenExtensionGroupPointer: {
         authority: resolveAccount('authority'),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -45,6 +45,15 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: Group Member Pointer
+    """
+    type SplTokenExtensionGroupMemberPointer implements SplTokenExtension {
+        extension: String
+        authority: Account
+        memberAddress: Account
+    }
+
+    """
     Token-2022 Extension: Interest-Bearing Config
     """
     type SplTokenExtensionInterestBearingConfig implements SplTokenExtension {


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `GroupMemberPointer`.

Ref #2644.