### PR TITLE
refactor(experimental): change `UnixTimestamp` to `bigint`

### DIFF
--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -532,7 +532,7 @@ export type SolanaErrorContext = DefaultUnspecifiedErrorContextToUndefined<
             key: CryptoKey;
         };
         [SOLANA_ERROR__TIMESTAMP_OUT_OF_RANGE]: {
-            value: number;
+            value: bigint;
         };
         [SOLANA_ERROR__TRANSACTION_ERROR__DUPLICATE_INSTRUCTION]: {
             index: number;

--- a/packages/rpc-api/src/__typetests__/get-block-type-test.ts
+++ b/packages/rpc-api/src/__typetests__/get-block-type-test.ts
@@ -26,7 +26,7 @@ const rpc = null as unknown as Rpc<GetBlockApi>;
 function assertBase(
     response: {
         blockHeight: bigint;
-        blockTime: number;
+        blockTime: bigint;
         blockhash: string;
         parentSlot: bigint;
         previousBlockhash: string;
@@ -34,7 +34,7 @@ function assertBase(
 ) {
     response.blockhash satisfies string;
     response.blockHeight satisfies bigint;
-    response.blockTime satisfies number;
+    response.blockTime satisfies bigint;
     response.parentSlot satisfies bigint;
     response.previousBlockhash satisfies string;
 }

--- a/packages/rpc-parsed-types/src/__typetests__/stake-accounts-test.ts
+++ b/packages/rpc-parsed-types/src/__typetests__/stake-accounts-test.ts
@@ -15,7 +15,7 @@ import type { JsonParsedStakeProgramAccount } from '../stake-accounts';
                 lockup: {
                     custodian: '11111111111111111111111111111111' as Address,
                     epoch: 0n,
-                    unixTimestamp: 0 as UnixTimestamp,
+                    unixTimestamp: 0n as UnixTimestamp,
                 },
                 rentExemptReserve: '2282880' as StringifiedBigInt,
             },
@@ -54,7 +54,7 @@ import type { JsonParsedStakeProgramAccount } from '../stake-accounts';
                 lockup: {
                     custodian: '11111111111111111111111111111111' as Address,
                     epoch: 0n,
-                    unixTimestamp: 0 as UnixTimestamp,
+                    unixTimestamp: 0n as UnixTimestamp,
                 },
                 rentExemptReserve: '2282880' as StringifiedBigInt,
             },

--- a/packages/rpc-parsed-types/src/__typetests__/sysvar-accounts-test.ts
+++ b/packages/rpc-parsed-types/src/__typetests__/sysvar-accounts-test.ts
@@ -7,10 +7,10 @@ import { JsonParsedSysvarAccount } from '../sysvar-accounts';
     const account = {
         info: {
             epoch: 0n as Epoch,
-            epochStartTimestamp: 1704907181 as UnixTimestamp,
+            epochStartTimestamp: 1704907181n as UnixTimestamp,
             leaderScheduleEpoch: 1n as Epoch,
             slot: 90829n as Slot,
-            unixTimestamp: 1704998009 as UnixTimestamp,
+            unixTimestamp: 1704998009n as UnixTimestamp,
         },
         type: 'clock' as const,
     };

--- a/packages/rpc-parsed-types/src/__typetests__/vote-accounts-test.ts
+++ b/packages/rpc-parsed-types/src/__typetests__/vote-accounts-test.ts
@@ -27,7 +27,7 @@ const account = {
         ],
         lastTimestamp: {
             slot: 228884530n as Slot,
-            timestamp: 1689090220 as UnixTimestamp,
+            timestamp: 1689090220n as UnixTimestamp,
         },
         nodePubkey: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr' as Address,
         priorVoters: [],

--- a/packages/rpc-subscriptions-api/src/__typetests__/block-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/block-notifications-type-test.ts
@@ -22,7 +22,7 @@ type BlockNotificationsApiNotificationBase = SolanaRpcResponse<
     Readonly<{
         block: {
             blockHeight: bigint;
-            blockTime: number;
+            blockTime: bigint;
             blockhash: string;
             parentSlot: bigint;
             previousBlockhash: string;

--- a/packages/rpc-types/src/__tests__/coercions-test.ts
+++ b/packages/rpc-types/src/__tests__/coercions-test.ts
@@ -55,15 +55,15 @@ describe('coercions', () => {
     });
     describe('unixTimestamp', () => {
         it('can coerce to `UnixTimestamp`', () => {
-            const raw = 1234 as UnixTimestamp;
-            const coerced = unixTimestamp(1234);
+            const raw = 1234n as UnixTimestamp;
+            const coerced = unixTimestamp(1234n);
             expect(coerced).toBe(raw);
         });
         it('throws on an out-of-range `UnixTimestamp`', () => {
-            const thisThrows = () => unixTimestamp(8.75e15);
+            const thisThrows = () => unixTimestamp(BigInt(8.75e15));
             expect(thisThrows).toThrow(
                 new SolanaError(SOLANA_ERROR__TIMESTAMP_OUT_OF_RANGE, {
-                    value: 8.75e15,
+                    value: BigInt(8.75e15),
                 }),
             );
         });

--- a/packages/rpc-types/src/__tests__/unix-timestamp-test.ts
+++ b/packages/rpc-types/src/__tests__/unix-timestamp-test.ts
@@ -3,33 +3,33 @@ import { assertIsUnixTimestamp } from '../unix-timestamp';
 describe('assertIsUnixTimestamp()', () => {
     it('throws when supplied a too large number', () => {
         expect(() => {
-            assertIsUnixTimestamp(Number.MAX_SAFE_INTEGER);
+            assertIsUnixTimestamp(BigInt(Number.MAX_SAFE_INTEGER));
         }).toThrow();
         expect(() => {
-            assertIsUnixTimestamp(8.64e15 + 1);
+            assertIsUnixTimestamp(BigInt(8.64e15 + 1));
         }).toThrow();
     });
     it('throws when supplied a too small number', () => {
         expect(() => {
-            assertIsUnixTimestamp(Number.MIN_SAFE_INTEGER);
+            assertIsUnixTimestamp(BigInt(Number.MIN_SAFE_INTEGER));
         }).toThrow();
         expect(() => {
-            assertIsUnixTimestamp(-8.64e15 - 1);
+            assertIsUnixTimestamp(BigInt(-8.64e15 - 1));
         }).toThrow();
     });
     it('does not throw when supplied a zero timestamp', () => {
         expect(() => {
-            assertIsUnixTimestamp(0);
+            assertIsUnixTimestamp(0n);
         }).not.toThrow();
     });
     it('does not throw when supplied a valid non-zero timestamp', () => {
         expect(() => {
-            assertIsUnixTimestamp(1_000_000_000);
+            assertIsUnixTimestamp(1_000_000_000n);
         }).not.toThrow();
     });
     it('does not throw when supplied the max valid timestamp', () => {
         expect(() => {
-            assertIsUnixTimestamp(8.64e15);
+            assertIsUnixTimestamp(BigInt(8.64e15));
         }).not.toThrow();
     });
 });

--- a/packages/rpc-types/src/__typetests__/coercions-typetests.ts
+++ b/packages/rpc-types/src/__typetests__/coercions-typetests.ts
@@ -6,4 +6,4 @@ import { UnixTimestamp, unixTimestamp } from '../unix-timestamp';
 lamports(50_000_000_000_000n) satisfies LamportsUnsafeBeyond2Pow53Minus1;
 stringifiedBigInt('50_000_000_000_000') satisfies StringifiedBigInt;
 stringifiedNumber('50_000_000_000_000') satisfies StringifiedNumber;
-unixTimestamp(0) satisfies UnixTimestamp;
+unixTimestamp(0n) satisfies UnixTimestamp;

--- a/packages/rpc-types/src/unix-timestamp.ts
+++ b/packages/rpc-types/src/unix-timestamp.ts
@@ -1,8 +1,8 @@
 import { SOLANA_ERROR__TIMESTAMP_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
-export type UnixTimestamp = number & { readonly __brand: unique symbol };
+export type UnixTimestamp = bigint & { readonly __brand: unique symbol };
 
-export function isUnixTimestamp(putativeTimestamp: number): putativeTimestamp is UnixTimestamp {
+export function isUnixTimestamp(putativeTimestamp: bigint): putativeTimestamp is UnixTimestamp {
     // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
     if (putativeTimestamp > 8.64e15 || putativeTimestamp < -8.64e15) {
         return false;
@@ -10,7 +10,7 @@ export function isUnixTimestamp(putativeTimestamp: number): putativeTimestamp is
     return true;
 }
 
-export function assertIsUnixTimestamp(putativeTimestamp: number): asserts putativeTimestamp is UnixTimestamp {
+export function assertIsUnixTimestamp(putativeTimestamp: bigint): asserts putativeTimestamp is UnixTimestamp {
     // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
 
     if (putativeTimestamp > 8.64e15 || putativeTimestamp < -8.64e15) {
@@ -20,7 +20,7 @@ export function assertIsUnixTimestamp(putativeTimestamp: number): asserts putati
     }
 }
 
-export function unixTimestamp(putativeTimestamp: number): UnixTimestamp {
+export function unixTimestamp(putativeTimestamp: bigint): UnixTimestamp {
     assertIsUnixTimestamp(putativeTimestamp);
     return putativeTimestamp;
 }


### PR DESCRIPTION
#### Problem

The Solana JSON RPC uses a Rust `i64` to represent a Unix Timestamp (see https://github.com/anza-xyz/agave/blob/acaf5b7d48e1b630cbaa4abc859393d8f59f0786/sdk/program/src/clock.rs#L169).

Until now, Web3.js was making the following assumptions:
- JavaScript's `Number.MAX_SAFE_INTEGER` (`2 ^ 53 -1`) as a Unix Timestamp lands us in the year 285,422,890.
- JavaScript's `Date` supports integers ranging from `- 8.64e15` to `8.64e15`.

Even though these date values are preposterous, since the RPC server can _technically_ vend a value outside of the ranges for `Number` and `Date`, it doesn't make sense to have these assumptions on the client. Instead, the JavaScript RPC client should exactly match the types that can be returned by the RPC.

For this reason, since the server's `UnixTimestamp` is a Rust `i64`, its JavaScript counterpart in Web3.js should be a `bigint`, to support the range of `i64`.

#### Summary of Changes

Change `UnixTimestamp` to a `bigint`, and constrain the type's integer ranges to that of Rust's `i64`.