### PR TITLE
Add `createKeyPairFromPrivateKeyBytes` helper

### DIFF
--- a/.changeset/curvy-stingrays-attend.md
+++ b/.changeset/curvy-stingrays-attend.md
@@ -1,0 +1,11 @@
+---
+'@solana/keys': patch
+---
+
+Add a `createKeyPairFromPrivateKeyBytes` helper that creates a keypair from the 32-byte private key bytes.
+
+```ts
+import { createKeyPairFromPrivateKeyBytes } from '@solana/keys';
+
+const { privateKey, publicKey } = await createKeyPairFromPrivateKeyBytes(new Uint8Array([...]));
+```

--- a/packages/keys/README.md
+++ b/packages/keys/README.md
@@ -81,6 +81,28 @@ const keypairBytes = new Uint8Array(JSON.parse(keypairFile.toString()));
 const { privateKey, publicKey } = await createKeyPairFromBytes(keypairBytes);
 ```
 
+### `createKeyPairFromPrivateKeyBytes()`
+
+Given a private key represented as a 32-bytes `Uint8Array`, creates an Ed25519 public/private key pair for use with other methods in this package that accept `CryptoKey` objects.
+
+```ts
+import { createKeyPairFromPrivateKeyBytes } from '@solana/keys';
+
+const { privateKey, publicKey } = await createKeyPairFromPrivateKeyBytes(new Uint8Array([...]));
+```
+
+This can be useful when you have a private key but not the corresponding public key or when you need to derive key pairs from seeds. For instance, the following code snippet derives a key pair from the hash of a message.
+
+```ts
+import { getUtf8Encoder } from '@solana/codecs-strings';
+import { createKeyPairFromPrivateKeyBytes } from '@solana/keys';
+
+const message = getUtf8Encoder().encode('Hello, World!');
+const seed = new Uint8Array(await crypto.subtle.digest('SHA-256', message));
+
+const derivedKeypair = await createKeyPairFromPrivateKeyBytes(seed);
+```
+
 ### `createPrivateKeyFromBytes()`
 
 Given a private key represented as a 32-bytes `Uint8Array`, creates an Ed25519 private key for use with other methods in this package that accept `CryptoKey` objects.

--- a/packages/keys/src/__typetests__/key-pair-typetests.ts
+++ b/packages/keys/src/__typetests__/key-pair-typetests.ts
@@ -1,6 +1,11 @@
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 
-import { createKeyPairFromBytes } from '../key-pair';
+import { createKeyPairFromBytes, createKeyPairFromPrivateKeyBytes } from '../key-pair';
 
 createKeyPairFromBytes(new Uint8Array()) satisfies Promise<CryptoKeyPair>;
 createKeyPairFromBytes(new Uint8Array() as ReadonlyUint8Array) satisfies Promise<CryptoKeyPair>;
+createKeyPairFromBytes(new Uint8Array(), true) satisfies Promise<CryptoKeyPair>;
+
+createKeyPairFromPrivateKeyBytes(new Uint8Array()) satisfies Promise<CryptoKeyPair>;
+createKeyPairFromPrivateKeyBytes(new Uint8Array() as ReadonlyUint8Array) satisfies Promise<CryptoKeyPair>;
+createKeyPairFromPrivateKeyBytes(new Uint8Array(), true) satisfies Promise<CryptoKeyPair>;


### PR DESCRIPTION
This PR adds a `createKeyPairFromPrivateKeyBytes` helper that creates a keypair from the 32-byte private key bytes.

```ts
import { createKeyPairFromPrivateKeyBytes } from '@solana/keys';

const { privateKey, publicKey } = await createKeyPairFromPrivateKeyBytes(new Uint8Array([...]));
```

This can be useful when you have a private key but not the corresponding public key or when you need to derive key pairs from seeds. For instance, the following code snippet derives a key pair from the hash of a message.

```ts
import { getUtf8Encoder } from '@solana/codecs-strings';
import { createKeyPairFromPrivateKeyBytes } from '@solana/keys';

const message = getUtf8Encoder().encode('Hello, World!');
const seed = new Uint8Array(await crypto.subtle.digest('SHA-256', message));

const derivedKeypair = await createKeyPairFromPrivateKeyBytes(seed);
```