### PR TITLE
Refactor fix for issue 479 as a transformer

### DIFF
--- a/packages/rpc-transformers/src/__tests__/request-transformer-test.ts
+++ b/packages/rpc-transformers/src/__tests__/request-transformer-test.ts
@@ -1,7 +1,7 @@
 import type { RpcRequestTransformer } from '@solana/rpc-spec';
 import type { Commitment } from '@solana/rpc-types';
 
-import { getDefaultRequestTransformerForSolanaRpc } from '../params-transformer';
+import { getDefaultRequestTransformerForSolanaRpc } from '../request-transformer';
 import { OPTIONS_OBJECT_POSITION_BY_METHOD } from '../request-transformer-options-object-position-config';
 
 describe('getDefaultRequestTransformerForSolanaRpc', () => {

--- a/packages/rpc-transformers/src/index.ts
+++ b/packages/rpc-transformers/src/index.ts
@@ -1,4 +1,4 @@
-export * from './params-transformer';
+export * from './request-transformer';
 export * from './params-transformer-bigint-downcast';
 export * from './params-transformer-integer-overflow';
 export * from './request-transformer-default-commitment';


### PR DESCRIPTION
This PR refactors the internal fix for issue 479 as a request transformer called `getFixForIssue479RequestTransformer`. this is part of a series of effort to extract all transformers into their own helper so the default transformer can be a simple composition of all of them.