### PR TITLE
refactor(experimental): graphql: export components for stitching schema

### DIFF
--- a/packages/rpc-graphql/README.md
+++ b/packages/rpc-graphql/README.md
@@ -35,7 +35,7 @@ for use in order to properly execute all queries.
 Rpc<GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi>;
 ```
 
-To initialize the RPC-GraphQL client, simple use `createRpcGraphQL`.
+To initialize the RPC-GraphQL client, simple use `createSolanaRpcGraphQL`.
 
 ```ts
 import { createSolanaRpc } from '@solana/rpc';
@@ -44,7 +44,7 @@ import { createSolanaRpc } from '@solana/rpc';
 const rpc = createSolanaRpc('https://api.devnet.solana.com');
 
 // Create the RPC-GraphQL client
-const rpcGraphQL = createRpcGraphQL(rpc);
+const rpcGraphQL = createSolanaRpcGraphQL(rpc);
 ```
 
 The `RpcGraphQL` type supports one method `query` which accepts a string

--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -7,7 +7,7 @@ import {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../index';
 import { createLocalhostSolanaRpc } from './__setup__';
 
 type GraphQLCompliantRpc = Rpc<
@@ -19,7 +19,7 @@ describe('account', () => {
     let rpcGraphQL: RpcGraphQL;
     beforeEach(() => {
         rpc = createLocalhostSolanaRpc();
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
 
     describe('basic queries', () => {

--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -8,7 +8,7 @@ import {
 } from '@solana/rpc';
 import type { Slot } from '@solana/rpc-types';
 
-import { createRpcGraphQL, RpcGraphQL } from '../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../index';
 import { mockBlockFull, mockBlockFullBase58, mockBlockFullBase64, mockBlockSignatures } from './__setup__';
 
 type GraphQLCompliantRpc = Rpc<
@@ -37,7 +37,7 @@ describe('block', () => {
                 return target[p as keyof GraphQLCompliantRpc];
             },
         });
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
     describe('basic queries', () => {
         it("can query a block's block time", async () => {

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -7,7 +7,7 @@ import {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../index';
 import { createLocalhostSolanaRpc } from './__setup__';
 
 type GraphQLCompliantRpc = Rpc<
@@ -19,7 +19,7 @@ describe('programAccounts', () => {
     let rpcGraphQL: RpcGraphQL;
     beforeEach(() => {
         rpc = createLocalhostSolanaRpc();
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
 
     describe('basic queries', () => {

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -8,7 +8,7 @@ import {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../index';
 import {
     mockTransactionAddressLookup,
     mockTransactionBase58,
@@ -48,7 +48,7 @@ describe('transaction', () => {
                 return target[p as keyof GraphQLCompliantRpc];
             },
         });
-        rpcGraphQL = createRpcGraphQL(mockRpc);
+        rpcGraphQL = createSolanaRpcGraphQL(mockRpc);
     });
 
     describe('basic queries', () => {

--- a/packages/rpc-graphql/src/index.ts
+++ b/packages/rpc-graphql/src/index.ts
@@ -12,18 +12,23 @@ export interface RpcGraphQL {
     ): ReturnType<typeof graphql>;
 }
 
+/**
+ * Create a GraphQL RPC client resolver.
+ *
+ * @param rpc       Solana RPC client.
+ * @param schema    GraphQL schema.
+ * @param config    Optional GraphQL resolver configurations.
+ * @returns         GraphQL RPC client resolver.
+ */
 export function createRpcGraphQL(
     rpc: Parameters<typeof createSolanaGraphQLContext>[0],
+    schema: ReturnType<typeof makeExecutableSchema>,
     config?: Partial<Parameters<typeof createSolanaGraphQLContext>[1]>,
 ): RpcGraphQL {
     const rpcGraphQLConfig = {
         maxDataSliceByteRange: config?.maxDataSliceByteRange ?? 200,
         maxMultipleAccountsBatchSize: config?.maxMultipleAccountsBatchSize ?? 100,
     };
-    const schema = makeExecutableSchema({
-        resolvers: createSolanaGraphQLTypeResolvers(),
-        typeDefs: createSolanaGraphQLTypeDefs(),
-    });
     return {
         async query(source, variableValues?) {
             const contextValue = createSolanaGraphQLContext(rpc, rpcGraphQLConfig);
@@ -36,3 +41,25 @@ export function createRpcGraphQL(
         },
     };
 }
+
+/**
+ * Create a Solana GraphQL RPC client resolver.
+ *
+ * Configures the client resolver to use the default Solana GraphQL schema.
+ *
+ * @param rpc       Solana RPC client.
+ * @param config    Optional GraphQL resolver configurations.
+ * @returns         Solana GraphQL RPC client resolver.
+ */
+export function createSolanaRpcGraphQL(
+    rpc: Parameters<typeof createSolanaGraphQLContext>[0],
+    config?: Partial<Parameters<typeof createSolanaGraphQLContext>[1]>,
+): RpcGraphQL {
+    const schema = makeExecutableSchema({
+        resolvers: createSolanaGraphQLTypeResolvers(),
+        typeDefs: createSolanaGraphQLTypeDefs(),
+    });
+    return createRpcGraphQL(rpc, schema, config);
+}
+
+export { createSolanaGraphQLTypeDefs, createSolanaGraphQLTypeResolvers };

--- a/packages/rpc-graphql/src/loaders/__tests__/account-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/account-loader-test.ts
@@ -7,7 +7,7 @@ import type {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../../index';
 
 const FOREVER_PROMISE = new Promise(() => {
     /* never resolve */
@@ -34,7 +34,7 @@ describe('account loader', () => {
             getProgramAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
             getTransaction: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
         };
-        rpcGraphQL = createRpcGraphQL(
+        rpcGraphQL = createSolanaRpcGraphQL(
             rpc as unknown as Rpc<
                 GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi
             >,
@@ -556,7 +556,7 @@ describe('account loader', () => {
             it('breaks multiple account requests into multiple `getMultipleAccounts` requests if the batch limit is exceeded', async () => {
                 expect.assertions(3);
 
-                rpcGraphQL = createRpcGraphQL(
+                rpcGraphQL = createSolanaRpcGraphQL(
                     rpc as unknown as Rpc<
                         GetAccountInfoApi &
                             GetBlockApi &
@@ -1265,7 +1265,7 @@ describe('account loader', () => {
                 it('splits multiple data slice requests beyond a provided byte limit into two requests', async () => {
                     expect.assertions(3);
                     const maxDataSliceByteRange = 100;
-                    rpcGraphQL = createRpcGraphQL(
+                    rpcGraphQL = createSolanaRpcGraphQL(
                         rpc as unknown as Rpc<
                             GetAccountInfoApi &
                                 GetBlockApi &
@@ -1427,7 +1427,7 @@ describe('account loader', () => {
                 it('honors a provided byte limit across encodings', async () => {
                     expect.assertions(5);
                     const maxDataSliceByteRange = 100;
-                    rpcGraphQL = createRpcGraphQL(
+                    rpcGraphQL = createSolanaRpcGraphQL(
                         rpc as unknown as Rpc<
                             GetAccountInfoApi &
                                 GetBlockApi &

--- a/packages/rpc-graphql/src/loaders/__tests__/block-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/block-loader-test.ts
@@ -8,7 +8,7 @@ import type {
 } from '@solana/rpc';
 import type { Slot } from '@solana/rpc-types';
 
-import { createRpcGraphQL, RpcGraphQL } from '../../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../../index';
 
 const FOREVER_PROMISE = new Promise(() => {
     /* never resolve */
@@ -29,7 +29,7 @@ describe('account loader', () => {
             getProgramAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
             getTransaction: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
         };
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
     describe('cached responses', () => {
         it('coalesces multiple requests for the same block into one', async () => {

--- a/packages/rpc-graphql/src/loaders/__tests__/program-accounts-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/program-accounts-loader-test.ts
@@ -7,7 +7,7 @@ import type {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../../index';
 
 const FOREVER_PROMISE = new Promise(() => {
     /* never resolve */
@@ -28,7 +28,7 @@ describe('account loader', () => {
             getProgramAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
             getTransaction: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
         };
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
     describe('cached responses', () => {
         it('coalesces multiple requests for the same program into one', async () => {

--- a/packages/rpc-graphql/src/loaders/__tests__/transaction-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/transaction-loader-test.ts
@@ -7,7 +7,7 @@ import type {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../../index';
 
 const FOREVER_PROMISE = new Promise(() => {
     /* never resolve */
@@ -28,7 +28,7 @@ describe('account loader', () => {
             getProgramAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
             getTransaction: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
         };
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
     describe('cached responses', () => {
         it('coalesces multiple requests for the same transaction into one', async () => {

--- a/packages/rpc-graphql/src/resolvers/__tests__/account-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/account-resolver-test.ts
@@ -8,7 +8,7 @@ import type {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../../index';
 
 const FOREVER_PROMISE = new Promise(() => {
     /* never resolve */
@@ -43,7 +43,7 @@ describe('account resolver', () => {
             getProgramAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
             getTransaction: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
         };
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
     describe('address-only requests', () => {
         describe('in the first level', () => {

--- a/packages/rpc-graphql/src/resolvers/__tests__/block-inputs-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/block-inputs-test.ts
@@ -7,7 +7,7 @@ import {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../..';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../..';
 import { mockBlockFull } from '../../__tests__/__setup__';
 
 type GraphQLCompliantRpc = Rpc<
@@ -34,7 +34,7 @@ describe('block inputs', () => {
                 return target[p as keyof GraphQLCompliantRpc];
             },
         });
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
     // Does not accept raw bigint, ie. 511226n
     it('can accept a bigint parameter as variable', async () => {

--- a/packages/rpc-graphql/src/resolvers/__tests__/block-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/block-resolver-test.ts
@@ -8,7 +8,7 @@ import type {
 } from '@solana/rpc';
 import type { Slot } from '@solana/rpc-types';
 
-import { createRpcGraphQL, RpcGraphQL } from '../../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../../index';
 
 const FOREVER_PROMISE = new Promise(() => {
     /* never resolve */
@@ -29,7 +29,7 @@ describe('block resolver', () => {
             getProgramAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
             getTransaction: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
         };
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
     describe('fragment spreads', () => {
         it('will resolve fields from fragment spreads', async () => {

--- a/packages/rpc-graphql/src/resolvers/__tests__/program-accounts-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/program-accounts-resolver-test.ts
@@ -7,7 +7,7 @@ import type {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../../index';
 
 const FOREVER_PROMISE = new Promise(() => {
     /* never resolve */
@@ -25,7 +25,7 @@ describe('program accounts resolver', () => {
             getProgramAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
             getTransaction: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
         };
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
     describe('inline fragments', () => {
         it('will resolve inline fragments with `jsonParsed` when `jsonParsed` fields are requested', async () => {

--- a/packages/rpc-graphql/src/resolvers/__tests__/transaction-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/transaction-resolver-test.ts
@@ -7,7 +7,7 @@ import type {
     Rpc,
 } from '@solana/rpc';
 
-import { createRpcGraphQL, RpcGraphQL } from '../../index';
+import { createSolanaRpcGraphQL, RpcGraphQL } from '../../index';
 
 const FOREVER_PROMISE = new Promise(() => {
     /* never resolve */
@@ -27,7 +27,7 @@ describe('transaction resolver', () => {
             getProgramAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
             getTransaction: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
         };
-        rpcGraphQL = createRpcGraphQL(rpc);
+        rpcGraphQL = createSolanaRpcGraphQL(rpc);
     });
     describe('fragment spreads', () => {
         it('will resolve fields from fragment spreads', async () => {

--- a/packages/rpc-graphql/src/schema/type-defs/index.ts
+++ b/packages/rpc-graphql/src/schema/type-defs/index.ts
@@ -5,6 +5,11 @@ import { rootTypeDefs } from './root';
 import { transactionTypeDefs } from './transaction';
 import { typeTypeDefs } from './types';
 
+/**
+ * Creates the GraphQL type definitions for the Solana GraphQL schema.
+ *
+ * @returns     Solana GraphQL type definitions.
+ */
 export function createSolanaGraphQLTypeDefs() {
     return [accountTypeDefs, blockTypeDefs, instructionTypeDefs, rootTypeDefs, typeTypeDefs, transactionTypeDefs];
 }

--- a/packages/rpc-graphql/src/schema/type-resolvers/index.ts
+++ b/packages/rpc-graphql/src/schema/type-resolvers/index.ts
@@ -7,6 +7,11 @@ import { rootTypeResolvers } from './root';
 import { transactionTypeResolvers } from './transaction';
 import { typeTypeResolvers } from './types';
 
+/**
+ * Create the GraphQL type resolvers for the Solana GraphQL schema.
+ *
+ * @returns     Solana GraphQL type resolvers.
+ */
 export function createSolanaGraphQLTypeResolvers(): Parameters<typeof makeExecutableSchema>[0]['resolvers'] {
     return {
         ...accountTypeResolvers,


### PR DESCRIPTION
This PR supercedes #2613. As suggested by @steveluscher, I've instead opted to
export the necessary components for downstream users to stitch together their own
schemas using the Solana GraphQL schema defined in this library.

This is mostly made possible by refactoring `createRpcGraphQL` to accept a `schema`
input argument, and rolling a new `createSolanaRpcGraphQL` to create an `RpcGraphQL`
with the default Solana schema.

Everywhere in the library (tests, etc.) I'm using the default `createSolanaRpcGraphQL`, but
downstream users can now use `createSolanaGraphQLTypeDefs` and
`createSolanaGraphQLTypeResolvers`, stitched together with their own type definitions and
type resolvers, to feed `createRpcGraphQL` the required schema object.