### PR TITLE
Use `lamports()` in deserialize transaction example

### DIFF
--- a/examples/deserialize-transaction/src/example.ts
+++ b/examples/deserialize-transaction/src/example.ts
@@ -26,6 +26,7 @@ import {
     getBase64Encoder,
     getCompiledTransactionMessageDecoder,
     getTransactionDecoder,
+    lamports,
     partiallySignTransactionMessageWithSigners,
     pipe,
     setTransactionMessageFeePayer,
@@ -107,7 +108,7 @@ const transactionMessage = pipe(
         appendTransactionMessageInstructions(
             [
                 getTransferSolInstruction({
-                    amount: 12345678,
+                    amount: lamports(12345678n),
                     destination: DESTINATION_ADDRESS,
                     source: SOURCE_ACCOUNT_SIGNER,
                 }),


### PR DESCRIPTION
Lest we lead anyone astray that this is denominated in SOL or that numbers are preferable over bigints.
