### PR TITLE
Add `toPayload` and `toText` optional functions to `RpcRequest`

### DIFF
--- a/.changeset/twelve-toys-guess.md
+++ b/.changeset/twelve-toys-guess.md
@@ -1,0 +1,6 @@
+---
+'@solana/rpc-transport-http': patch
+'@solana/rpc-spec': patch
+---
+
+Add `toPayload` and `toText` optional functions to `RpcRequest`

--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -45,8 +45,10 @@ An object that exposes all of the functions described by `TRpcMethods`, and fulf
 
 An object that describes the elements of a JSON RPC request. It consists of the following properties:
 
--   `methodName`: The name of the JSON RPC method to be called.
--   `params`: The parameters to be passed to the JSON RPC method.
+-   `methodName: string`: The name of the JSON RPC method to be called.
+-   `params: unknown`: The parameters to be passed to the JSON RPC method.
+-   `toPayload?: (methodName: string, params: unknown) => unknown`: An optional function that defines how the method name and parameters should be transformed into a JSON RPC payload.
+-   `toText?: (payload: unknown) => string`: An optional function that defines how the JSO RPC payload should be transformed into a JSON string.
 
 ### `RpcRequestTransformer`
 

--- a/packages/rpc-spec/src/__tests__/rpc-api-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-api-test.ts
@@ -51,6 +51,35 @@ describe('createRpcApi', () => {
         // Then we expect the plan to contain the transformed params.
         expect(plan.params).toEqual([2, 4, 6]);
     });
+    it('can customise how to transform a request into a payload using a request transformer', () => {
+        // Given a dummy API with a request transformer that sets the `toPayload` function.
+        const toPayload = (methodName: string, params: unknown) => ({
+            myMethod: methodName,
+            myParams: params,
+        });
+        const api = createRpcApi<DummyApi>({
+            requestTransformer: (request: RpcRequest) => ({ ...request, toPayload }),
+        });
+
+        // When we call a method on the API.
+        const plan = api.someMethod('foo');
+
+        // Then we expect the plan to contain the custom `toPayload` function.
+        expect(plan.toPayload).toBe(toPayload);
+    });
+    it('can customise how to transform a payload into a string using a request transformer', () => {
+        // Given a dummy API with a request transformer that sets the `toText` function.
+        const toText = (payload: unknown) => `{"myPayload":${JSON.stringify(payload)}}`;
+        const api = createRpcApi<DummyApi>({
+            requestTransformer: (request: RpcRequest) => ({ ...request, toText }),
+        });
+
+        // When we call a method on the API.
+        const plan = api.someMethod('foo');
+
+        // Then we expect the plan to contain the custom `toText` function.
+        expect(plan.toText).toBe(toText);
+    });
     it('includes the provided response transformer in the plan', () => {
         // Given a dummy API with a response transformer.
         const responseTransformer = <T>(response: RpcResponse) => response as RpcResponse<T>;

--- a/packages/rpc-spec/src/rpc-shared.ts
+++ b/packages/rpc-spec/src/rpc-shared.ts
@@ -1,6 +1,8 @@
 export type RpcRequest<TParams = unknown> = {
     readonly methodName: string;
     readonly params: TParams;
+    readonly toPayload?: (methodName: string, params: unknown) => unknown;
+    readonly toText?: (payload: unknown) => string;
 };
 
 export type RpcResponse<TResponse = unknown> = {

--- a/packages/rpc-spec/src/rpc-transport.ts
+++ b/packages/rpc-spec/src/rpc-transport.ts
@@ -3,6 +3,7 @@ import { RpcResponse } from './rpc-shared';
 type RpcTransportRequest = Readonly<{
     payload: unknown;
     signal?: AbortSignal;
+    toText?: (payload: unknown) => string;
 }>;
 
 export type RpcTransport = {

--- a/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
@@ -66,6 +66,10 @@ describe('createHttpTransport', () => {
                 }),
             );
         });
+        it('sets the string `body` using the `toText` function if provided', () => {
+            makeHttpRequest({ payload: 123, toText: x => ((x as number) * 2).toString() });
+            expect(fetchSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ body: '246' }));
+        });
         it('sets the accept header to `application/json`', () => {
             makeHttpRequest({ payload: 123 });
             expect(fetchSpy).toHaveBeenCalledWith(

--- a/packages/rpc-transport-http/src/http-transport.ts
+++ b/packages/rpc-transport-http/src/http-transport.ts
@@ -44,8 +44,9 @@ export function createHttpTransport(config: Config): RpcTransport {
     return async function makeHttpRequest<TResponse>({
         payload,
         signal,
+        toText,
     }: Parameters<RpcTransport>[0]): Promise<RpcResponse<TResponse>> {
-        const body = JSON.stringify(payload);
+        const body = toText ? toText(payload) : JSON.stringify(payload);
         const requestInfo = {
             ...dispatcherConfig,
             body,


### PR DESCRIPTION
This PR adds the following optional functions to the `RpcRequest` type:

```diff
  export type RpcRequest<TParams = unknown> = {
      readonly methodName: string;
      readonly params: TParams;
+     readonly toPayload?: (methodName: string, params: unknown) => unknown;
+     readonly toText?: (payload: unknown) => string;
  };
```

This enables `RpcRequestTransformers` to inject and even augment functions that define:
- How the payload should be constructed from a method name and a set of parameters.
- How the raw text body should be constructed from a payload.

If provided, the `toPayload` function is used by the `Rpc` object to create a payload before sending it to the `RpcTransformer`.

If provided, the `toText` function is passed as-is to the `RpcTransformer` which will use it to convert the payload to a string instead of `JSON.stringify`.

This is important because, `RpcRequestTransformers` can now affect how the JSON string will be send to the RPC server which makes it possible for an RPC API to provide unsafe integers in the JSON string as long as their RPC allows it (which is the case for Solana RPCs and `u64`/`i64` integers).

Currently, it is only possible to achieve that when we get the response back from the RPC Transformer. This PR allows the other side — the request — to have the same ability.

---

Here are some diagrams illustrating the RPC changes made by this PR.

### Current state

![Current Rpc Refactoring@2x](https://github.com/user-attachments/assets/2383e82f-421b-4f3a-8eaf-35993d92a85f)

### Proposed state

![Proposed Rpc Refactoring@2x](https://github.com/user-attachments/assets/bf0d31f8-9958-468b-ba98-61b4becedc11)
