### PR TITLE
feat: add isPublicKey with test

### DIFF
--- a/packages/library-legacy/src/publickey.ts
+++ b/packages/library-legacy/src/publickey.ts
@@ -251,6 +251,17 @@ export class PublicKey extends Struct {
     const pubkey = new PublicKey(pubkeyData);
     return isOnCurve(pubkey.toBytes());
   }
+
+  /**
+   * Check that a pubkey is valid.
+   */
+  static isPublicKey(value: PublicKeyInitData): boolean {
+    try{
+      return new PublicKey(value).toBase58().length === 44;
+    } catch (err) {
+      return false;
+    }
+  }
 }
 
 SOLANA_SCHEMA.set(PublicKey, {

--- a/packages/library-legacy/test/publickey.test.ts
+++ b/packages/library-legacy/test/publickey.test.ts
@@ -259,4 +259,12 @@ describe('PublicKey', function () {
     const decoded = PublicKey.decodeUnchecked(encoded);
     expect(decoded.equals(publicKey)).to.be.true;
   });
+
+  it('isPublicKey', () => {
+    const publicKey = Keypair.generate().publicKey;
+    expect(PublicKey.isPublicKey(publicKey)).to.be.true;
+    expect(PublicKey.isPublicKey(publicKey.toBase58())).to.be.true;
+    expect(PublicKey.isPublicKey(publicKey.toBase58().slice(0, -1))).to.be
+      .false;
+  });
 });


### PR DESCRIPTION
This PR aims to add a new functionality to validate if a `PublicKeyInitData `can actually construct a `PublicKey`