### PR TITLE
Pull in `ReadonlyUint8Array` as a type

### DIFF
--- a/packages/compat/src/transaction.ts
+++ b/packages/compat/src/transaction.ts
@@ -3,7 +3,7 @@ import type { SignatureBytes } from '@solana/keys';
 import { type SignaturesMap, Transaction, TransactionMessageBytes } from '@solana/transactions';
 import type { PublicKey, VersionedTransaction } from '@solana/web3.js';
 
-import { ReadonlyUint8Array } from '../../codecs-core/dist/types';
+import type { ReadonlyUint8Array } from '../../codecs-core/dist/types';
 
 function convertSignatures(transaction: VersionedTransaction, staticAccountKeys: PublicKey[]): SignaturesMap {
     return Object.fromEntries(

--- a/packages/signers/src/__tests__/sign-transaction-test.ts
+++ b/packages/signers/src/__tests__/sign-transaction-test.ts
@@ -15,7 +15,7 @@ import {
     TransactionWithLifetime,
 } from '@solana/transactions';
 
-import { ReadonlyUint8Array } from '../../../codecs-core/dist/types';
+import type { ReadonlyUint8Array } from '../../../codecs-core/dist/types';
 import {
     partiallySignTransactionMessageWithSigners,
     signAndSendTransactionMessageWithSigners,

--- a/packages/signers/src/keypair-signer.ts
+++ b/packages/signers/src/keypair-signer.ts
@@ -3,7 +3,7 @@ import { SOLANA_ERROR__SIGNER__EXPECTED_KEY_PAIR_SIGNER, SolanaError } from '@so
 import { createKeyPairFromBytes, generateKeyPair, signBytes } from '@solana/keys';
 import { partiallySignTransaction } from '@solana/transactions';
 
-import { ReadonlyUint8Array } from '../../codecs-core/dist/types';
+import type { ReadonlyUint8Array } from '../../codecs-core/dist/types';
 import { isMessagePartialSigner, MessagePartialSigner } from './message-partial-signer';
 import { isTransactionPartialSigner, TransactionPartialSigner } from './transaction-partial-signer';
 

--- a/packages/transaction-confirmation/src/__tests__/waiters-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/waiters-test.ts
@@ -9,7 +9,7 @@ import {
     TransactionWithDurableNonceLifetime,
 } from '@solana/transactions/dist/types/lifetime';
 
-import { ReadonlyUint8Array } from '../../../codecs-core/dist/types';
+import type { ReadonlyUint8Array } from '../../../codecs-core/dist/types';
 import {
     waitForDurableNonceTransactionConfirmation,
     waitForRecentTransactionConfirmation,


### PR DESCRIPTION
Downstream build systems are choking on this relative import, and I'm not sure that this will fix it, but it can't hurt.
