### PR TITLE
refactor(experimental): remove `UnixTimestamp` from allowed numerical values

### DIFF
--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -203,7 +203,6 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
         memoizedKeypaths = {
             getAccountInfo: jsonParsedAccountsConfigs.map(c => ['value', ...c]),
             getBlock: [
-                ['blockTime'],
                 ['transactions', KEYPATH_WILDCARD, 'meta', 'preTokenBalances', KEYPATH_WILDCARD, 'accountIndex'],
                 [
                     'transactions',
@@ -236,7 +235,6 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
                 ...messageConfig.map(c => ['transactions', KEYPATH_WILDCARD, 'transaction', 'message', ...c] as const),
                 ['rewards', KEYPATH_WILDCARD, 'commission'],
             ],
-            getBlockTime: [[]],
             getClusterNodes: [
                 [KEYPATH_WILDCARD, 'featureSet'],
                 [KEYPATH_WILDCARD, 'shredVersion'],

--- a/packages/rpc-subscriptions-api/src/index.ts
+++ b/packages/rpc-subscriptions-api/src/index.ts
@@ -88,7 +88,6 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<
         memoizedKeypaths = {
             accountNotifications: jsonParsedAccountsConfigs.map(c => ['value', ...c]),
             blockNotifications: [
-                ['value', 'block', 'blockTime'],
                 [
                     'value',
                     'block',


### PR DESCRIPTION
The point of this stack is to make `UnixTimestamp` a `bigint`, therefore it's no longer required to be permitted as `number`. See #3121.