### PR TITLE
The subscriptions coalescer now publishes the final message of the inner iterator

### DIFF
--- a/packages/rpc-subscriptions/src/rpc-subscriptions-coalescer.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-coalescer.ts
@@ -108,7 +108,7 @@ export function getRpcSubscriptionsWithSubscriptionCoalescing<TRpcSubscriptionsM
                                     while (true) {
                                         const iteratorResult = await safeRace([iterator.next(), abortPromise]);
                                         if (iteratorResult.done) {
-                                            return;
+                                            return iteratorResult.value;
                                         } else {
                                             yield iteratorResult.value;
                                         }


### PR DESCRIPTION
# Summary

What if a custom transport _returns_ its final value? Before this PR, the coalescer would not deliver the final message, if the `done` property and the `value` came in the same iteration.
