### PR TITLE
The RPC request coalescer now throws exceptions whether you configure it with an `AbortSignal` or not

### DIFF
--- a/.changeset/chilled-walls-scream.md
+++ b/.changeset/chilled-walls-scream.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc': patch
+---
+
+Fixed a bug where the RPC would fail to throw errors in the event that you configured it with an `AbortSignal`

--- a/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
+++ b/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
@@ -218,7 +218,8 @@ describe('RPC request coalescer', () => {
             });
         });
     });
-    describe('regression test #2910', () => { // https://github.com/solana-labs/solana-web3.js/pull/2910
+    // https://github.com/solana-labs/solana-web3.js/pull/2910
+    describe('regression test #2910', () => {
         beforeEach(() => {
             // Necessary to prevent the coalescer from bailing out.
             hashFn.mockReturnValue('samehash');

--- a/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
+++ b/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
@@ -218,4 +218,24 @@ describe('RPC request coalescer', () => {
             });
         });
     });
+    describe('regression test #2910', () => { // https://github.com/solana-labs/solana-web3.js/pull/2910
+        beforeEach(() => {
+            // Necessary to prevent the coalescer from bailing out.
+            hashFn.mockReturnValue('samehash');
+        });
+        it('throws an error in the case of failure, if it was not configured with an `AbortSignal`', async () => {
+            expect.assertions(1);
+            const mockError = { err: 'bad' };
+            mockTransport.mockRejectedValueOnce(mockError);
+            await expect(coalescedTransport({ payload: null })).rejects.toBe(mockError);
+        });
+        it('throws an error in the case of failure, if it was configured with an `AbortSignal`', async () => {
+            expect.assertions(1);
+            const mockError = { err: 'bad' };
+            mockTransport.mockRejectedValueOnce(mockError);
+            await expect(coalescedTransport({ payload: null, signal: new AbortController().signal })).rejects.toBe(
+                mockError,
+            );
+        });
+    });
 });

--- a/packages/rpc/src/rpc-request-coalescer.ts
+++ b/packages/rpc/src/rpc-request-coalescer.ts
@@ -83,9 +83,12 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
                     reject((e.target as AbortSignal).reason);
                 };
                 signal.addEventListener('abort', handleAbort);
-                responsePromise.then(resolve).finally(() => {
-                    signal.removeEventListener('abort', handleAbort);
-                });
+                responsePromise
+                    .then(resolve)
+                    .catch(reject)
+                    .finally(() => {
+                        signal.removeEventListener('abort', handleAbort);
+                    });
             });
         } else {
             return (await coalescedRequest.responsePromise) as TResponse;


### PR DESCRIPTION
# Summary

When an `AbortSignal` was supplied to the RPC request coalescer, it would fail to attach a rejection handler to the shim promise returned to the app.

# Test Plan

```
cd packages/rpc/
pnpm turbo test:unit:node test:unit:browser
```