### PR TITLE
Use fewer than all of the processors when running Turborepo

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/workflows/actions/install-dependencies
 
       - name: Compile
-        run: pnpm turbo run compile:ghpages --concurrency=100%
+        run: pnpm turbo run compile:ghpages --concurrency=95.84%
         env:
           REACT_EXAMPLE_APP_BASE_PATH: /solana-web3.js/example/
 

--- a/.github/workflows/publish-legacy-package.yml
+++ b/.github/workflows/publish-legacy-package.yml
@@ -38,7 +38,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build, Test, and Publish (force)
-        run: pnpm turbo run publish-packages-legacy --concurrency=100% --filter=@solana/web3.js --force=true
+        run: pnpm turbo run publish-packages-legacy --concurrency=95.84% --filter=@solana/web3.js --force=true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Choose Build Step
         id: build-step-decider
-        run: echo "step-name=${{ steps.changesets.outputs.hasChangesets == 'false' && 'publish-packages --concurrency=100%' || 'build' }}" >> $GITHUB_OUTPUT
+        run: echo "step-name=${{ steps.changesets.outputs.hasChangesets == 'false' && 'publish-packages --concurrency=95.84%' || 'build' }}" >> $GITHUB_OUTPUT
 
       - name: Run Build Step (force)
         run: pnpm turbo ${{ steps.build-step-decider.outputs.step-name }} --filter=!\@solana/web3.js --force=true

--- a/.github/workflows/publish-prerelease-packages.yml
+++ b/.github/workflows/publish-prerelease-packages.yml
@@ -47,7 +47,7 @@ jobs:
             xargs -t0 -n 1 -I {} \
               sh -c 'cd {} && pnpm pkg delete devDependencies'
           pnpm changeset version --snapshot preview
-          pnpm turbo publish-packages --concurrency=100% --filter=\!@solana/web3.js
+          pnpm turbo publish-packages --concurrency=95.84% --filter=\!@solana/web3.js
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm build
 
       - name: Build GitHub Pages
-        run: pnpm turbo run compile:ghpages --concurrency=100%
+        run: pnpm turbo run compile:ghpages --concurrency=95.84%
 
       - name: Stop Test Validator
         if: always() && steps.start-test-validator.outcome == 'success'

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
         "packages/*"
     ],
     "scripts": {
-        "build": "turbo run --concurrency=100% build",
-        "compile": "turbo run --concurrency=100% compile:js compile:typedefs",
-        "lint": "turbo run --concurrency=100% test:lint",
-        "style:fix": "turbo  run --concurrency=100% style:fix && pnpm prettier --log-level warn --ignore-unknown --write '{.,!packages}/*'",
-        "test": "turbo run --concurrency=100% test:unit:browser test:unit:node",
-        "test:live-with-test-validator": "turbo run --concurrency=100% test:live-with-test-validator",
+        "build": "turbo run --concurrency=95.84% build",
+        "compile": "turbo run --concurrency=95.84% compile:js compile:typedefs",
+        "lint": "turbo run --concurrency=95.84% test:lint",
+        "style:fix": "turbo  run --concurrency=95.84% style:fix && pnpm prettier --log-level warn --ignore-unknown --write '{.,!packages}/*'",
+        "test": "turbo run --concurrency=95.84% test:unit:browser test:unit:node",
+        "test:live-with-test-validator": "turbo run --concurrency=95.84% test:live-with-test-validator",
         "test:live-with-test-validator:setup": "./scripts/setup-test-validator.sh"
     },
     "devDependencies": {


### PR DESCRIPTION
# Summary

We're regularly getting [failures in CI](https://github.com/solana-labs/solana-web3.js/actions/runs/9911023987/job/27382758824) of the form ‘test timed out.’ I suspect this is just resource starvation on our very weak GitHub actions runners.

This PR sets concurrency to 95.84%. This number is selfishly chosen so that the script runs with exactly 46/48 processors on my dev machine.

# Test Plan

Looked at how Turborepo [computes concurrency](https://github.com/vercel/turbo/blob/be67cfd1dc388f636db3b3b598dd4ad286946b28/crates/turborepo-lib/src/opts.rs#L257). It basically rounds down.

```
// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=46dcdbb0c3fc5ee183bc4fe30e42ec57
(48 as f64 * 95.84 / 100.0).max(1.0) as u32) // 46
```
