### PR TITLE
[2] fix: Remove negative lookbehind from getHumanReadableErrorMessage regex

### DIFF
--- a/packages/errors/src/__tests__/message-formatter-test.ts
+++ b/packages/errors/src/__tests__/message-formatter-test.ts
@@ -85,14 +85,14 @@ describe('getErrorMessage', () => {
             const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
             messagesSpy.mockReturnValue({
                 // @ts-expect-error Mock error config doesn't conform to exported config.
-                123: "Something $severity happened: '$foo'. How $severity!",
+                123: "Something $severity happened: '$foo'. How \\\\$severity\\\\ is the \\$severity!",
             });
             const message = getErrorMessage(
                 // @ts-expect-error Mock error context doesn't conform to exported context.
                 123,
                 { foo: 'bar', severity: 'awful' },
             );
-            expect(message).toBe("Something awful happened: 'bar'. How awful!");
+            expect(message).toBe("Something awful happened: 'bar'. How \\awful\\ is the $severity!");
         });
         it('interpolates a Uint8Array variable into a error message format string', () => {
             const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');

--- a/packages/errors/src/__tests__/message-formatter-test.ts
+++ b/packages/errors/src/__tests__/message-formatter-test.ts
@@ -85,6 +85,19 @@ describe('getErrorMessage', () => {
             const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
             messagesSpy.mockReturnValue({
                 // @ts-expect-error Mock error config doesn't conform to exported config.
+                123: "Something $severity happened: '$foo'. How $severity!",
+            });
+            const message = getErrorMessage(
+                // @ts-expect-error Mock error context doesn't conform to exported context.
+                123,
+                { foo: 'bar', severity: 'awful' },
+            );
+            expect(message).toBe("Something awful happened: 'bar'. How awful!");
+        });
+        it('interpolates escaped variables into a error message format string', () => {
+            const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
+            messagesSpy.mockReturnValue({
+                // @ts-expect-error Mock error config doesn't conform to exported config.
                 123: "Something $severity happened: '$foo'. How \\\\$severity\\\\ is the \\$severity!",
             });
             const message = getErrorMessage(

--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -11,7 +11,7 @@ export function getHumanReadableErrorMessage<TErrorCode extends SolanaErrorCode>
     const message = messageFormatString.replace(/\\?\$(\w+)(\\){0,1}/g, (substring, variableName) => {
         // If not escaped, return the variable :: e.g. $foo => bar
         if (!substring.startsWith('\\')) {
-            return context[variableName as keyof typeof context];
+            return variableName in context ? `${context[variableName as keyof typeof context]}` : substring;
         }
 
         /**


### PR DESCRIPTION
Trying to fix the issue mentioned here : https://github.com/solana-labs/solana-web3.js/pull/2745

This is me attempting to speed up getting a patch through because this is resulting in some bugs in production which are hard to resolve due to the nested dependencies on the currently broken version of solana-web3.js

I tried to incorporate the changes from the above PR, while addressing the changes requested in [this comment](https://github.com/solana-labs/solana-web3.js/pull/2745#pullrequestreview-2089069306). I don't know enough about the context of the code to be 100% sure that this provides the exact expected functionality, but it passes the given unit tests.

cc: @steveluscher