### PR TITLE
Change webcrypto polyfill to not use a default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ This polyfill can be found at `@solana/webcrypto-ed25519-polyfill` and mimics th
 Determine if your target runtime supports Ed25519, and install the polyfill if it does not:
 
 ```ts
-import install from '@solana/webcrypto-ed25519-polyfill';
+import { install } from '@solana/webcrypto-ed25519-polyfill';
 import { generateKeyPair, signBytes, verifySignature } from '@solana/web3.js';
 
 install();

--- a/packages/webcrypto-ed25519-polyfill/README.md
+++ b/packages/webcrypto-ed25519-polyfill/README.md
@@ -29,7 +29,7 @@ Environments that support Ed25519 (see https://github.com/WICG/webcrypto-secure-
 For all others, simply import this polyfill before use.
 
 ```ts
-import install from '@solana/webcrypto-ed25519-polyfill';
+import { install } from '@solana/webcrypto-ed25519-polyfill';
 
 // Calling this will shim methods on `SubtleCrypto`, adding Ed25519 support.
 install();

--- a/packages/webcrypto-ed25519-polyfill/src/index.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/index.ts
@@ -1,2 +1,1 @@
-import { install } from './install';
-export default install;
+export * from './install';


### PR DESCRIPTION
This PR changes the webcrypto polyfill to not use a default export for `install`.

It previously used a default import because `install` is the only export from the library, and that remains true. But this seems to be causing issues that we don't see when we use default exports, so I think it's worth just changing it to export like everything else instead of fighting it.

The rc has no types for the webcrypto library, I'm not sure why. See https://www.npmjs.com/package/@solana/webcrypto-ed25519-polyfill?activeTab=code (dist/types/index.d.ts)

```ts
export {};
//# sourceMappingURL=index.d.ts.map
```

Locally this isn't the case, the type looks correct. I'm guessing it might be a turbocache/some other build thing?

But even if this is fixed, it still doesn't work. Adding the polyfill as a `workspace:*` dependency, and importing it with `import install from '@solana/webcrypto-ed25519-polyfill` results in an error that it isn't callable. Changing it to a default export works.

We could do more digging and figure out why this isn't working as is, but I think it's probably not worth it. 