### PR TITLE
feat(simulated_transaction): Add Inner Instructions

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -1004,17 +1004,21 @@ const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
         }),
       ),
     ),
-    innerInstructions: optional(nullable(array(
-      pick({
-        index: number(),
-        instructions: array(
-          union([
-            ParsedInstructionStruct,
-            PartiallyDecodedInstructionStruct,
-          ]),
+    innerInstructions: optional(
+      nullable(
+        array(
+          pick({
+            index: number(),
+            instructions: array(
+              union([
+                ParsedInstructionStruct,
+                PartiallyDecodedInstructionStruct,
+              ]),
+            ),
+          }),
         ),
-      }),
-    ))),
+      ),
+    ),
   }),
 );
 
@@ -5738,7 +5742,11 @@ export class Connection {
         config.commitment = this.commitment;
       }
 
-      if (configOrSigners && typeof configOrSigners === 'object' && 'innerInstructions' in configOrSigners) {
+      if (
+        configOrSigners &&
+        typeof configOrSigners === 'object' &&
+        'innerInstructions' in configOrSigners
+      ) {
         config.innerInstructions = configOrSigners.innerInstructions;
       }
 
@@ -5832,7 +5840,11 @@ export class Connection {
       config.sigVerify = true;
     }
 
-    if (configOrSigners && typeof configOrSigners === 'object' && 'innerInstructions' in configOrSigners) {
+    if (
+      configOrSigners &&
+      typeof configOrSigners === 'object' &&
+      'innerInstructions' in configOrSigners
+    ) {
       config.innerInstructions = configOrSigners.innerInstructions;
     }
 

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -979,7 +979,7 @@ const PartiallyDecodedInstructionStruct = pick({
 const ParsedInnerInstructionStruct = pick({
   index: number(),
   instructions: array(
-    union([ParsedInstructionStruct, PartiallyDecodedInstructionStruct])
+    union([ParsedInstructionStruct, PartiallyDecodedInstructionStruct]),
   ),
 });
 
@@ -997,10 +997,10 @@ const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
               lamports: number(),
               data: array(string()),
               rentEpoch: optional(number()),
-            })
-          )
-        )
-      )
+            }),
+          ),
+        ),
+      ),
     ),
     unitsConsumed: optional(number()),
     returnData: optional(
@@ -1008,11 +1008,11 @@ const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
         pick({
           programId: string(),
           data: tuple([string(), literal('base64')]),
-        })
-      )
+        }),
+      ),
     ),
     innerInstructions: optional(nullable(array(ParsedInnerInstructionStruct))),
-  })
+  }),
 );
 
 export type ParsedInnerInstruction = {
@@ -5723,7 +5723,8 @@ export class Connection {
     if ('message' in transactionOrMessage) {
       const versionedTx = transactionOrMessage;
       const wireTransaction = versionedTx.serialize();
-      const encodedTransaction = Buffer.from(wireTransaction).toString('base64');
+      const encodedTransaction =
+        Buffer.from(wireTransaction).toString('base64');
       if (Array.isArray(configOrSigners) || includeAccounts !== undefined) {
         throw new Error('Invalid arguments');
       }

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -967,7 +967,7 @@ export type SimulatedTransactionResponse = {
 const ParsedInstructionStruct = pick({
   program: string(),
   programId: PublicKeyFromString,
-  parsed: any(),
+  parsed: unknown(),
 });
 
 const PartiallyDecodedInstructionStruct = pick({
@@ -1208,7 +1208,7 @@ export type ParsedInstruction = {
   /** ID of the program for this instruction */
   programId: PublicKey;
   /** Parsed instruction info */
-  parsed?: any;
+  parsed: any;
 };
 
 /**

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -952,7 +952,7 @@ export type SimulateTransactionConfig = {
   };
   /** Optional parameter used to specify the minimum block slot that can be used for simulation */
   minContextSlot?: number;
-  /** Optional parameter used to include inner instructions in the response */
+  /** Optional parameter used to include inner instructions in the simulation */
   innerInstructions?: boolean;
 };
 

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -956,87 +956,24 @@ export type SimulateTransactionConfig = {
   innerInstructions?: boolean;
 };
 
-export type ParsedInnerInstruction = {
-  index: number;
-  instructions: UiInstruction[];
-};
-
-export type UiCompiledInstruction = {
-  programIdIndex: number;
-  accounts: number[];
-  data: string;
-  stackHeight?: number;
-};
-
-export type UiParsedInstruction = {
-  program: string;
-  programId: PublicKey;
-  parsed: {
-    info: any;
-    type: string;
-  };
-  stackHeight?: number;
-};
-
-export type UiPartiallyDecodedInstruction = {
-  programId: string;
-  accounts: string[];
-  data: string;
-  stackHeight?: number;
-};
-
-export type UiInstruction =
-  | { type: 'Compiled'; value: UiCompiledInstruction }
-  | { type: 'Parsed'; value: UiParsedInstruction }
-  | { type: 'PartiallyDecoded'; value: UiPartiallyDecodedInstruction };
-
-export type UiInnerInstructions = {
-  index: number;
-  instructions: UiInstruction[];
-};
-
 export type SimulatedTransactionResponse = {
   err: TransactionError | string | null;
   logs: Array<string> | null;
   accounts?: (SimulatedTransactionAccountInfo | null)[] | null;
   unitsConsumed?: number;
   returnData?: TransactionReturnData | null;
-  innerInstructions?: UiInnerInstructions[] | null;
+  innerInstructions?: ParsedInnerInstruction[] | null;
 };
-
-const UiCompiledInstructionStruct = pick({
-  programIdIndex: number(),
-  accounts: array(number()),
-  data: string(),
-  stackHeight: optional(number()),
-});
-
-const UiParsedInstructionStruct = pick({
+const ParsedInstructionStruct = pick({
   program: string(),
   programId: PublicKeyFromString,
-  parsed: pick({
-    info: any(),
-    type: string(),
-  }),
-  stackHeight: optional(number()),
+  parsed: any(),
 });
 
-const UiPartiallyDecodedInstructionStruct = pick({
-  programId: string(),
-  accounts: array(string()),
+const PartiallyDecodedInstructionStruct = pick({
+  programId: PublicKeyFromString,
+  accounts: array(PublicKeyFromString),
   data: string(),
-  stackHeight: optional(number()),
-});
-
-const UiInstructionStruct = union([
-  pick({ type: literal('Compiled'), value: UiCompiledInstructionStruct }),
-  pick({ type: literal('Parsed'), value: UiParsedInstructionStruct }),
-  pick({ type: literal('PartiallyDecoded'), value: UiPartiallyDecodedInstructionStruct }),
-]);
-
-const UiInnerInstructionsStruct = pick({
-  index: number(),
-  instructions: array(UiInstructionStruct),
 });
 
 const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
@@ -1067,9 +1004,24 @@ const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
         }),
       ),
     ),
-    innerInstructions: optional(array(UiInnerInstructionsStruct)),
+    innerInstructions: optional(nullable(array(
+      pick({
+        index: number(),
+        instructions: array(
+          union([
+            ParsedInstructionStruct,
+            PartiallyDecodedInstructionStruct,
+          ]),
+        ),
+      }),
+    ))),
   }),
 );
+
+export type ParsedInnerInstruction = {
+  index: number;
+  instructions: (ParsedInstruction | PartiallyDecodedInstruction)[];
+};
 
 export type TokenBalance = {
   accountIndex: number;

--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -956,31 +956,81 @@ export type SimulateTransactionConfig = {
   innerInstructions?: boolean;
 };
 
+export type UiCompiledInstruction = {
+  programIdIndex: number;
+  accounts: number[];
+  data: string;
+  stackHeight?: number;
+};
+
+export type UiParsedInstruction = {
+  program: string;
+  programId: PublicKey;
+  parsed?: any;
+};
+
+export type UiPartiallyDecodedInstruction = {
+  programId: string;
+  accounts: string[];
+  data: string;
+  stackHeight?: number;
+};
+
+export type UiInstruction =
+  | {type: 'Compiled'; value: UiCompiledInstruction}
+  | {
+      type: 'Parsed';
+      value: UiParsedInstruction | UiPartiallyDecodedInstruction;
+    };
+
+export type UiInnerInstructions = {
+  index: number;
+  instructions: UiInstruction[];
+};
+
+export type ParsedNewInnerInstruction = {
+  index: number;
+  instructions: UiInstruction[];
+};
+
 export type SimulatedTransactionResponse = {
   err: TransactionError | string | null;
   logs: Array<string> | null;
   accounts?: (SimulatedTransactionAccountInfo | null)[] | null;
   unitsConsumed?: number;
   returnData?: TransactionReturnData | null;
-  innerInstructions?: ParsedInnerInstruction[] | null;
+  innerInstructions?: ParsedNewInnerInstruction[] | null;
 };
-const ParsedInstructionStruct = pick({
+const UiCompiledInstructionStruct = pick({
+  programIdIndex: number(),
+  accounts: array(number()),
+  data: string(),
+  stackHeight: optional(number()),
+});
+const UiParsedInstructionStruct = pick({
   program: string(),
   programId: PublicKeyFromString,
   parsed: optional(any()),
 });
-
-const PartiallyDecodedInstructionStruct = pick({
-  programId: PublicKeyFromString,
-  accounts: array(PublicKeyFromString),
+const UiPartiallyDecodedInstructionStruct = pick({
+  programId: string(),
+  accounts: array(string()),
   data: string(),
+  stackHeight: optional(number()),
 });
-
-const ParsedInnerInstructionStruct = pick({
+const UiInstructionStruct = union([
+  pick({type: literal('Compiled'), value: UiCompiledInstructionStruct}),
+  pick({
+    type: literal('Parsed'),
+    value: union([
+      UiParsedInstructionStruct,
+      UiPartiallyDecodedInstructionStruct,
+    ]),
+  }),
+]);
+const UiInnerInstructionsStruct = pick({
   index: number(),
-  instructions: array(
-    union([ParsedInstructionStruct, PartiallyDecodedInstructionStruct]),
-  ),
+  instructions: array(UiInstructionStruct),
 });
 
 const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
@@ -1011,7 +1061,7 @@ const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
         }),
       ),
     ),
-    innerInstructions: optional(nullable(array(ParsedInnerInstructionStruct))),
+    innerInstructions: optional(array(UiInnerInstructionsStruct)),
   }),
 );
 


### PR DESCRIPTION
This PR aims to address the issue I've outlined in #2755 where the `innerInstructions` parameter is missing for transaction simulations