### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: token metadata

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1759,6 +1759,62 @@ describe('account', () => {
                     },
                 });
             });
+            it('token-metadata', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplTokenExtensionTokenMetadata {
+                                        additionalMetadata {
+                                            key
+                                            value
+                                        }
+                                        extension
+                                        mint {
+                                            address
+                                        }
+                                        name
+                                        symbol
+                                        updateAuthority {
+                                            address
+                                        }
+                                        uri
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    additionalMetadata: expect.arrayContaining([
+                                        {
+                                            key: expect.any(String),
+                                            value: expect.any(String),
+                                        },
+                                    ]),
+                                    extension: 'tokenMetadata',
+                                    mint: {
+                                        address: expect.any(String),
+                                    },
+                                    name: expect.any(String),
+                                    symbol: expect.any(String),
+                                    updateAuthority: {
+                                        address: expect.any(String),
+                                    },
+                                    uri: expect.any(String),
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -207,6 +207,20 @@ const resolveTokenExtensions = () => {
     };
 };
 
+const resolveAdditionalTokenMetadata = () => {
+    return (parent: { additionalMetadata?: [string, string][] }) => {
+        if (parent.additionalMetadata != undefined) {
+            return parent.additionalMetadata.map(([key, value]) => {
+                return {
+                    key,
+                    value,
+                };
+            });
+        }
+        return null;
+    };
+};
+
 function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'confidentialTransferFeeConfig') {
         return 'SplTokenExtensionConfidentialTransferFeeConfig';
@@ -237,6 +251,9 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     }
     if (extensionResult.extension === 'permanentDelegate') {
         return 'SplTokenExtensionPermanentDelegate';
+    }
+    if (extensionResult.extension === 'tokenMetadata') {
+        return 'SplTokenExtensionTokenMetadata';
     }
     if (extensionResult.extension === 'transferFeeConfig') {
         return 'SplTokenExtensionTransferFeeConfig';
@@ -301,6 +318,11 @@ export const accountResolvers = {
     },
     SplTokenExtensionPermanentDelegate: {
         delegate: resolveAccount('delegate'),
+    },
+    SplTokenExtensionTokenMetadata: {
+        additionalMetadata: resolveAdditionalTokenMetadata(),
+        mint: resolveAccount('mint'),
+        updateAuthority: resolveAccount('updateAuthority'),
     },
     SplTokenExtensionTransferFeeConfig: {
         transferFeeConfigAuthority: resolveAccount('transferFeeConfigAuthority'),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -97,6 +97,23 @@ export const accountTypeDefs = /* GraphQL */ `
         delegate: Account
     }
 
+    type SplTokenMetadataAdditionalMetadata {
+        key: String
+        value: String
+    }
+    """
+    Token-2022 Extension: Token Metadata
+    """
+    type SplTokenExtensionTokenMetadata implements SplTokenExtension {
+        extension: String
+        additionalMetadata: [SplTokenMetadataAdditionalMetadata]
+        mint: Account
+        name: String
+        symbol: String
+        updateAuthority: Account
+        uri: String
+    }
+
     type SplTokenTransferFeeConfig {
         epoch: Epoch
         maximumFee: BigInt


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `TokenMetadata`.

Ref #2644.