### PR TITLE
Correct the type of `getComputeUnitEstimateForTransactionMessage`

### DIFF
--- a/.changeset/rare-goats-sell.md
+++ b/.changeset/rare-goats-sell.md
@@ -1,0 +1,5 @@
+---
+'@solana/web3.js-experimental': patch
+---
+
+Fixed the type of `config` on `getComputeUnitEstimateForTransactionMessage`. It is now optional and does not include `transactionMessage`.

--- a/packages/library/src/compute-limit.ts
+++ b/packages/library/src/compute-limit.ts
@@ -12,7 +12,10 @@ type ComputeUnitEstimateForTransactionMessageFactoryConfig = Readonly<{
 }>;
 type ComputeUnitEstimateForTransactionMessageFunction = (
     transactionMessage: CompilableTransactionMessage | (ITransactionMessageWithFeePayer & TransactionMessage),
-    config: Omit<Parameters<typeof getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT>[0], 'rpc'>,
+    config?: Omit<
+        Parameters<typeof getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
+        'rpc' | 'transactionMessage'
+    >,
 ) => Promise<number>;
 
 export function getComputeUnitEstimateForTransactionMessageFactory({


### PR DESCRIPTION
Whoops. This `config` should have been optional and should not have contained `transactionMessage`
