### PR TITLE
fix: Remove negative lookbehind from getHumanReadableErrorMessage regex

### DIFF
--- a/packages/errors/src/__tests__/message-formatter-test.ts
+++ b/packages/errors/src/__tests__/message-formatter-test.ts
@@ -94,6 +94,20 @@ describe('getErrorMessage', () => {
             );
             expect(message).toBe("Something awful happened: 'bar'. How awful!");
         });
+        it('does not interpolate escaped variables', () => {
+            const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
+            messagesSpy.mockReturnValue({
+                // @ts-expect-error Mock error config doesn't conform to exported config.
+                123: 'Here is a $variable and here is a \\$escapedVariable.',
+            });
+            const message = getErrorMessage(
+                // @ts-expect-error Mock error config doesn't conform to exported config.
+                123,
+                { escapedVariable: 'bar', variable: 'foo' },
+            );
+            // prettier-ignore
+            expect(message).toBe('Here is a foo and here is a \\$escapedVariable.');
+        });
         it('interpolates a Uint8Array variable into a error message format string', () => {
             const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
             messagesSpy.mockReturnValue({

--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -7,9 +7,12 @@ export function getHumanReadableErrorMessage<TErrorCode extends SolanaErrorCode>
     context: object = {},
 ): string {
     const messageFormatString = SolanaErrorMessages[code];
-    const message = messageFormatString.replace(/(?<!\\)\$(\w+)/g, (substring, variableName) =>
-        variableName in context ? `${context[variableName as keyof typeof context]}` : substring,
-    );
+    const message = messageFormatString.replace(/\\?\$(\w+)/g, (substring, variableName) => {
+        if (substring.startsWith('\\') || !(variableName in context)) {
+            return substring;
+        }
+        return context[variableName as keyof typeof context];
+    });
     return message;
 }
 


### PR DESCRIPTION
Currently, the regex inside `getHumanReadableErrorMessage` in `@solana/errors` contains a negative lookbehind (`?<!`). When this regex is loaded into `iOS` browsers on `iOS < 16.4`, it breaks, as the lookbehind support in Javascript regex is relatively new. 

We discovered this when http://www.magiceden.io was broken for a number of iOS users, and patching the lookbehind regex was the fix. However it would be best if this could be patched at the source (here). 

In this PR we modify `getHumanReadableErrorMessage` to remove the negative lookbehind and replace it with a custom backslash check, and added a custom unit test for this case. 

(It is also worth noting that none of the error messages inside `SolanaErrorMessages` contain a backslash, I just wanted o keep the semantics the same)


More info about negative lookbehind iOS compatibility here:
* https://caniuse.com/js-regexp-lookbehind
* https://bugs.webkit.org/show_bug.cgi?id=174931