### PR TITLE
Rename `RpcRequest` to `RpcApiRequestPlan`

### DIFF
--- a/.changeset/fair-brooms-build.md
+++ b/.changeset/fair-brooms-build.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-spec': patch
+---
+
+Rename `RpcRequest` type to `RpcApiRequestPlan` to make room for new `RpcRequest` type

--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -43,13 +43,13 @@ An object that exposes all of the functions described by `TRpcMethods`, and fulf
 
 ### `RpcApi<TRpcMethods>`
 
-For each of `TRpcMethods` this object exposes a method with the same name that maps between its input arguments and a `RpcRequest<TResponse>` that describes how to prepare a JSON RPC request to fetch `TResponse`.
+For each of `TRpcMethods` this object exposes a method with the same name that maps between its input arguments and a `RpcApiRequestPlan<TResponse>` that describes how to prepare a JSON RPC request to fetch `TResponse`.
 
 ### `RpcApiMethods`
 
 This is a marker interface that all RPC method definitions must extend to be accepted for use with the `RpcApi` creator.
 
-### `RpcRequest`
+### `RpcApiRequestPlan`
 
 This type describes how a particular request should be issued to the JSON RPC server. Given a function that was called on a `Rpc`, this object gives you the opportunity to:
 
@@ -85,7 +85,7 @@ A config object with the following properties:
 
 ### `createRpcApi(config)`
 
-Creates a JavaScript proxy that converts _any_ function call called on it to a `RpcRequest` by:
+Creates a JavaScript proxy that converts _any_ function call called on it to a `RpcApiRequestPlan` by:
 
 -   setting `methodName` to the name of the function called
 -   setting `params` to the arguments supplied to that function, optionally transformed by `config.parametersTransformer`
@@ -101,7 +101,7 @@ const rpcApi = createRpcApi({
 // ...the following function call:
 rpcApi.foo('bar', { baz: 'bat' });
 
-// ...will produce the following `RpcRequest` object:
+// ...will produce the following `RpcApiRequestPlan` object:
 //
 //     {
 //         methodName: 'foo',

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -2,7 +2,7 @@ import { createRpcMessage } from '@solana/rpc-spec-types';
 
 import { createRpc, Rpc } from '../rpc';
 import { RpcApi } from '../rpc-api';
-import { RpcRequest } from '../rpc-request';
+import { RpcApiRequestPlan } from '../rpc-request';
 import { RpcTransport } from '../rpc-transport';
 
 interface TestRpcMethods {
@@ -50,7 +50,7 @@ describe('JSON-RPC 2.0', () => {
         beforeEach(() => {
             rpc = createRpc({
                 api: {
-                    someMethod(...params: unknown[]): RpcRequest<unknown> {
+                    someMethod(...params: unknown[]): RpcApiRequestPlan<unknown> {
                         return {
                             methodName: 'someMethodAugmented',
                             params: [...params, 'augmented', 'params'],
@@ -77,7 +77,7 @@ describe('JSON-RPC 2.0', () => {
             responseTransformer = jest.fn(response => `${response} processed response`);
             rpc = createRpc({
                 api: {
-                    someMethod(...params: unknown[]): RpcRequest<unknown> {
+                    someMethod(...params: unknown[]): RpcApiRequestPlan<unknown> {
                         return {
                             methodName: 'someMethod',
                             params,

--- a/packages/rpc-spec/src/rpc-api.ts
+++ b/packages/rpc-spec/src/rpc-api.ts
@@ -1,6 +1,6 @@
 import { Callable } from '@solana/rpc-spec-types';
 
-import { RpcRequest } from './rpc-request';
+import { RpcApiRequestPlan } from './rpc-request';
 
 export type RpcApiConfig = Readonly<{
     parametersTransformer?: <T extends unknown[]>(params: T, methodName: string) => unknown;
@@ -12,7 +12,7 @@ export type RpcApi<TRpcMethods> = {
 };
 
 type RpcReturnTypeMapper<TRpcMethod> = TRpcMethod extends Callable
-    ? (...rawParams: unknown[]) => RpcRequest<ReturnType<TRpcMethod>>
+    ? (...rawParams: unknown[]) => RpcApiRequestPlan<ReturnType<TRpcMethod>>
     : never;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,7 +38,7 @@ export function createRpcApi<TRpcMethods extends RpcApiMethods>(config?: RpcApiC
                 ...rawParams: Parameters<
                     TRpcMethods[TMethodName] extends CallableFunction ? TRpcMethods[TMethodName] : never
                 >
-            ): RpcRequest<ReturnType<TRpcMethods[TMethodName]>> {
+            ): RpcApiRequestPlan<ReturnType<TRpcMethods[TMethodName]>> {
                 const params = config?.parametersTransformer
                     ? config?.parametersTransformer(rawParams, methodName)
                     : rawParams;

--- a/packages/rpc-spec/src/rpc-request.ts
+++ b/packages/rpc-spec/src/rpc-request.ts
@@ -1,4 +1,4 @@
-export type RpcRequest<TResponse> = {
+export type RpcApiRequestPlan<TResponse> = {
     methodName: string;
     params: unknown;
     responseTransformer?: (response: unknown, methodName: string) => TResponse;

--- a/packages/rpc-spec/src/rpc.ts
+++ b/packages/rpc-spec/src/rpc.ts
@@ -8,7 +8,7 @@ import {
 } from '@solana/rpc-spec-types';
 
 import { RpcApi } from './rpc-api';
-import { PendingRpcRequest, RpcRequest, RpcSendOptions } from './rpc-request';
+import { PendingRpcRequest, RpcApiRequestPlan, RpcSendOptions } from './rpc-request';
 import { RpcTransport } from './rpc-transport';
 
 export type RpcConfig<TRpcMethods, TRpcTransport extends RpcTransport> = Readonly<{
@@ -63,7 +63,7 @@ function makeProxy<TRpcMethods, TRpcTransport extends RpcTransport>(
 
 function createPendingRpcRequest<TRpcMethods, TRpcTransport extends RpcTransport, TResponse>(
     rpcConfig: RpcConfig<TRpcMethods, TRpcTransport>,
-    pendingRequest: RpcRequest<TResponse>,
+    pendingRequest: RpcApiRequestPlan<TResponse>,
 ): PendingRpcRequest<TResponse> {
     return {
         async send(options?: RpcSendOptions): Promise<TResponse> {


### PR DESCRIPTION
In this PR, we continue cleaning up the type namespace by renaming `RpcRequest` to `RpcApiRequestPlan`. This is because:

- `RpcRequest` will be used to define a proper request interface that will unify the RPC layers.
- `RpcApiRequestPlan` better describes what the type actually does. If you call `myRpcApi.myMethod({ foo: 42 })`, then you will be given an object that contains everything you need to send it to a transport without actually sending it to a transport. This is the role of the `Rpc` type which wraps the `RpcApi` proxy and transforms this `RpcApiRequestPlan` into a `PendingRpcRequest` which contains the desired `send` function.