### PR TITLE
Turbocharge the `reverseCodec()`

### DIFF
--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -33,6 +33,7 @@
         "web3"
     ],
     "scripts": {
+        "benchmark": "./src/__benchmarks__/run.ts",
         "compile:js": "tsup --config build-scripts/tsup.config.package.ts",
         "compile:typedefs": "tsc -p ./tsconfig.declarations.json",
         "dev": "jest -c ../../node_modules/@solana/test-config/jest-dev.config.ts --rootDir . --watch",
@@ -67,6 +68,9 @@
     },
     "dependencies": {
         "@solana/errors": "workspace:*"
+    },
+    "devDependencies": {
+        "tinybench": "^2.8.0"
     },
     "peerDependencies": {
         "typescript": ">=5"

--- a/packages/codecs-core/src/__benchmarks__/run.ts
+++ b/packages/codecs-core/src/__benchmarks__/run.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env -S pnpm dlx tsx
+
+import { webcrypto as crypto } from 'node:crypto';
+
+import { Bench } from 'tinybench';
+
+import { createCodec, FixedSizeCodec } from '../codec';
+import { ReadonlyUint8Array } from '../readonly-uint8array';
+import { reverseCodec } from '../reverse-codec';
+
+const bench = new Bench({
+    throws: true,
+});
+
+const noopCodec: FixedSizeCodec<ReadonlyUint8Array, ReadonlyUint8Array> = createCodec({
+    fixedSize: 32,
+    read(bytes, offset) {
+        return [bytes.slice(offset), bytes.length];
+    },
+    write(value, bytes, offset) {
+        bytes.set(value, offset);
+        return value.length + offset;
+    },
+});
+
+const bytes32 = new Uint8Array(32);
+function randomizeBytes() {
+    crypto.getRandomValues(bytes32);
+}
+
+const reverseBytes = reverseCodec(noopCodec);
+
+bench
+    .add(
+        'Decode reverse',
+        () => {
+            reverseBytes.decode(bytes32);
+        },
+        { beforeEach: randomizeBytes },
+    )
+    .add(
+        'Encode reverse',
+        () => {
+            reverseBytes.encode(bytes32);
+        },
+        { beforeEach: randomizeBytes },
+    );
+
+(async () => {
+    await bench.warmup();
+    await bench.run();
+
+    console.table(bench.table());
+})();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,10 @@ importers:
       typescript:
         specifier: '>=5'
         version: 5.4.5
+    devDependencies:
+      tinybench:
+        specifier: ^2.8.0
+        version: 2.8.0
 
   packages/codecs-data-structures:
     dependencies:


### PR DESCRIPTION
# Preamble

This is, what I hope to be, the first of many performance PRs. In general, we've prioritized correctness and readability in the codecs up until this point. The next step is to unroll that a bit to achieve great performance.

* Copy as little as possible.
  * Operate in-place wherever possible, like in this PR
  * Everywhere else, replace every possible call to `slice()` with `subarray()` which creates a new view over the same underlying data
* Do as little math as possible

# Summary

In this PR, we implement the reverse codec without using `reverse()` or cloning the source data. We instead write elements of the source into the target in reverse order.

# Results

* 7.5x speedup for decode
* 1.5x speedup for encode

## Before

```
> ./src/__benchmarks__/run.ts

┌─────────┬──────────────────┬─────────────┬───────────────────┬──────────┬─────────┐
│ (index) │ Task Name        │ ops/sec     │ Average Time (ns) │ Margin   │ Samples │
├─────────┼──────────────────┼─────────────┼───────────────────┼──────────┼─────────┤
│ 0       │ 'Decode reverse' │ '376,722'   │ 2654.4716237883   │ '±1.02%' │ 188362  │
│ 1       │ 'Encode reverse' │ '2,922,232' │ 342.2041376564442 │ '±0.10%' │ 1461117 │
└─────────┴──────────────────┴─────────────┴───────────────────┴──────────┴─────────┘
```

## After

```
> ./src/__benchmarks__/run.ts

┌─────────┬──────────────────┬─────────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name        │ ops/sec     │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼──────────────────┼─────────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'Decode reverse' │ '2,961,665' │ 337.6479015528495  │ '±1.24%' │ 1480833 │
│ 1       │ 'Encode reverse' │ '4,234,486' │ 236.15613552370152 │ '±0.11%' │ 2117244 │
└─────────┴──────────────────┴─────────────┴────────────────────┴──────────┴─────────┘
```