### PR TITLE
refactor(experimental): graphql: token-2022 extensions: RemoveKey

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2673,6 +2673,20 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            metadata: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            updateAuthority: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            key: 'key',
+                            idempotent: true,
+                        },
+                        type: 'removeTokenMetadataKey',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -3654,6 +3654,53 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('remove-token-metadata-key', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenMetadataRemoveKey {
+                                        idempotent
+                                        key
+                                        metadata {
+                                            address
+                                        }
+                                        updateAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        idempotent: expect.any(Boolean),
+                                        key: expect.any(String),
+                                        metadata: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        updateAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -407,6 +407,10 @@ export const instructionResolvers = {
         mintAuthority: resolveAccount('mintAuthority'),
         updateAuthority: resolveAccount('updateAuthority'),
     },
+    SplTokenMetadataRemoveKey: {
+        metadata: resolveAccount('metadata'),
+        updateAuthority: resolveAccount('updateAuthority'),
+    },
     SplTokenMetadataUpdateField: {
         metadata: resolveAccount('metadata'),
         updateAuthority: resolveAccount('updateAuthority'),
@@ -931,6 +935,9 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'updateTokenMetadataField') {
                         return 'SplTokenMetadataUpdateField';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'removeTokenMetadataKey') {
+                        return 'SplTokenMetadataRemoveKey';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -1083,6 +1083,17 @@ export const instructionTypeDefs = /* GraphQL */ `
         value: String
     }
 
+    """
+    Spl Token Metadata: RemoveKey instruction
+    """
+    type SplTokenMetadataRemoveKey implements TransactionInstruction {
+        programId: Address
+        idempotent: Boolean
+        key: String
+        metadata: Account
+        updateAuthority: Account
+    }
+
     type Lockup {
         custodian: Account
         epoch: Epoch


### PR DESCRIPTION
This PR adds support for Token-2022's RemoveKey instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.