### PR TITLE
Update library readme to include extending RpcApiMethods

### DIFF
--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -410,6 +410,8 @@ This means the library can support future additions to the official [Solana JSON
 Here’s an example of how a developer at QuickNode might build a custom RPC type-spec for their in-house RPC methods:
 
 ```ts
+import { RpcApiMethods } from '@solana/web3.js';
+
 // Define the method's response payload.
 type NftCollectionDetailsApiResponse = Readonly<{
     address: string;
@@ -424,7 +426,7 @@ type NftCollectionDetailsApiResponse = Readonly<{
 }>;
 
 // Set up an interface for the request method.
-interface NftCollectionDetailsApi {
+interface NftCollectionDetailsApi extends RpcApiMethods {
     // Define the method's name, parameters and response type
     qn_fetchNFTCollectionDetails(args: { contracts: string[] }): NftCollectionDetailsApiResponse;
 }


### PR DESCRIPTION
As written there's a type error because the `createRpcApi` expects the methods object to extend `RpcApiMethods`:
<img width="1249" alt="Screenshot 2024-05-10 at 16 54 27" src="https://github.com/solana-labs/solana-web3.js/assets/1711350/03536ecc-7239-49b5-a8f2-c2545b480cb2">

This PR just updates the readme so the example `NftCollectionDetailsApi` extends `RpcApiMethods` which fixes the type error 