### PR TITLE
feat: add `iconUrl` to `ValidatorInfo` type

### DIFF
--- a/packages/library-legacy/src/validator-info.ts
+++ b/packages/library-legacy/src/validator-info.ts
@@ -33,7 +33,7 @@ export type Info = {
   website?: string;
   /** optional, extra information the validator chose to share */
   details?: string;
-  /** optional, validator logo URL
+  /** optional, validator logo URL */
   iconUrl?: string;
   /** optional, used to identify validators on keybase.io */
   keybaseUsername?: string;

--- a/packages/library-legacy/src/validator-info.ts
+++ b/packages/library-legacy/src/validator-info.ts
@@ -33,6 +33,8 @@ export type Info = {
   website?: string;
   /** optional, extra information the validator chose to share */
   details?: string;
+  /** optional, validator logo URL
+  iconUrl?: string;
   /** optional, used to identify validators on keybase.io */
   keybaseUsername?: string;
 };
@@ -41,6 +43,7 @@ const InfoString = pick({
   name: string(),
   website: optional(string()),
   details: optional(string()),
+  iconUrl: optional(string()),
   keybaseUsername: optional(string()),
 });
 

--- a/packages/library-legacy/test/validator-info.test.ts
+++ b/packages/library-legacy/test/validator-info.test.ts
@@ -5,7 +5,7 @@ import {Keypair} from '../src/keypair';
 import {PublicKey} from '../src/publickey';
 import {ValidatorInfo} from '../src/validator-info';
 
-describe('ValidatorInfo', () => {
+describe.only('ValidatorInfo', () => {
   it('from config account data', () => {
     const keypair = Keypair.fromSeed(Uint8Array.from(Array(32).fill(8)));
 
@@ -14,6 +14,7 @@ describe('ValidatorInfo', () => {
       {
         name: 'Validator',
         keybaseUsername: 'validator_id',
+        iconUrl: 'https://example.com/icon',
       },
     );
 
@@ -27,7 +28,7 @@ describe('ValidatorInfo', () => {
     // 4) Use modified `solana-validator-info` tool to publish validator info
     // 5) And then use it again to fetch the data! (feel free to trim some A's)
     const configData = Buffer.from(
-      'AgdRlwF0SPKsXcI8nrx6x4wKJyV6xhRFjeCk8W+AAAAAABOY9ixtGkV8UbpqS189vS9p/KkyFiGNyJl+QWvRfZPKATUAAAAAAAAAeyJrZXliYXNlVXNlcm5hbWUiOiJ2YWxpZGF0b3JfaWQiLCJuYW1lIjoiVmFsaWRhdG9yIn0',
+      'AgdRlwF0SPKsXcI8nrx6x4wKJyV6xhRFjeCk8W+AAAAAABOY9ixtGkV8UbpqS189vS9p/KkyFiGNyJl+QWvRfZPKAVoAAAAAAAAAeyJrZXliYXNlVXNlcm5hbWUiOiJ2YWxpZGF0b3JfaWQiLCJuYW1lIjoiVmFsaWRhdG9yIiwiaWNvblVybCI6Imh0dHBzOi8vZXhhbXBsZS5jb20vaWNvbiJ9',
       'base64',
     );
     const info = ValidatorInfo.fromConfigData(configData);


### PR DESCRIPTION
Adds iconUrl to validator `Info` type in` /library-legacy/src/validator-info.ts`.

As can be seen when running `solana -um validator-info get,` validators have already started adding it to their information.

I couldn't find code regarding this in the TP, but I'm happy to add it if I missed it.