### PR TITLE
Replace all instances of `Promise.race` with a memory-leak-free version

### DIFF
--- a/.changeset/plenty-plums-drop.md
+++ b/.changeset/plenty-plums-drop.md
@@ -1,0 +1,6 @@
+---
+'@solana/transaction-confirmation': patch
+'@solana/rpc-subscriptions': patch
+---
+
+Fixed a memory leak with transaction confirmation and subscriptions

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -66,6 +66,7 @@
         "@solana/errors": "workspace:*",
         "@solana/fast-stable-stringify": "workspace:*",
         "@solana/functional": "workspace:*",
+        "@solana/promises": "workspace:*",
         "@solana/rpc-subscriptions-api": "workspace:*",
         "@solana/rpc-subscriptions-spec": "workspace:*",
         "@solana/rpc-subscriptions-transport-websocket": "workspace:*",

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-coalescer.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-coalescer.ts
@@ -1,3 +1,4 @@
+import { safeRace } from '@solana/promises';
 import { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
 
 import { getCachedAbortableIterableFactory } from './cached-abortable-iterable';
@@ -105,7 +106,7 @@ export function getRpcSubscriptionsWithSubscriptionCoalescing<TRpcSubscriptionsM
                                 try {
                                     const iterator = iterable[Symbol.asyncIterator]();
                                     while (true) {
-                                        const iteratorResult = await Promise.race([iterator.next(), abortPromise]);
+                                        const iteratorResult = await safeRace([iterator.next(), abortPromise]);
                                         if (iteratorResult.done) {
                                             return;
                                         } else {

--- a/packages/transaction-confirmation/README.md
+++ b/packages/transaction-confirmation/README.md
@@ -102,10 +102,11 @@ try {
 When no other heuristic exists to infer that a transaction has expired, you can use this promise factory with a commitment level. It throws after 30 seconds when the commitment is `processed`, and 60 seconds otherwise. You would typically race this with another confirmation strategy.
 
 ```ts
+import { safeRace } from '@solana/promises';
 import { getTimeoutPromise } from '@solana/transaction-confirmation';
 
 try {
-    await Promise.race([getCustomTransactionConfirmationPromise(/* ... */), getTimeoutPromise({ commitment })]);
+    await safeRace([getCustomTransactionConfirmationPromise(/* ... */), getTimeoutPromise({ commitment })]);
 } catch (e) {
     if (e instanceof DOMException && e.name === 'TimeoutError') {
         console.log('Could not confirm transaction after a timeout');

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -69,6 +69,7 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*",
         "@solana/keys": "workspace:*",
+        "@solana/promises": "workspace:*",
         "@solana/rpc": "workspace:*",
         "@solana/rpc-subscriptions": "workspace:*",
         "@solana/rpc-types": "workspace:*",

--- a/packages/transaction-confirmation/src/confirmation-strategy-nonce.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-nonce.ts
@@ -1,6 +1,7 @@
 import type { Address } from '@solana/addresses';
 import { getBase58Decoder, getBase64Encoder } from '@solana/codecs-strings';
 import { SOLANA_ERROR__INVALID_NONCE, SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND, SolanaError } from '@solana/errors';
+import { safeRace } from '@solana/promises';
 import type { GetAccountInfoApi, Rpc } from '@solana/rpc';
 import type { AccountNotificationsApi, RpcSubscriptions } from '@solana/rpc-subscriptions';
 import type { Base64EncodedDataResponse, Commitment } from '@solana/rpc-types';
@@ -108,7 +109,7 @@ export function createNonceInvalidationPromiseFactory<TCluster extends 'devnet' 
             }
         })();
         try {
-            return await Promise.race([nonceAccountDidAdvancePromise, nonceIsAlreadyInvalidPromise]);
+            return await safeRace([nonceAccountDidAdvancePromise, nonceIsAlreadyInvalidPromise]);
         } finally {
             abortController.abort();
         }

--- a/packages/transaction-confirmation/src/confirmation-strategy-racer.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-racer.ts
@@ -1,4 +1,5 @@
 import type { Signature } from '@solana/keys';
+import { safeRace } from '@solana/promises';
 import type { Commitment } from '@solana/rpc-types';
 
 import { createRecentSignatureConfirmationPromiseFactory } from './confirmation-strategy-recent-signature';
@@ -30,7 +31,7 @@ export async function raceStrategies<TConfig extends BaseTransactionConfirmation
             ...config,
             abortSignal: abortController.signal,
         });
-        return await Promise.race([
+        return await safeRace([
             getRecentSignatureConfirmationPromise({
                 abortSignal: abortController.signal,
                 commitment,

--- a/packages/transaction-confirmation/src/confirmation-strategy-recent-signature.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-recent-signature.ts
@@ -1,5 +1,6 @@
 import { getSolanaErrorFromTransactionError } from '@solana/errors';
 import type { Signature } from '@solana/keys';
+import { safeRace } from '@solana/promises';
 import type { GetSignatureStatusesApi, Rpc } from '@solana/rpc';
 import type { RpcSubscriptions, SignatureNotificationsApi } from '@solana/rpc-subscriptions';
 import { type Commitment, commitmentComparator } from '@solana/rpc-types';
@@ -80,7 +81,7 @@ export function createRecentSignatureConfirmationPromiseFactory<
             }
         })();
         try {
-            return await Promise.race([signatureDidCommitPromise, signatureStatusLookupPromise]);
+            return await safeRace([signatureDidCommitPromise, signatureStatusLookupPromise]);
         } finally {
             abortController.abort();
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -860,6 +860,9 @@ importers:
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional
+      '@solana/promises':
+        specifier: workspace:*
+        version: link:../promises
       '@solana/rpc-subscriptions-api':
         specifier: workspace:*
         version: link:../rpc-subscriptions-api
@@ -1121,6 +1124,9 @@ importers:
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
+      '@solana/promises':
+        specifier: workspace:*
+        version: link:../promises
       '@solana/rpc':
         specifier: workspace:*
         version: link:../rpc


### PR DESCRIPTION
# Summary

Nearly everything in this library that raced two or more promises together would leak memory if some of those promises never resolved.

One particularly bad case of this was in the subscriptions transport, where an ‘abort promise’ that may never actually abort would be raced with the promise for the next notification message. Unless the abort was eventually called, every promise would be retained forever and memory use would grow unbounded, eventually crashing the process.

# Test Plan

Given this test script:

```ts
// test.mjs
import { createSolanaRpcSubscriptions } from "@solana/rpc-subscriptions";

const rpcSubscriptions = createSolanaRpcSubscriptions("ws://127.0.0.1:8900");

const slotMessages = await rpcSubscriptions.slotNotifications().subscribe({
  // Never aborted.
  abortSignal: AbortSignal.any([]),
});

for await (const _n of slotMessages);

console.log("bye");
```

Run…

```shell
pnpm --inspect node test.mjs
```

Then…

1. Open chrome://inspect
2. Open the ‘Memory’ tab
3. Take two heap snapshots far apart in time, clicking ‘collect garbage’ before the second one
4. Select ‘objects allocated between Snapshot 1 and Snapshot 2’

## Before

Notice that promises just keep accumulating, and the pool never stops growing.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lE1zD7Jpg6mWNv3djNKZ/b869161e-ffcc-44f1-9cb0-521a9ebea491.png)

## After

Notice that only a handful of promises are allocated, and they stay constant at ~37 promises.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lE1zD7Jpg6mWNv3djNKZ/062efdbd-dc04-46d1-b9df-8a6a8f903989.png)

A special thank you to @WilfredAlmeida for shaking down the RC version of web3.js 2.0 and finding this leak in a long-running process.

Closes #3069.
