### PR TITLE
Tighten return type of isProgramError

### DIFF
--- a/.changeset/warm-pears-sip.md
+++ b/.changeset/warm-pears-sip.md
@@ -1,0 +1,5 @@
+---
+'@solana/programs': patch
+---
+
+Tighten return type of isProgramError

--- a/packages/programs/src/__typetests__/program-error-typetest.ts
+++ b/packages/programs/src/__typetests__/program-error-typetest.ts
@@ -25,8 +25,12 @@ const programAddress = '1111' as Address;
     // [isProgramError]: It narrow down the error type and its custom program error code.
     const error = {} as Error;
     if (isProgramError(error, tx, programAddress, 42)) {
-        error satisfies SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & { context: { code: 42 } };
+        error satisfies SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
+            readonly context: { readonly code: 42 };
+        };
         // @ts-expect-error Expected error to have code 42
-        error satisfies SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & { context: { code: 43 } };
+        error satisfies SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
+            readonly context: { readonly code: 43 };
+        };
     }
 }

--- a/packages/programs/src/program-error.ts
+++ b/packages/programs/src/program-error.ts
@@ -6,7 +6,8 @@ export function isProgramError<TProgramErrorCode extends number>(
     transactionMessage: { instructions: Record<number, { programAddress: Address }> },
     programAddress: Address,
     code?: TProgramErrorCode,
-): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & { context: { code: TProgramErrorCode } } {
+): error is Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> &
+    SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> {
     if (!isSolanaError(error, SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM)) {
         return false;
     }


### PR DESCRIPTION
This PR makes the `isProgramError` helper return `Readonly` objects as suggested in [this Kinobi PR](https://github.com/kinobi-so/kinobi/pull/127).