### PR TITLE
fix: Compare public key values not references

### DIFF
--- a/src/programs/system.ts
+++ b/src/programs/system.ts
@@ -860,7 +860,7 @@ export class SystemProgram {
       {pubkey: params.fromPubkey, isSigner: true, isWritable: true},
       {pubkey: params.newAccountPubkey, isSigner: false, isWritable: true},
     ];
-    if (params.basePubkey != params.fromPubkey) {
+    if (!params.basePubkey.equals(params.fromPubkey)) {
       keys.push({
         pubkey: params.basePubkey,
         isSigner: true,


### PR DESCRIPTION
#### Problem

As mentioned in #3118, using `==` or `!=` to compare two `PublicKey` objects will compare their references. This means the conditional will only evaluate to be a match if they are the same object. Additionally, if two build targets or versions of `@solana/web3.js` are being used, these will always be different objects, even if the keys are the same value.

We've encountered the latter issue before, and this appears to be the last place in the legacy library where we still do this conditional without using the `PublicKey.equals` method.

#### Summary of Changes

Run a search through the codebase for any public key comparisons using `==` or `!=` and update them to use `PublicKey.equals`. There's only one.

Closes #3118