### PR TITLE
Add new `RpcRequest`, `RpcResponse` types and their transformer types

### DIFF
--- a/.changeset/light-bugs-compare.md
+++ b/.changeset/light-bugs-compare.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-spec': patch
+---
+
+Add new `RpcRequest` and `RpcResponse` types with `RpcRequestTransformer`, `RpcResponseTransformer` and `createJsonRpcResponseTransformer` functions

--- a/packages/rpc-spec/src/__tests__/rpc-shared-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-shared-test.ts
@@ -1,0 +1,56 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { createJsonRpcResponseTransformer, RpcRequest, RpcResponse } from '../rpc-shared';
+
+describe('createJsonRpcResponseTransformer', () => {
+    it('can alter the value of the json Promise', async () => {
+        expect.assertions(1);
+
+        // Given a request and a response that returns a number.
+        const request = { methodName: 'someMethod', params: [123] };
+        const response = {
+            json: () => Promise.resolve(123),
+            text: () => Promise.resolve('123'),
+        };
+
+        // When we create a JSON transformer that doubles the number.
+        const transformer = createJsonRpcResponseTransformer((json: unknown) => (json as number) * 2);
+
+        // Then the transformed response should return the doubled number.
+        const transformedResponse = transformer(response, request);
+        transformedResponse satisfies RpcResponse<number>;
+        await expect(transformedResponse.json()).resolves.toBe(246);
+    });
+
+    it('does not alter the value of the text Promise', async () => {
+        expect.assertions(1);
+
+        // Given a request and a response that returns a number.
+        const request = { methodName: 'someMethod', params: [123] };
+        const response = {
+            json: () => Promise.resolve(123),
+            text: () => Promise.resolve('123'),
+        };
+
+        // When we create a JSON transformer that doubles the number.
+        const transformer = createJsonRpcResponseTransformer((json: unknown) => (json as number) * 2);
+
+        // Then the text should function should return the original string.
+        const transformedResponse = transformer(response, request);
+        await expect(transformedResponse.text()).resolves.toBe('123');
+    });
+
+    it('returns a frozen object as the Reponse', () => {
+        // Given any response.
+        const response = {
+            json: () => Promise.resolve(123),
+            text: () => Promise.resolve('123'),
+        };
+
+        // When we pass it through a JSON transformer.
+        const transformedResponse = createJsonRpcResponseTransformer(x => x)(response, {} as RpcRequest);
+
+        // Then we expect the transformed response to be frozen.
+        expect(transformedResponse).toBeFrozenObject();
+    });
+});

--- a/packages/rpc-spec/src/index.ts
+++ b/packages/rpc-spec/src/index.ts
@@ -1,4 +1,5 @@
 export * from './rpc';
 export * from './rpc-api';
 export * from './rpc-request';
+export * from './rpc-shared';
 export * from './rpc-transport';

--- a/packages/rpc-spec/src/rpc-shared.ts
+++ b/packages/rpc-spec/src/rpc-shared.ts
@@ -1,0 +1,35 @@
+export type RpcRequest<TParams = unknown> = {
+    readonly methodName: string;
+    readonly params: TParams;
+};
+
+export type RpcResponse<TResponse = unknown> = {
+    readonly json: () => Promise<TResponse>;
+    readonly text: () => Promise<string>;
+};
+
+export type RpcRequestTransformer = {
+    <TParams>(request: RpcRequest<unknown>): RpcRequest<TParams>;
+};
+
+export type RpcResponseTransformer = {
+    <TResponse>(response: RpcResponse<unknown>, request: RpcRequest<unknown>): RpcResponse<TResponse>;
+};
+
+export type RpcResponseTransformerFor<TResponse> = {
+    (response: RpcResponse<unknown>, request: RpcRequest<unknown>): RpcResponse<TResponse>;
+};
+
+export function createJsonRpcResponseTransformer<TResponse>(
+    jsonTransformer: (json: unknown, request: RpcRequest) => TResponse,
+): RpcResponseTransformerFor<TResponse> {
+    return function (response: RpcResponse, request: RpcRequest): RpcResponse<TResponse> {
+        return Object.freeze({
+            ...response,
+            json: async () => {
+                const json = await response.json();
+                return jsonTransformer(json, request);
+            },
+        });
+    };
+}


### PR DESCRIPTION
Now that we've made room for these new types, we add the following:

- `RpcRequest`: The method name and the params are all we need to create a request. Combining them into a single object makes it easier to play with RPC requests. For instance, we can now have a `RpcRequestTransformer` instead of a `RpcParamsTransformer`.
- `RpcResponse`: This is the response abstraction that all the layers of the RPC packages will use moving forward. Instead of a simple `unknown` piece of data, the `RpcResponse` object contains two async methods:
  - `json`: Returns the parsed piece of data.
  - `text`: Returns the unparsed piece of data (as a string).
- `RpcRequestTransformer` and `RpcResponseTransformer`: Functions that take a request/response and return a new request/response respectively. Note that the response transformer also provides the associated request as a second argument.
- `RpcResponseTransformerFor`: Same as `RpcResponseTransformer` but we know exactly the type of the return data we expect.
- `createJsonRpcResponseTransformer`: This function is a helper that transforms a function of type `(json: unknown) => T` to a `RpcResponseTransformerFor<T>` by wrapping it in a `json` async function.