### PR TITLE
Add support for importing JWK keys in crypto polyfill

### DIFF
--- a/.changeset/quiet-hornets-look.md
+++ b/.changeset/quiet-hornets-look.md
@@ -1,0 +1,5 @@
+---
+'@solana/webcrypto-ed25519-polyfill': patch
+---
+
+Add support for importing JWK keys


### PR DESCRIPTION
This PR enables the crypto polyfill package to import JSON Web Keys (JWK) as `CryptoKeys`.

This means the following API will now work with the polyfill as long as we only use the `OKP` (octet key pair) key type and the `Ed25519` curve.

```ts
const publicKey = await crypto.subtle.importKey(
    'jwk',
    {
        crv /* curve */: 'Ed25519',
        ext /* extractable */: true,
        key_ops /* key operations */: ['verify'],
        kty /* key type */: 'OKP' /* octet key pair */,
        x /* public key x-coordinate (base64-URL encoded) */: "...",
    },
    'Ed25519',
    true,
    ['verify'],
);

const privateKey = await crypto.subtle.importKey(
    'jwk',
    {
        crv /* curve */: 'Ed25519',
        d /* private key (base64-URL encoded) */: "...",
        ext /* extractable */: false,
        key_ops /* key operations */: ['sign'],
        kty /* key type */: 'OKP' /* octet key pair */,
        x /* public key x-coordinate (base64-URL encoded) */: "...",
    },
    'Ed25519',
    false,
    ['sign'],
);
```