### PR TITLE
refactor(experimental): type reconciliation: `GetAccountInfoApi`

### DIFF
--- a/packages/rpc-api/src/getAccountInfo.ts
+++ b/packages/rpc-api/src/getAccountInfo.ts
@@ -13,11 +13,7 @@ import type {
     SolanaRpcResponse,
 } from '@solana/rpc-types';
 
-type GetAccountInfoApiResponseBase = SolanaRpcResponse<AccountInfoBase | null>;
-
-type NestInRpcResponseOrNull<T> = Readonly<{
-    value: T | null;
-}>;
+type GetAccountInfoApiResponse<T> = (AccountInfoBase & T) | null;
 
 type GetAccountInfoApiCommonConfig = Readonly<{
     // Defaults to `finalized`
@@ -42,7 +38,7 @@ export interface GetAccountInfoApi extends RpcApiMethods {
             Readonly<{
                 encoding: 'base64';
             }>,
-    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase64EncodedData>;
+    ): SolanaRpcResponse<GetAccountInfoApiResponse<AccountInfoWithBase64EncodedData>>;
     getAccountInfo(
         address: Address,
         config: GetAccountInfoApiCommonConfig &
@@ -50,14 +46,14 @@ export interface GetAccountInfoApi extends RpcApiMethods {
             Readonly<{
                 encoding: 'base64+zstd';
             }>,
-    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase64EncodedZStdCompressedData>;
+    ): SolanaRpcResponse<GetAccountInfoApiResponse<AccountInfoWithBase64EncodedZStdCompressedData>>;
     getAccountInfo(
         address: Address,
         config: GetAccountInfoApiCommonConfig &
             Readonly<{
                 encoding: 'jsonParsed';
             }>,
-    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithJsonData>;
+    ): SolanaRpcResponse<GetAccountInfoApiResponse<AccountInfoWithJsonData>>;
     getAccountInfo(
         address: Address,
         config: GetAccountInfoApiCommonConfig &
@@ -65,9 +61,9 @@ export interface GetAccountInfoApi extends RpcApiMethods {
             Readonly<{
                 encoding: 'base58';
             }>,
-    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase58EncodedData>;
+    ): SolanaRpcResponse<GetAccountInfoApiResponse<AccountInfoWithBase58EncodedData>>;
     getAccountInfo(
         address: Address,
         config?: GetAccountInfoApiCommonConfig,
-    ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase58Bytes>;
+    ): SolanaRpcResponse<GetAccountInfoApiResponse<AccountInfoWithBase58Bytes>>;
 }


### PR DESCRIPTION
I have no idea if this stack is actually going to do us any material good, but here goes...

In many API definitions across `@solana/rpc-api`, we waffle between using the 
`SolanaRpcResponse` wrapper in the "base types" and in the method signatures.

This can make things _extremely_ difficult to follow when updating types. It's also
tricky to spot if we're accurately returning an RPC Response object on the methods
that should be.

This stack updates every delinquent method to use the same pattern:

- All base types are defined above the interface.
- Any methods that return an RPC Response declare so in the **method signature**.

The entire stack is the same, for each method in the title, so I'm not going to update
each PR's description.

👉 There is one method whose types were incorrect. It's this one:
https://github.com/solana-labs/solana-web3.js/pull/2892