### PR TITLE
chore: fix publish CI

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,6 +2,9 @@
   "$schema": "https://json.schemastore.org/semantic-release.json",
   "branches": ["maintenance/v1.x"],
   "commitPaths": ["./src/"],
+  "overrides": {
+    "conventional-changelog-conventionalcommits": ">= 8.0.0"
+  },
   "repositoryUrl": "git@github.com:solana-labs/solana-web3.js.git",
   "preset": "conventionalcommits",
   "presetConfig": {


### PR DESCRIPTION
As described in https://github.com/semantic-release/release-notes-generator/issues/657, add an override for `conventional-changelog-conventionalcommits` to fix the date parsing issue in semantic release.

The PR to update the dependency within `@commitlint/config-conventional` is still open.