### PR TITLE
`__DEV__` logic is now ‘NODE_ENV is not production’

### DIFF
--- a/.changeset/rich-eggs-tease.md
+++ b/.changeset/rich-eggs-tease.md
@@ -1,0 +1,10 @@
+---
+'@solana/errors': patch
+'@solana/rpc': patch
+'@solana/rpc-subscriptions': patch
+'@solana/rpc-subscriptions-transport-websocket': patch
+'@solana/rpc-transport-http': patch
+'@solana/webcrypto-ed25519-polyfill': patch
+---
+
+`__DEV__` mode will now be the default if you don't set `process.env.NODE_ENV` at all. This means fewer people ‘accidentally’ finding themselves in production mode with minified error messages.

--- a/packages/build-scripts/dev-flag.ts
+++ b/packages/build-scripts/dev-flag.ts
@@ -15,12 +15,12 @@ function replaceDev(source: string): string {
     const root = j(source);
     root.find(j.Identifier, { name: '__DEV__' }).replaceWith(() =>
         j.binaryExpression(
-            '===',
+            '!==',
             j.memberExpression(
                 j.memberExpression(j.identifier('process'), j.identifier('env')),
                 j.identifier('NODE_ENV'),
             ),
-            j.stringLiteral('development'),
+            j.stringLiteral('production'),
         ),
     );
     return root.toSource();

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscription-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscription-test.ts
@@ -2,7 +2,6 @@ import {
     SOLANA_ERROR__RPC_SUBSCRIPTIONS__CANNOT_CREATE_SUBSCRIPTION_REQUEST,
     SOLANA_ERROR__RPC_SUBSCRIPTIONS__EXPECTED_SERVER_SUBSCRIPTION_ID,
     SolanaError,
-    SolanaErrorCode,
 } from '@solana/errors';
 import { createRpcMessage } from '@solana/rpc-spec-types';
 
@@ -263,12 +262,14 @@ describe('JSON-RPC 2.0 Subscriptions', () => {
         expect.assertions(1);
         iterable.mockImplementation(async function* () {
             yield Promise.resolve({
-                error: { code: 123, message: 'o no' },
+                error: { code: SOLANA_ERROR__RPC_SUBSCRIPTIONS__EXPECTED_SERVER_SUBSCRIPTION_ID },
                 id: 0,
             });
         });
         const subscribePromise = rpc.thingNotifications().subscribe({ abortSignal: new AbortController().signal });
-        await expect(subscribePromise).rejects.toThrow(new SolanaError(123 as SolanaErrorCode, undefined));
+        await expect(subscribePromise).rejects.toThrow(
+            new SolanaError(SOLANA_ERROR__RPC_SUBSCRIPTIONS__EXPECTED_SERVER_SUBSCRIPTION_ID),
+        );
     });
     it('throws errors when the connection fails to construct', async () => {
         expect.assertions(1);


### PR DESCRIPTION
# Summary

A few folks have been caught out _not_ having _any_ setting for `NODE_ENV`. In cases like this, the `__DEV__` flag will be `false` because `NODE_ENV` is not `'development'`.

It would be preferable for development to be the default when there is no `NODE_ENV`. This means it will be harder to get ‘into’ production mode (you have to set an env variable) but it will mean that people fall into the pit of success when debug functionality is what they're looking for.

# Test Plan

```
pnpm i
pnpm turbo compile:js
```

Observe that all of the `__DEV__` constants have been replaced with `process.env.NODE_ENV !== 'production'`
