### PR TITLE
fix: deprecate the `getStakeActivation` RPC method

### DIFF
--- a/packages/library-legacy/src/connection.ts
+++ b/packages/library-legacy/src/connection.ts
@@ -3640,6 +3640,8 @@ export class Connection {
 
   /**
    * Returns epoch activation information for a stake account that has been delegated
+   *
+   * @deprecated Deprecated since RPC v1.18; will be removed in a future version.
    */
   async getStakeActivation(
     publicKey: PublicKey,

--- a/packages/rpc-api/src/getStakeActivation.ts
+++ b/packages/rpc-api/src/getStakeActivation.ts
@@ -14,6 +14,8 @@ type GetStakeActivationApiResponse = Readonly<{
 export interface GetStakeActivationApi extends RpcApiMethods {
     /**
      * Returns epoch activation information for a stake account
+     *
+     * @deprecated Deprecated since RPC v1.18; will be removed in a future version.
      */
     getStakeActivation(
         address: Address,


### PR DESCRIPTION
This was deprecated in https://github.com/anza-xyz/agave/pull/69
