### PR TITLE
Correct the type of `innerInstructions` in JSON RPC errors

### DIFF
--- a/.changeset/sour-mugs-press.md
+++ b/.changeset/sour-mugs-press.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': patch
+---
+
+The `innerInstructions` property of JSON-RPC errors used snake case rather than camelCase for `stackHeight` and `programId`. This has been corrected.

--- a/packages/errors/src/json-rpc-error.ts
+++ b/packages/errors/src/json-rpc-error.ts
@@ -61,21 +61,21 @@ export interface RpcSimulateTransactionResult {
                         accounts: number[];
                         data: string;
                         programIdIndex: number;
-                        stack_height?: number;
+                        stackHeight?: number;
                     }
                   | {
                         // Parsed
                         parsed: unknown;
                         program: string;
-                        program_id: string;
-                        stack_height?: number;
+                        programId: string;
+                        stackHeight?: number;
                     }
                   | {
                         // PartiallyDecoded
                         accounts: string[];
                         data: string;
-                        program_id: string;
-                        stack_height?: number;
+                        programId: string;
+                        stackHeight?: number;
                     }
               )[];
           }[]


### PR DESCRIPTION
These names are camel-cased. This can't be imported from `@solana/rpc-types` because `@solana/errors` must be zero dependency.
