### PR TITLE
Reset errors when changing account/chain

### DIFF
--- a/examples/react-app/src/routes/root.tsx
+++ b/examples/react-app/src/routes/root.tsx
@@ -1,4 +1,5 @@
 import { Box, Code, Container, DataList, Flex, Heading, Spinner, Text } from '@radix-ui/themes';
+import { getUiWalletAccountStorageKey } from '@wallet-standard/react';
 import { Suspense, useContext } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
@@ -14,6 +15,10 @@ import { SelectedWalletAccountContext } from '../context/SelectedWalletAccountCo
 function Root() {
     const { chain } = useContext(ChainContext);
     const [selectedWalletAccount] = useContext(SelectedWalletAccountContext);
+    const errorBoundaryResetKeys = [
+        chain,
+        selectedWalletAccount && getUiWalletAccountStorageKey(selectedWalletAccount),
+    ].filter(Boolean);
     return (
         <Container mx={{ initial: '3', xs: '6' }}>
             {selectedWalletAccount ? (
@@ -52,12 +57,18 @@ function Root() {
                     </Flex>
                     <DataList.Root orientation={{ initial: 'vertical', sm: 'horizontal' }} size="3">
                         <FeaturePanel label="Sign Message">
-                            <ErrorBoundary FallbackComponent={FeatureNotSupportedCallout}>
+                            <ErrorBoundary
+                                FallbackComponent={FeatureNotSupportedCallout}
+                                resetKeys={errorBoundaryResetKeys}
+                            >
                                 <SolanaSignMessageFeaturePanel account={selectedWalletAccount} />
                             </ErrorBoundary>
                         </FeaturePanel>
                         <FeaturePanel label="Sign And Send Transaction">
-                            <ErrorBoundary FallbackComponent={FeatureNotSupportedCallout}>
+                            <ErrorBoundary
+                                FallbackComponent={FeatureNotSupportedCallout}
+                                resetKeys={errorBoundaryResetKeys}
+                            >
                                 <SolanaSignAndSendTransactionFeaturePanel account={selectedWalletAccount} />
                             </ErrorBoundary>
                         </FeaturePanel>


### PR DESCRIPTION
# Summary

Previously, if you encountered an error (eg. some feature is not supported by some wallet / on some chain) the error message would never go away, even if you switched to a wallet that _did_ support it.

This PR resets the error boundary when the account/chain changes.

# Test Plan

1. Select Trust wallet account, which does not support `signAndSendTransaction` on devnet/testnet.
2. Switch to Phantom wallet account.

Observe that the error is cleared and the sign and send feature panel appears.
