### PR TITLE
Refactor number codecs + allow offloading lamport codec to an inner codec

### DIFF
--- a/packages/codecs-data-structures/src/__typetests__/enum-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/enum-typetest.ts
@@ -30,7 +30,7 @@ type DirectionInput = Direction | keyof typeof Direction;
     getEnumEncoder(Direction) satisfies FixedSizeEncoder<DirectionInput, 1>;
     getEnumEncoder(Feedback, { size: getU32Encoder() }) satisfies FixedSizeEncoder<FeedbackInput, 4>;
     getEnumEncoder(Feedback, {
-        size: {} as VariableSizeEncoder<number>,
+        size: {} as VariableSizeEncoder<bigint | number>,
     }) satisfies VariableSizeEncoder<FeedbackInput>;
 }
 
@@ -47,8 +47,10 @@ type DirectionInput = Direction | keyof typeof Direction;
     getEnumCodec(Feedback) satisfies FixedSizeCodec<FeedbackInput, Feedback, 1>;
     getEnumCodec(Direction) satisfies FixedSizeCodec<DirectionInput, Direction, 1>;
     getEnumCodec(Feedback, { size: getU32Codec() }) satisfies FixedSizeCodec<FeedbackInput, Feedback, 4>;
-    getEnumCodec(Feedback, { size: {} as VariableSizeCodec<number> }) satisfies VariableSizeCodec<
-        FeedbackInput,
-        Feedback
-    >;
+    getEnumCodec(Feedback, {
+        size: {} as VariableSizeCodec<bigint | number, number>,
+    }) satisfies VariableSizeCodec<FeedbackInput, Feedback>;
+    getEnumCodec(Feedback, {
+        size: {} as VariableSizeCodec<bigint | number, bigint>,
+    }) satisfies VariableSizeCodec<FeedbackInput, Feedback>;
 }

--- a/packages/codecs-data-structures/src/__typetests__/literal-union-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/literal-union-typetest.ts
@@ -14,9 +14,9 @@ import { getLiteralUnionCodec, getLiteralUnionDecoder, getLiteralUnionEncoder } 
     // [getLiteralUnionEncoder]: It knows if the encoder is fixed size or variable size.
     getLiteralUnionEncoder(['one', 2, 3n]) satisfies FixedSizeEncoder<'one' | 2 | 3n, 1>;
     getLiteralUnionEncoder(['one', 2, 3n], { size: getU32Encoder() }) satisfies FixedSizeEncoder<'one' | 2 | 3n, 4>;
-    getLiteralUnionEncoder(['one', 2, 3n], { size: {} as VariableSizeEncoder<number> }) satisfies VariableSizeEncoder<
-        'one' | 2 | 3n
-    >;
+    getLiteralUnionEncoder(['one', 2, 3n], {
+        size: {} as VariableSizeEncoder<bigint | number>,
+    }) satisfies VariableSizeEncoder<'one' | 2 | 3n>;
 }
 
 {
@@ -36,7 +36,10 @@ import { getLiteralUnionCodec, getLiteralUnionDecoder, getLiteralUnionEncoder } 
         'one' | 2 | 3n,
         4
     >;
-    getLiteralUnionCodec(['one', 2, 3n], { size: {} as VariableSizeCodec<number> }) satisfies VariableSizeCodec<
-        'one' | 2 | 3n
-    >;
+    getLiteralUnionCodec(['one', 2, 3n], {
+        size: {} as VariableSizeCodec<bigint | number, number>,
+    }) satisfies VariableSizeCodec<'one' | 2 | 3n>;
+    getLiteralUnionCodec(['one', 2, 3n], {
+        size: {} as VariableSizeCodec<bigint | number, bigint>,
+    }) satisfies VariableSizeCodec<'one' | 2 | 3n>;
 }

--- a/packages/codecs-numbers/src/__tests__/__setup__.ts
+++ b/packages/codecs-numbers/src/__tests__/__setup__.ts
@@ -2,7 +2,7 @@ import { Codec, createCodec, Encoder } from '@solana/codecs-core';
 import { SOLANA_ERROR__CODECS__NUMBER_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
 export const assertValid = <T>(codec: Codec<T>, number: T, bytes: string, decodedNumber?: T): void => {
-    // Serialize.
+    // Encode.
     const actualBytes = codec.encode(number);
     const actualBytesBase16 = base16.decode(actualBytes);
     expect(actualBytesBase16).toBe(bytes);
@@ -16,6 +16,12 @@ export const assertValid = <T>(codec: Codec<T>, number: T, bytes: string, decode
     const deserializationWithOffset = codec.read(base16.encode(`ffffff${bytes}`), 3);
     expect(deserializationWithOffset[0]).toBe(decodedNumber ?? number);
     expect(deserializationWithOffset[1]).toBe(actualBytes.length + 3);
+};
+
+export const assertValidEncode = <T>(encoder: Encoder<T>, number: T, bytes: string): void => {
+    const actualBytes = encoder.encode(number);
+    const actualBytesBase16 = base16.decode(actualBytes);
+    expect(actualBytesBase16).toBe(bytes);
 };
 
 type RangeErrorValues = {

--- a/packages/codecs-numbers/src/__tests__/f32-test.ts
+++ b/packages/codecs-numbers/src/__tests__/f32-test.ts
@@ -1,6 +1,6 @@
 import { Endian } from '../common';
 import { getF32Codec } from '../f32';
-import { assertValid } from './__setup__';
+import { assertValid, assertValidEncode } from './__setup__';
 
 const APPROX_PI = 3.1415927410125732;
 const f32 = getF32Codec;
@@ -13,11 +13,17 @@ describe('getF32Codec', () => {
 
         assertValid(f32LE, 0, '00000000');
         assertValid(f32BE, 0, '00000000');
+        assertValidEncode(f32LE, 0n, '00000000');
+        assertValidEncode(f32BE, 0n, '00000000');
 
         assertValid(f32LE, 1, '0000803f');
         assertValid(f32BE, 1, '3f800000');
+        assertValidEncode(f32LE, 1n, '0000803f');
+        assertValidEncode(f32BE, 1n, '3f800000');
         assertValid(f32LE, 42, '00002842');
         assertValid(f32BE, 42, '42280000');
+        assertValidEncode(f32LE, 42n, '00002842');
+        assertValidEncode(f32BE, 42n, '42280000');
         assertValid(f32LE, Math.PI, 'db0f4940', APPROX_PI);
         assertValid(f32BE, Math.PI, '40490fdb', APPROX_PI);
 

--- a/packages/codecs-numbers/src/__tests__/f64-test.ts
+++ b/packages/codecs-numbers/src/__tests__/f64-test.ts
@@ -1,6 +1,6 @@
 import { Endian } from '../common';
 import { getF64Codec } from '../f64';
-import { assertValid } from './__setup__';
+import { assertValid, assertValidEncode } from './__setup__';
 
 const APPROX_PI = 3.141592653589793;
 const f64 = getF64Codec;
@@ -13,11 +13,17 @@ describe('getF64Codec', () => {
 
         assertValid(f64LE, 0, '0000000000000000');
         assertValid(f64BE, 0, '0000000000000000');
+        assertValidEncode(f64LE, 0n, '0000000000000000');
+        assertValidEncode(f64BE, 0n, '0000000000000000');
 
         assertValid(f64LE, 1, '000000000000f03f');
         assertValid(f64BE, 1, '3ff0000000000000');
         assertValid(f64LE, 42, '0000000000004540');
         assertValid(f64BE, 42, '4045000000000000');
+        assertValidEncode(f64LE, 1n, '000000000000f03f');
+        assertValidEncode(f64BE, 1n, '3ff0000000000000');
+        assertValidEncode(f64LE, 42n, '0000000000004540');
+        assertValidEncode(f64BE, 42n, '4045000000000000');
         assertValid(f64LE, Math.PI, '182d4454fb210940', APPROX_PI);
         assertValid(f64BE, Math.PI, '400921fb54442d18', APPROX_PI);
 

--- a/packages/codecs-numbers/src/__tests__/i16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i16-test.ts
@@ -1,6 +1,6 @@
 import { Endian } from '../common';
 import { getI16Codec } from '../i16';
-import { assertRangeError, assertValid } from './__setup__';
+import { assertRangeError, assertValid, assertValidEncode } from './__setup__';
 
 const MIN = -Number('0x7fff') - 1;
 const MAX = Number('0x7fff');
@@ -23,6 +23,12 @@ describe('getI16Codec', () => {
         assertValid(i16BE, 1, '0001');
         assertValid(i16LE, 42, '2a00');
         assertValid(i16BE, 42, '002a');
+        assertValidEncode(i16LE, 0n, '0000');
+        assertValidEncode(i16BE, 0n, '0000');
+        assertValidEncode(i16LE, 1n, '0100');
+        assertValidEncode(i16BE, 1n, '0001');
+        assertValidEncode(i16LE, 42n, '2a00');
+        assertValidEncode(i16BE, 42n, '002a');
         assertValid(i16LE, -1, 'ffff');
         assertValid(i16BE, -1, 'ffff');
         assertValid(i16LE, -42, 'd6ff');
@@ -33,18 +39,30 @@ describe('getI16Codec', () => {
         assertValid(i16BE, MIN + 1, '8001');
         assertValid(i16LE, MAX - 1, 'fe7f');
         assertValid(i16BE, MAX - 1, '7ffe');
+        assertValidEncode(i16LE, BigInt(MIN + 1), '0180');
+        assertValidEncode(i16BE, BigInt(MIN + 1), '8001');
+        assertValidEncode(i16LE, BigInt(MAX - 1), 'fe7f');
+        assertValidEncode(i16BE, BigInt(MAX - 1), '7ffe');
 
         // Boundaries.
         assertValid(i16LE, MIN, '0080');
         assertValid(i16BE, MIN, '8000');
         assertValid(i16LE, MAX, 'ff7f');
         assertValid(i16BE, MAX, '7fff');
+        assertValidEncode(i16LE, BigInt(MIN), '0080');
+        assertValidEncode(i16BE, BigInt(MIN), '8000');
+        assertValidEncode(i16LE, BigInt(MAX), 'ff7f');
+        assertValidEncode(i16BE, BigInt(MAX), '7fff');
 
         // Out of range.
         assertRangeError(rangeErrorValues, i16LE, MIN - 1);
         assertRangeError(rangeErrorValues, i16BE, MIN - 1);
         assertRangeError(rangeErrorValues, i16LE, MAX + 1);
         assertRangeError(rangeErrorValues, i16BE, MAX + 1);
+        assertRangeError(rangeErrorValues, i16LE, BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, i16BE, BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, i16LE, BigInt(MAX + 1));
+        assertRangeError(rangeErrorValues, i16BE, BigInt(MAX + 1));
     });
 
     it('has the right size', () => {

--- a/packages/codecs-numbers/src/__tests__/i32-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i32-test.ts
@@ -1,6 +1,6 @@
 import { Endian } from '../common';
 import { getI32Codec } from '../i32';
-import { assertRangeError, assertValid } from './__setup__';
+import { assertRangeError, assertValid, assertValidEncode } from './__setup__';
 
 const MIN = -Number('0x7fffffff') - 1;
 const MAX = Number('0x7fffffff');
@@ -23,6 +23,12 @@ describe('getI32Codec', () => {
         assertValid(i32BE, 1, '00000001');
         assertValid(i32LE, 42, '2a000000');
         assertValid(i32BE, 42, '0000002a');
+        assertValidEncode(i32LE, 0n, '00000000');
+        assertValidEncode(i32BE, 0n, '00000000');
+        assertValidEncode(i32LE, 1n, '01000000');
+        assertValidEncode(i32BE, 1n, '00000001');
+        assertValidEncode(i32LE, 42n, '2a000000');
+        assertValidEncode(i32BE, 42n, '0000002a');
         assertValid(i32LE, -1, 'ffffffff');
         assertValid(i32BE, -1, 'ffffffff');
         assertValid(i32LE, -42, 'd6ffffff');
@@ -33,18 +39,30 @@ describe('getI32Codec', () => {
         assertValid(i32BE, MIN + 1, '80000001');
         assertValid(i32LE, MAX - 1, 'feffff7f');
         assertValid(i32BE, MAX - 1, '7ffffffe');
+        assertValidEncode(i32LE, BigInt(MIN + 1), '01000080');
+        assertValidEncode(i32BE, BigInt(MIN + 1), '80000001');
+        assertValidEncode(i32LE, BigInt(MAX - 1), 'feffff7f');
+        assertValidEncode(i32BE, BigInt(MAX - 1), '7ffffffe');
 
         // Boundaries.
         assertValid(i32LE, MIN, '00000080');
         assertValid(i32BE, MIN, '80000000');
         assertValid(i32LE, MAX, 'ffffff7f');
         assertValid(i32BE, MAX, '7fffffff');
+        assertValidEncode(i32LE, BigInt(MIN), '00000080');
+        assertValidEncode(i32BE, BigInt(MIN), '80000000');
+        assertValidEncode(i32LE, BigInt(MAX), 'ffffff7f');
+        assertValidEncode(i32BE, BigInt(MAX), '7fffffff');
 
         // Out of range.
         assertRangeError(rangeErrorValues, i32LE, MIN - 1);
         assertRangeError(rangeErrorValues, i32BE, MIN - 1);
         assertRangeError(rangeErrorValues, i32LE, MAX + 1);
         assertRangeError(rangeErrorValues, i32BE, MAX + 1);
+        assertRangeError(rangeErrorValues, i32LE, BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, i32BE, BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, i32LE, BigInt(MAX + 1));
+        assertRangeError(rangeErrorValues, i32BE, BigInt(MAX + 1));
     });
 
     it('has the right size', () => {

--- a/packages/codecs-numbers/src/__tests__/i8-test.ts
+++ b/packages/codecs-numbers/src/__tests__/i8-test.ts
@@ -1,5 +1,5 @@
 import { getI8Codec } from '../i8';
-import { assertRangeError, assertValid } from './__setup__';
+import { assertRangeError, assertValid, assertValidEncode } from './__setup__';
 
 const MIN = -Number('0x7f') - 1;
 const MAX = Number('0x7f');
@@ -16,20 +16,26 @@ describe('getI8Codec', () => {
         assertValid(i8(), 0, '00');
         assertValid(i8(), 1, '01');
         assertValid(i8(), 42, '2a');
+        assertValidEncode(i8(), 0n, '00');
+        assertValidEncode(i8(), 1n, '01');
+        assertValidEncode(i8(), 42n, '2a');
         assertValid(i8(), -1, 'ff');
         assertValid(i8(), -42, 'd6');
 
         // Pre-boundaries.
         assertValid(i8(), MIN + 1, '81');
         assertValid(i8(), MAX - 1, '7e');
+        assertValidEncode(i8(), BigInt(MAX - 1), '7e');
 
         // Boundaries.
         assertValid(i8(), MIN, '80');
         assertValid(i8(), MAX, '7f');
+        assertValidEncode(i8(), BigInt(MAX), '7f');
 
         // Out of range.
         assertRangeError(rangeErrorValues, i8(), MIN - 1);
         assertRangeError(rangeErrorValues, i8(), MAX + 1);
+        assertRangeError(rangeErrorValues, i8(), BigInt(MAX + 1));
     });
 
     it('has the right size', () => {

--- a/packages/codecs-numbers/src/__tests__/short-u16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/short-u16-test.ts
@@ -1,5 +1,5 @@
 import { getShortU16Codec } from '../short-u16';
-import { assertRangeError, assertValid } from './__setup__';
+import { assertRangeError, assertValid, assertValidEncode } from './__setup__';
 
 const MIN = 0;
 const MAX = 65535;
@@ -20,18 +20,31 @@ describe('getShortU16Codec', () => {
         assertValid(shortU16(), 128, '8001');
         assertValid(shortU16(), 16383, 'ff7f');
         assertValid(shortU16(), 16384, '808001');
+        assertValidEncode(shortU16(), 0n, '00');
+        assertValidEncode(shortU16(), 1n, '01');
+        assertValidEncode(shortU16(), 42n, '2a');
+        assertValidEncode(shortU16(), 127n, '7f');
+        assertValidEncode(shortU16(), 128n, '8001');
+        assertValidEncode(shortU16(), 16383n, 'ff7f');
+        assertValidEncode(shortU16(), 16384n, '808001');
 
         // Pre-boundaries.
         assertValid(shortU16(), MIN + 1, '01');
         assertValid(shortU16(), MAX - 1, 'feff03');
+        assertValidEncode(shortU16(), BigInt(MIN + 1), '01');
+        assertValidEncode(shortU16(), BigInt(MAX - 1), 'feff03');
 
         // Boundaries.
         assertValid(shortU16(), MIN, '00');
         assertValid(shortU16(), MAX, 'ffff03');
+        assertValidEncode(shortU16(), BigInt(MIN), '00');
+        assertValidEncode(shortU16(), BigInt(MAX), 'ffff03');
 
         // Out of range.
         assertRangeError(rangeErrorValues, shortU16(), MIN - 1);
         assertRangeError(rangeErrorValues, shortU16(), MAX + 1);
+        assertRangeError(rangeErrorValues, shortU16(), BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, shortU16(), BigInt(MAX + 1));
 
         // Assert re-serialization.
         const codec = shortU16();

--- a/packages/codecs-numbers/src/__tests__/u16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u16-test.ts
@@ -1,6 +1,6 @@
 import { Endian } from '../common';
 import { getU16Codec } from '../u16';
-import { assertRangeError, assertValid } from './__setup__';
+import { assertRangeError, assertValid, assertValidEncode } from './__setup__';
 
 const MIN = 0;
 const MAX = Number('0xffff');
@@ -22,28 +22,46 @@ describe('getU16Codec', () => {
         assertValid(u16BE, 1, '0001');
         assertValid(u16LE, 42, '2a00');
         assertValid(u16BE, 42, '002a');
+        assertValidEncode(u16LE, 1n, '0100');
+        assertValidEncode(u16BE, 1n, '0001');
+        assertValidEncode(u16LE, 42n, '2a00');
+        assertValidEncode(u16BE, 42n, '002a');
 
         // Half bytes.
         assertValid(u16LE, HALF, 'ff00');
         assertValid(u16BE, HALF, '00ff');
+        assertValidEncode(u16LE, BigInt(HALF), 'ff00');
+        assertValidEncode(u16BE, BigInt(HALF), '00ff');
 
         // Pre-boundaries.
         assertValid(u16LE, MIN + 1, '0100');
         assertValid(u16BE, MIN + 1, '0001');
         assertValid(u16LE, MAX - 1, 'feff');
         assertValid(u16BE, MAX - 1, 'fffe');
+        assertValidEncode(u16LE, BigInt(MIN + 1), '0100');
+        assertValidEncode(u16BE, BigInt(MIN + 1), '0001');
+        assertValidEncode(u16LE, BigInt(MAX - 1), 'feff');
+        assertValidEncode(u16BE, BigInt(MAX - 1), 'fffe');
 
         // Boundaries.
         assertValid(u16LE, MIN, '0000');
         assertValid(u16BE, MIN, '0000');
         assertValid(u16LE, MAX, 'ffff');
         assertValid(u16BE, MAX, 'ffff');
+        assertValidEncode(u16LE, BigInt(MIN), '0000');
+        assertValidEncode(u16BE, BigInt(MIN), '0000');
+        assertValidEncode(u16LE, BigInt(MAX), 'ffff');
+        assertValidEncode(u16BE, BigInt(MAX), 'ffff');
 
         // Out of range.
         assertRangeError(rangeErrorValues, u16LE, MIN - 1);
         assertRangeError(rangeErrorValues, u16BE, MIN - 1);
         assertRangeError(rangeErrorValues, u16LE, MAX + 1);
         assertRangeError(rangeErrorValues, u16BE, MAX + 1);
+        assertRangeError(rangeErrorValues, u16LE, BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, u16BE, BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, u16LE, BigInt(MAX + 1));
+        assertRangeError(rangeErrorValues, u16BE, BigInt(MAX + 1));
     });
 
     it('has the right size', () => {

--- a/packages/codecs-numbers/src/__tests__/u32-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u32-test.ts
@@ -1,6 +1,6 @@
 import { Endian } from '../common';
 import { getU32Codec } from '../u32';
-import { assertRangeError, assertValid } from './__setup__';
+import { assertRangeError, assertValid, assertValidEncode } from './__setup__';
 
 const MIN = 0;
 const MAX = Number('0xffffffff');
@@ -22,28 +22,46 @@ describe('getU32Codec', () => {
         assertValid(u32BE, 1, '00000001');
         assertValid(u32LE, 42, '2a000000');
         assertValid(u32BE, 42, '0000002a');
+        assertValidEncode(u32LE, 1n, '01000000');
+        assertValidEncode(u32BE, 1n, '00000001');
+        assertValidEncode(u32LE, 42n, '2a000000');
+        assertValidEncode(u32BE, 42n, '0000002a');
 
         // Half bytes.
         assertValid(u32LE, HALF, 'ffff0000');
         assertValid(u32BE, HALF, '0000ffff');
+        assertValidEncode(u32LE, BigInt(HALF), 'ffff0000');
+        assertValidEncode(u32BE, BigInt(HALF), '0000ffff');
 
         // Pre-boundaries.
         assertValid(u32LE, MIN + 1, '01000000');
         assertValid(u32BE, MIN + 1, '00000001');
         assertValid(u32LE, MAX - 1, 'feffffff');
         assertValid(u32BE, MAX - 1, 'fffffffe');
+        assertValidEncode(u32LE, BigInt(MIN + 1), '01000000');
+        assertValidEncode(u32BE, BigInt(MIN + 1), '00000001');
+        assertValidEncode(u32LE, BigInt(MAX - 1), 'feffffff');
+        assertValidEncode(u32BE, BigInt(MAX - 1), 'fffffffe');
 
         // Boundaries.
         assertValid(u32LE, MIN, '00000000');
         assertValid(u32BE, MIN, '00000000');
         assertValid(u32LE, MAX, 'ffffffff');
         assertValid(u32BE, MAX, 'ffffffff');
+        assertValidEncode(u32LE, BigInt(MIN), '00000000');
+        assertValidEncode(u32BE, BigInt(MIN), '00000000');
+        assertValidEncode(u32LE, BigInt(MAX), 'ffffffff');
+        assertValidEncode(u32BE, BigInt(MAX), 'ffffffff');
 
         // Out of range.
         assertRangeError(rangeErrorValues, u32LE, MIN - 1);
         assertRangeError(rangeErrorValues, u32BE, MIN - 1);
         assertRangeError(rangeErrorValues, u32LE, MAX + 1);
         assertRangeError(rangeErrorValues, u32BE, MAX + 1);
+        assertRangeError(rangeErrorValues, u32LE, BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, u32BE, BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, u32LE, BigInt(MAX + 1));
+        assertRangeError(rangeErrorValues, u32BE, BigInt(MAX + 1));
     });
 
     it('has the right size', () => {

--- a/packages/codecs-numbers/src/__tests__/u8-test.ts
+++ b/packages/codecs-numbers/src/__tests__/u8-test.ts
@@ -1,5 +1,5 @@
 import { getU8Codec } from '../u8';
-import { assertRangeError, assertValid } from './__setup__';
+import { assertRangeError, assertValid, assertValidEncode } from './__setup__';
 
 const MIN = 0;
 const MAX = Number('0xff');
@@ -15,18 +15,26 @@ describe('getU8Codec', () => {
         expect.hasAssertions();
         assertValid(u8(), 1, '01');
         assertValid(u8(), 42, '2a');
+        assertValidEncode(u8(), 1n, '01');
+        assertValidEncode(u8(), 42n, '2a');
 
         // Pre-boundaries.
         assertValid(u8(), MIN + 1, '01');
         assertValid(u8(), MAX - 1, 'fe');
+        assertValidEncode(u8(), BigInt(MIN + 1), '01');
+        assertValidEncode(u8(), BigInt(MAX - 1), 'fe');
 
         // Boundaries.
         assertValid(u8(), MIN, '00');
         assertValid(u8(), MAX, 'ff');
+        assertValidEncode(u8(), BigInt(MIN), '00');
+        assertValidEncode(u8(), BigInt(MAX), 'ff');
 
         // Out of range.
         assertRangeError(rangeErrorValues, u8(), MIN - 1);
         assertRangeError(rangeErrorValues, u8(), MAX + 1);
+        assertRangeError(rangeErrorValues, u8(), BigInt(MIN - 1));
+        assertRangeError(rangeErrorValues, u8(), BigInt(MAX + 1));
     });
 
     it('has the right size', () => {

--- a/packages/codecs-numbers/src/__typetests__/codecs.ts
+++ b/packages/codecs-numbers/src/__typetests__/codecs.ts
@@ -1,0 +1,169 @@
+import type {
+    FixedSizeNumberCodec,
+    FixedSizeNumberDecoder,
+    FixedSizeNumberEncoder,
+    NumberCodec,
+    NumberDecoder,
+    NumberEncoder,
+} from '../common';
+import { getF32Codec, getF32Decoder, getF32Encoder } from '../f32';
+import { getF64Codec, getF64Decoder, getF64Encoder } from '../f64';
+import { getI8Codec, getI8Decoder, getI8Encoder } from '../i8';
+import { getI16Codec, getI16Decoder, getI16Encoder } from '../i16';
+import { getI32Codec, getI32Decoder, getI32Encoder } from '../i32';
+import { getI64Codec, getI64Decoder, getI64Encoder } from '../i64';
+import { getI128Codec, getI128Decoder, getI128Encoder } from '../i128';
+import { getShortU16Codec, getShortU16Decoder, getShortU16Encoder } from '../short-u16';
+import { getU8Codec, getU8Decoder, getU8Encoder } from '../u8';
+import { getU16Codec, getU16Decoder, getU16Encoder } from '../u16';
+import { getU32Codec, getU32Decoder, getU32Encoder } from '../u32';
+import { getU64Codec, getU64Decoder, getU64Encoder } from '../u64';
+import { getU128Codec, getU128Decoder, getU128Encoder } from '../u128';
+
+getF32Encoder() satisfies NumberEncoder;
+getF32Encoder() satisfies FixedSizeNumberEncoder;
+getF32Decoder() satisfies NumberDecoder;
+getF32Decoder() satisfies FixedSizeNumberDecoder;
+getF32Codec() satisfies NumberCodec;
+getF32Codec() satisfies FixedSizeNumberCodec;
+getF32Codec() satisfies NumberEncoder;
+getF32Codec() satisfies FixedSizeNumberEncoder;
+getF32Codec() satisfies NumberDecoder;
+getF32Codec() satisfies FixedSizeNumberDecoder;
+
+getF64Encoder() satisfies NumberEncoder;
+getF64Encoder() satisfies FixedSizeNumberEncoder;
+getF64Decoder() satisfies NumberDecoder;
+getF64Decoder() satisfies FixedSizeNumberDecoder;
+getF64Codec() satisfies NumberCodec;
+getF64Codec() satisfies FixedSizeNumberCodec;
+getF64Codec() satisfies NumberEncoder;
+getF64Codec() satisfies FixedSizeNumberEncoder;
+getF64Codec() satisfies NumberDecoder;
+getF64Codec() satisfies FixedSizeNumberDecoder;
+
+getI8Encoder() satisfies NumberEncoder;
+getI8Encoder() satisfies FixedSizeNumberEncoder;
+getI8Decoder() satisfies NumberDecoder;
+getI8Decoder() satisfies FixedSizeNumberDecoder;
+getI8Codec() satisfies NumberCodec;
+getI8Codec() satisfies FixedSizeNumberCodec;
+getI8Codec() satisfies NumberEncoder;
+getI8Codec() satisfies FixedSizeNumberEncoder;
+getI8Codec() satisfies NumberDecoder;
+getI8Codec() satisfies FixedSizeNumberDecoder;
+
+getI16Encoder() satisfies NumberEncoder;
+getI16Encoder() satisfies FixedSizeNumberEncoder;
+getI16Decoder() satisfies NumberDecoder;
+getI16Decoder() satisfies FixedSizeNumberDecoder;
+getI16Codec() satisfies NumberCodec;
+getI16Codec() satisfies FixedSizeNumberCodec;
+getI16Codec() satisfies NumberEncoder;
+getI16Codec() satisfies FixedSizeNumberEncoder;
+getI16Codec() satisfies NumberDecoder;
+getI16Codec() satisfies FixedSizeNumberDecoder;
+
+getI32Encoder() satisfies NumberEncoder;
+getI32Encoder() satisfies FixedSizeNumberEncoder;
+getI32Decoder() satisfies NumberDecoder;
+getI32Decoder() satisfies FixedSizeNumberDecoder;
+getI32Codec() satisfies NumberCodec;
+getI32Codec() satisfies FixedSizeNumberCodec;
+getI32Codec() satisfies NumberEncoder;
+getI32Codec() satisfies FixedSizeNumberEncoder;
+getI32Codec() satisfies NumberDecoder;
+getI32Codec() satisfies FixedSizeNumberDecoder;
+
+getI64Encoder() satisfies NumberEncoder;
+getI64Encoder() satisfies FixedSizeNumberEncoder;
+getI64Decoder() satisfies NumberDecoder;
+getI64Decoder() satisfies FixedSizeNumberDecoder;
+getI64Codec() satisfies NumberCodec;
+getI64Codec() satisfies FixedSizeNumberCodec;
+getI64Codec() satisfies NumberEncoder;
+getI64Codec() satisfies FixedSizeNumberEncoder;
+getI64Codec() satisfies NumberDecoder;
+getI64Codec() satisfies FixedSizeNumberDecoder;
+
+getI128Encoder() satisfies NumberEncoder;
+getI128Encoder() satisfies FixedSizeNumberEncoder;
+getI128Decoder() satisfies NumberDecoder;
+getI128Decoder() satisfies FixedSizeNumberDecoder;
+getI128Codec() satisfies NumberCodec;
+getI128Codec() satisfies FixedSizeNumberCodec;
+getI128Codec() satisfies NumberEncoder;
+getI128Codec() satisfies FixedSizeNumberEncoder;
+getI128Codec() satisfies NumberDecoder;
+getI128Codec() satisfies FixedSizeNumberDecoder;
+
+getShortU16Encoder() satisfies NumberEncoder;
+// @ts-expect-error variable size encoder
+getShortU16Encoder() satisfies FixedSizeNumberEncoder;
+getShortU16Decoder() satisfies NumberDecoder;
+// @ts-expect-error variable size decoder
+getShortU16Decoder() satisfies FixedSizeNumberDecoder;
+getShortU16Codec() satisfies NumberCodec;
+// @ts-expect-error variable size codec
+getShortU16Codec() satisfies FixedSizeNumberCodec;
+getShortU16Codec() satisfies NumberEncoder;
+// @ts-expect-error variable size encoder
+getShortU16Codec() satisfies FixedSizeNumberEncoder;
+getShortU16Codec() satisfies NumberDecoder;
+// @ts-expect-error variable size decoder
+getShortU16Codec() satisfies FixedSizeNumberDecoder;
+
+getU8Encoder() satisfies NumberEncoder;
+getU8Encoder() satisfies FixedSizeNumberEncoder;
+getU8Decoder() satisfies NumberDecoder;
+getU8Decoder() satisfies FixedSizeNumberDecoder;
+getU8Codec() satisfies NumberCodec;
+getU8Codec() satisfies FixedSizeNumberCodec;
+getU8Codec() satisfies NumberEncoder;
+getU8Codec() satisfies FixedSizeNumberEncoder;
+getU8Codec() satisfies NumberDecoder;
+getU8Codec() satisfies FixedSizeNumberDecoder;
+
+getU16Encoder() satisfies NumberEncoder;
+getU16Encoder() satisfies FixedSizeNumberEncoder;
+getU16Decoder() satisfies NumberDecoder;
+getU16Decoder() satisfies FixedSizeNumberDecoder;
+getU16Codec() satisfies NumberCodec;
+getU16Codec() satisfies FixedSizeNumberCodec;
+getU16Codec() satisfies NumberEncoder;
+getU16Codec() satisfies FixedSizeNumberEncoder;
+getU16Codec() satisfies NumberDecoder;
+getU16Codec() satisfies FixedSizeNumberDecoder;
+
+getU32Encoder() satisfies NumberEncoder;
+getU32Encoder() satisfies FixedSizeNumberEncoder;
+getU32Decoder() satisfies NumberDecoder;
+getU32Decoder() satisfies FixedSizeNumberDecoder;
+getU32Codec() satisfies NumberCodec;
+getU32Codec() satisfies FixedSizeNumberCodec;
+getU32Codec() satisfies NumberEncoder;
+getU32Codec() satisfies FixedSizeNumberEncoder;
+getU32Codec() satisfies NumberDecoder;
+getU32Codec() satisfies FixedSizeNumberDecoder;
+
+getU64Encoder() satisfies NumberEncoder;
+getU64Encoder() satisfies FixedSizeNumberEncoder;
+getU64Decoder() satisfies NumberDecoder;
+getU64Decoder() satisfies FixedSizeNumberDecoder;
+getU64Codec() satisfies NumberCodec;
+getU64Codec() satisfies FixedSizeNumberCodec;
+getU64Codec() satisfies NumberEncoder;
+getU64Codec() satisfies FixedSizeNumberEncoder;
+getU64Codec() satisfies NumberDecoder;
+getU64Codec() satisfies FixedSizeNumberDecoder;
+
+getU128Encoder() satisfies NumberEncoder;
+getU128Encoder() satisfies FixedSizeNumberEncoder;
+getU128Decoder() satisfies NumberDecoder;
+getU128Decoder() satisfies FixedSizeNumberDecoder;
+getU128Codec() satisfies NumberCodec;
+getU128Codec() satisfies FixedSizeNumberCodec;
+getU128Codec() satisfies NumberEncoder;
+getU128Codec() satisfies FixedSizeNumberEncoder;
+getU128Codec() satisfies NumberDecoder;
+getU128Codec() satisfies FixedSizeNumberDecoder;

--- a/packages/codecs-numbers/src/common.ts
+++ b/packages/codecs-numbers/src/common.ts
@@ -1,12 +1,10 @@
 import { Codec, Decoder, Encoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 /** Defines a encoder for numbers and bigints. */
-export type NumberEncoder = Encoder<bigint | number> | Encoder<number>;
+export type NumberEncoder = Encoder<bigint | number>;
 
 /** Defines a fixed-size encoder for numbers and bigints. */
-export type FixedSizeNumberEncoder<TSize extends number = number> =
-    | FixedSizeEncoder<bigint | number, TSize>
-    | FixedSizeEncoder<number, TSize>;
+export type FixedSizeNumberEncoder<TSize extends number = number> = FixedSizeEncoder<bigint | number, TSize>;
 
 /** Defines a decoder for numbers and bigints. */
 export type NumberDecoder = Decoder<bigint> | Decoder<number>;
@@ -17,12 +15,12 @@ export type FixedSizeNumberDecoder<TSize extends number = number> =
     | FixedSizeDecoder<number, TSize>;
 
 /** Defines a codec for numbers and bigints. */
-export type NumberCodec = Codec<bigint | number, bigint> | Codec<number>;
+export type NumberCodec = Codec<bigint | number, bigint> | Codec<bigint | number, number>;
 
 /** Defines a fixed-size codec for numbers and bigints. */
 export type FixedSizeNumberCodec<TSize extends number = number> =
     | FixedSizeCodec<bigint | number, bigint, TSize>
-    | FixedSizeCodec<number, number, TSize>;
+    | FixedSizeCodec<bigint | number, number, TSize>;
 
 /** Defines the config for number codecs that use more than one byte. */
 export type NumberCodecConfig = {

--- a/packages/codecs-numbers/src/f32.ts
+++ b/packages/codecs-numbers/src/f32.ts
@@ -7,7 +7,7 @@ export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
     numberEncoderFactory({
         config,
         name: 'f32',
-        set: (view, value, le) => view.setFloat32(0, typeof value === 'bigint' ? Number(value) : value, le),
+        set: (view, value, le) => view.setFloat32(0, Number(value), le),
         size: 4,
     });
 

--- a/packages/codecs-numbers/src/f32.ts
+++ b/packages/codecs-numbers/src/f32.ts
@@ -3,11 +3,11 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 4> =>
+export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 4> =>
     numberEncoderFactory({
         config,
         name: 'f32',
-        set: (view, value, le) => view.setFloat32(0, value, le),
+        set: (view, value, le) => view.setFloat32(0, typeof value === 'bigint' ? Number(value) : value, le),
         size: 4,
     });
 
@@ -19,5 +19,5 @@ export const getF32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
-export const getF32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 4> =>
+export const getF32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 4> =>
     combineCodec(getF32Encoder(config), getF32Decoder(config));

--- a/packages/codecs-numbers/src/f64.ts
+++ b/packages/codecs-numbers/src/f64.ts
@@ -7,7 +7,7 @@ export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
     numberEncoderFactory({
         config,
         name: 'f64',
-        set: (view, value, le) => view.setFloat64(0, typeof value === 'bigint' ? Number(value) : value, le),
+        set: (view, value, le) => view.setFloat64(0, Number(value), le),
         size: 8,
     });
 

--- a/packages/codecs-numbers/src/f64.ts
+++ b/packages/codecs-numbers/src/f64.ts
@@ -3,11 +3,11 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 8> =>
+export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 8> =>
     numberEncoderFactory({
         config,
         name: 'f64',
-        set: (view, value, le) => view.setFloat64(0, value, le),
+        set: (view, value, le) => view.setFloat64(0, typeof value === 'bigint' ? Number(value) : value, le),
         size: 8,
     });
 
@@ -19,5 +19,5 @@ export const getF64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
-export const getF64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 8> =>
+export const getF64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 8> =>
     combineCodec(getF64Encoder(config), getF64Decoder(config));

--- a/packages/codecs-numbers/src/i16.ts
+++ b/packages/codecs-numbers/src/i16.ts
@@ -8,7 +8,7 @@ export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         config,
         name: 'i16',
         range: [-Number('0x7fff') - 1, Number('0x7fff')],
-        set: (view, value, le) => view.setInt16(0, typeof value === 'bigint' ? Number(value) : value, le),
+        set: (view, value, le) => view.setInt16(0, Number(value), le),
         size: 2,
     });
 

--- a/packages/codecs-numbers/src/i16.ts
+++ b/packages/codecs-numbers/src/i16.ts
@@ -3,12 +3,12 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 2> =>
+export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 2> =>
     numberEncoderFactory({
         config,
         name: 'i16',
         range: [-Number('0x7fff') - 1, Number('0x7fff')],
-        set: (view, value, le) => view.setInt16(0, value, le),
+        set: (view, value, le) => view.setInt16(0, typeof value === 'bigint' ? Number(value) : value, le),
         size: 2,
     });
 
@@ -20,5 +20,5 @@ export const getI16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 2,
     });
 
-export const getI16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 2> =>
+export const getI16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 2> =>
     combineCodec(getI16Encoder(config), getI16Decoder(config));

--- a/packages/codecs-numbers/src/i32.ts
+++ b/packages/codecs-numbers/src/i32.ts
@@ -8,7 +8,7 @@ export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         config,
         name: 'i32',
         range: [-Number('0x7fffffff') - 1, Number('0x7fffffff')],
-        set: (view, value, le) => view.setInt32(0, typeof value === 'bigint' ? Number(value) : value, le),
+        set: (view, value, le) => view.setInt32(0, Number(value), le),
         size: 4,
     });
 

--- a/packages/codecs-numbers/src/i32.ts
+++ b/packages/codecs-numbers/src/i32.ts
@@ -3,12 +3,12 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 4> =>
+export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 4> =>
     numberEncoderFactory({
         config,
         name: 'i32',
         range: [-Number('0x7fffffff') - 1, Number('0x7fffffff')],
-        set: (view, value, le) => view.setInt32(0, value, le),
+        set: (view, value, le) => view.setInt32(0, typeof value === 'bigint' ? Number(value) : value, le),
         size: 4,
     });
 
@@ -20,5 +20,5 @@ export const getI32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
-export const getI32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 4> =>
+export const getI32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 4> =>
     combineCodec(getI32Encoder(config), getI32Decoder(config));

--- a/packages/codecs-numbers/src/i8.ts
+++ b/packages/codecs-numbers/src/i8.ts
@@ -2,11 +2,11 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getI8Encoder = (): FixedSizeEncoder<number, 1> =>
+export const getI8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
     numberEncoderFactory({
         name: 'i8',
         range: [-Number('0x7f') - 1, Number('0x7f')],
-        set: (view, value) => view.setInt8(0, value),
+        set: (view, value) => view.setInt8(0, typeof value === 'bigint' ? Number(value) : value),
         size: 1,
     });
 
@@ -17,4 +17,5 @@ export const getI8Decoder = (): FixedSizeDecoder<number, 1> =>
         size: 1,
     });
 
-export const getI8Codec = (): FixedSizeCodec<number, number, 1> => combineCodec(getI8Encoder(), getI8Decoder());
+export const getI8Codec = (): FixedSizeCodec<bigint | number, number, 1> =>
+    combineCodec(getI8Encoder(), getI8Decoder());

--- a/packages/codecs-numbers/src/i8.ts
+++ b/packages/codecs-numbers/src/i8.ts
@@ -6,7 +6,7 @@ export const getI8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
     numberEncoderFactory({
         name: 'i8',
         range: [-Number('0x7f') - 1, Number('0x7f')],
-        set: (view, value) => view.setInt8(0, typeof value === 'bigint' ? Number(value) : value),
+        set: (view, value) => view.setInt8(0, Number(value)),
         size: 1,
     });
 

--- a/packages/codecs-numbers/src/short-u16.ts
+++ b/packages/codecs-numbers/src/short-u16.ts
@@ -15,20 +15,20 @@ import { assertNumberIsBetweenForCodec } from './assertions';
  * Encodes short u16 numbers.
  * @see {@link getShortU16Codec} for a more detailed description.
  */
-export const getShortU16Encoder = (): VariableSizeEncoder<number> =>
+export const getShortU16Encoder = (): VariableSizeEncoder<bigint | number> =>
     createEncoder({
-        getSizeFromValue: (value: number): number => {
+        getSizeFromValue: (value: bigint | number): number => {
             if (value <= 0b01111111) return 1;
             if (value <= 0b0011111111111111) return 2;
             return 3;
         },
         maxSize: 3,
-        write: (value: number, bytes: Uint8Array, offset: Offset): Offset => {
+        write: (value: bigint | number, bytes: Uint8Array, offset: Offset): Offset => {
             assertNumberIsBetweenForCodec('shortU16', 0, 65535, value);
             const shortU16Bytes = [0];
             for (let ii = 0; ; ii += 1) {
                 // Shift the bits of the value over such that the next 7 bits are at the right edge.
-                const alignedValue = value >> (ii * 7);
+                const alignedValue = Number(value) >> (ii * 7);
                 if (alignedValue === 0) {
                     // No more bits to consume.
                     break;
@@ -80,5 +80,5 @@ export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
  * pattern until the 3rd byte. The 3rd byte, if needed, uses
  * all 8 bits to store the last byte of the original value.
  */
-export const getShortU16Codec = (): VariableSizeCodec<number> =>
+export const getShortU16Codec = (): VariableSizeCodec<bigint | number, number> =>
     combineCodec(getShortU16Encoder(), getShortU16Decoder());

--- a/packages/codecs-numbers/src/u16.ts
+++ b/packages/codecs-numbers/src/u16.ts
@@ -8,7 +8,7 @@ export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         config,
         name: 'u16',
         range: [0, Number('0xffff')],
-        set: (view, value, le) => view.setUint16(0, typeof value === 'bigint' ? Number(value) : value, le),
+        set: (view, value, le) => view.setUint16(0, Number(value), le),
         size: 2,
     });
 

--- a/packages/codecs-numbers/src/u16.ts
+++ b/packages/codecs-numbers/src/u16.ts
@@ -3,12 +3,12 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 2> =>
+export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 2> =>
     numberEncoderFactory({
         config,
         name: 'u16',
         range: [0, Number('0xffff')],
-        set: (view, value, le) => view.setUint16(0, value, le),
+        set: (view, value, le) => view.setUint16(0, typeof value === 'bigint' ? Number(value) : value, le),
         size: 2,
     });
 
@@ -20,5 +20,5 @@ export const getU16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 2,
     });
 
-export const getU16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 2> =>
+export const getU16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 2> =>
     combineCodec(getU16Encoder(config), getU16Decoder(config));

--- a/packages/codecs-numbers/src/u32.ts
+++ b/packages/codecs-numbers/src/u32.ts
@@ -3,12 +3,12 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<number, 4> =>
+export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 4> =>
     numberEncoderFactory({
         config,
         name: 'u32',
         range: [0, Number('0xffffffff')],
-        set: (view, value, le) => view.setUint32(0, value, le),
+        set: (view, value, le) => view.setUint32(0, typeof value === 'bigint' ? Number(value) : value, le),
         size: 4,
     });
 
@@ -20,5 +20,5 @@ export const getU32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
-export const getU32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<number, number, 4> =>
+export const getU32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 4> =>
     combineCodec(getU32Encoder(config), getU32Decoder(config));

--- a/packages/codecs-numbers/src/u32.ts
+++ b/packages/codecs-numbers/src/u32.ts
@@ -8,7 +8,7 @@ export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         config,
         name: 'u32',
         range: [0, Number('0xffffffff')],
-        set: (view, value, le) => view.setUint32(0, typeof value === 'bigint' ? Number(value) : value, le),
+        set: (view, value, le) => view.setUint32(0, Number(value), le),
         size: 4,
     });
 

--- a/packages/codecs-numbers/src/u8.ts
+++ b/packages/codecs-numbers/src/u8.ts
@@ -2,11 +2,11 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
-export const getU8Encoder = (): FixedSizeEncoder<number, 1> =>
+export const getU8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
     numberEncoderFactory({
         name: 'u8',
         range: [0, Number('0xff')],
-        set: (view, value) => view.setUint8(0, value),
+        set: (view, value) => view.setUint8(0, typeof value === 'bigint' ? Number(value) : value),
         size: 1,
     });
 
@@ -17,4 +17,5 @@ export const getU8Decoder = (): FixedSizeDecoder<number, 1> =>
         size: 1,
     });
 
-export const getU8Codec = (): FixedSizeCodec<number, number, 1> => combineCodec(getU8Encoder(), getU8Decoder());
+export const getU8Codec = (): FixedSizeCodec<bigint | number, number, 1> =>
+    combineCodec(getU8Encoder(), getU8Decoder());

--- a/packages/codecs-numbers/src/u8.ts
+++ b/packages/codecs-numbers/src/u8.ts
@@ -6,7 +6,7 @@ export const getU8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
     numberEncoderFactory({
         name: 'u8',
         range: [0, Number('0xff')],
-        set: (view, value) => view.setUint8(0, typeof value === 'bigint' ? Number(value) : value),
+        set: (view, value) => view.setUint8(0, Number(value)),
         size: 1,
     });
 

--- a/packages/rpc-types/src/__tests__/lamports-test.ts
+++ b/packages/rpc-types/src/__tests__/lamports-test.ts
@@ -12,7 +12,16 @@ import {
 } from '@solana/codecs-numbers';
 import { SOLANA_ERROR__LAMPORTS_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
-import { assertIsLamports, getLamportsCodec, getLamportsDecoder, getLamportsEncoder, lamports } from '../lamports';
+import {
+    assertIsLamports,
+    getLamportsCodec,
+    getLamportsCodecFromCodec,
+    getLamportsDecoder,
+    getLamportsDecoderFromDecoder,
+    getLamportsEncoder,
+    getLamportsEncoderFromEncoder,
+    lamports,
+} from '../lamports';
 
 describe('assertIsLamports()', () => {
     it('throws when supplied a negative number', () => {
@@ -52,23 +61,35 @@ describe('getLamportsEncoder', () => {
         const buffer = encoder.encode(lamportsValue);
         expect(buffer).toStrictEqual(new Uint8Array([0, 202, 154, 59, 0, 0, 0, 0]));
     });
+
+    it('has a fixed size of 8', () => {
+        const encoder = getLamportsEncoder();
+        expect(encoder.fixedSize).toBe(8);
+    });
+});
+
+describe('getLamportsEncoderFromEncoder', () => {
     it('encodes a lamports value using a passed u8 encoder', () => {
         const lamportsValue = lamports(100n);
-        const encoder = getLamportsEncoder(getU8Encoder());
+        const encoder = getLamportsEncoderFromEncoder(getU8Encoder());
         const buffer = encoder.encode(lamportsValue);
-        expect(buffer).toStrictEqual(new Uint8Array([100, 0, 0, 0, 0, 0, 0, 0]));
+        expect(buffer).toStrictEqual(new Uint8Array([100]));
     });
     it('encodes a lamports value using a passed big-endian u16 encoder', () => {
         const lamportsValue = lamports(100n);
-        const encoder = getLamportsEncoder(getU16Encoder({ endian: Endian.Big }));
+        const encoder = getLamportsEncoderFromEncoder(getU16Encoder({ endian: Endian.Big }));
         const buffer = encoder.encode(lamportsValue);
-        expect(buffer).toStrictEqual(new Uint8Array([0, 100, 0, 0, 0, 0, 0, 0]));
+        expect(buffer).toStrictEqual(new Uint8Array([0, 100]));
     });
     it('encodes a lamports value using a passed u64 encoder', () => {
         const lamportsValue = lamports(BigInt('0xffffffffffffffff'));
-        const encoder = getLamportsEncoder(getU64Encoder());
+        const encoder = getLamportsEncoderFromEncoder(getU64Encoder());
         const buffer = encoder.encode(lamportsValue);
         expect(buffer).toStrictEqual(new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]));
+    });
+    it('has a fixed size of 1 for a passed u8 encoder', () => {
+        const encoder = getLamportsEncoderFromEncoder(getU8Encoder());
+        expect(encoder.fixedSize).toBe(1);
     });
 });
 
@@ -79,23 +100,34 @@ describe('getLamportsDecoder', () => {
         const lamportsValue = decoder.decode(buffer);
         expect(lamportsValue).toStrictEqual(lamports(300_500_000_000n));
     });
-    it('decodes an 8-byte buffer into a lamports value using a passed u8 decoder', () => {
-        const buffer = new Uint8Array([100, 0, 0, 0, 0, 0, 0, 0]);
-        const decoder = getLamportsDecoder(getU8Decoder());
+    it('has a fixed size of 8', () => {
+        const decoder = getLamportsDecoder();
+        expect(decoder.fixedSize).toBe(8);
+    });
+});
+
+describe('getLamportsDecoderFromDecoder', () => {
+    it('decodes a 1-byte buffer into a lamports value using a passed u8 decoder', () => {
+        const buffer = new Uint8Array([100]);
+        const decoder = getLamportsDecoderFromDecoder(getU8Decoder());
         const lamportsValue = decoder.decode(buffer);
         expect(lamportsValue).toStrictEqual(lamports(100n));
     });
-    it('decodes an 8-byte buffer into a lamports value using a passed big-endian u16 decoder', () => {
-        const buffer = new Uint8Array([0, 100, 0, 0, 0, 0, 0, 0]);
-        const decoder = getLamportsDecoder(getU16Decoder({ endian: Endian.Big }));
+    it('decodes a 2-byte buffer into a lamports value using a passed big-endian u16 decoder', () => {
+        const buffer = new Uint8Array([0, 100]);
+        const decoder = getLamportsDecoderFromDecoder(getU16Decoder({ endian: Endian.Big }));
         const lamportsValue = decoder.decode(buffer);
         expect(lamportsValue).toStrictEqual(lamports(100n));
     });
     it('decodes an 8-byte buffer into a lamports value using a passed u64 decoder', () => {
         const buffer = new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]);
-        const decoder = getLamportsDecoder(getU64Decoder());
+        const decoder = getLamportsDecoderFromDecoder(getU64Decoder());
         const lamportsValue = decoder.decode(buffer);
         expect(lamportsValue).toStrictEqual(lamports(BigInt('0xffffffffffffffff')));
+    });
+    it('has a fixed size of 1 for a passed u8 decoder', () => {
+        const decoder = getLamportsDecoderFromDecoder(getU8Decoder());
+        expect(decoder.fixedSize).toBe(1);
     });
 });
 
@@ -106,46 +138,58 @@ describe('getLamportsCodec', () => {
         const buffer = codec.encode(lamportsValue);
         expect(buffer).toStrictEqual(new Uint8Array([0, 202, 154, 59, 0, 0, 0, 0]));
     });
-    it('encodes a lamports value using a passed u8 codec', () => {
-        const lamportsValue = lamports(100n);
-        const codec = getLamportsCodec(getU8Codec());
-        const buffer = codec.encode(lamportsValue);
-        expect(buffer).toStrictEqual(new Uint8Array([100, 0, 0, 0, 0, 0, 0, 0]));
-    });
-    it('encodes a lamports value using a passed big-endian u16 codec', () => {
-        const lamportsValue = lamports(100n);
-        const codec = getLamportsCodec(getU16Codec({ endian: Endian.Big }));
-        const buffer = codec.encode(lamportsValue);
-        expect(buffer).toStrictEqual(new Uint8Array([0, 100, 0, 0, 0, 0, 0, 0]));
-    });
-    it('encodes a lamports value using a passed u64 codec', () => {
-        const lamportsValue = lamports(BigInt('0xffffffffffffffff'));
-        const codec = getLamportsCodec(getU64Codec());
-        const buffer = codec.encode(lamportsValue);
-        expect(buffer).toStrictEqual(new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]));
-    });
     it('decodes an 8-byte buffer into a lamports value using the default u64 decoder', () => {
         const buffer = new Uint8Array([0, 29, 50, 247, 69, 0, 0, 0]);
         const codec = getLamportsCodec();
         const lamportsValue = codec.decode(buffer);
         expect(lamportsValue).toStrictEqual(lamports(300_500_000_000n));
     });
-    it('decodes an 8-byte buffer into a lamports value using a passed u8 codec', () => {
-        const buffer = new Uint8Array([100, 0, 0, 0, 0, 0, 0, 0]);
-        const codec = getLamportsCodec(getU8Codec());
+    it('has a fixed size of 8', () => {
+        const codec = getLamportsCodec();
+        expect(codec.fixedSize).toBe(8);
+    });
+});
+
+describe('getLamportsCodecFromCodec', () => {
+    it('encodes a lamports value using a passed u8 codec', () => {
+        const lamportsValue = lamports(100n);
+        const codec = getLamportsCodecFromCodec(getU8Codec());
+        const buffer = codec.encode(lamportsValue);
+        expect(buffer).toStrictEqual(new Uint8Array([100]));
+    });
+    it('encodes a lamports value using a passed big-endian u16 codec', () => {
+        const lamportsValue = lamports(100n);
+        const codec = getLamportsCodecFromCodec(getU16Codec({ endian: Endian.Big }));
+        const buffer = codec.encode(lamportsValue);
+        expect(buffer).toStrictEqual(new Uint8Array([0, 100]));
+    });
+    it('encodes a lamports value using a passed u64 codec', () => {
+        const lamportsValue = lamports(BigInt('0xffffffffffffffff'));
+        const codec = getLamportsCodecFromCodec(getU64Codec());
+        const buffer = codec.encode(lamportsValue);
+        expect(buffer).toStrictEqual(new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]));
+    });
+
+    it('decodes a 1-byte buffer into a lamports value using a passed u8 codec', () => {
+        const buffer = new Uint8Array([100]);
+        const codec = getLamportsCodecFromCodec(getU8Codec());
         const lamportsValue = codec.decode(buffer);
         expect(lamportsValue).toStrictEqual(lamports(100n));
     });
-    it('decodes an 8-byte buffer into a lamports value using a passed big-endian u16 codec', () => {
-        const buffer = new Uint8Array([0, 100, 0, 0, 0, 0, 0, 0]);
-        const codec = getLamportsCodec(getU16Codec({ endian: Endian.Big }));
+    it('decodes a 2-byte buffer into a lamports value using a passed big-endian u16 codec', () => {
+        const buffer = new Uint8Array([0, 100]);
+        const codec = getLamportsCodecFromCodec(getU16Codec({ endian: Endian.Big }));
         const lamportsValue = codec.decode(buffer);
         expect(lamportsValue).toStrictEqual(lamports(100n));
     });
     it('decodes an 8-byte buffer into a lamports value using a passed u64 codec', () => {
         const buffer = new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]);
-        const codec = getLamportsCodec(getU64Codec());
+        const codec = getLamportsCodecFromCodec(getU64Codec());
         const lamportsValue = codec.decode(buffer);
         expect(lamportsValue).toStrictEqual(lamports(BigInt('0xffffffffffffffff')));
+    });
+    it('has a fixed size of 1 for a passed u8 codec', () => {
+        const decoder = getLamportsCodecFromCodec(getU8Codec());
+        expect(decoder.fixedSize).toBe(1);
     });
 });

--- a/packages/rpc-types/src/__typetests__/lamports-typetests.ts
+++ b/packages/rpc-types/src/__typetests__/lamports-typetests.ts
@@ -1,0 +1,107 @@
+import {
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    ReadonlyUint8Array,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '@solana/codecs-core';
+
+import {
+    getLamportsCodec,
+    getLamportsCodecFromCodec,
+    getLamportsDecoder,
+    getLamportsDecoderFromDecoder,
+    getLamportsEncoder,
+    getLamportsEncoderFromEncoder,
+    LamportsUnsafeBeyond2Pow53Minus1,
+} from '../lamports';
+
+// Default encoder
+{
+    const encoder = getLamportsEncoder();
+    encoder satisfies FixedSizeEncoder<LamportsUnsafeBeyond2Pow53Minus1, 8>;
+    encoder.fixedSize satisfies 8;
+    encoder.encode(1n as LamportsUnsafeBeyond2Pow53Minus1) satisfies ReadonlyUint8Array;
+}
+
+// Fixed size inner encoder
+{
+    const innerEncoder = {} as FixedSizeEncoder<bigint | number, 42>;
+    const encoder = getLamportsEncoderFromEncoder(innerEncoder);
+    encoder satisfies FixedSizeEncoder<LamportsUnsafeBeyond2Pow53Minus1, 42>;
+    encoder.fixedSize satisfies 42;
+    encoder.encode(1n as LamportsUnsafeBeyond2Pow53Minus1) satisfies ReadonlyUint8Array;
+}
+
+// Variable size inner encoder
+{
+    const innerEncoder = {} as VariableSizeEncoder<bigint | number>;
+    const encoder = getLamportsEncoderFromEncoder(innerEncoder);
+    encoder satisfies VariableSizeEncoder<LamportsUnsafeBeyond2Pow53Minus1>;
+    encoder.getSizeFromValue satisfies (value: bigint | number) => number;
+    encoder.maxSize satisfies number | undefined;
+    encoder.encode(1n as LamportsUnsafeBeyond2Pow53Minus1) satisfies ReadonlyUint8Array;
+}
+
+// Default decoder
+{
+    const decoder = getLamportsDecoder();
+    decoder satisfies FixedSizeDecoder<LamportsUnsafeBeyond2Pow53Minus1, 8>;
+    decoder.fixedSize satisfies 8;
+    decoder.decode(null as unknown as ReadonlyUint8Array) satisfies LamportsUnsafeBeyond2Pow53Minus1;
+}
+
+// Fixed size inner decoder
+{
+    const innerDecoder = {} as FixedSizeDecoder<bigint, 42> | FixedSizeDecoder<number, 42>;
+    const decoder = getLamportsDecoderFromDecoder(innerDecoder);
+    decoder satisfies FixedSizeDecoder<LamportsUnsafeBeyond2Pow53Minus1, 42>;
+    decoder.fixedSize satisfies 42;
+    decoder.decode(null as unknown as ReadonlyUint8Array) satisfies LamportsUnsafeBeyond2Pow53Minus1;
+}
+
+// Variable size inner decoder
+{
+    const innerDecoder = {} as VariableSizeDecoder<bigint> | VariableSizeDecoder<number>;
+    const decoder = getLamportsDecoderFromDecoder(innerDecoder);
+    decoder satisfies VariableSizeDecoder<LamportsUnsafeBeyond2Pow53Minus1>;
+    decoder.maxSize satisfies number | undefined;
+    decoder.decode(null as unknown as ReadonlyUint8Array) satisfies LamportsUnsafeBeyond2Pow53Minus1;
+}
+
+// Default codec
+{
+    const codec = getLamportsCodec();
+    codec satisfies FixedSizeCodec<LamportsUnsafeBeyond2Pow53Minus1, LamportsUnsafeBeyond2Pow53Minus1, 8>;
+    codec satisfies FixedSizeEncoder<LamportsUnsafeBeyond2Pow53Minus1, 8>;
+    codec satisfies FixedSizeDecoder<LamportsUnsafeBeyond2Pow53Minus1, 8>;
+    codec.fixedSize satisfies 8;
+    codec.encode(1n as LamportsUnsafeBeyond2Pow53Minus1) satisfies ReadonlyUint8Array;
+    codec.decode(null as unknown as ReadonlyUint8Array) satisfies LamportsUnsafeBeyond2Pow53Minus1;
+}
+
+// Fixed size inner codec
+{
+    const innerCodec = {} as FixedSizeCodec<bigint | number, bigint, 42> | FixedSizeCodec<bigint | number, number, 42>;
+    const codec = getLamportsCodecFromCodec(innerCodec);
+    codec satisfies FixedSizeCodec<LamportsUnsafeBeyond2Pow53Minus1, LamportsUnsafeBeyond2Pow53Minus1, 42>;
+    codec satisfies FixedSizeEncoder<LamportsUnsafeBeyond2Pow53Minus1, 42>;
+    codec satisfies FixedSizeDecoder<LamportsUnsafeBeyond2Pow53Minus1, 42>;
+    codec.fixedSize satisfies 42;
+    codec.encode(1n as LamportsUnsafeBeyond2Pow53Minus1) satisfies ReadonlyUint8Array;
+    codec.decode(null as unknown as ReadonlyUint8Array) satisfies LamportsUnsafeBeyond2Pow53Minus1;
+}
+
+// Variable size codec
+{
+    const innerCodec = {} as VariableSizeCodec<bigint | number, bigint> | VariableSizeCodec<bigint | number, number>;
+    const codec = getLamportsCodecFromCodec(innerCodec);
+    codec satisfies VariableSizeCodec<LamportsUnsafeBeyond2Pow53Minus1, LamportsUnsafeBeyond2Pow53Minus1>;
+    codec satisfies VariableSizeCodec<LamportsUnsafeBeyond2Pow53Minus1>;
+    codec satisfies VariableSizeCodec<LamportsUnsafeBeyond2Pow53Minus1>;
+    codec.maxSize satisfies number | undefined;
+    codec.encode(1n as LamportsUnsafeBeyond2Pow53Minus1) satisfies ReadonlyUint8Array;
+    codec.decode(null as unknown as ReadonlyUint8Array) satisfies LamportsUnsafeBeyond2Pow53Minus1;
+}


### PR DESCRIPTION
This is a prerequisite for https://github.com/kinobi-so/kinobi/issues/141, as the `solAmountTypeNode` can be defined with any number type:

```json
"type": {
  "kind": "solAmountTypeNode",
  "number": {
    "kind": "numberTypeNode",
    "format": "u64",
    "endian": "be"
  }
}
```

In order to render this using `getLamportsEncoder` etc without restricting the wrapped number type, we need to allow passing an arbitrary number encoder/decoder as a lamports encoder.

This is enabled by generalising number encoders to all encode a `bigint | number`, instead of the smaller ones being restricted to only encoding numbers. They will still decode to only `number`. An existing range check restricts the values to the appropriate range. 

This means that any number encoder can receive a `bigint` value, ie a Lamports value, so any number encoder can be used to encode lamports. When decoding we additionally convert any `Number` to a `BigInt`, and pass to our `lamports` function to get a Lamports value. 