### PR TITLE
Remove temporary fix for Agave issue 479

### DIFF
--- a/.changeset/tasty-cups-think.md
+++ b/.changeset/tasty-cups-think.md
@@ -1,0 +1,7 @@
+---
+'@solana/rpc-transformers': patch
+---
+
+Remove temporary fix for Agave issue 479
+
+The fix is now deployed on mainnet-beta (See https://github.com/anza-xyz/agave/issues/479 and https://github.com/anza-xyz/agave/pull/483).

--- a/packages/rpc-transformers/src/__tests__/request-transformer-test.ts
+++ b/packages/rpc-transformers/src/__tests__/request-transformer-test.ts
@@ -220,28 +220,6 @@ describe('getDefaultRequestTransformerForSolanaRpc', () => {
             },
         );
     });
-    // FIXME Remove when https://github.com/anza-xyz/agave/pull/483 is deployed.
-    it.each([undefined, 'processed', 'confirmed', 'finalized'])(
-        'sets the `preflightCommitment` to `processed` when `skipPreflight` is `true` and `preflightCommitment` is `%s` on calls to `sendTransaction`',
-        explicitPreflightCommitment => {
-            const requestTransformer = getDefaultRequestTransformerForSolanaRpc();
-            expect(
-                requestTransformer({
-                    methodName: 'sendTransaction',
-                    params: [
-                        null,
-                        {
-                            // eslint-disable-next-line jest/no-conditional-in-test
-                            ...(explicitPreflightCommitment
-                                ? { preflightCommitment: explicitPreflightCommitment }
-                                : null),
-                            skipPreflight: true,
-                        },
-                    ],
-                }).params,
-            ).toContainEqual(expect.objectContaining({ preflightCommitment: 'processed' }));
-        },
-    );
     describe('given an integer overflow handler', () => {
         let onIntegerOverflow: jest.Mock;
         let requestTransformer: RpcRequestTransformer;

--- a/packages/rpc-transformers/src/request-transformer.ts
+++ b/packages/rpc-transformers/src/request-transformer.ts
@@ -23,27 +23,6 @@ export function getDefaultRequestTransformerForSolanaRpc(config?: RequestTransfo
                 defaultCommitment: config?.defaultCommitment,
                 optionsObjectPositionByMethod: OPTIONS_OBJECT_POSITION_BY_METHOD,
             }),
-            // FIXME Remove when https://github.com/anza-xyz/agave/pull/483 is deployed.
-            getFixForIssue479RequestTransformer(),
         );
-    };
-}
-
-// See https://github.com/anza-xyz/agave/issues/479
-function getFixForIssue479RequestTransformer(): RpcRequestTransformer {
-    return <TParams>(request: RpcRequest<TParams>): RpcRequest => {
-        if (request.methodName !== 'sendTransaction') {
-            return request;
-        }
-
-        const params = request.params as [unknown, { skipPreflight?: boolean } | undefined];
-        if (params[1]?.skipPreflight !== true) {
-            return request;
-        }
-
-        return Object.freeze({
-            ...request,
-            params: [params[0], { ...params[1], preflightCommitment: 'processed' }, ...params.slice(2)],
-        });
     };
 }


### PR DESCRIPTION
This PR removes the temporary request transformer that was waiting for [this PR](https://github.com/anza-xyz/agave/pull/483) to be merged and available on mainnet-beta.