### PR TITLE
Fix typo in rpc-spec/README.md 

### DIFF
--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -33,7 +33,7 @@ const response = await rpc
 
 ### `PendingRpcRequest<TResponse>`
 
-Pending requests are the result of calling a supported method on on `Rpc` object. They encapsulate all of the information necessary to make the request without actually making it.
+Pending requests are the result of calling a supported method on an `Rpc` object. They encapsulate all of the information necessary to make the request without actually making it.
 
 Calling the `send(options)` method on a `PendingRpcRequest` will trigger the request and return a promise for `TResponse`.
 


### PR DESCRIPTION
Corrected a duplicated word in the `PendingRpcRequest<TResponse>` section of the [README](https://github.com/solana-labs/solana-web3.js/blob/master/packages/rpc-spec/README.md).
