### PR TITLE
refactor(experimental): GraphQL: Refactor program accounts filters

### DIFF
--- a/.changeset/sixty-months-relate.md
+++ b/.changeset/sixty-months-relate.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-graphql': minor
+---
+
+Update program accounts filters for `programAccounts` query

--- a/packages/rpc-api/src/__tests__/get-program-accounts-test.ts
+++ b/packages/rpc-api/src/__tests__/get-program-accounts-test.ts
@@ -2290,4 +2290,174 @@ describe('getProgramAccounts', () => {
             expect(accountInfo[0].account.data).toStrictEqual(['dGVzdCA=', 'base64']);
         });
     });
+
+    describe('when called with a data size filter', () => {
+        it('returns the matching accounts', async () => {
+            expect.assertions(3);
+            const program =
+                'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+
+            const programAccounts = await rpc
+                .getProgramAccounts(program, {
+                    encoding: 'jsonParsed',
+                    filters: [
+                        {
+                            dataSize: 165n, // Token account size
+                        },
+                    ],
+                })
+                .send();
+
+            programAccounts.forEach(item => {
+                expect(item).toMatchObject({
+                    account: {
+                        data: {
+                            parsed: {
+                                info: {
+                                    isNative: expect.any(Boolean),
+                                    mint: expect.any(String),
+                                    owner: expect.any(String),
+                                    state: expect.any(String),
+                                    tokenAmount: {
+                                        amount: expect.any(String),
+                                        decimals: expect.any(Number),
+                                        uiAmount: expect.any(Number),
+                                        uiAmountString: expect.any(String),
+                                    },
+                                },
+                                type: 'account',
+                            },
+                            program: 'spl-token',
+                            space: 165n, // Token account space
+                        },
+                        executable: false,
+                        lamports: expect.any(BigInt),
+                        owner: expect.any(String),
+                        rentEpoch: expect.any(BigInt),
+                        space: 165n, // Token account space
+                    },
+                    pubkey: expect.any(String),
+                });
+            });
+        });
+    });
+
+    describe('when called with a memcmpy filter', () => {
+        it('returns the matching accounts', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/spl-token-mint-account.json
+            const mint =
+                'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' as Address<'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr'>;
+            const program =
+                'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+
+            const programAccounts = await rpc
+                .getProgramAccounts(program, {
+                    encoding: 'jsonParsed',
+                    filters: [
+                        {
+                            memcmp: {
+                                bytes: mint,
+                                encoding: 'base58',
+                                offset: 0n,
+                            },
+                        },
+                    ],
+                })
+                .send();
+
+            programAccounts.forEach(item => {
+                expect(item).toMatchObject({
+                    account: {
+                        data: {
+                            parsed: {
+                                info: {
+                                    isNative: expect.any(Boolean),
+                                    mint, // Matches mint address provided in filter.
+                                    owner: expect.any(String),
+                                    state: expect.any(String),
+                                    tokenAmount: {
+                                        amount: expect.any(String),
+                                        decimals: expect.any(Number),
+                                        uiAmount: expect.any(Number),
+                                        uiAmountString: expect.any(String),
+                                    },
+                                },
+                                type: 'account',
+                            },
+                            program: 'spl-token',
+                            space: 165n, // Token account space
+                        },
+                        executable: false,
+                        lamports: expect.any(BigInt),
+                        owner: expect.any(String),
+                        rentEpoch: expect.any(BigInt),
+                        space: 165n, // Token account space
+                    },
+                    pubkey: expect.any(String),
+                });
+            });
+        });
+    });
+
+    describe('when called with both a data size and a memcmpy filter', () => {
+        it('returns the matching accounts', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/spl-token-mint-account.json
+            const mint =
+                'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' as Address<'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr'>;
+            const program =
+                'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+
+            const programAccounts = await rpc
+                .getProgramAccounts(program, {
+                    encoding: 'jsonParsed',
+                    filters: [
+                        {
+                            dataSize: 165n, // Token account size
+                        },
+                        {
+                            memcmp: {
+                                bytes: mint,
+                                encoding: 'base58',
+                                offset: 0n,
+                            },
+                        },
+                    ],
+                })
+                .send();
+
+            programAccounts.forEach(item => {
+                expect(item).toMatchObject({
+                    account: {
+                        data: {
+                            parsed: {
+                                info: {
+                                    isNative: expect.any(Boolean),
+                                    mint, // Matches mint address provided in filter.
+                                    owner: expect.any(String),
+                                    state: expect.any(String),
+                                    tokenAmount: {
+                                        amount: expect.any(String),
+                                        decimals: expect.any(Number),
+                                        uiAmount: expect.any(Number),
+                                        uiAmountString: expect.any(String),
+                                    },
+                                },
+                                type: 'account',
+                            },
+                            program: 'spl-token',
+                            space: 165n, // Token account space
+                        },
+                        executable: false,
+                        lamports: expect.any(BigInt),
+                        owner: expect.any(String),
+                        rentEpoch: expect.any(BigInt),
+                        space: 165n, // Token account space
+                    },
+                    pubkey: expect.any(String),
+                });
+            });
+        });
+    });
 });

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -1,3 +1,4 @@
+import type { Address } from '@solana/addresses';
 import {
     GetAccountInfoApi,
     GetBlockApi,
@@ -610,6 +611,166 @@ describe('programAccounts', () => {
                         programAccounts: expect.arrayContaining([
                             {
                                 data: 'dGVzdCA=', // As tested on local RPC
+                            },
+                        ]),
+                    },
+                });
+            });
+        });
+    });
+    describe('when called with a data size filter', () => {
+        const programAddress =
+            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+
+        describe('when using memcmp filter', () => {
+            it('returns the matching accounts', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    dataSizeFilters: [
+                        {
+                            dataSize: 165n, // Token account size
+                        },
+                    ],
+                    programAddress,
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($programAddress: Address!, $dataSizeFilters: [ProgramAccountsDataSizeFilter!]!) {
+                        programAccounts(
+                            programAddress: $programAddress
+                            commitment: null
+                            dataSizeFilters: $dataSizeFilters
+                        ) {
+                            ... on TokenAccount {
+                                mint {
+                                    address
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                console.log(result);
+                expect(result).toMatchObject({
+                    data: {
+                        programAccounts: expect.arrayContaining([
+                            {
+                                mint: {
+                                    address: expect.any(String),
+                                },
+                            },
+                        ]),
+                    },
+                });
+            });
+        });
+    });
+    describe('when called with a memcmp filter', () => {
+        // See scripts/fixtures/spl-token-mint-account.json
+        const mintAddress =
+            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' as Address<'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr'>;
+        const programAddress =
+            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+
+        describe('when using memcmp filter', () => {
+            it('returns the matching accounts', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    memcmpFilters: [
+                        {
+                            bytes: mintAddress, // Mint address in data.
+                            encoding: 'BASE_58', // Base58-encoded address.
+                            offset: 0, // Offset 0 for mint address.
+                        },
+                    ],
+                    programAddress,
+                };
+                const source = /* GraphQL */ `
+                    query testQuery($programAddress: Address!, $memcmpFilters: [ProgramAccountsMemcmpFilter!]!) {
+                        programAccounts(
+                            programAddress: $programAddress
+                            commitment: null
+                            dataSizeFilters: null
+                            memcmpFilters: $memcmpFilters
+                        ) {
+                            ... on TokenAccount {
+                                mint {
+                                    address
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                console.log(result);
+                expect(result).toMatchObject({
+                    data: {
+                        programAccounts: expect.arrayContaining([
+                            {
+                                mint: {
+                                    address: mintAddress,
+                                },
+                            },
+                        ]),
+                    },
+                });
+            });
+        });
+    });
+
+    describe('when called with both a data size and a memcmpy filter', () => {
+        // See scripts/fixtures/spl-token-mint-account.json
+        const mintAddress =
+            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' as Address<'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr'>;
+        const programAddress =
+            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+
+        describe('when using memcmp filter', () => {
+            it('returns the matching accounts', async () => {
+                expect.assertions(1);
+                const variableValues = {
+                    dataSizeFilters: [
+                        {
+                            dataSize: 165n, // Token account size
+                        },
+                    ],
+                    memcmpFilters: [
+                        {
+                            bytes: mintAddress, // Mint address in data.
+                            encoding: 'BASE_58', // Base58-encoded address.
+                            offset: 0, // Offset 0 for mint address.
+                        },
+                    ],
+                    programAddress,
+                };
+                const source = /* GraphQL */ `
+                    query testQuery(
+                        $programAddress: Address!
+                        $dataSizeFilters: [ProgramAccountsDataSizeFilter!]!
+                        $memcmpFilters: [ProgramAccountsMemcmpFilter!]!
+                    ) {
+                        programAccounts(
+                            programAddress: $programAddress
+                            commitment: null
+                            dataSizeFilters: $dataSizeFilters
+                            memcmpFilters: $memcmpFilters
+                        ) {
+                            ... on TokenAccount {
+                                mint {
+                                    address
+                                }
+                            }
+                        }
+                    }
+                `;
+                const result = await rpcGraphQL.query(source, variableValues);
+                console.log(result);
+                expect(result).toMatchObject({
+                    data: {
+                        programAccounts: expect.arrayContaining([
+                            {
+                                mint: {
+                                    address: mintAddress,
+                                },
                             },
                         ]),
                     },

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -43,7 +43,18 @@ export type ProgramAccountsLoaderArgsBase = {
     commitment?: Commitment;
     dataSlice?: { length: number; offset: number };
     encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
-    filters?: readonly { memcmp: { bytes: string; offset: number } }[];
+    filters?: (
+        | {
+              dataSize: bigint;
+          }
+        | {
+              memcmp: {
+                  bytes: string;
+                  encoding: 'base58' | 'base64';
+                  offset: bigint;
+              };
+          }
+    )[];
     minContextSlot?: Slot;
 };
 export type ProgramAccountsLoaderArgs = ProgramAccountsLoaderArgsBase & { programAddress: Address };

--- a/packages/rpc-graphql/src/loaders/program-accounts.ts
+++ b/packages/rpc-graphql/src/loaders/program-accounts.ts
@@ -19,14 +19,7 @@ async function loadProgramAccounts(
     rpc: Rpc<GetProgramAccountsApi>,
     { programAddress, ...config }: ProgramAccountsLoaderArgs,
 ): Promise<ProgramAccountsLoaderValue> {
-    // @ts-expect-error FIX ME: https://github.com/microsoft/TypeScript/issues/43187
-    return await rpc
-        .getProgramAccounts(
-            programAddress,
-            // @ts-expect-error FIX ME: https://github.com/microsoft/TypeScript/issues/43187
-            config,
-        )
-        .send();
+    return await rpc.getProgramAccounts(programAddress, config).send();
 }
 
 function createProgramAccountsBatchLoadFn(rpc: Rpc<GetProgramAccountsApi>, config: Config) {

--- a/packages/rpc-graphql/src/resolvers/resolve-info/program-accounts.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/program-accounts.ts
@@ -12,7 +12,18 @@ import { buildAccountArgSetWithVisitor } from './account';
 export function buildProgramAccountsLoaderArgSetFromResolveInfo(
     args: {
         commitment?: Commitment;
-        filters?: readonly { memcmp: { bytes: string; offset: number } }[];
+        filters?: (
+            | {
+                  dataSize: bigint;
+              }
+            | {
+                  memcmp: {
+                      bytes: string;
+                      encoding: 'base58' | 'base64';
+                      offset: bigint;
+                  };
+              }
+        )[];
         minContextSlot?: Slot;
         programAddress: Address;
     },

--- a/packages/rpc-graphql/src/schema/type-defs/root.ts
+++ b/packages/rpc-graphql/src/schema/type-defs/root.ts
@@ -5,7 +5,8 @@ export const rootTypeDefs = /* GraphQL */ `
         programAccounts(
             programAddress: Address!
             commitment: Commitment
-            filters: [ProgramAccountsFilter]
+            dataSizeFilters: [ProgramAccountsDataSizeFilter]
+            memcmpFilters: [ProgramAccountsMemcmpFilter]
             minContextSlot: Slot
         ): [Account]
         transaction(signature: Signature!, commitment: CommitmentWithoutProcessed): Transaction

--- a/packages/rpc-graphql/src/schema/type-defs/types.ts
+++ b/packages/rpc-graphql/src/schema/type-defs/types.ts
@@ -37,11 +37,19 @@ export const typeTypeDefs = /* GraphQL */ `
 
     scalar Lamports
 
-    input ProgramAccountsFilter {
-        bytes: BigInt
-        dataSize: BigInt
-        encoding: AccountEncoding
-        offset: BigInt
+    input ProgramAccountsDataSizeFilter {
+        dataSize: BigInt!
+    }
+
+    enum ProgramAccountsMemcmpFilterAccountEncoding {
+        BASE_58
+        BASE_64
+    }
+
+    input ProgramAccountsMemcmpFilter {
+        bytes: String!
+        encoding: ProgramAccountsMemcmpFilterAccountEncoding!
+        offset: BigInt!
     }
 
     type ReturnData {

--- a/packages/rpc-graphql/src/schema/type-resolvers/types.ts
+++ b/packages/rpc-graphql/src/schema/type-resolvers/types.ts
@@ -55,6 +55,10 @@ export const typeTypeResolvers = {
     Epoch: bigIntScalarAlias,
     Hash: stringScalarAlias,
     Lamports: bigIntScalarAlias,
+    ProgramAccountsMemcmpFilterAccountEncoding: {
+        BASE_58: 'base58',
+        BASE_64: 'base64',
+    },
     Signature: stringScalarAlias,
     Slot: bigIntScalarAlias,
     SplTokenDefaultAccountState: {


### PR DESCRIPTION
#### Problem
The filters input parameter for the GraphQL resolver is malformed. This PR brings it to parity with the Solana JSON RPC API as well as the `@solana/rpc-api` package's definition for program accounts filters.

#### Summary of Changes
First add some test coverage to `@solana/rpc-api` for program accounts filters to ensure everything is working properly.

Then, refactor the GraphQL API for the `programAccounts` query to correct the program accounts filters input. Finally, add some tests for GraphQL.

Since GraphQL doesn't allow unions as input types, I had to split the two types of filters into two separate filters for the GraphQL API, then coalesce them into the same `filters` argument for the RPC.