### PR TITLE
Build with a concurrency of 1 on CI

### DIFF
--- a/.github/workflows/publish-canary-releases.yml
+++ b/.github/workflows/publish-canary-releases.yml
@@ -12,6 +12,8 @@ env:
   # Among other things, opts out of Turborepo telemetry
   # See https://consoledonottrack.com/
   DO_NOT_TRACK: '1'
+  # Some tasks slow down considerably on GitHub Actions runners when concurrency is high
+  TURBO_CONCURRENCY: 1
   # Enables Turborepo Remote Caching.
   TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -47,7 +49,7 @@ jobs:
             xargs -t0 -n 1 -I {} \
               sh -c 'cd {} && pnpm pkg delete devDependencies'
           pnpm changeset version --snapshot canary
-          pnpm turbo publish-packages --concurrency=95.84%
+          pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -14,6 +14,8 @@ env:
   # Among other things, opts out of Turborepo telemetry
   # See https://consoledonottrack.com/
   DO_NOT_TRACK: '1'
+  # Some tasks slow down considerably on GitHub Actions runners when concurrency is high
+  TURBO_CONCURRENCY: 1
   # Enables Turborepo Remote Caching.
   TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -55,7 +57,7 @@ jobs:
         uses: ./.github/workflows/actions/install-dependencies
 
       - name: Compile
-        run: pnpm turbo run compile:ghpages --concurrency=95.84%
+        run: pnpm turbo run compile:ghpages --concurrency=${TURBO_CONCURRENCY:-1}
         env:
           REACT_EXAMPLE_APP_BASE_PATH: /solana-web3.js/example/
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -12,6 +12,8 @@ env:
   # Among other things, opts out of Turborepo telemetry
   # See https://consoledonottrack.com/
   DO_NOT_TRACK: '1'
+  # Some tasks slow down considerably on GitHub Actions runners when concurrency is high
+  TURBO_CONCURRENCY: 1
   # Enables Turborepo Remote Caching.
   TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -45,7 +47,7 @@ jobs:
 
       - name: Choose Build Step
         id: build-step-decider
-        run: echo "step-name=${{ steps.changesets.outputs.hasChangesets == 'false' && 'publish-packages --concurrency=95.84%' || 'build' }}" >> $GITHUB_OUTPUT
+        run: echo "step-name=${{ steps.changesets.outputs.hasChangesets == 'false' && 'publish-packages --concurrency=${TURBO_CONCURRENCY:-1}' || 'build' }}" >> $GITHUB_OUTPUT
 
       - name: Run Build Step (force)
         run: pnpm turbo ${{ steps.build-step-decider.outputs.step-name }} --force=true

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,6 +7,8 @@ env:
   # Among other things, opts out of Turborepo telemetry
   # See https://consoledonottrack.com/
   DO_NOT_TRACK: '1'
+  # Some tasks slow down considerably on GitHub Actions runners when concurrency is high
+  TURBO_CONCURRENCY: 1
   # Enables Turborepo Remote Caching.
   TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -44,10 +46,10 @@ jobs:
         uses: ./.github/workflows/actions/setup-validator
 
       - name: Build & Test
-        run: pnpm build
+        run: pnpm build # Don't add --concurrency here; it's already baked in
 
       - name: Build GitHub Pages
-        run: pnpm turbo run compile:ghpages --concurrency=95.84%
+        run: pnpm turbo run compile:ghpages --concurrency=${TURBO_CONCURRENCY:-1}
 
       - name: Stop Test Validator
         if: always() && steps.start-test-validator.outcome == 'success'

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
         "packages/*"
     ],
     "scripts": {
-        "build": "turbo run --concurrency=95.84% build",
-        "compile": "turbo run --concurrency=95.84% compile:js compile:typedefs",
-        "lint": "turbo run --concurrency=95.84% test:lint",
-        "style:fix": "turbo  run --concurrency=95.84% style:fix && pnpm prettier --log-level warn --ignore-unknown --write '{.,!packages}/*'",
-        "test": "turbo run --concurrency=95.84% test:unit:browser test:unit:node",
-        "test:live-with-test-validator": "turbo run --concurrency=95.84% test:live-with-test-validator",
+        "build": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} build",
+        "compile": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} compile:js compile:typedefs",
+        "lint": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:lint",
+        "style:fix": "turbo  run --concurrency=${TURBO_CONCURRENCY:-95.84%} style:fix && pnpm prettier --log-level warn --ignore-unknown --write '{.,!packages}/*'",
+        "test": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:unit:browser test:unit:node",
+        "test:live-with-test-validator": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:live-with-test-validator",
         "test:live-with-test-validator:setup": "./scripts/setup-test-validator.sh"
     },
     "devDependencies": {


### PR DESCRIPTION
# Summary

GitHub Actions runners are anemic, and a new CPU-intensive test has made it impossible for CI to pass: https://github.com/solana-labs/solana-web3.js/actions/runs/10288741934/job/28474891140

I suspect this is because concurrent build tasks result in the CPU being starved for cycles. Let's try to put it back to 1 for CI only.
