### PR TITLE
Combine `RpcResponseTransformer` and `RpcResponseTransformerFor`

### DIFF
--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -65,8 +65,6 @@ This allows the `RpcApi` to decide whether they want the parsed JSON object or t
 
 A function that accepts an `RpcResponse` and returns another `RpcResponse`. This allows the `RpcApi` to transform the response before it is returned to the caller.
 
-Note that a `RpcResponseTransformerFor<T>` generic function type is also available to ensure the response data returned by the transformer matches the expected type `T`.
-
 ### `RpcApi<TRpcMethods>`
 
 For each of `TRpcMethods` this object exposes a method with the same name that maps between its input arguments and a `RpcApiRequestPlan<TResponse>` that describes how to prepare a JSON RPC request to fetch `TResponse`.
@@ -143,13 +141,13 @@ A config object with the following properties:
 -   `requestTransformer<T>(request: RpcRequest<T>): RpcRequest`: An optional function that transforms the `RpcRequest` before it is sent to the JSON RPC server.
 -   `responseTransformer<T>(response: RpcResponse, request: RpcRequest): RpcResponse<T>`: An optional function that transforms the `RpcResponse` before it is returned to the caller.
 
-### `createJsonRpcResponseTransformer<T>(jsonTransformer)`
+### `createJsonRpcResponseTransformer(jsonTransformer)`
 
-Creates an `RpcResponseTransformerFor<T>` function from a function that transforms any JSON value to a value of type `T` by wrapping it in a `json` async function.
+Creates an `RpcResponseTransformer<T>` function from a function that transforms any JSON value to a value of type `T` by wrapping it in a `json` async function.
 
 ```ts
-const getResultTransformer = createJsonRpcResponseTransformer((json: unknown) => {
-    return (json as { result: TResponse }).result;
+const getResultTransformer = createJsonRpcResponseTransformer((json: unknown): unknown => {
+    return (json as { result: unknown }).result;
 });
 ```
 

--- a/packages/rpc-spec/src/rpc-api.ts
+++ b/packages/rpc-spec/src/rpc-api.ts
@@ -1,6 +1,6 @@
 import { Callable } from '@solana/rpc-spec-types';
 
-import { RpcRequest, RpcRequestTransformer, RpcResponseTransformer, RpcResponseTransformerFor } from './rpc-shared';
+import { RpcRequest, RpcRequestTransformer, RpcResponseTransformer } from './rpc-shared';
 
 export type RpcApiConfig = Readonly<{
     requestTransformer?: RpcRequestTransformer;
@@ -8,7 +8,7 @@ export type RpcApiConfig = Readonly<{
 }>;
 
 export type RpcApiRequestPlan<TResponse> = RpcRequest & {
-    responseTransformer?: RpcResponseTransformerFor<TResponse>;
+    responseTransformer?: RpcResponseTransformer<TResponse>;
 };
 
 export type RpcApi<TRpcMethods> = {
@@ -50,7 +50,11 @@ export function createRpcApi<TRpcMethods extends RpcApiMethods>(config?: RpcApiC
                 return Object.freeze({
                     ...request,
                     ...(config?.responseTransformer
-                        ? { responseTransformer: config.responseTransformer<ReturnType<TRpcMethods[TMethodName]>> }
+                        ? {
+                              responseTransformer: config.responseTransformer as RpcResponseTransformer<
+                                  ReturnType<TRpcMethods[TMethodName]>
+                              >,
+                          }
                         : {}),
                 });
             };

--- a/packages/rpc-spec/src/rpc-shared.ts
+++ b/packages/rpc-spec/src/rpc-shared.ts
@@ -12,17 +12,13 @@ export type RpcRequestTransformer = {
     <TParams>(request: RpcRequest<TParams>): RpcRequest;
 };
 
-export type RpcResponseTransformer = {
-    <TResponse>(response: RpcResponse, request: RpcRequest): RpcResponse<TResponse>;
-};
-
-export type RpcResponseTransformerFor<TResponse> = {
+export type RpcResponseTransformer<TResponse = unknown> = {
     (response: RpcResponse, request: RpcRequest): RpcResponse<TResponse>;
 };
 
-export function createJsonRpcResponseTransformer<TResponse>(
+export function createJsonRpcResponseTransformer<TResponse = unknown>(
     jsonTransformer: (json: unknown, request: RpcRequest) => TResponse,
-): RpcResponseTransformerFor<TResponse> {
+): RpcResponseTransformer<TResponse> {
     return function (response: RpcResponse, request: RpcRequest): RpcResponse<TResponse> {
         return Object.freeze({
             ...response,


### PR DESCRIPTION
This PR combines the `RpcResponseTransformer` and `RpcResponseTransformerFor` types by using an optional type parameter.

Initially, `RpcResponseTransformer` was defining a generic function (as opposed to a generic type that applies its type parameter to the function). However, this was only needed in the `rpc-api` file to do:

```ts
config.responseTransformer<TypeExpectationHere>;
```

The same can be achieved using:

```ts
config.responseTransformer as RpcResponseTransformer<TypeExpectationHere>;
```

Without loosening any types as `config.responseTransformer<T>` was equivalent to a type-cast.

This makes it less tedious to define response transformers as we don't have to always cast our return type to an abstract type `T` even when we know the real return type.