### PR TITLE
refactor(experimental): graphql: token-2022 extensions: InitializeMetadata

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2642,6 +2642,23 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            metadata: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            updateAuthority: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            mint: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            mintAuthority: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            name: 'Test',
+                            symbol: 'tst',
+                            uri: 'http://test.test',
+                        },
+                        type: 'initializeTokenMetadata',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -3555,7 +3555,7 @@ describe('transaction', () => {
                             message {
                                 instructions {
                                     programId
-                                    ... on SplTokenMetadataInitializeMetadata {
+                                    ... on SplTokenMetadataInitialize {
                                         metadata {
                                             address
                                         }

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -3546,6 +3546,67 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('initialize-token-metadata', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenMetadataInitializeMetadata {
+                                        metadata {
+                                            address
+                                        }
+                                        mint {
+                                            address
+                                        }
+                                        mintAuthority {
+                                            address
+                                        }
+                                        name
+                                        symbol
+                                        updateAuthority {
+                                            address
+                                        }
+                                        uri
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        metadata: {
+                                            address: expect.any(String),
+                                        },
+                                        mint: {
+                                            address: expect.any(String),
+                                        },
+                                        mintAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        name: expect.any(String),
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        symbol: expect.any(String),
+                                        updateAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        uri: expect.any(String),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -401,7 +401,7 @@ export const instructionResolvers = {
         hookProgramId: resolveAccount('programId'),
         mint: resolveAccount('mint'),
     },
-    SplTokenMetadataInitializeMetadata: {
+    SplTokenMetadataInitialize: {
         metadata: resolveAccount('metadata'),
         mint: resolveAccount('mint'),
         mintAuthority: resolveAccount('mintAuthority'),
@@ -923,7 +923,7 @@ export const instructionResolvers = {
                         return 'SplTokenGroupInitializeMember';
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeTokenMetadata') {
-                        return 'SplTokenMetadataInitializeMetadata';
+                        return 'SplTokenMetadataInitialize';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -401,6 +401,12 @@ export const instructionResolvers = {
         hookProgramId: resolveAccount('programId'),
         mint: resolveAccount('mint'),
     },
+    SplTokenMetadataInitializeMetadata: {
+        metadata: resolveAccount('metadata'),
+        mint: resolveAccount('mint'),
+        mintAuthority: resolveAccount('mintAuthority'),
+        updateAuthority: resolveAccount('updateAuthority'),
+    },
     SplTokenMintToCheckedInstruction: {
         account: resolveAccount('account'),
         authority: resolveAccount('authority'),
@@ -915,6 +921,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'initializeTokenGroupMember') {
                         return 'SplTokenGroupInitializeMember';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'initializeTokenMetadata') {
+                        return 'SplTokenMetadataInitializeMetadata';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -1058,6 +1058,20 @@ export const instructionTypeDefs = /* GraphQL */ `
         memberMintAuthority: Account
     }
 
+    """
+    Spl Token Metadata: InitializeMetadata instruction
+    """
+    type SplTokenMetadataInitializeMetadata implements TransactionInstruction {
+        programId: Address
+        metadata: Account
+        mint: Account
+        mintAuthority: Account
+        name: String
+        symbol: String
+        updateAuthority: Account
+        uri: String
+    }
+
     type Lockup {
         custodian: Account
         epoch: Epoch

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -1061,7 +1061,7 @@ export const instructionTypeDefs = /* GraphQL */ `
     """
     Spl Token Metadata: InitializeMetadata instruction
     """
-    type SplTokenMetadataInitializeMetadata implements TransactionInstruction {
+    type SplTokenMetadataInitialize implements TransactionInstruction {
         programId: Address
         metadata: Account
         mint: Account


### PR DESCRIPTION
This PR adds support for Token-2022's InitializeMetadata instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.