### PR TITLE
Retrict the type of subscription iterables to `AsyncIterable`

### DIFF
--- a/packages/rpc-subscriptions-transport-websocket/src/__typetests__/websocket-connection-typetest.ts
+++ b/packages/rpc-subscriptions-transport-websocket/src/__typetests__/websocket-connection-typetest.ts
@@ -1,0 +1,24 @@
+import { RpcWebSocketConnection } from '../websocket-connection';
+
+const connection = null as unknown as RpcWebSocketConnection;
+
+// [DESCRIBE] RpcWebSocketConnection
+{
+    // It is an `AsyncIterable`
+    {
+        connection satisfies AsyncIterable<unknown>;
+    }
+
+    // It produces an `AsyncIterator`
+    {
+        connection[Symbol.asyncIterator]() satisfies AsyncIterator<unknown>;
+    }
+
+    // Is not an `AsyncIterableIterator`
+    {
+        // @ts-expect-error Should not be able to produce an iterable.
+        connection satisfies AsyncIterableIterator<unknown>;
+        // @ts-expect-error Should not be able to produce an iterable.
+        connection[Symbol.asyncIterator]() satisfies AsyncIterableIterator<unknown>;
+    }
+}

--- a/packages/rpc-subscriptions-transport-websocket/src/websocket-connection.ts
+++ b/packages/rpc-subscriptions-transport-websocket/src/websocket-connection.ts
@@ -24,10 +24,9 @@ type IteratorState =
           onError: Parameters<ConstructorParameters<typeof Promise>[0]>[1];
           onMessage: Parameters<ConstructorParameters<typeof Promise>[0]>[0];
       };
-export type RpcWebSocketConnection = Readonly<{
+export interface RpcWebSocketConnection extends AsyncIterable<unknown> {
     send(payload: unknown): Promise<void>;
-    [Symbol.asyncIterator](): AsyncGenerator<unknown>;
-}>;
+}
 
 let EXPLICIT_ABORT_TOKEN: symbol;
 function createExplicitAbortToken() {


### PR DESCRIPTION
# Summary

We want to return `Iterables` from here; it's not important that a generator itself is iterable.
