### PR TITLE
refactor(experimental): graphql: token-2022 extensions: UpdateAuthority Emit

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2687,6 +2687,32 @@ export const mockTransactionToken2022AllExtensions = {
                     programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
                     stackHeight: null,
                 },
+                {
+                    parsed: {
+                        info: {
+                            metadata: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            updateAuthority: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            newAuthority: '2Pwe6Yahh5cbzvCwRMtTYFeboSwYiWeHhYJzZZBsU6eB',
+                        },
+                        type: 'updateTokenMetadataAuthority',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
+                {
+                    parsed: {
+                        info: {
+                            metadata: 'FsHcsGiY43QmZc6yTgwYC1DA5U3ZgycXxn3bd2oBjrEZ',
+                            start: 0,
+                            end: 100,
+                        },
+                        type: 'emitTokenMetadata',
+                    },
+                    program: 'spl-token',
+                    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                    stackHeight: null,
+                },
                 // TODO (more) ...
             ],
             recentBlockhash: '6vRS7MoToVccMqfQecdVC6UbmARaT5mha91zhreqnce9',

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -3701,6 +3701,96 @@ describe('transaction', () => {
                     },
                 });
             });
+
+            it('update-token-metadata-authority', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenMetadataUpdateAuthority {
+                                        metadata {
+                                            address
+                                        }
+                                        newAuthority {
+                                            address
+                                        }
+                                        updateAuthority {
+                                            address
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        metadata: {
+                                            address: expect.any(String),
+                                        },
+                                        newAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        updateAuthority: {
+                                            address: expect.any(String),
+                                        },
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
+
+            it('emit-token-metadata', async () => {
+                expect.assertions(1);
+                const source = /* GraphQL */ `
+                    query testQuery($signature: Signature!) {
+                        transaction(signature: $signature) {
+                            message {
+                                instructions {
+                                    programId
+                                    ... on SplTokenMetadataEmit {
+                                        end
+                                        metadata {
+                                            address
+                                        }
+                                        start
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, { signature });
+                expect(result).toMatchObject({
+                    data: {
+                        transaction: {
+                            message: {
+                                instructions: expect.arrayContaining([
+                                    {
+                                        end: expect.any(BigInt),
+                                        metadata: {
+                                            address: expect.any(String),
+                                        },
+                                        programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+                                        start: expect.any(BigInt),
+                                    },
+                                ]),
+                            },
+                        },
+                    },
+                });
+            });
         });
     });
 });

--- a/packages/rpc-graphql/src/resolvers/instruction.ts
+++ b/packages/rpc-graphql/src/resolvers/instruction.ts
@@ -401,6 +401,9 @@ export const instructionResolvers = {
         hookProgramId: resolveAccount('programId'),
         mint: resolveAccount('mint'),
     },
+    SplTokenMetadataEmit: {
+        metadata: resolveAccount('metadata'),
+    },
     SplTokenMetadataInitialize: {
         metadata: resolveAccount('metadata'),
         mint: resolveAccount('mint'),
@@ -409,6 +412,11 @@ export const instructionResolvers = {
     },
     SplTokenMetadataRemoveKey: {
         metadata: resolveAccount('metadata'),
+        updateAuthority: resolveAccount('updateAuthority'),
+    },
+    SplTokenMetadataUpdateAuthority: {
+        metadata: resolveAccount('metadata'),
+        newAuthority: resolveAccount('newAuthority'),
         updateAuthority: resolveAccount('updateAuthority'),
     },
     SplTokenMetadataUpdateField: {
@@ -938,6 +946,12 @@ export const instructionResolvers = {
                     }
                     if (jsonParsedConfigs.instructionType === 'removeTokenMetadataKey') {
                         return 'SplTokenMetadataRemoveKey';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'updateTokenMetadataAuthority') {
+                        return 'SplTokenMetadataUpdateAuthority';
+                    }
+                    if (jsonParsedConfigs.instructionType === 'emitTokenMetadata') {
+                        return 'SplTokenMetadataEmit';
                     }
                 }
                 if (jsonParsedConfigs.programName === 'stake') {

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -1094,6 +1094,26 @@ export const instructionTypeDefs = /* GraphQL */ `
         updateAuthority: Account
     }
 
+    """
+    Spl Token Metadata: UpdateAuthority instruction
+    """
+    type SplTokenMetadataUpdateAuthority implements TransactionInstruction {
+        programId: Address
+        metadata: Account
+        newAuthority: Account
+        updateAuthority: Account
+    }
+
+    """
+    Spl Token Metadata: Emit instruction
+    """
+    type SplTokenMetadataEmit implements TransactionInstruction {
+        programId: Address
+        metadata: Account
+        end: BigInt
+        start: BigInt
+    }
+
     type Lockup {
         custodian: Account
         epoch: Epoch


### PR DESCRIPTION
This PR adds support for Token-2022's UpdateAuthority Emit instruction in the GraphQL schema.

Continuing work on https://github.com/solana-labs/solana-web3.js/issues/2406.