### PR TITLE
Repair the type of `getProgramAccounts` with respect to the `memcmp` filter

### DIFF
--- a/packages/rpc-subscriptions-api/src/__typetests__/program-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/program-notifications-type-test.ts
@@ -192,9 +192,11 @@ rpcSubscriptions
 ({
     filters: [
         {
-            bytes: 'bytes' as Base58EncodedBytes,
-            encoding: 'base58',
-            offset: 0n as U64UnsafeBeyond2Pow53Minus1,
+            memcmp: {
+                bytes: 'bytes' as Base58EncodedBytes,
+                encoding: 'base58',
+                offset: 0n as U64UnsafeBeyond2Pow53Minus1,
+            },
         },
     ],
 }) satisfies Parameters<RpcSubscriptions<ProgramNotificationsApi>['programNotifications']>[1];
@@ -202,19 +204,23 @@ rpcSubscriptions
 ({
     filters: [
         {
-            // @ts-expect-error Can't flop them
-            bytes: 'bytes' as Base58EncodedBytes,
-            encoding: 'base64',
-            offset: 0n as U64UnsafeBeyond2Pow53Minus1,
+            // @ts-expect-error Can't flop the encodings
+            memcmp: {
+                bytes: 'bytes' as Base58EncodedBytes,
+                encoding: 'base64',
+                offset: 0n as U64UnsafeBeyond2Pow53Minus1,
+            },
         },
     ],
 }) satisfies Parameters<RpcSubscriptions<ProgramNotificationsApi>['programNotifications']>[1];
 ({
     filters: [
         {
-            bytes: 'bytes' as Base64EncodedBytes,
-            encoding: 'base64',
-            offset: 0n as U64UnsafeBeyond2Pow53Minus1,
+            memcmp: {
+                bytes: 'bytes' as Base64EncodedBytes,
+                encoding: 'base64',
+                offset: 0n as U64UnsafeBeyond2Pow53Minus1,
+            },
         },
     ],
 }) satisfies Parameters<RpcSubscriptions<ProgramNotificationsApi>['programNotifications']>[1];
@@ -222,10 +228,12 @@ rpcSubscriptions
 ({
     filters: [
         {
-            // @ts-expect-error Can't flop them
-            bytes: 'bytes' as Base64EncodedBytes,
-            encoding: 'base58',
-            offset: 0n as U64UnsafeBeyond2Pow53Minus1,
+            // @ts-expect-error Can't flop the encodings
+            memcmp: {
+                bytes: 'bytes' as Base64EncodedBytes,
+                encoding: 'base58',
+                offset: 0n as U64UnsafeBeyond2Pow53Minus1,
+            },
         },
     ],
 }) satisfies Parameters<RpcSubscriptions<ProgramNotificationsApi>['programNotifications']>[1];

--- a/packages/rpc-subscriptions-api/src/program-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/program-notifications.ts
@@ -26,9 +26,7 @@ type ProgramNotificationsMemcmpFilterBase64 = Readonly<{
     offset: U64UnsafeBeyond2Pow53Minus1;
 }>;
 
-type ProgramNotificationsDatasizeFilter = Readonly<{
-    dataSize: U64UnsafeBeyond2Pow53Minus1;
-}>;
+type ProgramNotificationsDatasizeFilter = U64UnsafeBeyond2Pow53Minus1;
 
 type ProgramNotificationsApiNotificationBase<TData> = SolanaRpcResponse<
     Readonly<{
@@ -40,11 +38,10 @@ type ProgramNotificationsApiNotificationBase<TData> = SolanaRpcResponse<
 type ProgramNotificationsApiCommonConfig = Readonly<{
     commitment?: Commitment;
     // The resultant account must meet ALL filter criteria to be included in the returned results
-    filters?: readonly (
-        | ProgramNotificationsDatasizeFilter
-        | ProgramNotificationsMemcmpFilterBase58
-        | ProgramNotificationsMemcmpFilterBase64
-    )[];
+    filters?: readonly Readonly<
+        | { dataSize: ProgramNotificationsDatasizeFilter }
+        | { memcmp: ProgramNotificationsMemcmpFilterBase58 | ProgramNotificationsMemcmpFilterBase64 }
+    >[];
 }>;
 
 export interface ProgramNotificationsApi extends RpcSubscriptionsApiMethods {


### PR DESCRIPTION
This typespec was wrong. The `memcmp` filter is nested under `{ memcmp: /* ... */ }`
