### PR TITLE
Add more response transformers

### DIFF
--- a/.changeset/light-owls-own.md
+++ b/.changeset/light-owls-own.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-transformers': patch
+---
+
+Add `getThrowSolanaErrorResponseTransformer`, `getResultResponseTransformer`, `getBigIntUpcastResponseTransformer` and `getTreeWalkerResponseTransformer` helpers

--- a/packages/rpc-transformers/src/index.ts
+++ b/packages/rpc-transformers/src/index.ts
@@ -6,4 +6,6 @@ export * from './request-transformer-options-object-position-config';
 export * from './response-transformer';
 export * from './response-transformer-allowed-numeric-values';
 export * from './response-transformer-bigint-upcast';
+export * from './response-transformer-result';
+export * from './response-transformer-throw-solana-error';
 export * from './tree-traversal';

--- a/packages/rpc-transformers/src/response-transformer-result.ts
+++ b/packages/rpc-transformers/src/response-transformer-result.ts
@@ -1,0 +1,7 @@
+import { createJsonRpcResponseTransformer } from '@solana/rpc-spec';
+
+type JsonRpcResponse = { result: unknown };
+
+export function getResultResponseTransformer() {
+    return createJsonRpcResponseTransformer(json => (json as JsonRpcResponse).result);
+}

--- a/packages/rpc-transformers/src/response-transformer-throw-solana-error.ts
+++ b/packages/rpc-transformers/src/response-transformer-throw-solana-error.ts
@@ -1,0 +1,14 @@
+import { getSolanaErrorFromJsonRpcError } from '@solana/errors';
+import { createJsonRpcResponseTransformer } from '@solana/rpc-spec';
+
+type JsonRpcResponse = { error: Parameters<typeof getSolanaErrorFromJsonRpcError>[0] } | { result: unknown };
+
+export function getThrowSolanaErrorResponseTransformer() {
+    return createJsonRpcResponseTransformer(json => {
+        const jsonRpcResponse = json as JsonRpcResponse;
+        if ('error' in jsonRpcResponse) {
+            throw getSolanaErrorFromJsonRpcError(jsonRpcResponse.error);
+        }
+        return jsonRpcResponse;
+    });
+}

--- a/packages/rpc-transformers/src/response-transformer.ts
+++ b/packages/rpc-transformers/src/response-transformer.ts
@@ -1,41 +1,34 @@
 import { getSolanaErrorFromJsonRpcError } from '@solana/errors';
+import { pipe } from '@solana/functional';
 import { RpcRequest, RpcResponse, RpcResponseTransformer } from '@solana/rpc-spec';
 
 import { AllowedNumericKeypaths } from './response-transformer-allowed-numeric-values';
-import { getBigIntUpcastVisitor } from './response-transformer-bigint-upcast';
+import { getBigIntUpcastResponseTransformer, getBigIntUpcastVisitor } from './response-transformer-bigint-upcast';
+import { getResultResponseTransformer } from './response-transformer-result';
+import { getThrowSolanaErrorResponseTransformer } from './response-transformer-throw-solana-error';
 import { getTreeWalker } from './tree-traversal';
 
 export type ResponseTransformerConfig<TApi> = Readonly<{
     allowedNumericKeyPaths?: AllowedNumericKeypaths<TApi>;
 }>;
 
-type JsonRpcResponse = { error: Parameters<typeof getSolanaErrorFromJsonRpcError>[0] } | { result: unknown };
-
 export function getDefaultResponseTransformerForSolanaRpc<TApi>(
     config?: ResponseTransformerConfig<TApi>,
 ): RpcResponseTransformer {
-    return <T>(rawResponse: RpcResponse, request: RpcRequest): RpcResponse<T> => {
-        return {
-            ...rawResponse,
-            json: async () => {
-                const methodName = request.methodName as keyof TApi;
-                const rawData = (await rawResponse.json()) as JsonRpcResponse;
-                if ('error' in rawData) {
-                    throw getSolanaErrorFromJsonRpcError(rawData.error);
-                }
-                const keyPaths =
-                    config?.allowedNumericKeyPaths && methodName
-                        ? config.allowedNumericKeyPaths[methodName]
-                        : undefined;
-                const traverse = getTreeWalker([getBigIntUpcastVisitor(keyPaths ?? [])]);
-                const initialState = {
-                    keyPath: [],
-                };
-                return traverse(rawData.result, initialState) as T;
-            },
-        };
+    return (response: RpcResponse, request: RpcRequest): RpcResponse => {
+        const methodName = request.methodName as keyof TApi;
+        const keyPaths =
+            config?.allowedNumericKeyPaths && methodName ? config.allowedNumericKeyPaths[methodName] : undefined;
+        return pipe(
+            response,
+            r => getThrowSolanaErrorResponseTransformer()(r, request),
+            r => getResultResponseTransformer()(r, request),
+            r => getBigIntUpcastResponseTransformer(keyPaths ?? [])(r, request),
+        );
     };
 }
+
+type JsonRpcResponse = { error: Parameters<typeof getSolanaErrorFromJsonRpcError>[0] } | { result: unknown };
 
 export function getDefaultResponseTransformerForSolanaRpcSubscriptions<TApi>(
     config?: ResponseTransformerConfig<TApi>,

--- a/packages/rpc-transformers/src/tree-traversal.ts
+++ b/packages/rpc-transformers/src/tree-traversal.ts
@@ -1,4 +1,9 @@
-import { RpcRequest, RpcRequestTransformer } from '@solana/rpc-spec';
+import {
+    createJsonRpcResponseTransformer,
+    RpcRequest,
+    RpcRequestTransformer,
+    RpcResponseTransformer,
+} from '@solana/rpc-spec';
 
 export type KeyPathWildcard = { readonly __brand: unique symbol };
 export type KeyPath = ReadonlyArray<KeyPath | KeyPathWildcard | number | string>;
@@ -50,4 +55,13 @@ export function getTreeWalkerRequestTransformer<TState extends TraversalState>(
             params: traverse(request.params, initialState),
         });
     };
+}
+
+export function getTreeWalkerResponseTransformer<TState extends TraversalState>(
+    visitors: NodeVisitor[],
+    initialState: TState,
+): RpcResponseTransformer {
+    return createJsonRpcResponseTransformer(json => {
+        return getTreeWalker(visitors)(json, initialState);
+    });
 }


### PR DESCRIPTION
This PR refactors the `getDefaultResponseTransformerForSolanaRpc` function by creating four new response transformers and delegating to them:

- `getThrowSolanaErrorResponseTransformer`: Throws a `SolanaError` if the RPC response is an error.
- `getResultResponseTransformer`: Access the `result` attribute of the RPC response.
- `getBigIntUpcastResponseTransformer`: Upcasts all numeric values to bigints unless they are within the provided allowed keypaths.
- `getTreeWalkerResponseTransformer`: Helper that creates response transformers from visitors.