### PR TITLE
Correct the return type of `simulateTransaction` when accounts are not loaded

### DIFF
--- a/.changeset/fast-cars-knock.md
+++ b/.changeset/fast-cars-knock.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-api': patch
+---
+
+Fixed a TypeScript error where the return value of `simulateTransaction` claimed there was an `accounts` property at the top level when it is in fact `value.accounts`

--- a/packages/rpc-api/src/simulateTransaction.ts
+++ b/packages/rpc-api/src/simulateTransaction.ts
@@ -127,7 +127,7 @@ export interface SimulateTransactionApi extends RpcApiMethods {
     simulateTransaction(
         base58EncodedWireTransaction: Base58EncodedBytes,
         config?: SigVerifyAndReplaceRecentBlockhashConfig & SimulateTransactionConfigBase,
-    ): SimulateTransactionApiResponseBase & { accounts: null };
+    ): SimulateTransactionApiResponseBase & SolanaRpcResponse<{ readonly accounts: null }>;
 
     /** Simulate sending a transaction */
     simulateTransaction(
@@ -160,5 +160,5 @@ export interface SimulateTransactionApi extends RpcApiMethods {
     simulateTransaction(
         base64EncodedWireTransaction: Base64EncodedWireTransaction,
         config: SigVerifyAndReplaceRecentBlockhashConfig & SimulateTransactionConfigBase & { encoding: 'base64' },
-    ): SimulateTransactionApiResponseBase & { accounts: null };
+    ): SimulateTransactionApiResponseBase & SolanaRpcResponse<{ readonly accounts: null }>;
 }


### PR DESCRIPTION
This was returning `accounts: null` at the top level instead of inside `value`

See https://github.com/solana-labs/solana-web3.js/commit/7192f3d37e6cf65e144c8cd920fa20a71b2b1fe0
