### PR TITLE
Rehabilitate the fetch benchmark

### DIFF
--- a/packages/fetch-impl/LICENSE
+++ b/packages/fetch-impl/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2023 Solana Labs, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/fetch-impl/package.json
+++ b/packages/fetch-impl/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "@solana/fetch-impl",
+    "version": "0.0.0",
+    "private": true,
+    "scripts": {
+        "benchmark": "./src/__benchmarks__/run.ts"
+    },
+    "devDependencies": {
+        "tinybench": "^2.6.0",
+        "undici": "^6.19.2"
+    }
+}

--- a/packages/fetch-impl/src/__benchmarks__/run.ts
+++ b/packages/fetch-impl/src/__benchmarks__/run.ts
@@ -4,9 +4,7 @@ import { ok } from 'node:assert';
 import process from 'node:process';
 
 import { Bench } from 'tinybench';
-import { Agent, Dispatcher } from 'undici';
-
-import fetchImpl from '../index.node';
+import { Agent, Dispatcher, fetch } from 'undici';
 
 const NUM_CONCURRENT_REQUESTS = 1024;
 const URL = process.argv[2];
@@ -44,7 +42,7 @@ function getTestInit() {
 async function makeConcurrentRequests(num: number = NUM_CONCURRENT_REQUESTS) {
     await Promise.all(
         Array.from({ length: num }).map(() =>
-            fetchImpl(URL, {
+            fetch(URL, {
                 dispatcher,
                 ...getTestInit(),
             }),
@@ -58,40 +56,36 @@ bench
             dispatcher = undefined;
         },
     })
-    // FIXME: https://github.com/nodejs/undici/issues/2808
-    // .add('unlimited connections http/2', () => makeConcurrentRequests(), {
-    //     beforeEach: createDispatcher.bind(null, { allowH2: true, connections: null }),
-    // })
+    .add('unlimited connections http/2', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { allowH2: true, connections: null }),
+    })
     .add('unlimited connections', () => makeConcurrentRequests(), {
         beforeEach: createDispatcher.bind(null, { connections: null }),
     })
     .add('16 connections', () => makeConcurrentRequests(), {
         beforeEach: createDispatcher.bind(null, { connections: 16 }),
     })
-    // FIXME: https://github.com/nodejs/undici/issues/2808
-    // .add('16 connections, http/2', () => makeConcurrentRequests(), {
-    //     beforeEach: createDispatcher.bind(null, { allowH2: true, connections: 16 }),
-    // })
+    .add('16 connections, http/2', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { allowH2: true, connections: 16 }),
+    })
     .add('16 connections, pipeline 2 wide', () => makeConcurrentRequests(), {
         beforeEach: createDispatcher.bind(null, { connections: 16, pipelining: 2 }),
     })
     .add('32 connections', () => makeConcurrentRequests(), {
         beforeEach: createDispatcher.bind(null, { connections: 32 }),
     })
-    // FIXME: https://github.com/nodejs/undici/issues/2808
-    // .add('32 connections, http/2', () => makeConcurrentRequests(), {
-    //     beforeEach: createDispatcher.bind(null, { allowH2: true, connections: 32 }),
-    // })
+    .add('32 connections, http/2', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { allowH2: true, connections: 32 }),
+    })
     .add('32 connections, pipeline 2 wide', () => makeConcurrentRequests(), {
         beforeEach: createDispatcher.bind(null, { connections: 32, pipelining: 2 }),
     })
     .add('64 connections', () => makeConcurrentRequests(), {
         beforeEach: createDispatcher.bind(null, { connections: 64 }),
     })
-    // FIXME: https://github.com/nodejs/undici/issues/2808
-    // .add('64 connections, http/2', () => makeConcurrentRequests(), {
-    //     beforeEach: createDispatcher.bind(null, { allowH2: true, connections: 64 }),
-    // })
+    .add('64 connections, http/2', () => makeConcurrentRequests(), {
+        beforeEach: createDispatcher.bind(null, { allowH2: true, connections: 64 }),
+    })
     .add('64 connections, pipeline 2 wide', () => makeConcurrentRequests(), {
         beforeEach: createDispatcher.bind(null, { connections: 64, pipelining: 2 }),
     });

--- a/packages/fetch-impl/tsconfig.json
+++ b/packages/fetch-impl/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "compilerOptions": {
+        "esModuleInterop": true,
+        "lib": ["DOM", "ES5"]
+    },
+    "display": "Fetch Implementation",
+    "extends": "@solana/tsconfig/base.json",
+    "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,15 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
 
+  packages/fetch-impl:
+    devDependencies:
+      tinybench:
+        specifier: ^2.6.0
+        version: 2.8.0
+      undici:
+        specifier: ^6.19.2
+        version: 6.19.2
+
   packages/functional:
     dependencies:
       typescript:


### PR DESCRIPTION
This code was mistakenly deleted in #2267. We still want to be able to run these benchmarks.

```
cd packages/fetch-impl/
pnpm i
pnpm benchmark
```
