### PR TITLE
Use `RpcRequestTransformer` type parameter on request argument

### DIFF
--- a/packages/rpc-spec/src/__tests__/rpc-api-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-api-test.ts
@@ -24,8 +24,10 @@ describe('createRpcApi', () => {
     it('applies the request transformer to the provided method name', () => {
         // Given a dummy API with a request transformer that appends 'Transformed' to the method name.
         const api = createRpcApi<DummyApi>({
-            requestTransformer: <T>(request: RpcRequest<unknown>) =>
-                ({ ...request, methodName: `${request.methodName}Transformed` }) as RpcRequest<T>,
+            requestTransformer: (request: RpcRequest) => ({
+                ...request,
+                methodName: `${request.methodName}Transformed`,
+            }),
         });
 
         // When we call a method on the API.
@@ -37,8 +39,10 @@ describe('createRpcApi', () => {
     it('applies the request transformer to the provided params', () => {
         // Given a dummy API with a request transformer that doubles the provided params.
         const api = createRpcApi<DummyApi>({
-            requestTransformer: <T>(request: RpcRequest<unknown>) =>
-                ({ ...request, params: (request.params as number[]).map(x => x * 2) }) as RpcRequest<T>,
+            requestTransformer: (request: RpcRequest) => ({
+                ...request,
+                params: (request.params as number[]).map(x => x * 2),
+            }),
         });
 
         // When we call a method on the API.
@@ -49,7 +53,7 @@ describe('createRpcApi', () => {
     });
     it('includes the provided response transformer in the plan', () => {
         // Given a dummy API with a response transformer.
-        const responseTransformer = <T>(response: RpcResponse<unknown>) => response as RpcResponse<T>;
+        const responseTransformer = <T>(response: RpcResponse) => response as RpcResponse<T>;
         const api = createRpcApi<DummyApi>({ responseTransformer });
 
         // When we call a method on the API.
@@ -71,8 +75,7 @@ describe('createRpcApi', () => {
     it('also returns a frozen object with a request transformer', () => {
         // Given a dummy API with a request transformer.
         const api = createRpcApi<DummyApi>({
-            requestTransformer: <T>(request: RpcRequest<unknown>) =>
-                ({ ...request, methodName: 'transformed' }) as RpcRequest<T>,
+            requestTransformer: (request: RpcRequest) => ({ ...request, methodName: 'transformed' }),
         });
 
         // When we call a method on the API.

--- a/packages/rpc-spec/src/rpc-shared.ts
+++ b/packages/rpc-spec/src/rpc-shared.ts
@@ -9,15 +9,15 @@ export type RpcResponse<TResponse = unknown> = {
 };
 
 export type RpcRequestTransformer = {
-    <TParams>(request: RpcRequest<unknown>): RpcRequest<TParams>;
+    <TParams>(request: RpcRequest<TParams>): RpcRequest;
 };
 
 export type RpcResponseTransformer = {
-    <TResponse>(response: RpcResponse<unknown>, request: RpcRequest<unknown>): RpcResponse<TResponse>;
+    <TResponse>(response: RpcResponse, request: RpcRequest): RpcResponse<TResponse>;
 };
 
 export type RpcResponseTransformerFor<TResponse> = {
-    (response: RpcResponse<unknown>, request: RpcRequest<unknown>): RpcResponse<TResponse>;
+    (response: RpcResponse, request: RpcRequest): RpcResponse<TResponse>;
 };
 
 export function createJsonRpcResponseTransformer<TResponse>(


### PR DESCRIPTION
This PR fixes a previous mistake on this stack by moving the `TParam` generic type parameter from the `RpcRequest` return type to the `RpcRequest` argument.

```ts
// Before.
<TParams>(request: RpcRequest) => RpcRequest<TParams>;

// After.
<TParams>(request: RpcRequest<TParams>) => RpcRequest;
```

This is because when transforming requests, we want to assert on what we are getting. Whereas, when transforming responses, we want to assert on what we are returning. Note that this is how the parameter transformer used to work before this stack.