### PR TITLE
fix: Rewrite the message printer as a parser to avoid problems with regexes in old browsers

### DIFF
--- a/.changeset/proud-poems-try.md
+++ b/.changeset/proud-poems-try.md
@@ -1,0 +1,5 @@
+---
+"@solana/errors": patch
+---
+
+The development mode error message printer no longer fatals on Safari < 16.4.

--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -2,15 +2,83 @@ import { SolanaErrorCode } from './codes';
 import { encodeContextObject } from './context';
 import { SolanaErrorMessages } from './messages';
 
+const enum StateType {
+    EscapeSequence,
+    Text,
+    Variable,
+}
+type State = Readonly<{
+    [START_INDEX]: number;
+    [TYPE]: StateType;
+}>;
+const START_INDEX = 'i';
+const TYPE = 't';
+
 export function getHumanReadableErrorMessage<TErrorCode extends SolanaErrorCode>(
     code: TErrorCode,
     context: object = {},
 ): string {
     const messageFormatString = SolanaErrorMessages[code];
-    const message = messageFormatString.replace(/(?<!\\)\$(\w+)/g, (substring, variableName) =>
-        variableName in context ? `${context[variableName as keyof typeof context]}` : substring,
-    );
-    return message;
+    if (messageFormatString.length === 0) {
+        return '';
+    }
+    let state: State;
+    function commitStateUpTo(endIndex?: number) {
+        if (state[TYPE] === StateType.Variable) {
+            const variableName = messageFormatString.slice(state[START_INDEX] + 1, endIndex);
+            fragments.push(
+                variableName in context ? `${context[variableName as keyof typeof context]}` : `$${variableName}`,
+            );
+        } else if (state[TYPE] === StateType.Text) {
+            fragments.push(messageFormatString.slice(state[START_INDEX], endIndex));
+        }
+    }
+    const fragments: string[] = [];
+    messageFormatString.split('').forEach((char, ii) => {
+        if (ii === 0) {
+            state = {
+                [START_INDEX]: 0,
+                [TYPE]:
+                    messageFormatString[0] === '\\'
+                        ? StateType.EscapeSequence
+                        : messageFormatString[0] === '$'
+                          ? StateType.Variable
+                          : StateType.Text,
+            };
+            return;
+        }
+        let nextState;
+        switch (state[TYPE]) {
+            case StateType.EscapeSequence:
+                nextState = { [START_INDEX]: ii, [TYPE]: StateType.Text };
+                break;
+            case StateType.Text:
+                if (char === '\\') {
+                    nextState = { [START_INDEX]: ii, [TYPE]: StateType.EscapeSequence };
+                } else if (char === '$') {
+                    nextState = { [START_INDEX]: ii, [TYPE]: StateType.Variable };
+                }
+                break;
+            case StateType.Variable:
+                if (char === '\\') {
+                    nextState = { [START_INDEX]: ii, [TYPE]: StateType.EscapeSequence };
+                } else if (char === '$') {
+                    commitStateUpTo(ii);
+                    nextState = { [START_INDEX]: ii, [TYPE]: StateType.Variable };
+                } else if (!char.match(/\w/)) {
+                    nextState = { [START_INDEX]: ii, [TYPE]: StateType.Text };
+                }
+                break;
+        }
+        if (nextState) {
+            if (state[TYPE] !== nextState[TYPE]) {
+                commitStateUpTo(ii);
+            }
+            state = nextState;
+        }
+    });
+    commitStateUpTo();
+    return fragments.join('');
 }
 
 export function getErrorMessage<TErrorCode extends SolanaErrorCode>(code: TErrorCode, context: object = {}): string {


### PR DESCRIPTION
# Summary

@C-o-d-e-C-o-w-b-o-y and @lukecaan noticed that negative lookbehinds crash old versions of Safari (#2745).

This PR reimplements the message printer as a parser.

# Test plan

```
cd packages/errors/
pnpm turbo test:unit:node test:unit:browser
```