### PR TITLE
`SolanaErrors` with a nested `cause` now specify the `cause` property as `SolanaError | undefined`

### DIFF
--- a/examples/transfer-lamports/src/example.ts
+++ b/examples/transfer-lamports/src/example.ts
@@ -200,8 +200,7 @@ try {
             // TODO(@lorisleiva): Replace this with `isSystemProgramError()`
             isProgramError<SystemError>(e.cause, transactionMessage, SYSTEM_PROGRAM_ADDRESS)
                 ? getSystemErrorMessage(e.cause.context.code)
-                : // @ts-expect-error FIXME(#2959)
-                  e.cause?.message;
+                : e.cause?.message;
         log.error(preflightErrorContext, '%s: %s', preflightErrorMessage, errorDetailMessage);
     } else {
         throw e;

--- a/packages/errors/src/__typetests__/error-typetest.ts
+++ b/packages/errors/src/__typetests__/error-typetest.ts
@@ -1,5 +1,5 @@
 import * as SolanaErrorCodeModule from '../codes';
-import { SolanaErrorCode } from '../codes';
+import { SolanaErrorCode, SolanaErrorCodeWithCause } from '../codes';
 import { SolanaErrorContext } from '../context';
 import { isSolanaError, SolanaError } from '../error';
 
@@ -56,3 +56,7 @@ null as unknown as SolanaErrorContext satisfies {
                   : SolanaErrorContext[Code][PP];
           };
 };
+
+// Special errors have a nested `cause` property that is an optional `SolanaError`
+const errorWithCause = null as unknown as SolanaError<SolanaErrorCodeWithCause>;
+errorWithCause.cause satisfies SolanaError | undefined;

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -535,3 +535,8 @@ export type SolanaErrorCode =
     | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_ACCOUNT_COST_LIMIT
     | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_BLOCK_COST_LIMIT
     | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_VOTE_COST_LIMIT;
+
+/**
+ * Errors of this type are understood to have an optional `SolanaError` nested inside as `cause`.
+ */
+export type SolanaErrorCodeWithCause = typeof SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE;

--- a/packages/errors/src/error.ts
+++ b/packages/errors/src/error.ts
@@ -1,4 +1,4 @@
-import { SolanaErrorCode } from './codes';
+import { SolanaErrorCode, SolanaErrorCodeWithCause } from './codes';
 import { SolanaErrorContext } from './context';
 import { getErrorMessage } from './message-formatter';
 
@@ -23,6 +23,7 @@ type SolanaErrorCodedContext = Readonly<{
 }>;
 
 export class SolanaError<TErrorCode extends SolanaErrorCode = SolanaErrorCode> extends Error {
+    readonly cause?: TErrorCode extends SolanaErrorCodeWithCause ? SolanaError : unknown = this.cause;
     readonly context: SolanaErrorCodedContext[TErrorCode];
     constructor(
         ...[code, contextAndErrorOptions]: SolanaErrorContext[TErrorCode] extends undefined


### PR DESCRIPTION
Closes #2959.