### PR TITLE
refactor(experimental): graphql: token-2022 extensions: InitializeTokenGroupMember

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2627,6 +2627,21 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            member: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            memberMint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            memberMintAuthority: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            group: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            groupUpdateAuthority: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                        },
+                        type: 'initializeTokenGroupMember',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -3485,6 +3485,67 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('initialize-token-group-member', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenGroupInitializeMember {
+                                        group {
+                                            address
+                                        }
+                                        groupUpdateAuthority {
+                                            address
+                                        }
+                                        member {
+                                            address
+                                        }
+                                        memberMint {
+                                            address
+                                        }
+                                        memberMintAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        group: {
+                                            address: expect.any(String),
+                                        },
+                                        groupUpdateAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        member: {
+                                            address: expect.any(String),
+                                        },
+                                        memberMint: {
+                                            address: expect.any(String),
+                                        },
+                                        memberMintAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -296,6 +296,13 @@ export const instructionResolvers = {
         mintAuthority: resolveAccount('mintAuthority'),
         updateAuthority: resolveAccount('updateAuthority'),
     },
+    SplTokenGroupInitializeMember: {
+        group: resolveAccount('group'),
+        groupUpdateAuthority: resolveAccount('groupUpdateAuthority'),
+        member: resolveAccount('member'),
+        memberMint: resolveAccount('memberMint'),
+        memberMintAuthority: resolveAccount('memberMintAuthority'),
+    },
     SplTokenGroupUpdateGroupAuthority: {
         group: resolveAccount('group'),
         newAuthority: resolveAccount('newAuthority'),
@@ -905,6 +912,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'updateTokenGroupAuthority') {
                         return 'SplTokenGroupUpdateGroupAuthority';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializeTokenGroupMember') {
+                        return 'SplTokenGroupInitializeMember';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -1046,6 +1046,18 @@ export const instructionTypeDefs = /* GraphQL */ `
         updateAuthority: Account
     }
 
+    """
+    Spl Token Group: InitializeMember instruction
+    """
+    type SplTokenGroupInitializeMember implements TransactionInstruction {
+        programId: Address
+        group: Account
+        groupUpdateAuthority: Account
+        member: Account
+        memberMint: Account
+        memberMintAuthority: Account
+    }
+
     type Lockup {
         custodian: Account
         epoch: Epoch


### PR DESCRIPTION
This PR adds support for Token-2022's InitializeTokenGroupMember instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.