### PR TITLE
refactor(experimental): graphql: patch `onlyFieldsRequested` for GraphQL default fields

### DIFF
--- a/packages/rpc-graphql/src/resolvers/resolve-info/visitor.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/visitor.ts
@@ -62,6 +62,10 @@ export function onlyFieldsRequested(fieldNames: string[], info: GraphQLResolveIn
     function checkFieldsWithVisitor(root: RootNode | null) {
         injectableRootVisitor(info, root, {
             fieldNodeOperation(_info, node) {
+                // Ignore the GraphQL default fields.
+                if (node.name.value === '__id' || node.name.value === '__typename') {
+                    return;
+                }
                 onlyFieldsRequested = fieldNames.includes(node.name.value);
                 if (!onlyFieldsRequested) {
                     return BREAK;


### PR DESCRIPTION
As mentioned in [this review comment](https://github.com/solana-labs/solana-web3.js/pull/2643#discussion_r1597258324), the `onlyFieldsRequested` visitor
check - which evaluates if a query has only requested fields matching some
set of field names - is not configured to ignore GraphQL's default fields, such
as `__id` and `__typename`.

This PR adds those fields to the helper's "ignore list".