### PR TITLE
Repair the type of the `chain` argument to `useSignTransaction` and `useSignAndSendTransaction`

### DIFF
--- a/packages/react/src/__tests__/useSignAndSendTransaction-test.ts
+++ b/packages/react/src/__tests__/useSignAndSendTransaction-test.ts
@@ -77,11 +77,7 @@ describe('useSignAndSendTransaction', () => {
     });
     it('fatals when passed a wallet account that does not support the specified chain', () => {
         const { result } = renderHook(() =>
-            useSignAndSendTransaction(
-                { ...mockUiWalletAccount, chains: ['solana:basednet'] },
-                // @ts-expect-error Using a non-supported chain on purpose, as part of the test.
-                'solana:danknet',
-            ),
+            useSignAndSendTransaction({ ...mockUiWalletAccount, chains: ['solana:basednet'] }, 'solana:danknet'),
         );
         expect(result.__type).toBe('error');
         expect(result.current).toEqual(

--- a/packages/react/src/__tests__/useSignTransaction-test.ts
+++ b/packages/react/src/__tests__/useSignTransaction-test.ts
@@ -77,11 +77,7 @@ describe('useSignTransaction', () => {
     });
     it('fatals when passed a wallet account that does not support the specified chain', () => {
         const { result } = renderHook(() =>
-            useSignTransaction(
-                { ...mockUiWalletAccount, chains: ['solana:basednet'] },
-                // @ts-expect-error Using a non-supported chain on purpose, as part of the test.
-                'solana:danknet',
-            ),
+            useSignTransaction({ ...mockUiWalletAccount, chains: ['solana:basednet'] }, 'solana:danknet'),
         );
         expect(result.__type).toBe('error');
         expect(result.current).toEqual(

--- a/packages/react/src/__typetests__/useSignAndSendTransaction-typetest.ts
+++ b/packages/react/src/__typetests__/useSignAndSendTransaction-typetest.ts
@@ -1,0 +1,31 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import { address } from '@solana/addresses';
+import { UiWalletAccount } from '@wallet-standard/ui';
+
+import { useSignAndSendTransaction } from '../useSignAndSendTransaction';
+
+const mockWalletAccount = {
+    address: address('123'),
+    chains: ['solana:danknet', 'bitcoin:mainnet'] as const,
+    features: [],
+    publicKey: new Uint8Array([1, 2, 3]),
+    '~uiWalletHandle': null as unknown as UiWalletAccount['~uiWalletHandle'],
+} as const;
+
+// [DESCRIBE] useSignAndSendTransaction.
+{
+    // It accepts any chain in the solana namespace
+    useSignAndSendTransaction(mockWalletAccount, 'solana:danknet');
+    useSignAndSendTransaction(mockWalletAccount, 'solana:basednet');
+
+    // It accepts one of the chains actually supported by the wallet account
+    useSignAndSendTransaction(mockWalletAccount, 'solana:danknet');
+
+    // It rejects a chain in a non-Solana namespace
+    useSignAndSendTransaction(
+        mockWalletAccount,
+        // @ts-expect-error Non-Solana chain
+        'bitcoin:mainnet',
+    );
+}

--- a/packages/react/src/__typetests__/useSignTransaction-typetest.ts
+++ b/packages/react/src/__typetests__/useSignTransaction-typetest.ts
@@ -1,0 +1,31 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import { address } from '@solana/addresses';
+import { UiWalletAccount } from '@wallet-standard/ui';
+
+import { useSignTransaction } from '../useSignTransaction';
+
+const mockWalletAccount = {
+    address: address('123'),
+    chains: ['solana:danknet', 'bitcoin:mainnet'] as const,
+    features: [],
+    publicKey: new Uint8Array([1, 2, 3]),
+    '~uiWalletHandle': null as unknown as UiWalletAccount['~uiWalletHandle'],
+} as const;
+
+// [DESCRIBE] useSignTransaction.
+{
+    // It accepts any chain in the solana namespace
+    useSignTransaction(mockWalletAccount, 'solana:danknet');
+    useSignTransaction(mockWalletAccount, 'solana:basednet');
+
+    // It accepts one of the chains actually supported by the wallet account
+    useSignTransaction(mockWalletAccount, 'solana:danknet');
+
+    // It rejects a chain in a non-Solana namespace
+    useSignTransaction(
+        mockWalletAccount,
+        // @ts-expect-error Non-Solana chain
+        'bitcoin:mainnet',
+    );
+}

--- a/packages/react/src/useSignAndSendTransaction.ts
+++ b/packages/react/src/useSignAndSendTransaction.ts
@@ -27,9 +27,18 @@ type Output = SolanaSignAndSendTransactionOutput;
  * Returns a function you can call to sign and send a serialized transaction.
  */
 export function useSignAndSendTransaction<TWalletAccount extends UiWalletAccount>(
-    ...config: Parameters<typeof useSignAndSendTransactions<TWalletAccount>>
+    uiWalletAccount: TWalletAccount,
+    chain: OnlySolanaChains<TWalletAccount['chains']>,
+): (input: Input) => Promise<Output>;
+export function useSignAndSendTransaction<TWalletAccount extends UiWalletAccount>(
+    uiWalletAccount: TWalletAccount,
+    chain: `solana:${string}`,
+): (input: Input) => Promise<Output>;
+export function useSignAndSendTransaction<TWalletAccount extends UiWalletAccount>(
+    uiWalletAccount: TWalletAccount,
+    chain: `solana:${string}`,
 ): (input: Input) => Promise<Output> {
-    const signAndSendTransactions = useSignAndSendTransactions(...config);
+    const signAndSendTransactions = useSignAndSendTransactions(uiWalletAccount, chain);
     return useCallback(
         async input => {
             const [result] = await signAndSendTransactions(input);
@@ -41,7 +50,7 @@ export function useSignAndSendTransaction<TWalletAccount extends UiWalletAccount
 
 function useSignAndSendTransactions<TWalletAccount extends UiWalletAccount>(
     uiWalletAccount: TWalletAccount,
-    chain: OnlySolanaChains<TWalletAccount['chains']>,
+    chain: `solana:${string}`,
 ): (...inputs: readonly Input[]) => Promise<readonly Output[]> {
     if (!uiWalletAccount.chains.includes(chain)) {
         throw new WalletStandardError(WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED, {

--- a/packages/react/src/useSignTransaction.ts
+++ b/packages/react/src/useSignTransaction.ts
@@ -28,9 +28,18 @@ type Output = SolanaSignTransactionOutput;
  * Returns a function you can call to sign a serialized transaction.
  */
 export function useSignTransaction<TWalletAccount extends UiWalletAccount>(
-    ...config: Parameters<typeof useSignTransactions<TWalletAccount>>
+    uiWalletAccount: TWalletAccount,
+    chain: OnlySolanaChains<TWalletAccount['chains']>,
+): (input: Input) => Promise<Output>;
+export function useSignTransaction<TWalletAccount extends UiWalletAccount>(
+    uiWalletAccount: TWalletAccount,
+    chain: `solana:${string}`,
+): (input: Input) => Promise<Output>;
+export function useSignTransaction<TWalletAccount extends UiWalletAccount>(
+    uiWalletAccount: TWalletAccount,
+    chain: `solana:${string}`,
 ): (input: Input) => Promise<Output> {
-    const signTransactions = useSignTransactions(...config);
+    const signTransactions = useSignTransactions(uiWalletAccount, chain);
     return useCallback(
         async input => {
             const [result] = await signTransactions(input);
@@ -42,7 +51,7 @@ export function useSignTransaction<TWalletAccount extends UiWalletAccount>(
 
 function useSignTransactions<TWalletAccount extends UiWalletAccount>(
     uiWalletAccount: TWalletAccount,
-    chain: OnlySolanaChains<TWalletAccount['chains']>,
+    chain: `solana:${string}`,
 ): (...inputs: readonly Input[]) => Promise<readonly Output[]> {
     if (!uiWalletAccount.chains.includes(chain)) {
         throw new WalletStandardError(WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED, {

--- a/packages/react/src/useWalletAccountTransactionSendingSigner.ts
+++ b/packages/react/src/useWalletAccountTransactionSendingSigner.ts
@@ -10,15 +10,27 @@ import { getAbortablePromise } from './abortable-promise';
 import { OnlySolanaChains } from './chain';
 import { useSignAndSendTransaction } from './useSignAndSendTransaction';
 
+type ExtraConfig = Readonly<{
+    getOptions?(transaction: Transaction): Readonly<{ minContextSlot?: bigint }> | undefined;
+}>;
+
 /**
  * Returns an object that conforms to the `TransactionSendingSigner` interface of `@solana/signers`.
  */
 export function useWalletAccountTransactionSendingSigner<TWalletAccount extends UiWalletAccount>(
     uiWalletAccount: TWalletAccount,
     chain: OnlySolanaChains<TWalletAccount['chains']>,
-    extraConfig?: Readonly<{
-        getOptions?(transaction: Transaction): Readonly<{ minContextSlot?: bigint }> | undefined;
-    }>,
+    extraConfig?: ExtraConfig,
+): TransactionSendingSigner<TWalletAccount['address']>;
+export function useWalletAccountTransactionSendingSigner<TWalletAccount extends UiWalletAccount>(
+    uiWalletAccount: TWalletAccount,
+    chain: `solana:${string}`,
+    extraConfig?: ExtraConfig,
+): TransactionSendingSigner<TWalletAccount['address']>;
+export function useWalletAccountTransactionSendingSigner<TWalletAccount extends UiWalletAccount>(
+    uiWalletAccount: TWalletAccount,
+    chain: `solana:${string}`,
+    extraConfig?: ExtraConfig,
 ): TransactionSendingSigner<TWalletAccount['address']> {
     const encoderRef = useRef<ReturnType<typeof getTransactionEncoder>>();
     const signAndSendTransaction = useSignAndSendTransaction(uiWalletAccount, chain);

--- a/packages/react/src/useWalletAccountTransactionSigner.ts
+++ b/packages/react/src/useWalletAccountTransactionSigner.ts
@@ -9,6 +9,10 @@ import { getAbortablePromise } from './abortable-promise';
 import { OnlySolanaChains } from './chain';
 import { useSignTransaction } from './useSignTransaction';
 
+type ExtraConfig = Readonly<{
+    getOptions?(transaction: Transaction): Readonly<{ minContextSlot?: bigint }> | undefined;
+}>;
+
 /**
  * Returns an object that conforms to the `TransactionModifyingSigner` interface of
  * `@solana/signers`.
@@ -16,9 +20,17 @@ import { useSignTransaction } from './useSignTransaction';
 export function useWalletAccountTransactionSigner<TWalletAccount extends UiWalletAccount>(
     uiWalletAccount: TWalletAccount,
     chain: OnlySolanaChains<TWalletAccount['chains']>,
-    extraConfig?: Readonly<{
-        getOptions?(transaction: Transaction): Readonly<{ minContextSlot?: bigint }> | undefined;
-    }>,
+    extraConfig?: ExtraConfig,
+): TransactionModifyingSigner<TWalletAccount['address']>;
+export function useWalletAccountTransactionSigner<TWalletAccount extends UiWalletAccount>(
+    uiWalletAccount: TWalletAccount,
+    chain: `solana:${string}`,
+    extraConfig?: ExtraConfig,
+): TransactionModifyingSigner<TWalletAccount['address']>;
+export function useWalletAccountTransactionSigner<TWalletAccount extends UiWalletAccount>(
+    uiWalletAccount: TWalletAccount,
+    chain: `solana:${string}`,
+    extraConfig?: ExtraConfig,
 ): TransactionModifyingSigner<TWalletAccount['address']> {
     const encoderRef = useRef<ReturnType<typeof getTransactionCodec>>();
     const signTransaction = useSignTransaction(uiWalletAccount, chain);


### PR DESCRIPTION
# Summary

When the chains were not known – as in the case of having a plain old `UiWalletAccount` – this invocation would fail to typecheck:

```ts
useSignTransaction(
  account,
  "solana:mainnet" // ERROR
);
```

This was because `OnlySolanaChains<IdentifierArray>` is `never`.

This PR fixes it so that you get both good autocomplete when the chains are known, and you can supply any `solana:*` chain in any case.
