### PR TITLE
Support SPL Token account state within the schema for Token Account 

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1959,6 +1959,226 @@ describe('account', () => {
                     },
                 });
             });
+
+            it('transfer-fee-amount', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionTransferFeeAmount {
+                                        extension
+                                        withheldAmount
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'transferFeeAmount',
+                                    withheldAmount: expect.any(BigInt)
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('transfer-hook-account', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionTransferHookAccount {
+                                        extension
+                                        transferring
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'transferHookAccount',
+                                    transferring: expect.any(Boolean)
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('confidential-transfer-fee-amount', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionConfidentialTransferFeeAmount {
+                                        extension
+                                        withheldAmount
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'confidentialTransferFeeAmount',
+                                    withheldAmount: expect.any(String)
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('non-transferable-account', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionNonTransferableAccount {
+                                        extension
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'nonTransferableAccount',
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('immutable-owner', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionImmutableOwner {
+                                        extension
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'immutableOwner',
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('memo-transfer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionMemoTransfer {
+                                        extension
+                                        requireIncomingTransferMemos
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'memoTransfer',
+                                    requireIncomingTransferMemos: expect.any(Boolean)
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('cpi-guard', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionCpiGuard {
+                                        extension
+                                        lockCpi
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'cpiGuard',
+                                    lockCpi: expect.any(Boolean)
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1984,7 +1984,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'transferFeeAmount',
-                                    withheldAmount: expect.any(BigInt)
+                                    withheldAmount: expect.any(BigInt),
                                 },
                             ]),
                         },
@@ -2016,7 +2016,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'transferHookAccount',
-                                    transferring: expect.any(Boolean)
+                                    transferring: expect.any(Boolean),
                                 },
                             ]),
                         },
@@ -2048,7 +2048,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'confidentialTransferFeeAmount',
-                                    withheldAmount: expect.any(String)
+                                    withheldAmount: expect.any(String),
                                 },
                             ]),
                         },
@@ -2140,7 +2140,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'memoTransfer',
-                                    requireIncomingTransferMemos: expect.any(Boolean)
+                                    requireIncomingTransferMemos: expect.any(Boolean),
                                 },
                             ]),
                         },
@@ -2172,7 +2172,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'cpiGuard',
-                                    lockCpi: expect.any(Boolean)
+                                    lockCpi: expect.any(Boolean),
                                 },
                             ]),
                         },

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -270,6 +270,27 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'confidentialTransferAccount') {
         return 'SplTokenExtensionConfidentialTransferAccount';
     }
+    if (extensionResult.extension === 'transferFeeAmount') {
+        return 'SplTokenExtensionTransferFeeAmount';
+    }
+    if (extensionResult.extension === 'transferHookAccount') {
+        return 'SplTokenExtensionTransferHookAccount';
+    }
+    if (extensionResult.extension === 'confidentialTransferFeeAmount') {
+        return 'SplTokenExtensionConfidentialTransferFeeAmount';
+    }
+    if (extensionResult.extension === 'nonTransferableAccount') {
+        return 'SplTokenExtensionNonTransferableAccount';
+    }
+    if (extensionResult.extension === 'immutableOwner') {
+        return 'SplTokenExtensionImmutableOwner';
+    }
+    if (extensionResult.extension === 'memoTransfer') {
+        return 'SplTokenExtensionMemoTransfer';
+    }
+    if (extensionResult.extension === 'cpiGuard') {
+        return 'SplTokenExtensionCpiGuard';
+    }
 }
 
 export const accountResolvers = {

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -160,6 +160,60 @@ export const accountTypeDefs = /* GraphQL */ `
         authority: Account
         hookProgramId: Account
     }
+    
+    """
+    Token-2022 Extension: Transfer Fee Amount 
+    """
+    type SplTokenExtensionTransferFeeAmount implements SplTokenExtension {
+        extension: String
+        withheldAmount: BigInt 
+    }
+    
+    """
+    Token-2022 Extension: Transfer Hook Account 
+    """
+    type SplTokenExtensionTransferHookAccount implements SplTokenExtension {
+        extension: String
+        transferring: Boolean 
+    }
+    
+    """
+    Token-2022 Extension: Confidential Transfer Fee Amount
+    """
+    type SplTokenExtensionConfidentialTransferFeeAmount implements SplTokenExtension {
+        extension: String
+        withheldAmount: String 
+    }
+    
+    """
+    Token-2022 Extension: NonTransferableAccount 
+    """
+    type SplTokenExtensionNonTransferableAccount implements SplTokenExtension {
+        extension: String
+    }
+    
+    """
+    Token-2022 Extension: ImmutableOwner 
+    """
+    type SplTokenExtensionImmutableOwner implements SplTokenExtension {
+        extension: String
+    }
+    
+    """
+    Token-2022 Extension: MemoTransfer 
+    """
+    type SplTokenExtensionMemoTransfer implements SplTokenExtension {
+        extension: String
+        requireIncomingTransferMemos: Boolean
+    }
+    
+    """
+    Token-2022 Extension: CpiGuard 
+    """
+    type SplTokenExtensionCpiGuard implements SplTokenExtension {
+        extension: String
+        lockCpi: Boolean
+    }
 
     """
     Token-2022 Extension: ConfidentialTransferAccount

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -160,55 +160,55 @@ export const accountTypeDefs = /* GraphQL */ `
         authority: Account
         hookProgramId: Account
     }
-    
+
     """
-    Token-2022 Extension: Transfer Fee Amount 
+    Token-2022 Extension: Transfer Fee Amount
     """
     type SplTokenExtensionTransferFeeAmount implements SplTokenExtension {
         extension: String
-        withheldAmount: BigInt 
+        withheldAmount: BigInt
     }
-    
+
     """
-    Token-2022 Extension: Transfer Hook Account 
+    Token-2022 Extension: Transfer Hook Account
     """
     type SplTokenExtensionTransferHookAccount implements SplTokenExtension {
         extension: String
-        transferring: Boolean 
+        transferring: Boolean
     }
-    
+
     """
     Token-2022 Extension: Confidential Transfer Fee Amount
     """
     type SplTokenExtensionConfidentialTransferFeeAmount implements SplTokenExtension {
         extension: String
-        withheldAmount: String 
+        withheldAmount: String
     }
-    
+
     """
-    Token-2022 Extension: NonTransferableAccount 
+    Token-2022 Extension: NonTransferableAccount
     """
     type SplTokenExtensionNonTransferableAccount implements SplTokenExtension {
         extension: String
     }
-    
+
     """
-    Token-2022 Extension: ImmutableOwner 
+    Token-2022 Extension: ImmutableOwner
     """
     type SplTokenExtensionImmutableOwner implements SplTokenExtension {
         extension: String
     }
-    
+
     """
-    Token-2022 Extension: MemoTransfer 
+    Token-2022 Extension: MemoTransfer
     """
     type SplTokenExtensionMemoTransfer implements SplTokenExtension {
         extension: String
         requireIncomingTransferMemos: Boolean
     }
-    
+
     """
-    Token-2022 Extension: CpiGuard 
+    Token-2022 Extension: CpiGuard
     """
     type SplTokenExtensionCpiGuard implements SplTokenExtension {
         extension: String


### PR DESCRIPTION
## Support for following: 

- TransferFeeAmount
- ImmutableOwner
- MemoTransfer
- CpiGuard
- NonTransferableAccount
- ConfidentialTransferFeeAmount
- TransferHookAccount

Ref https://github.com/solana-labs/solana-web3.js/issues/2644.