### PR TITLE
Simulate with max compute units, not u32::MAX

### DIFF
--- a/.changeset/chilly-seas-act.md
+++ b/.changeset/chilly-seas-act.md
@@ -1,0 +1,5 @@
+---
+"@solana/web3.js-experimental": patch
+---
+
+Simulate with the maximum quantity of compute units (1.4M) instead of `u32::MAX`

--- a/packages/library/src/__tests__/compute-limit-internal-test.ts
+++ b/packages/library/src/__tests__/compute-limit-internal-test.ts
@@ -108,7 +108,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
                             // prettier-ignore
                             new Uint8Array([
                                 0x02, // SetComputeUnitLimit instruction inde
-                                0xff, 0xff, 0xff, 0xff, // U32::MAX
+                                0xc0, 0x5c, 0x15, 0x00, // 1,400,000, MAX_COMPUTE_UNITS
                             ]),
                         programAddress: 'ComputeBudget111111111111111111111111111111',
                     },
@@ -158,7 +158,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
                         transactionMessage.instructions[0],
                         {
                             ...transactionMessage.instructions[1],
-                            data: new Uint8Array([0x02, 0xff, 0xff, 0xff, 0xff]), // Replaced with U32::MAX
+                            data: new Uint8Array([0x02, 0xc0, 0x5c, 0x15, 0x00]), // Replaced with MAX_COMPUTE_UNITS
                         },
                         transactionMessage.instructions[2],
                     ],
@@ -233,14 +233,16 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
         });
         await expect(estimatePromise).resolves.toBe(42);
     });
-    it('caps the estimated compute units to U32::MAX', async () => {
+    it('caps the estimated compute units to MAX_COMPUTE_UNITS of 1.4M', async () => {
         expect.assertions(1);
-        sendSimulateTransactionRequest.mockResolvedValue({ value: { unitsConsumed: 4294967295n /* U32::MAX + 1 */ } });
+        sendSimulateTransactionRequest.mockResolvedValue({
+            value: { unitsConsumed: 1400000n /* MAX_COMPUTE_UNITS */ },
+        });
         const estimatePromise = getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT({
             rpc,
             transactionMessage: mockTransactionMessage,
         });
-        await expect(estimatePromise).resolves.toBe(4294967295 /* U32::MAX */);
+        await expect(estimatePromise).resolves.toBe(1400000 /* MAX_COMPUTE_UNITS */);
     });
     it('throws with the cause when simulation fails', async () => {
         expect.assertions(1);

--- a/packages/library/src/compute-limit-internal.ts
+++ b/packages/library/src/compute-limit-internal.ts
@@ -141,7 +141,7 @@ export async function getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_
      */
     const existingSetComputeUnitLimitInstructionIndex =
         transactionMessage.instructions.findIndex(isSetComputeLimitInstruction);
-    const maxComputeUnitLimitInstruction = createComputeUnitLimitInstruction(4_294_967_295 /* U32::MAX */);
+    const maxComputeUnitLimitInstruction = createComputeUnitLimitInstruction(1_400_000 /* MAX_COMPUTE_UNIT_LIMIT */);
     if (existingSetComputeUnitLimitInstructionIndex === -1) {
         compilableTransactionMessage = appendTransactionMessageInstruction(
             maxComputeUnitLimitInstruction,


### PR DESCRIPTION
#### Problem

Looking through recent updates to the monorepo, this caught my eye: https://github.com/anza-xyz/agave/issues/885

The simulation utility sets `u32::MAX`, which will fail once that feature is enabled.

#### Solution

Set `MAX_COMPUTE_UNITS`, hardcoded to 1,400,000, instead of `u32::MAX`.