### PR TITLE
Fix missing export in `@solana/keys`

### DIFF
--- a/.changeset/weak-peaches-fly.md
+++ b/.changeset/weak-peaches-fly.md
@@ -1,0 +1,5 @@
+---
+'@solana/keys': patch
+---
+
+Fix missing export in `@solana/keys` package. This means, the `getPublicKeyFromPrivateKey` function is now properly exported.

--- a/packages/keys/src/index.ts
+++ b/packages/keys/src/index.ts
@@ -1,3 +1,4 @@
 export * from './key-pair';
 export * from './private-key';
+export * from './public-key';
 export * from './signatures';


### PR DESCRIPTION
Some complete idiot (me) forgot to export the `public-key` file from the `@solana/keys` package. This PR fixes it. Thanks SolAndy for pointing this out.