### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: confidentialTransferAccount

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1930,7 +1930,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'transferFeeAmount',
-                                    withheldAmount: expect.any(BigInt)
+                                    withheldAmount: expect.any(BigInt),
                                 },
                             ]),
                         },
@@ -1962,7 +1962,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'transferHookAccount',
-                                    transferring: expect.any(Boolean)
+                                    transferring: expect.any(Boolean),
                                 },
                             ]),
                         },
@@ -1994,7 +1994,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'confidentialTransferFeeAmount',
-                                    withheldAmount: expect.any(String)
+                                    withheldAmount: expect.any(String),
                                 },
                             ]),
                         },
@@ -2086,7 +2086,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'memoTransfer',
-                                    requireIncomingTransferMemos: expect.any(Boolean)
+                                    requireIncomingTransferMemos: expect.any(Boolean),
                                 },
                             ]),
                         },
@@ -2118,7 +2118,7 @@ describe('account', () => {
                             extensions: expect.arrayContaining([
                                 {
                                     extension: 'cpiGuard',
-                                    lockCpi: expect.any(Boolean)
+                                    lockCpi: expect.any(Boolean),
                                 },
                             ]),
                         },

--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1293,6 +1293,8 @@ describe('account', () => {
             const megaMintAddress = '5gSwsLGzyCwgwPJSnxjsQCaFeE19ZFaibHMLky9TDFim';
             // See scripts/fixtures/spl-token-22-mint-mega-token-member.json
             const megaMemberAddress = 'CXZDzjSrQ5jPaBgk6ckTQrLPTnUURiY2GnAgVCS9Fggz';
+            // See scripts/fixtures/spl-token-22-account-mega-token-member.json
+            const megaAccountAddress = 'aUg6iJ3p43hTJsxHrQ1KfqMQYStoFvqcSJRcc51cYzK';
             it('mint-close-authority', async () => {
                 expect.assertions(1);
                 const source = /* GraphQL */ `
@@ -1897,6 +1899,226 @@ describe('account', () => {
                                     mint: {
                                         address: expect.any(String),
                                     },
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('transfer-fee-amount', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionTransferFeeAmount {
+                                        extension
+                                        withheldAmount
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'transferFeeAmount',
+                                    withheldAmount: expect.any(BigInt)
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('transfer-hook-account', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionTransferHookAccount {
+                                        extension
+                                        transferring
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'transferHookAccount',
+                                    transferring: expect.any(Boolean)
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('confidential-transfer-fee-amount', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionConfidentialTransferFeeAmount {
+                                        extension
+                                        withheldAmount
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'confidentialTransferFeeAmount',
+                                    withheldAmount: expect.any(String)
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('non-transferable-account', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionNonTransferableAccount {
+                                        extension
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'nonTransferableAccount',
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('immutable-owner', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionImmutableOwner {
+                                        extension
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'immutableOwner',
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('memo-transfer', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionMemoTransfer {
+                                        extension
+                                        requireIncomingTransferMemos
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'memoTransfer',
+                                    requireIncomingTransferMemos: expect.any(Boolean)
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('cpi-guard', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionCpiGuard {
+                                        extension
+                                        lockCpi
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    extension: 'cpiGuard',
+                                    lockCpi: expect.any(Boolean)
                                 },
                             ]),
                         },

--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -2125,6 +2125,60 @@ describe('account', () => {
                     },
                 });
             });
+
+            it('confidentialTransferAccount', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionConfidentialTransferAccount {
+                                        actualPendingBalanceCreditCounter
+                                        allowConfidentialCredits
+                                        allowNonConfidentialCredits
+                                        approved
+                                        availableBalance
+                                        decryptableAvailableBalance
+                                        elgamalPubkey
+                                        expectedPendingBalanceCreditCounter
+                                        maximumPendingBalanceCreditCounter
+                                        pendingBalanceCreditCounter
+                                        pendingBalanceHi
+                                        pendingBalanceLo
+                                        extension
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    actualPendingBalanceCreditCounter: null,
+                                    allowConfidentialCredits: expect.any(Boolean),
+                                    allowNonConfidentialCredits: expect.any(Boolean),
+                                    approved: expect.any(Boolean),
+                                    availableBalance: expect.any(String),
+                                    decryptableAvailableBalance: expect.any(String),
+                                    elgamalPubkey: expect.any(String),
+                                    expectedPendingBalanceCreditCounter: null,
+                                    extension: 'confidentialTransferAccount',
+                                    maximumPendingBalanceCreditCounter: null,
+                                    pendingBalanceCreditCounter: null,
+                                    pendingBalanceHi: expect.any(String),
+                                    pendingBalanceLo: expect.any(String),
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -288,6 +288,9 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'cpiGuard') {
         return 'SplTokenExtensionCpiGuard';
     }
+    if (extensionResult.extension === 'confidentialTransferAccount') {
+        return 'SplTokenExtensionConfidentialTransferAccount';
+    }
 }
 
 export const accountResolvers = {

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -267,6 +267,27 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'transferHook') {
         return 'SplTokenExtensionTransferHook';
     }
+    if (extensionResult.extension === 'transferFeeAmount') {
+        return 'SplTokenExtensionTransferFeeAmount';
+    }
+    if (extensionResult.extension === 'transferHookAccount') {
+        return 'SplTokenExtensionTransferHookAccount';
+    }
+    if (extensionResult.extension === 'confidentialTransferFeeAmount') {
+        return 'SplTokenExtensionConfidentialTransferFeeAmount';
+    }
+    if (extensionResult.extension === 'nonTransferableAccount') {
+        return 'SplTokenExtensionNonTransferableAccount';
+    }
+    if (extensionResult.extension === 'immutableOwner') {
+        return 'SplTokenExtensionImmutableOwner';
+    }
+    if (extensionResult.extension === 'memoTransfer') {
+        return 'SplTokenExtensionMemoTransfer';
+    }
+    if (extensionResult.extension === 'cpiGuard') {
+        return 'SplTokenExtensionCpiGuard';
+    }
 }
 
 export const accountResolvers = {

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -160,6 +160,60 @@ export const accountTypeDefs = /* GraphQL */ `
         authority: Account
         hookProgramId: Account
     }
+    
+    """
+    Token-2022 Extension: Transfer Fee Amount 
+    """
+    type SplTokenExtensionTransferFeeAmount implements SplTokenExtension {
+        extension: String
+        withheldAmount: BigInt 
+    }
+    
+    """
+    Token-2022 Extension: Transfer Hook Account 
+    """
+    type SplTokenExtensionTransferHookAccount implements SplTokenExtension {
+        extension: String
+        transferring: Boolean 
+    }
+    
+    """
+    Token-2022 Extension: Confidential Transfer Fee Amount
+    """
+    type SplTokenExtensionConfidentialTransferFeeAmount implements SplTokenExtension {
+        extension: String
+        withheldAmount: String 
+    }
+    
+    """
+    Token-2022 Extension: NonTransferableAccount 
+    """
+    type SplTokenExtensionNonTransferableAccount implements SplTokenExtension {
+        extension: String
+    }
+    
+    """
+    Token-2022 Extension: ImmutableOwner 
+    """
+    type SplTokenExtensionImmutableOwner implements SplTokenExtension {
+        extension: String
+    }
+    
+    """
+    Token-2022 Extension: MemoTransfer 
+    """
+    type SplTokenExtensionMemoTransfer implements SplTokenExtension {
+        extension: String
+        requireIncomingTransferMemos: Boolean
+    }
+    
+    """
+    Token-2022 Extension: CpiGuard 
+    """
+    type SplTokenExtensionCpiGuard implements SplTokenExtension {
+        extension: String
+        lockCpi: Boolean
+    }
 
     """
     Account interface

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -216,6 +216,25 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: ConfidentialTransferAccount
+    """
+    type SplTokenExtensionConfidentialTransferAccount implements SplTokenExtension {
+        extension: String
+        actualPendingBalanceCreditCounter: Int
+        allowConfidentialCredits: Boolean
+        allowNonConfidentialCredits: Boolean
+        approved: Boolean
+        availableBalance: String
+        decryptableAvailableBalance: String
+        elgamalPubkey: String
+        expectedPendingBalanceCreditCounter: Int
+        maximumPendingBalanceCreditCounter: Int
+        pendingBalanceCreditCounter: Int
+        pendingBalanceHi: String
+        pendingBalanceLo: String
+    }
+
+    """
     Account interface
     """
     interface Account {

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -160,55 +160,55 @@ export const accountTypeDefs = /* GraphQL */ `
         authority: Account
         hookProgramId: Account
     }
-    
+
     """
-    Token-2022 Extension: Transfer Fee Amount 
+    Token-2022 Extension: Transfer Fee Amount
     """
     type SplTokenExtensionTransferFeeAmount implements SplTokenExtension {
         extension: String
-        withheldAmount: BigInt 
+        withheldAmount: BigInt
     }
-    
+
     """
-    Token-2022 Extension: Transfer Hook Account 
+    Token-2022 Extension: Transfer Hook Account
     """
     type SplTokenExtensionTransferHookAccount implements SplTokenExtension {
         extension: String
-        transferring: Boolean 
+        transferring: Boolean
     }
-    
+
     """
     Token-2022 Extension: Confidential Transfer Fee Amount
     """
     type SplTokenExtensionConfidentialTransferFeeAmount implements SplTokenExtension {
         extension: String
-        withheldAmount: String 
+        withheldAmount: String
     }
-    
+
     """
-    Token-2022 Extension: NonTransferableAccount 
+    Token-2022 Extension: NonTransferableAccount
     """
     type SplTokenExtensionNonTransferableAccount implements SplTokenExtension {
         extension: String
     }
-    
+
     """
-    Token-2022 Extension: ImmutableOwner 
+    Token-2022 Extension: ImmutableOwner
     """
     type SplTokenExtensionImmutableOwner implements SplTokenExtension {
         extension: String
     }
-    
+
     """
-    Token-2022 Extension: MemoTransfer 
+    Token-2022 Extension: MemoTransfer
     """
     type SplTokenExtensionMemoTransfer implements SplTokenExtension {
         extension: String
         requireIncomingTransferMemos: Boolean
     }
-    
+
     """
-    Token-2022 Extension: CpiGuard 
+    Token-2022 Extension: CpiGuard
     """
     type SplTokenExtensionCpiGuard implements SplTokenExtension {
         extension: String


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for ConfidentialTransferAccount.

Ref https://github.com/solana-labs/solana-web3.js/issues/2644.