### PR TITLE
Enable `useDefineForClassFields`

### DIFF
--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -16,7 +16,8 @@
         "preserveWatchOutput": true,
         "skipLibCheck": true,
         "strict": true,
-        "target": "ESNext"
+        "target": "ESNext",
+        "useDefineForClassFields": true
     },
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Summary

This is a runtime change from old TypeScript to that which ECMAScript decided upon. You can read all about it [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier).

It would probably be wise to be explicit about this setting, and furthermore to align it with the spec, just in case we change out bundlers later that have some behaviour different than `tsup`.

# Test Plan

Modules.

```diff
var SolanaError = class extends Error {
+ context;
  constructor(...[code, contextAndErrorOptions]) {
    let context;
```

Browser bundle.

```diff
  var SolanaError = class extends Error {
    constructor(...[code, contextAndErrorOptions]) {
      let context;
      let errorOptions;
      if (contextAndErrorOptions) {
        const { cause, ...contextRest } = contextAndErrorOptions;
        if (cause) {
          errorOptions = { cause };
        }
        if (Object.keys(contextRest).length > 0) {
          context = contextRest;
        }
      }
      const message = getErrorMessage(code, context);
      super(message, errorOptions);
+     __publicField(this, "context");
      this.context = {
```

CI run.
