### PR TITLE
chore: rename transactionLogs back to logs

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -5787,7 +5787,7 @@ export class Connection {
         action: 'simulate',
         signature: '',
         transactionMessage: res.error.message,
-        transactionLogs: logs,
+        logs: logs,
       });
     }
     return res.result;
@@ -5928,7 +5928,7 @@ export class Connection {
         action: skipPreflight ? 'send' : 'simulate',
         signature: '',
         transactionMessage: res.error.message,
-        transactionLogs: logs,
+        logs: logs,
       });
     }
     return res.result;


### PR DESCRIPTION
The rename to transactionLogs was breaking a downstream test and is not really necessary to be renamed.