### PR TITLE
Add edge-light export using Node output for Vercel edge runtime

### DIFF
--- a/.changeset/unlucky-jars-travel.md
+++ b/.changeset/unlucky-jars-travel.md
@@ -1,0 +1,42 @@
+---
+'@solana/rpc-subscriptions-transport-websocket': patch
+'@solana/webcrypto-ed25519-polyfill': patch
+'@solana/transaction-confirmation': patch
+'@solana/codecs-data-structures': patch
+'@solana/rpc-subscriptions-spec': patch
+'@solana/fast-stable-stringify': patch
+'@solana/rpc-subscriptions-api': patch
+'@solana/transaction-messages': patch
+'@solana/rpc-transport-http': patch
+'@solana/rpc-subscriptions': patch
+'@solana/rpc-parsed-types': patch
+'@solana/rpc-transformers': patch
+'@solana/codecs-numbers': patch
+'@solana/codecs-strings': patch
+'@solana/rpc-spec-types': patch
+'@solana/instructions': patch
+'@solana/transactions': patch
+'@solana/codecs-core': patch
+'@solana/rpc-graphql': patch
+'@solana/assertions': patch
+'@solana/functional': patch
+'@solana/addresses': patch
+'@solana/rpc-types': patch
+'@solana/accounts': patch
+'@solana/programs': patch
+'@solana/promises': patch
+'@solana/rpc-spec': patch
+'@solana/web3.js': patch
+'@solana/options': patch
+'@solana/rpc-api': patch
+'@solana/signers': patch
+'@solana/sysvars': patch
+'@solana/codecs': patch
+'@solana/compat': patch
+'@solana/errors': patch
+'@solana/react': patch
+'@solana/keys': patch
+'@solana/rpc': patch
+---
+
+Add edge-light to package exports

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for representing, fetching and decoding Solana accounts",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for generating account addresses",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for asserting that a JavaScript environment supports certain features necessary for the operation of the Solana JavaScript SDK",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Core types and helpers for encoding and decoding byte arrays on Solana",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Codecs for various data structures",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Codecs for numbers of different sizes and endianness",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Codecs for strings of different sizes and encodings",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "A library for encoding and decoding any data structure",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for converting from legacy web3js classes",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/crypto-impl/package.json
+++ b/packages/crypto-impl/package.json
@@ -8,6 +8,11 @@
             "require": "./dist/index.node.cjs",
             "types": "./dist/types/index.browser.d.ts"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs",
+            "types": "./dist/types/index.browser.d.ts"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs",

--- a/packages/crypto-impl/package.json
+++ b/packages/crypto-impl/package.json
@@ -3,6 +3,11 @@
     "version": "0.0.0",
     "private": true,
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs",
+            "types": "./dist/types/index.browser.d.ts"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Throw, identify, and decode Solana JavaScript errors",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/fast-stable-stringify/package.json
+++ b/packages/fast-stable-stringify/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/fast-stable-stringify/package.json
+++ b/packages/fast-stable-stringify/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Deterministic stringification for when performance and bundle size matters",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Functional JavaScript helpers",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for creating transaction instructions",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for generating and transforming key material",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Solana Javascript API",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Managing and serializing Rust-like Option types in JavaScript",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for defining programs and resolving program errors",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/promises/package.json
+++ b/packages/promises/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/promises/package.json
+++ b/packages/promises/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for using JavaScript promises",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "React hooks for building Solana apps",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Defines all default Solana RPC methods as types",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "A library for resolving GraphQl query calls to the Solana JSON RPC API",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Type definitions for parsed types used in the Solana RPC",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Shared generic JSON RPC specifications",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "A generic implementation of JSON RPCs using proxies",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Defines all default Solana RPC subscriptions as types",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "A generic implementation of JSON RPC Subscriptions using proxies",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-subscriptions-transport-websocket/package.json
+++ b/packages/rpc-subscriptions-transport-websocket/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-subscriptions-transport-websocket/package.json
+++ b/packages/rpc-subscriptions-transport-websocket/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "An RPC Subscriptions transport that uses WebSockets",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "A library for subscribing to Solana RPC notifications",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Reusable transformers for patching RPC inputs and outputs",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "An RPC transport that uses HTTP requests",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Type definitions for values used in the Solana RPC, and helper functions for working with them",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "A library for sending JSON RPC requests to Solana RPCs",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "An abstraction layer over signing messages and transactions in Solana",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "An abstraction layer over signing messages and transactions in Solana",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/text-encoding-impl/package.json
+++ b/packages/text-encoding-impl/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/text-encoding-impl/package.json
+++ b/packages/text-encoding-impl/package.json
@@ -3,6 +3,10 @@
     "version": "0.0.0",
     "private": true,
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for confirming Solana transactions",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for creating transaction messages",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "Helpers for creating and serializing transactions",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -7,6 +7,10 @@
             "import": "./dist/index.node.mjs",
             "require": "./dist/index.node.cjs"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -3,6 +3,10 @@
     "version": "2.0.0-rc.1",
     "description": "A polyfill that adds Ed25519 key manipulation capabilities to `SubtleCrypto` in environments where it is not yet supported",
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs"

--- a/packages/ws-impl/package.json
+++ b/packages/ws-impl/package.json
@@ -8,6 +8,11 @@
             "require": "./dist/index.node.cjs",
             "types": "./dist/types/index.browser.d.ts"
         },
+        "workerd": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs",
+            "types": "./dist/types/index.browser.d.ts"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs",

--- a/packages/ws-impl/package.json
+++ b/packages/ws-impl/package.json
@@ -3,6 +3,11 @@
     "version": "0.0.0",
     "private": true,
     "exports": {
+        "edge-light": {
+            "import": "./dist/index.node.mjs",
+            "require": "./dist/index.node.cjs",
+            "types": "./dist/types/index.browser.d.ts"
+        },
         "browser": {
             "import": "./dist/index.browser.mjs",
             "require": "./dist/index.browser.cjs",


### PR DESCRIPTION
- Vercel edge runtime uses the `browser` export by default. This doesn't work well for us, because our crypto libs depend on a secure context to function in a browser environment, which the edge runtime is not. 
- This PR adds an `edge-light` export, which is the export version that can be used to target the Vercel edge runtime. We just duplicate our Node export here, as this matches the behaviour we want in an edge API route.
- In Next, the `edge-light` export must come before the `browser` one to be used, so I've made it the first export. See https://github.com/vercel/next.js/issues/69175 