### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: token group

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1815,6 +1815,50 @@ describe('account', () => {
                     },
                 });
             });
+            it('token-group', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on MintAccount {
+                                extensions {
+                                    ... on SplTokenExtensionTokenGroup {
+                                        extension
+                                        maxSize
+                                        mint {
+                                            address
+                                        }
+                                        size
+                                        updateAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { address: megaMintAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'tokenGroup',
+                                    maxSize: expect.any(BigInt),
+                                    mint: {
+                                        address: expect.any(String),
+                                    },
+                                    size: expect.any(BigInt),
+                                    updateAuthority: {
+                                        address: expect.any(String),
+                                    },
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -252,6 +252,9 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'permanentDelegate') {
         return 'SplTokenExtensionPermanentDelegate';
     }
+    if (extensionResult.extension === 'tokenGroup') {
+        return 'SplTokenExtensionTokenGroup';
+    }
     if (extensionResult.extension === 'tokenMetadata') {
         return 'SplTokenExtensionTokenMetadata';
     }
@@ -318,6 +321,10 @@ export const accountResolvers = {
     },
     SplTokenExtensionPermanentDelegate: {
         delegate: resolveAccount('delegate'),
+    },
+    SplTokenExtensionTokenGroup: {
+        mint: resolveAccount('mint'),
+        updateAuthority: resolveAccount('updateAuthority'),
     },
     SplTokenExtensionTokenMetadata: {
         additionalMetadata: resolveAdditionalTokenMetadata(),

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -97,6 +97,17 @@ export const accountTypeDefs = /* GraphQL */ `
         delegate: Account
     }
 
+    """
+    Token-2022 Extension: Token Group
+    """
+    type SplTokenExtensionTokenGroup implements SplTokenExtension {
+        extension: String
+        maxSize: BigInt
+        mint: Account
+        size: BigInt
+        updateAuthority: Account
+    }
+
     type SplTokenMetadataAdditionalMetadata {
         key: String
         value: String


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for `TokenGroup`.

Ref #2644.