### PR TITLE
Update RPC APIs to use new types

### DIFF
--- a/.changeset/metal-spoons-matter.md
+++ b/.changeset/metal-spoons-matter.md
@@ -1,0 +1,8 @@
+---
+'@solana/rpc-subscriptions-api': patch
+'@solana/rpc-transformers': patch
+'@solana/rpc-spec': patch
+'@solana/rpc-api': patch
+---
+
+Make `RpcApi` use new `RpcRequestTransformer` and `RpcResponseTransformer`

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -1,14 +1,14 @@
 import { createRpcApi, RpcApi } from '@solana/rpc-spec';
 import {
     AllowedNumericKeypaths,
-    getDefaultParamsTransformerForSolanaRpc,
+    getDefaultRequestTransformerForSolanaRpc,
     getDefaultResponseTransformerForSolanaRpc,
     innerInstructionsConfigs,
     jsonParsedAccountsConfigs,
     jsonParsedTokenAccountsConfigs,
     KEYPATH_WILDCARD,
     messageConfig,
-    ParamsTransformerConfig,
+    RequestTransformerConfig,
 } from '@solana/rpc-transformers';
 
 import { GetAccountInfoApi } from './getAccountInfo';
@@ -179,13 +179,13 @@ export type {
     SimulateTransactionApi,
 };
 
-type Config = ParamsTransformerConfig;
+type Config = RequestTransformerConfig;
 
 export function createSolanaRpcApi<
     TRpcMethods extends SolanaRpcApi | SolanaRpcApiDevnet | SolanaRpcApiMainnet | SolanaRpcApiTestnet = SolanaRpcApi,
 >(config?: Config): RpcApi<TRpcMethods> {
     return createRpcApi<TRpcMethods>({
-        parametersTransformer: getDefaultParamsTransformerForSolanaRpc(config) as (params: unknown[]) => unknown[],
+        requestTransformer: getDefaultRequestTransformerForSolanaRpc(config),
         responseTransformer: getDefaultResponseTransformerForSolanaRpc({
             allowedNumericKeyPaths: getAllowedNumericKeypaths(),
         }),

--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -113,14 +113,14 @@ A config object with the following properties:
 
 Creates a JavaScript proxy that converts _any_ function call called on it to a `RpcApiRequestPlan` by:
 
--   setting `methodName` to the name of the function called
--   setting `params` to the arguments supplied to that function, optionally transformed by `config.parametersTransformer`
--   setting `responseTransformer` to `config.responseTransformer` or the identity function if no such config exists
+-   setting `methodName` to the name of the function called, optionally transformed by `config.requestTransformer`.
+-   setting `params` to the arguments supplied to that function, optionally transformed by `config.requestTransformer`.
+-   setting `responseTransformer` to `config.responseTransformer`, if provided.
 
 ```ts
 // For example, given this `RpcApi`:
 const rpcApi = createRpcApi({
-    paramsTransformer: (...rawParams) => rawParams.reverse(),
+    requestTransformer: (...rawParams) => rawParams.reverse(),
     responseTransformer: response => response.result,
 });
 
@@ -140,8 +140,8 @@ rpcApi.foo('bar', { baz: 'bat' });
 
 A config object with the following properties:
 
--   `parametersTransformer<T>(params: T, methodName): unknown`: An optional function that maps between the shape of the arguments an RPC method was called with and the shape of the params expected by the JSON RPC server.
--   `responseTransformer<T>(response, methodName): T`: An optional function that maps between the shape of the JSON RPC server response for a given method and the shape of the response expected by the `RpcApi`.
+-   `requestTransformer<T>(request: RpcRequest<T>): RpcRequest`: An optional function that transforms the `RpcRequest` before it is sent to the JSON RPC server.
+-   `responseTransformer<T>(response: RpcResponse, request: RpcRequest): RpcResponse<T>`: An optional function that transforms the `RpcResponse` before it is returned to the caller.
 
 ### `createJsonRpcResponseTransformer<T>(jsonTransformer)`
 

--- a/packages/rpc-spec/src/__tests__/rpc-api-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-api-test.ts
@@ -1,0 +1,84 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { createRpcApi } from '../rpc-api';
+import { RpcRequest, RpcResponse } from '../rpc-shared';
+
+type DummyApi = {
+    someMethod(...args: unknown[]): unknown;
+};
+
+describe('createRpcApi', () => {
+    it('returns a plan containing the method name and parameters provided', () => {
+        // Given a dummy API.
+        const api = createRpcApi<DummyApi>();
+
+        // When we call a method on the API.
+        const plan = api.someMethod(1, 'two', { three: [4] });
+
+        // Then we expect the plan to contain the method name and the provided parameters.
+        expect(plan).toEqual({
+            methodName: 'someMethod',
+            params: [1, 'two', { three: [4] }],
+        });
+    });
+    it('applies the request transformer to the provided method name', () => {
+        // Given a dummy API with a request transformer that appends 'Transformed' to the method name.
+        const api = createRpcApi<DummyApi>({
+            requestTransformer: <T>(request: RpcRequest<unknown>) =>
+                ({ ...request, methodName: `${request.methodName}Transformed` }) as RpcRequest<T>,
+        });
+
+        // When we call a method on the API.
+        const plan = api.someMethod();
+
+        // Then we expect the plan to contain the transformed method name.
+        expect(plan.methodName).toBe('someMethodTransformed');
+    });
+    it('applies the request transformer to the provided params', () => {
+        // Given a dummy API with a request transformer that doubles the provided params.
+        const api = createRpcApi<DummyApi>({
+            requestTransformer: <T>(request: RpcRequest<unknown>) =>
+                ({ ...request, params: (request.params as number[]).map(x => x * 2) }) as RpcRequest<T>,
+        });
+
+        // When we call a method on the API.
+        const plan = api.someMethod(1, 2, 3);
+
+        // Then we expect the plan to contain the transformed params.
+        expect(plan.params).toEqual([2, 4, 6]);
+    });
+    it('includes the provided response transformer in the plan', () => {
+        // Given a dummy API with a response transformer.
+        const responseTransformer = <T>(response: RpcResponse<unknown>) => response as RpcResponse<T>;
+        const api = createRpcApi<DummyApi>({ responseTransformer });
+
+        // When we call a method on the API.
+        const plan = api.someMethod(1, 2, 3);
+
+        // Then we expect the plan to contain the response transformer.
+        expect(plan.responseTransformer).toBe(responseTransformer);
+    });
+    it('returns a frozen object', () => {
+        // Given a dummy API.
+        const api = createRpcApi<DummyApi>();
+
+        // When we call a method on the API.
+        const plan = api.someMethod();
+
+        // Then we expect the returned plan to be frozen.
+        expect(plan).toBeFrozenObject();
+    });
+    it('also returns a frozen object with a request transformer', () => {
+        // Given a dummy API with a request transformer.
+        const api = createRpcApi<DummyApi>({
+            requestTransformer: <T>(request: RpcRequest<unknown>) =>
+                ({ ...request, methodName: 'transformed' }) as RpcRequest<T>,
+        });
+
+        // When we call a method on the API.
+        const plan = api.someMethod();
+
+        // Then we expect the returned plan to be frozen.
+        expect(plan).toBeFrozenObject();
+    });
+});

--- a/packages/rpc-spec/src/rpc.ts
+++ b/packages/rpc-spec/src/rpc.ts
@@ -74,12 +74,13 @@ function createPendingRpcRequest<TRpcMethods, TRpcTransport extends RpcTransport
     return {
         async send(options?: RpcSendOptions): Promise<TResponse> {
             const { methodName, params, responseTransformer } = pendingRequest;
-            const response = await rpcConfig.transport<TResponse>({
+            const request = Object.freeze({ methodName, params });
+            const rawResponse = await rpcConfig.transport<TResponse>({
                 payload: createRpcMessage(methodName, params),
                 signal: options?.abortSignal,
             });
-            const responseData = await response.json();
-            return responseTransformer ? responseTransformer(responseData, methodName) : responseData;
+            const response = responseTransformer ? responseTransformer(rawResponse, request) : rawResponse;
+            return await response.json();
         },
     };
 }

--- a/packages/rpc-subscriptions-api/src/index.ts
+++ b/packages/rpc-subscriptions-api/src/index.ts
@@ -5,11 +5,11 @@ import {
 } from '@solana/rpc-subscriptions-spec';
 import {
     AllowedNumericKeypaths,
-    getDefaultParamsTransformerForSolanaRpc,
-    getDefaultResponseTransformerForSolanaRpc,
+    getDefaultRequestTransformerForSolanaRpc,
+    getDefaultResponseTransformerForSolanaRpcSubscriptions,
     jsonParsedAccountsConfigs,
     KEYPATH_WILDCARD,
-    ParamsTransformerConfig,
+    RequestTransformerConfig,
 } from '@solana/rpc-transformers';
 
 import { AccountNotificationsApi } from './account-notifications';
@@ -44,14 +44,18 @@ export type {
     VoteNotificationsApi,
 };
 
-type Config = ParamsTransformerConfig;
+type Config = RequestTransformerConfig;
 
 function createSolanaRpcSubscriptionsApi_INTERNAL<TApi extends RpcSubscriptionsApiMethods>(
     config?: Config,
 ): RpcSubscriptionsApi<TApi> {
     return createRpcSubscriptionsApi<TApi>({
-        parametersTransformer: getDefaultParamsTransformerForSolanaRpc(config) as (params: unknown[]) => unknown[],
-        responseTransformer: getDefaultResponseTransformerForSolanaRpc({
+        // TODO(loris): Replace with request transformer.
+        parametersTransformer: <T extends unknown[]>(params: T, notificationName: string) => {
+            return getDefaultRequestTransformerForSolanaRpc(config)({ methodName: notificationName, params })
+                .params as unknown[];
+        },
+        responseTransformer: getDefaultResponseTransformerForSolanaRpcSubscriptions({
             allowedNumericKeyPaths: getAllowedNumericKeypaths(),
         }),
         subscribeNotificationNameTransformer: (notificationName: string) =>

--- a/packages/rpc-transformers/src/__tests__/response-transformer-test.ts
+++ b/packages/rpc-transformers/src/__tests__/response-transformer-test.ts
@@ -1,15 +1,26 @@
 import { SOLANA_ERROR__JSON_RPC__PARSE_ERROR, SolanaError } from '@solana/errors';
+import { RpcRequest, RpcResponse } from '@solana/rpc-spec';
 
 import { getDefaultResponseTransformerForSolanaRpc } from '../response-transformer';
 import { KEYPATH_WILDCARD } from '../tree-traversal';
 
+function createMockResponse<T>(jsonResponse: T): RpcResponse<T> {
+    return {
+        json: () => Promise.resolve(jsonResponse),
+        text: () => Promise.resolve(JSON.stringify(jsonResponse)),
+    };
+}
+
 describe('getDefaultResponseTransformerForSolanaRpc', () => {
     describe('given an array as input', () => {
         const input = [10, 10n, '10', ['10', [10n, 10], 10]] as const;
-        const response = { result: input };
-        it('casts the numbers in the array to a `bigint`, recursively', () => {
+        const request = {} as RpcRequest;
+        const response = createMockResponse({ result: input });
+        it('casts the numbers in the array to a `bigint`, recursively', async () => {
+            expect.assertions(1);
             const transformer = getDefaultResponseTransformerForSolanaRpc();
-            expect(transformer(response)).toStrictEqual([
+            const transformedResponse = transformer(response, request);
+            await expect(transformedResponse.json()).resolves.toStrictEqual([
                 BigInt(input[0]),
                 input[1],
                 input[2],
@@ -19,11 +30,14 @@ describe('getDefaultResponseTransformerForSolanaRpc', () => {
     });
     describe('given an object as input', () => {
         const input = { a: 10, b: 10n, c: { c1: '10', c2: 10 } } as const;
-        const response = { result: input };
+        const request = {} as RpcRequest;
+        const response = createMockResponse({ result: input });
 
-        it('casts the numbers in the object to `bigints`, recursively', () => {
+        it('casts the numbers in the object to `bigints`, recursively', async () => {
+            expect.assertions(1);
             const transformer = getDefaultResponseTransformerForSolanaRpc();
-            expect(transformer(response)).toStrictEqual({
+            const transformedResponse = transformer(response, request);
+            await expect(transformedResponse.json()).resolves.toStrictEqual({
                 a: BigInt(input.a),
                 b: input.b,
                 c: { c1: input.c.c1, c2: BigInt(input.c.c2) },
@@ -40,23 +54,29 @@ describe('getDefaultResponseTransformerForSolanaRpc', () => {
             ${'numeric response'}                                | ${[[]]}                                              | ${10}                                                               | ${10}
         `(
             'performs no `bigint` upcasts on $description when the allowlist is of the form in test case $#',
-            ({ allowedKeyPaths, expectation, input }) => {
+            async ({ allowedKeyPaths, expectation, input }) => {
+                expect.assertions(1);
                 const transformer = getDefaultResponseTransformerForSolanaRpc({
                     allowedNumericKeyPaths: { getFoo: allowedKeyPaths },
                 });
-                const response = { result: input };
-                expect(transformer(response, 'getFoo')).toStrictEqual(expectation);
+                const request = { methodName: 'getFoo' } as RpcRequest;
+                const response = createMockResponse({ result: input });
+                const transformedResponse = transformer(response, request);
+                await expect(transformedResponse.json()).resolves.toStrictEqual(expectation);
             },
         );
     });
     describe('given a JSON RPC error as input', () => {
-        const input = {
+        const request = {} as RpcRequest;
+        const response = createMockResponse({
             error: { code: SOLANA_ERROR__JSON_RPC__PARSE_ERROR, message: 'o no' },
-        };
+        });
 
-        it('throws it as a SolanaError', () => {
+        it('throws it as a SolanaError', async () => {
+            expect.assertions(1);
             const transformer = getDefaultResponseTransformerForSolanaRpc();
-            expect(() => transformer(input)).toThrow(
+            const transformedResponse = transformer(response, request);
+            await expect(transformedResponse.json()).rejects.toThrow(
                 new SolanaError(SOLANA_ERROR__JSON_RPC__PARSE_ERROR, { __serverMessage: 'o no' }),
             );
         });


### PR DESCRIPTION
This PR updates the RPC Api layer such that they use the new `RpcRequest`, `RpcResponse`, `RpcRequestTransformer` and `RpcResponseTransformer` types.

Note that I had to duplicate the implementation of `getDefaultResponseTransformerForSolanaRpc` into `getDefaultResponseTransformerForSolanaRpcSubscriptions` in order to leave RPC Subscription packages unaffected by the refactoring. These will have their own dedicated PR stack further down the line.