### PR TITLE
Allow RpcRequest params to be of any type, instead of requiring an array

### DIFF
--- a/.changeset/unlucky-pumpkins-itch.md
+++ b/.changeset/unlucky-pumpkins-itch.md
@@ -1,0 +1,5 @@
+---
+"@solana/rpc-spec": patch
+---
+
+Allow Rpc Request params to be any type, instead of requiring an array

--- a/packages/rpc-spec/src/rpc-api.ts
+++ b/packages/rpc-spec/src/rpc-api.ts
@@ -3,7 +3,7 @@ import { Callable } from '@solana/rpc-spec-types';
 import { RpcRequest } from './rpc-request';
 
 export type RpcApiConfig = Readonly<{
-    parametersTransformer?: <T extends unknown[]>(params: T, methodName: string) => unknown[];
+    parametersTransformer?: <T extends unknown[]>(params: T, methodName: string) => unknown;
     responseTransformer?: <T>(response: unknown, methodName: string) => T;
 }>;
 

--- a/packages/rpc-spec/src/rpc-request.ts
+++ b/packages/rpc-spec/src/rpc-request.ts
@@ -1,6 +1,6 @@
 export type RpcRequest<TResponse> = {
     methodName: string;
-    params: unknown[];
+    params: unknown;
     responseTransformer?: (response: unknown, methodName: string) => TResponse;
 };
 


### PR DESCRIPTION
This provides flexibility for APIs that do not use an array of params. For example Helius' non-standard APIs expect `params` to be an object and don't use an array wrapper, like this:

```json
{
    "jsonrpc": "2.0",
    "id": "text",
    "method": "getTokenAccounts",
    "params": {
        "owner": "some-address",
        "limit": 100
    }
}
```

This can be handled with a `parametersTransformer`:

```ts
const api = createRpcApi<HeliusDasApi>({
    parametersTransformer: (params) => params[0],
});
```

But currently this is a type error, because `parametersTransformer` is required to return `unknown[]`. This PR allows it to just return `unknown` so that the above is no longer a type error. 