### PR TITLE
Fixed a bug where the RPC coalescer would leave the application with no request even though there were consumers

### DIFF
--- a/.changeset/early-eyes-mix.md
+++ b/.changeset/early-eyes-mix.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc': patch
+---
+
+Fixed a bug where coalesced RPC calls could end up aborted even though there were still interested consumers. This would happen if the consumer count fell to zero, then rose above zero again, in the same runloop.

--- a/packages/rpc/src/rpc-request-coalescer.ts
+++ b/packages/rpc/src/rpc-request-coalescer.ts
@@ -69,10 +69,12 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
                 const handleAbort = (e: AbortSignalEventMap['abort']) => {
                     signal.removeEventListener('abort', handleAbort);
                     coalescedRequest.numConsumers -= 1;
-                    if (coalescedRequest.numConsumers === 0) {
-                        const abortController = coalescedRequest.abortController;
-                        abortController.abort(EXPLICIT_ABORT_TOKEN);
-                    }
+                    Promise.resolve().then(() => {
+                        if (coalescedRequest.numConsumers === 0) {
+                            const abortController = coalescedRequest.abortController;
+                            abortController.abort(EXPLICIT_ABORT_TOKEN);
+                        }
+                    });
                     reject((e.target as AbortSignal).reason);
                 };
                 signal.addEventListener('abort', handleAbort);


### PR DESCRIPTION
# Summary

If multiple consumers made the same RPC call, then all of them aborted, then another consumer made the same RPC call, all in the same runloop, you'd end up with zero inflight requests and the remaining callers would never recieve their response.
