### PR TITLE
`setTransactionMessageFeePayer{Signer}` now accepts a broader range of inputs

### DIFF
--- a/packages/signers/src/__typetests__/fee-payer-typetest.ts
+++ b/packages/signers/src/__typetests__/fee-payer-typetest.ts
@@ -1,0 +1,41 @@
+import { ITransactionMessageWithFeePayer, TransactionMessage } from '@solana/transaction-messages';
+
+import { ITransactionMessageWithFeePayerSigner, setTransactionMessageFeePayerSigner } from '../fee-payer-signer';
+import { TransactionSigner } from '../transaction-signer';
+
+const aliceSigner = null as unknown as TransactionSigner<'alice'>;
+const bobSigner = null as unknown as TransactionSigner<'bob'>;
+
+const message = null as unknown as TransactionMessage;
+
+// [DESCRIBE] setTransactionFeePayerSigner
+{
+    // It adds the fee payer signer to the new message
+    {
+        const messageWithFeePayer = setTransactionMessageFeePayerSigner(aliceSigner, message);
+        messageWithFeePayer satisfies ITransactionMessageWithFeePayerSigner<'alice'>;
+    }
+
+    // It *replaces* an existing fee payer signer with the new one
+    {
+        const messageWithAliceFeePayerSigner = null as unknown as ITransactionMessageWithFeePayerSigner<'alice'> &
+            TransactionMessage;
+        const messageWithBobFeePayerSigner = setTransactionMessageFeePayerSigner(
+            bobSigner,
+            messageWithAliceFeePayerSigner,
+        );
+        // @ts-expect-error Alice should no longer be a payer.
+        messageWithBobFeePayerSigner satisfies ITransactionMessageWithFeePayerSigner<'alice'>;
+        messageWithBobFeePayerSigner satisfies ITransactionMessageWithFeePayerSigner<'bob'>;
+    }
+
+    // It *replaces* an existing fee payer address with the new signer
+    {
+        const messageWithMalloryFeePayer = null as unknown as ITransactionMessageWithFeePayer<'mallory'> &
+            TransactionMessage;
+        const messageWithBobFeePayerSigner = setTransactionMessageFeePayerSigner(bobSigner, messageWithMalloryFeePayer);
+        // @ts-expect-error Mallory should no longer be a payer.
+        messageWithBobFeePayerSigner satisfies ITransactionMessageWithFeePayer<'mallory'>;
+        messageWithBobFeePayerSigner satisfies ITransactionMessageWithFeePayerSigner<'bob'>;
+    }
+}

--- a/packages/signers/src/fee-payer-signer.ts
+++ b/packages/signers/src/fee-payer-signer.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { BaseTransactionMessage } from '@solana/transaction-messages';
 
 import { TransactionSigner } from './transaction-signer';
 
@@ -16,14 +16,16 @@ export function setTransactionMessageFeePayerSigner<
     TTransactionMessage extends BaseTransactionMessage,
 >(
     feePayerSigner: TransactionSigner<TFeePayerAddress>,
-    transactionMessage: TTransactionMessage | (ITransactionMessageWithFeePayer<string> & TTransactionMessage),
-): ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & TTransactionMessage {
+    transactionMessage: TTransactionMessage,
+): ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & Omit<TTransactionMessage, 'feePayer' | 'feePayerSigner'> {
     if ('feePayer' in transactionMessage && feePayerSigner.address === transactionMessage.feePayer) {
         if ('feePayerSigner' in transactionMessage)
-            return transactionMessage as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & TTransactionMessage;
+            return transactionMessage as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> &
+                Omit<TTransactionMessage, 'feePayer' | 'feePayerSigner'>;
         const out = { ...transactionMessage, feePayerSigner };
         Object.freeze(out);
-        return out as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & TTransactionMessage;
+        return out as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> &
+            Omit<TTransactionMessage, 'feePayer' | 'feePayerSigner'>;
     }
     const out = {
         ...transactionMessage,

--- a/packages/transaction-messages/src/__typetests__/fee-payer-typetests.ts
+++ b/packages/transaction-messages/src/__typetests__/fee-payer-typetests.ts
@@ -1,0 +1,28 @@
+import { Address } from '@solana/addresses';
+
+import { ITransactionMessageWithFeePayer, setTransactionMessageFeePayer } from '../fee-payer';
+import { TransactionMessage } from '../transaction-message';
+
+const aliceAddress = 'alice' as Address<'alice'>;
+const bobAddress = 'bob' as Address<'bob'>;
+
+const message = null as unknown as TransactionMessage;
+
+// [DESCRIBE] setTransactionFeePayer
+{
+    // It adds the fee payer to the new message
+    {
+        const messageWithFeePayer = setTransactionMessageFeePayer(aliceAddress, message);
+        messageWithFeePayer satisfies ITransactionMessageWithFeePayer<'alice'>;
+    }
+
+    // It *replaces* an existing fee payer with the new one
+    {
+        const messageWithAliceFeePayer = null as unknown as ITransactionMessageWithFeePayer<'alice'> &
+            TransactionMessage;
+        const messageWithBobFeePayer = setTransactionMessageFeePayer(bobAddress, messageWithAliceFeePayer);
+        // @ts-expect-error Alice should no longer be a payer.
+        messageWithBobFeePayer satisfies ITransactionMessageWithFeePayer<'alice'>;
+        messageWithBobFeePayer satisfies ITransactionMessageWithFeePayer<'bob'>;
+    }
+}

--- a/packages/transaction-messages/src/fee-payer.ts
+++ b/packages/transaction-messages/src/fee-payer.ts
@@ -11,10 +11,10 @@ export function setTransactionMessageFeePayer<
     TTransaction extends BaseTransactionMessage,
 >(
     feePayer: Address<TFeePayerAddress>,
-    transaction: TTransaction | (ITransactionMessageWithFeePayer<string> & TTransaction),
-): ITransactionMessageWithFeePayer<TFeePayerAddress> & TTransaction {
+    transaction: TTransaction,
+): ITransactionMessageWithFeePayer<TFeePayerAddress> & Omit<TTransaction, 'feePayer'> {
     if ('feePayer' in transaction && feePayer === transaction.feePayer) {
-        return transaction as ITransactionMessageWithFeePayer<TFeePayerAddress> & TTransaction;
+        return transaction as ITransactionMessageWithFeePayer<TFeePayerAddress> & Omit<TTransaction, 'feePayer'>;
     }
     const out = {
         ...transaction,


### PR DESCRIPTION
# Summary

These functions would not accept a simple `CompilableTransactionMessage` as input. Furthermore, this type was intended to _unset_ the existing fee payer and replace it with the one passed in. Instead, this was producing the union of the old and new fee payers.

# Test Plan

```
pnpm turbo compile:typedefs
```

Closes #2854.