### PR TITLE
Update RPC transports to use new types

### DIFF
--- a/.changeset/stupid-tomatoes-reflect.md
+++ b/.changeset/stupid-tomatoes-reflect.md
@@ -1,0 +1,8 @@
+---
+'@solana/rpc-transport-http': patch
+'@solana/rpc-spec': patch
+'@solana/rpc-api': patch
+'@solana/rpc': patch
+---
+
+Make `RpcTransport` return new `RpcReponse` type instead of parsed JSON data

--- a/packages/rpc-api/src/__tests__/get-health-test.ts
+++ b/packages/rpc-api/src/__tests__/get-health-test.ts
@@ -1,8 +1,15 @@
 import { SOLANA_ERROR__JSON_RPC__SERVER_ERROR_NODE_UNHEALTHY, SolanaError } from '@solana/errors';
-import { createRpc, type Rpc } from '@solana/rpc-spec';
+import { createRpc, type Rpc, type RpcResponse } from '@solana/rpc-spec';
 
 import { createSolanaRpcApi, GetHealthApi } from '../index';
 import { createLocalhostSolanaRpc } from './__setup__';
+
+function createMockResponse<T>(jsonResponse: T): RpcResponse<T> {
+    return {
+        json: () => Promise.resolve(jsonResponse),
+        text: () => Promise.resolve(JSON.stringify(jsonResponse)),
+    };
+}
 
 describe('getHealth', () => {
     describe('when the node is healthy', () => {
@@ -29,7 +36,7 @@ describe('getHealth', () => {
         beforeEach(() => {
             rpc = createRpc({
                 api: createSolanaRpcApi(),
-                transport: jest.fn().mockResolvedValue({ error: errorObject }),
+                transport: jest.fn().mockResolvedValue(createMockResponse({ error: errorObject })),
             });
         });
         it('returns an error message', async () => {

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -3,10 +3,18 @@ import { createRpcMessage } from '@solana/rpc-spec-types';
 import { createRpc, Rpc } from '../rpc';
 import { RpcApi } from '../rpc-api';
 import { RpcApiRequestPlan } from '../rpc-request';
+import { RpcResponse } from '../rpc-shared';
 import { RpcTransport } from '../rpc-transport';
 
 interface TestRpcMethods {
     someMethod(...args: unknown[]): unknown;
+}
+
+function createMockResponse<T>(jsonResponse: T): RpcResponse<T> {
+    return {
+        json: () => Promise.resolve(jsonResponse),
+        text: () => Promise.resolve(JSON.stringify(jsonResponse)),
+    };
 }
 
 describe('JSON-RPC 2.0', () => {
@@ -34,7 +42,7 @@ describe('JSON-RPC 2.0', () => {
     });
     it('returns results from the transport', async () => {
         expect.assertions(1);
-        (makeHttpRequest as jest.Mock).mockResolvedValueOnce(123);
+        (makeHttpRequest as jest.Mock).mockResolvedValueOnce(createMockResponse(123));
         const result = await rpc.someMethod().send();
         expect(result).toBe(123);
     });
@@ -90,13 +98,13 @@ describe('JSON-RPC 2.0', () => {
         });
         it('calls the response transformer with the response from the JSON-RPC 2.0 endpoint', async () => {
             expect.assertions(1);
-            (makeHttpRequest as jest.Mock).mockResolvedValueOnce(123);
+            (makeHttpRequest as jest.Mock).mockResolvedValueOnce(createMockResponse(123));
             await rpc.someMethod().send();
             expect(responseTransformer).toHaveBeenCalledWith(123, 'someMethod');
         });
         it('returns the processed response', async () => {
             expect.assertions(1);
-            (makeHttpRequest as jest.Mock).mockResolvedValueOnce(123);
+            (makeHttpRequest as jest.Mock).mockResolvedValueOnce(createMockResponse(123));
             const result = await rpc.someMethod().send();
             expect(result).toBe('123 processed response');
         });

--- a/packages/rpc-spec/src/rpc-transport.ts
+++ b/packages/rpc-spec/src/rpc-transport.ts
@@ -1,8 +1,10 @@
-type RpcTransportConfig = Readonly<{
+import { RpcResponse } from './rpc-shared';
+
+type RpcTransportRequest = Readonly<{
     payload: unknown;
     signal?: AbortSignal;
 }>;
 
-export interface RpcTransport {
-    <TResponse>(config: RpcTransportConfig): Promise<TResponse>;
-}
+export type RpcTransport = {
+    <TResponse>(request: RpcTransportRequest): Promise<RpcResponse<TResponse>>;
+};

--- a/packages/rpc-spec/src/rpc.ts
+++ b/packages/rpc-spec/src/rpc.ts
@@ -3,7 +3,6 @@ import {
     createRpcMessage,
     Flatten,
     OverloadImplementations,
-    RpcResponseData,
     UnionToIntersection,
 } from '@solana/rpc-spec-types';
 
@@ -68,12 +67,12 @@ function createPendingRpcRequest<TRpcMethods, TRpcTransport extends RpcTransport
     return {
         async send(options?: RpcSendOptions): Promise<TResponse> {
             const { methodName, params, responseTransformer } = pendingRequest;
-            const payload = createRpcMessage(methodName, params);
-            const response = await rpcConfig.transport<RpcResponseData<unknown>>({
-                payload,
+            const response = await rpcConfig.transport<TResponse>({
+                payload: createRpcMessage(methodName, params),
                 signal: options?.abortSignal,
             });
-            return (responseTransformer ? responseTransformer(response, methodName) : response) as TResponse;
+            const responseData = await response.json();
+            return responseTransformer ? responseTransformer(responseData, methodName) : responseData;
         },
     };
 }

--- a/packages/rpc-transport-http/src/__tests__/http-transport-abort-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-abort-test.ts
@@ -71,12 +71,13 @@ describe('createHttpTransport and `AbortSignal`', () => {
         it('resolves with the response', async () => {
             expect.assertions(1);
             jest.mocked(fetchSpy).mockResolvedValueOnce({
-                json: () => ({ ok: true }),
+                json: () => Promise.resolve({ ok: true }),
                 ok: true,
             } as unknown as Response);
             const sendPromise = makeHttpRequest({ payload: 123, signal: abortSignal });
             abortController.abort('I got bored waiting');
-            await expect(sendPromise).resolves.toMatchObject({
+            const response = await sendPromise;
+            await expect(response.json()).resolves.toMatchObject({
                 ok: true,
             });
         });

--- a/packages/rpc-transport-http/src/http-transport.ts
+++ b/packages/rpc-transport-http/src/http-transport.ts
@@ -1,5 +1,5 @@
 import { SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR, SolanaError } from '@solana/errors';
-import { RpcTransport } from '@solana/rpc-spec';
+import { RpcResponse, RpcTransport } from '@solana/rpc-spec';
 import type Dispatcher from 'undici-types/dispatcher';
 
 import {
@@ -44,7 +44,7 @@ export function createHttpTransport(config: Config): RpcTransport {
     return async function makeHttpRequest<TResponse>({
         payload,
         signal,
-    }: Parameters<RpcTransport>[0]): Promise<TResponse> {
+    }: Parameters<RpcTransport>[0]): Promise<RpcResponse<TResponse>> {
         const body = JSON.stringify(payload);
         const requestInfo = {
             ...dispatcherConfig,
@@ -66,6 +66,9 @@ export function createHttpTransport(config: Config): RpcTransport {
                 statusCode: response.status,
             });
         }
-        return (await response.json()) as TResponse;
+        return Object.freeze({
+            json: () => response.json(),
+            text: () => response.text(),
+        });
     };
 }


### PR DESCRIPTION
This PR updates the RPC Transport layer by making sure they return the new `RpcResponse` interface instead of returning the parsed response data directly.