### PR TITLE
refactor(experimental): fix transaction references in signers documentation

### DIFF
--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -470,8 +470,8 @@ const myInstruction: IInstruction = {
     // ...
 };
 
-const signerA: TransactionSigner<'1111'>;
-const signerB: TransactionSigner<'2222'>;
+const mySignerA: TransactionSigner<'1111'>;
+const mySignerB: TransactionSigner<'2222'>;
 const myInstructionWithSigners = addSignersToInstruction([mySignerA, mySignerB], myInstruction);
 
 // myInstructionWithSigners.accounts[0].signer === mySignerA
@@ -528,20 +528,20 @@ const mySignedTransaction = await signTransactionMessageWithSigners(myTransactio
 mySignedTransaction satisfies IFullySignedTransaction;
 ```
 
-#### `signAndSendTransactionWithSigners()`
+#### `signAndSendTransactionMessageWithSigners()`
 
 Extracts all signers inside the provided transaction and uses them to sign it before sending it immediately to the blockchain. It returns the signature of the sent transaction (i.e. its identifier).
 
 ```ts
-const myTransactionSignature = await signAndSendTransactionWithSigners(myTransaction);
+const transactionSignature = await signAndSendTransactionMessageWithSigners(transactionMessage);
 
 // With additional config.
-const myTransactionSignature = await signAndSendTransactionWithSigners(myTransaction, {
+const transactionSignature = await signAndSendTransactionMessageWithSigners(transactionMessage, {
     abortSignal: myAbortController.signal,
 });
 ```
 
-Similarly to the `partiallySignTransactionWithSigners` function, it first uses all `TransactionModifyingSigners` sequentially before using all `TransactionPartialSigners` in parallel. It then sends the transaction using the `TransactionSendingSigner` it identified.
+Similarly to the `partiallySignTransactionMessageWithSigners` function, it first uses all `TransactionModifyingSigners` sequentially before using all `TransactionPartialSigners` in parallel. It then sends the transaction using the `TransactionSendingSigner` it identified.
 
 Here as well, composite transaction signers are treated such that at least one sending signer is used if any. When a `TransactionSigner` implements more than one interface, use it as a:
 
@@ -551,21 +551,21 @@ Here as well, composite transaction signers are treated such that at least one s
 
 The provided transaction must contain exactly one `TransactionSendingSigner` inside its account metas. If more than one composite signers implement the `TransactionSendingSigner` interface, one of them will be selected as the sending signer. Otherwise, if multiple `TransactionSendingSigners` must be selected, the function will throw an error.
 
-If you'd like to assert that a transaction makes use of exactly one `TransactionSendingSigner` _before_ calling this function, you may use the `assertIsTransactionWithSingleSendingSigner` function.
+If you'd like to assert that a transaction makes use of exactly one `TransactionSendingSigner` _before_ calling this function, you may use the `assertIsTransactionMessageWithSingleSendingSigner` function.
 
 ```ts
-assertIsTransactionWithSingleSendingSigner(myTransaction);
-const myTransactionSignature = await signAndSendTransactionWithSigners(myTransaction);
+assertIsTransactionMessageWithSingleSendingSigner(transactionMessage);
+const transactionSignature = await signAndSendTransactionMessageWithSigners(transactionMessage);
 ```
 
 Alternatively, you may use the `isTransactionWithSingleSendingSigner()` function to provide a fallback in case the transaction does not contain any sending signer.
 
 ```ts
 let transactionSignature: SignatureBytes;
-if (isTransactionWithSingleSendingSigner(transaction)) {
-    transactionSignature = await signAndSendTransactionWithSigners(transaction);
+if (isTransactionWithSingleSendingSigner(transactionMessage)) {
+    transactionSignature = await signAndSendTransactionMessageWithSigners(transactionMessage);
 } else {
-    const signedTransaction = await signTransactionWithSigners(transaction);
+    const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
     const encodedTransaction = getBase64EncodedWireTransaction(signedTransaction);
     transactionSignature = await rpc.sendTransaction(encodedTransaction).send();
 }

--- a/packages/signers/src/__tests__/sign-transaction-test.ts
+++ b/packages/signers/src/__tests__/sign-transaction-test.ts
@@ -38,7 +38,7 @@ jest.mock('@solana/transactions', () => ({
     compileTransaction: jest.fn(),
 }));
 
-describe('partiallySignTransactionWithSigners', () => {
+describe('partiallySignTransactionMessageWithSigners', () => {
     it('signs the transaction with its extracted signers', async () => {
         expect.assertions(3);
 
@@ -406,7 +406,7 @@ describe('partiallySignTransactionWithSigners', () => {
     });
 });
 
-describe('signTransactionWithSigners', () => {
+describe('signTransactionMessageWithSigners', () => {
     it('signs the transaction with its extracted signers', async () => {
         expect.assertions(3);
 
@@ -472,7 +472,7 @@ describe('signTransactionWithSigners', () => {
         const promise = signTransactionMessageWithSigners(transactionMessage);
 
         // Then we expect an error letting us know the transaction is not fully signed.
-        // This is because sending signers are ignored by signTransactionWithSigners.
+        // This is because sending signers are ignored by signTransactionMessageWithSigners.
         await expect(promise).rejects.toThrow(
             new SolanaError(SOLANA_ERROR__TRANSACTION__SIGNATURES_MISSING, {
                 addresses: ['2222' as Address],
@@ -530,7 +530,7 @@ describe('signTransactionWithSigners', () => {
     });
 });
 
-describe('signAndSendTransactionWithSigners', () => {
+describe('signAndSendTransactionMessageWithSigners', () => {
     it('signs and sends the transaction with the provided signers', async () => {
         expect.assertions(3);
 


### PR DESCRIPTION
Some of the functions and examples in the signers documentation (and some comments in the tests) hadn't been updating since the `transaction` to `transactionMessage` refactoring.