### PR TITLE
bug: wrap memcmp filters of getProgramAccounts in required `memcmp` object

### DIFF
--- a/packages/rpc-types/src/account-filters.ts
+++ b/packages/rpc-types/src/account-filters.ts
@@ -6,9 +6,11 @@ export type DataSlice = Readonly<{
 }>;
 
 export type GetProgramAccountsMemcmpFilter = Readonly<{
-    bytes: string;
-    encoding: 'base58' | 'base64';
-    offset: U64UnsafeBeyond2Pow53Minus1;
+    memcmp: Readonly<{
+        bytes: string;
+        encoding: 'base58' | 'base64';
+        offset: U64UnsafeBeyond2Pow53Minus1;
+    }>;
 }>;
 
 export type GetProgramAccountsDatasizeFilter = Readonly<{


### PR DESCRIPTION
Not sure if this is the right place to fix or if the intention was to have a transformer somewhere that wraps the filter in a `memcmp` object.

In current version GPA with a memcmp filter turns into the following params:
```
{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "getProgramAccounts",
  "params": [
    "<program-id>",
    {
      "encoding": "base64",
      "filters": [
        {
          "offset": 0,
          "bytes": "6",
          "encoding": "base58"
        }
      ],
      "commitment": "confirmed"
    }
  ]
}
```

The filter should however be wrapped in a `memcmp` object:
```
{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "getProgramAccounts",
  "params": [
    "<program-id>",
    {
      "encoding": "base64",
      "filters": [
        {
          "memcmp": {
             "offset": 0,
            "bytes": "6",
            "encoding": "base58"
          }
        }
      ],
      "commitment": "confirmed"
    }
  ]
}
```

Reference: https://solana.com/docs/rpc/http/getprogramaccounts