### PR TITLE
Add support for exporting keys as JWK in crypto polyfill

### DIFF
--- a/.changeset/five-sloths-greet.md
+++ b/.changeset/five-sloths-greet.md
@@ -1,0 +1,5 @@
+---
+'@solana/webcrypto-ed25519-polyfill': patch
+---
+
+Add support for exporting keys as JWK


### PR DESCRIPTION
This PR enables the crypto polyfill package to export `CryptoKeys` as JSON Web Keys (JWK).

This means the following API will now work with the polyfill as long as we only use the `OKP` (octet key pair) key type and the `Ed25519` curve.

```ts
const { publicKey, privateKey } = await generateKeyPair();
const publicJwk = await crypto.subtle.exportKey('jwk', publicKey);
const privateJwk = await crypto.subtle.exportKey('jwk', privateKey);
```

Note that I used `atob`/`btoa` in order to convert from bytes to base64URL encoded strings as the JWK standard requires. I could have used/modified the more robust `getBase64Codec` but this required importing `@solana/codecs-strings` in the polyfill which felt like an overkill.
