### PR TITLE
docs: add example on how to use connection.confirmTransaction in the non deprecated way.

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -3724,7 +3724,17 @@ export class Connection {
     commitment?: Commitment,
   ): Promise<RpcResponseAndContext<SignatureResult>>;
 
-  /** @deprecated Instead, call `confirmTransaction` and pass in {@link TransactionConfirmationStrategy} */
+  /** @deprecated Instead, call `confirmTransaction` and pass in {@link TransactionConfirmationStrategy}
+   *  @example
+   * ``` ts
+   * const latestBlockHash = await connection.getLatestBlockhash()
+   * await connection.confirmTransaction({
+   *   blockhash: latestBlockHash.blockhash,
+   *    lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
+   *    signature: airdropSignature,
+   *   })
+   *   ```
+   */
   // eslint-disable-next-line no-dupe-class-members
   confirmTransaction(
     strategy: TransactionSignature,

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -3718,7 +3718,23 @@ export class Connection {
     }
     return res.result;
   }
-
+  /**
+   *
+   * @param strategy - {@link TransactionConfirmationStrategy} possibly blockhash or durable nonce based
+   * @param commitment - 'processed' | 'confirmed' | 'finalized' default: connection.commitment
+   * @example
+   * ``` ts
+   * const { blockhash, lastValidBlockheight } = await connection.getLatestBlockhash();
+   * const tx = new Transaction({ blockhash, lastValidBlockheight });
+   * const signature = await connection.sendTransaction(tx);
+   * const confirmationStrategy: BlockheightBasedTransactionConfirmationStrategy = {
+   *   blockhash,
+   *   lastValidBlockheight,
+   *   signature,
+   * };
+   * await connection.confirmTransaction(confirmationStrategy);
+   * ```
+   */
   confirmTransaction(
     strategy: TransactionConfirmationStrategy,
     commitment?: Commitment,

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -5537,17 +5537,18 @@ export class Connection {
   }
 
   /**
-   * Request an allocation of lamports to the specified address
+   * Requests an allocation of lamports to the specified address.
+   * You need to confirm the airdrop with `confirmTransaction()` afterwards.
    *
+   * Consider using `airdropIfRequired` provided by [@solana-developers/helpers](https://github.com/solana-developers/helpers)
+   * It takes care of confirming the airdrop.
    * ```typescript
-   * import { Connection, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
-   *
-   * (async () => {
-   *   const connection = new Connection("https://api.testnet.solana.com", "confirmed");
-   *   const myAddress = new PublicKey("2nr1bHFT86W9tGnyvmYW4vcHKsQB3sVQfnddasz4kExM");
-   *   const signature = await connection.requestAirdrop(myAddress, LAMPORTS_PER_SOL);
-   *   await connection.confirmTransaction(signature);
-   * })();
+   *   const newBalance = await airdropIfRequired(
+   *     connection,
+   *     keypair.publicKey,
+   *     0.5 * LAMPORTS_PER_SOL,
+   *     1 * LAMPORTS_PER_SOL,
+   *   );
    * ```
    */
   async requestAirdrop(

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -3724,16 +3724,17 @@ export class Connection {
     commitment?: Commitment,
   ): Promise<RpcResponseAndContext<SignatureResult>>;
 
-  /** @deprecated Instead, call `confirmTransaction` and pass in {@link TransactionConfirmationStrategy}
-   *  @example
-   * ``` ts
-   * const latestBlockHash = await connection.getLatestBlockhash()
-   * await connection.confirmTransaction({
-   *   blockhash: latestBlockHash.blockhash,
-   *    lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
-   *    signature: airdropSignature,
-   *   })
-   *   ```
+  /** @deprecated This function signature was deprecated because:
+   *
+   * Confirming a transaction using a blockhash, other than the one that was actually used in the transaction
+   * will yield incorrect information, such as ‘your blockhash is now invalid’ when it's either not or it's
+   * been invalid for quite some time.
+   *
+   * Instead, call `confirmTransaction` and pass in {@link TransactionConfirmationStrategy} .
+   *
+   * If you used this to confirm an airdrop consider using `airdropIfRequired` provided by
+   * [@solana-developers/helpers](https://github.com/solana-developers/helpers) it takes
+   * care of confirming the airdrop transaction.
    */
   // eslint-disable-next-line no-dupe-class-members
   confirmTransaction(


### PR DESCRIPTION
Added this stackexchange answer by John as a tsdoc comment so people don't need to leave their editor to find the solution. 
https://solana.stackexchange.com/questions/2839/how-to-properly-call-confirmtransaction-so-that-it-is-not-deprecated