### PR TITLE
refactor(experimental): adjust `UnixTimestamp` integer range

### DIFF
--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -501,7 +501,8 @@ export const SolanaErrorMessages: Readonly<{
     [SOLANA_ERROR__SUBTLE_CRYPTO__GENERATE_FUNCTION_UNIMPLEMENTED]: 'No key generation implementation could be found.',
     [SOLANA_ERROR__SUBTLE_CRYPTO__SIGN_FUNCTION_UNIMPLEMENTED]: 'No signing implementation could be found.',
     [SOLANA_ERROR__SUBTLE_CRYPTO__VERIFY_FUNCTION_UNIMPLEMENTED]: 'No key export implementation could be found.',
-    [SOLANA_ERROR__TIMESTAMP_OUT_OF_RANGE]: 'Timestamp value must be in the range [-8.64e15, 8.64e15]. `$value` given',
+    [SOLANA_ERROR__TIMESTAMP_OUT_OF_RANGE]:
+        'Timestamp value must be in the range [-(2n ** 63n), (2n ** 63n) - 1]. `$value` given',
     [SOLANA_ERROR__TRANSACTION_ERROR__ACCOUNT_BORROW_OUTSTANDING]:
         'Transaction processing left an account with an outstanding borrowed reference',
     [SOLANA_ERROR__TRANSACTION_ERROR__ACCOUNT_IN_USE]: 'Account in use',

--- a/packages/rpc-types/README.md
+++ b/packages/rpc-types/README.md
@@ -38,7 +38,9 @@ This type represents a number which has been encoded as a string for transit ove
 
 ### `UnixTimestampUnsafeBeyond2Pow53Minus1`
 
-This type represents a number in the range $[-8.64 \times 10^{15}, 8.64 \times 10^{15}]$. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
+This type represents a Unix timestamp in _seconds_.
+
+**Note**: Despite the fact that this type is represented as a `bigint` in client code and an `i64` in server code, the JSON-RPC implementation represents a Unix timestamp as an IEEE 754 floating point number. This means that you can only safely send or receive values up to $2^{53} - 1$ between the client and the RPC server. See https://github.com/solana-labs/solana/issues/30741 for more detail.
 
 ## Functions
 

--- a/packages/rpc-types/src/__tests__/coercions-test.ts
+++ b/packages/rpc-types/src/__tests__/coercions-test.ts
@@ -60,10 +60,10 @@ describe('coercions', () => {
             expect(coerced).toBe(raw);
         });
         it('throws on an out-of-range `UnixTimestampUnsafeBeyond2Pow53Minus1`', () => {
-            const thisThrows = () => unixTimestamp(BigInt(8.75e15));
+            const thisThrows = () => unixTimestamp(BigInt(2n ** 63n));
             expect(thisThrows).toThrow(
                 new SolanaError(SOLANA_ERROR__TIMESTAMP_OUT_OF_RANGE, {
-                    value: BigInt(8.75e15),
+                    value: BigInt(2n ** 63n),
                 }),
             );
         });

--- a/packages/rpc-types/src/__tests__/unix-timestamp-test.ts
+++ b/packages/rpc-types/src/__tests__/unix-timestamp-test.ts
@@ -3,18 +3,18 @@ import { assertIsUnixTimestamp } from '../unix-timestamp';
 describe('assertIsUnixTimestamp()', () => {
     it('throws when supplied a too large number', () => {
         expect(() => {
-            assertIsUnixTimestamp(BigInt(Number.MAX_SAFE_INTEGER));
+            assertIsUnixTimestamp(BigInt(2n ** 63n));
         }).toThrow();
         expect(() => {
-            assertIsUnixTimestamp(BigInt(8.64e15 + 1));
+            assertIsUnixTimestamp(BigInt('9223372036854775808'));
         }).toThrow();
     });
     it('throws when supplied a too small number', () => {
         expect(() => {
-            assertIsUnixTimestamp(BigInt(Number.MIN_SAFE_INTEGER));
+            assertIsUnixTimestamp(BigInt(BigInt(-(2n ** 63n)) - 1n));
         }).toThrow();
         expect(() => {
-            assertIsUnixTimestamp(BigInt(-8.64e15 - 1));
+            assertIsUnixTimestamp(BigInt('-9223372036854775809'));
         }).toThrow();
     });
     it('does not throw when supplied a zero timestamp', () => {
@@ -29,7 +29,10 @@ describe('assertIsUnixTimestamp()', () => {
     });
     it('does not throw when supplied the max valid timestamp', () => {
         expect(() => {
-            assertIsUnixTimestamp(BigInt(8.64e15));
+            assertIsUnixTimestamp(BigInt(BigInt(2n ** 63n) - 1n));
+        }).not.toThrow();
+        expect(() => {
+            assertIsUnixTimestamp(BigInt('9223372036854775807'));
         }).not.toThrow();
     });
 });

--- a/packages/rpc-types/src/unix-timestamp.ts
+++ b/packages/rpc-types/src/unix-timestamp.ts
@@ -2,20 +2,18 @@ import { SOLANA_ERROR__TIMESTAMP_OUT_OF_RANGE, SolanaError } from '@solana/error
 
 export type UnixTimestampUnsafeBeyond2Pow53Minus1 = bigint & { readonly __brand: unique symbol };
 
+// Largest possible value to be represented by an i64
+const maxI64Value = 9223372036854775807n; // 2n ** 63n - 1n
+const minI64Value = -9223372036854775808n; // -(2n ** 63n)
+
 export function isUnixTimestamp(putativeTimestamp: bigint): putativeTimestamp is UnixTimestampUnsafeBeyond2Pow53Minus1 {
-    // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
-    if (putativeTimestamp > 8.64e15 || putativeTimestamp < -8.64e15) {
-        return false;
-    }
-    return true;
+    return putativeTimestamp >= minI64Value && putativeTimestamp <= maxI64Value;
 }
 
 export function assertIsUnixTimestamp(
     putativeTimestamp: bigint,
 ): asserts putativeTimestamp is UnixTimestampUnsafeBeyond2Pow53Minus1 {
-    // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
-
-    if (putativeTimestamp > 8.64e15 || putativeTimestamp < -8.64e15) {
+    if (putativeTimestamp < minI64Value || putativeTimestamp > maxI64Value) {
         throw new SolanaError(SOLANA_ERROR__TIMESTAMP_OUT_OF_RANGE, {
             value: putativeTimestamp,
         });


### PR DESCRIPTION
Now that `UnixTimestamp` is a `bigint`, its supported integer range has increased. Following the RPC's limits for Rust's `i64`, the type now supports integer ranges from `- 2^63` to `2^63 - 1`.

https://doc.rust-lang.org/std/primitive.i64.html#associatedconstant.MAX
https://doc.rust-lang.org/std/primitive.i64.html#associatedconstant.MIN