### PR TITLE
refactor(experimental): graphql: token-2022 extensions account state: confidentialTransferAccount

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1293,6 +1293,8 @@ describe('account', () => {
             const megaMintAddress = '5gSwsLGzyCwgwPJSnxjsQCaFeE19ZFaibHMLky9TDFim';
             // See scripts/fixtures/spl-token-22-mint-mega-token-member.json
             const megaMemberAddress = 'CXZDzjSrQ5jPaBgk6ckTQrLPTnUURiY2GnAgVCS9Fggz';
+            // See scripts/fixtures/spl-token-22-account-mega-token-member.json
+            const megaAccountAddress = 'aUg6iJ3p43hTJsxHrQ1KfqMQYStoFvqcSJRcc51cYzK';
             it('mint-close-authority', async () => {
                 expect.assertions(1);
                 const source = /* GraphQL */ `
@@ -1897,6 +1899,60 @@ describe('account', () => {
                                     mint: {
                                         address: expect.any(String),
                                     },
+                                },
+                            ]),
+                        },
+                    },
+                });
+            });
+
+            it('confidential-transfer-account', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($address: Address!) {
+                        account(address: $address) {
+                            ... on TokenAccount {
+                                extensions {
+                                    ... on SplTokenExtensionConfidentialTransferAccount {
+                                        actualPendingBalanceCreditCounter
+                                        allowConfidentialCredits
+                                        allowNonConfidentialCredits
+                                        approved
+                                        availableBalance
+                                        decryptableAvailableBalance
+                                        elgamalPubkey
+                                        expectedPendingBalanceCreditCounter
+                                        maximumPendingBalanceCreditCounter
+                                        pendingBalanceCreditCounter
+                                        pendingBalanceHi
+                                        pendingBalanceLo
+                                        extension
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+
+                const result = await rpcGraphQL.query(source, { address: megaAccountAddress });
+                expect(result).toMatchObject({
+                    data: {
+                        account: {
+                            extensions: expect.arrayContaining([
+                                {
+                                    actualPendingBalanceCreditCounter: null,
+                                    allowConfidentialCredits: expect.any(Boolean),
+                                    allowNonConfidentialCredits: expect.any(Boolean),
+                                    approved: expect.any(Boolean),
+                                    availableBalance: expect.any(String),
+                                    decryptableAvailableBalance: expect.any(String),
+                                    elgamalPubkey: expect.any(String),
+                                    expectedPendingBalanceCreditCounter: null,
+                                    extension: 'confidentialTransferAccount',
+                                    maximumPendingBalanceCreditCounter: null,
+                                    pendingBalanceCreditCounter: null,
+                                    pendingBalanceHi: expect.any(String),
+                                    pendingBalanceLo: expect.any(String),
                                 },
                             ]),
                         },

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -267,6 +267,9 @@ function resolveTokenExtensionType(extensionResult: Token2022ExtensionResult) {
     if (extensionResult.extension === 'transferHook') {
         return 'SplTokenExtensionTransferHook';
     }
+    if (extensionResult.extension === 'confidentialTransferAccount') {
+        return 'SplTokenExtensionConfidentialTransferAccount';
+    }
 }
 
 export const accountResolvers = {

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -162,6 +162,25 @@ export const accountTypeDefs = /* GraphQL */ `
     }
 
     """
+    Token-2022 Extension: ConfidentialTransferAccount
+    """
+    type SplTokenExtensionConfidentialTransferAccount implements SplTokenExtension {
+        extension: String
+        actualPendingBalanceCreditCounter: Int
+        allowConfidentialCredits: Boolean
+        allowNonConfidentialCredits: Boolean
+        approved: Boolean
+        availableBalance: String
+        decryptableAvailableBalance: String
+        elgamalPubkey: String
+        expectedPendingBalanceCreditCounter: Int
+        maximumPendingBalanceCreditCounter: Int
+        pendingBalanceCreditCounter: Int
+        pendingBalanceHi: String
+        pendingBalanceLo: String
+    }
+
+    """
     Account interface
     """
     interface Account {


### PR DESCRIPTION
This PR adds Token-2022 extension parsed account state support for ConfidentialTransferAccount.

Ref https://github.com/solana-labs/solana-web3.js/issues/2644.