### PR TITLE
refactor(experimental): graphql: token-2022 extensions: InitializeTokenGroup

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2586,6 +2586,21 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            group: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            maxSize: 22,
+                            mintAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                            updateAuthority: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            mint: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                        },
+                        type: 'initializeTokenGroup',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -3343,7 +3343,7 @@ describe('transaction', () => {
                             message {
                                 instructions {
                                     programId
-                                    ... on SplTokenInitializeTokenGroup {
+                                    ... on SplTokenGroupInitializeGroup {
                                         group {
                                             address
                                         }

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -3334,6 +3334,63 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('initialize-token-group', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenInitializeTokenGroup {
+                                        group {
+                                            address
+                                        }
+                                        maxSize
+                                        mint {
+                                            address
+                                        }
+                                        mintAuthority {
+                                            address
+                                        }
+                                        updateAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        group: {
+                                            address: expect.any(String),
+                                        },
+                                        maxSize: expect.any(BigInt),
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        mintAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        updateAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -369,6 +369,12 @@ export const instructionResolvers = {
         delegate: resolveAccount('delegate'),
         mint: resolveAccount('mint'),
     },
+    SplTokenInitializeTokenGroup: {
+        group: resolveAccount('group'),
+        mint: resolveAccount('mint'),
+        mintAuthority: resolveAccount('mintAuthority'),
+        updateAuthority: resolveAccount('updateAuthority'),
+    },
     SplTokenInitializeTransferFeeConfig: {
         mint: resolveAccount('mint'),
         transferFeeConfigAuthority: resolveAccount('transferFeeConfigAuthority'),
@@ -881,6 +887,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeConfidentialTransferFeeConfig') {
                         return 'SplTokenInitializeConfidentialTransferFeeConfig';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializeTokenGroup') {
+                        return 'SplTokenInitializeTokenGroup';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -290,6 +290,12 @@ export const instructionResolvers = {
     SplTokenGetAccountDataSizeInstruction: {
         mint: resolveAccount('mint'),
     },
+    SplTokenGroupInitializeGroup: {
+        group: resolveAccount('group'),
+        mint: resolveAccount('mint'),
+        mintAuthority: resolveAccount('mintAuthority'),
+        updateAuthority: resolveAccount('updateAuthority'),
+    },
     SplTokenHarvestWithheldConfidentialTransferTokensToMint: {
         mint: resolveAccount('mint'),
     },
@@ -368,12 +374,6 @@ export const instructionResolvers = {
     SplTokenInitializePermanentDelegateInstruction: {
         delegate: resolveAccount('delegate'),
         mint: resolveAccount('mint'),
-    },
-    SplTokenInitializeTokenGroup: {
-        group: resolveAccount('group'),
-        mint: resolveAccount('mint'),
-        mintAuthority: resolveAccount('mintAuthority'),
-        updateAuthority: resolveAccount('updateAuthority'),
     },
     SplTokenInitializeTransferFeeConfig: {
         mint: resolveAccount('mint'),
@@ -889,7 +889,7 @@ export const instructionResolvers = {
                         return 'SplTokenInitializeConfidentialTransferFeeConfig';
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeTokenGroup') {
-                        return 'SplTokenInitializeTokenGroup';
+                        return 'SplTokenGroupInitializeGroup';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -1015,9 +1015,9 @@ export const instructionTypeDefs = /* GraphQL */ `
     }
 
     """
-    SplToken-2022: InitializeTokenGroup instruction
+    Spl Token Group: InitializeGroup instruction
     """
-    type SplTokenInitializeTokenGroup implements TransactionInstruction {
+    type SplTokenGroupInitializeGroup implements TransactionInstruction {
         programId: Address
         group: Account
         maxSize: BigInt

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -1014,6 +1014,18 @@ export const instructionTypeDefs = /* GraphQL */ `
         withheldAmount: String
     }
 
+    """
+    SplToken-2022: InitializeTokenGroup instruction
+    """
+    type SplTokenInitializeTokenGroup implements TransactionInstruction {
+        programId: Address
+        group: Account
+        maxSize: BigInt
+        mint: Account
+        mintAuthority: Account
+        updateAuthority: Account
+    }
+
     type Lockup {
         custodian: Account
         epoch: Epoch


### PR DESCRIPTION
This PR adds support for Token-2022's InitializeTokenGroup instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.