### PR TITLE
Add `fromJson` and `toJson` options to HTTP transport

### DIFF
--- a/.changeset/slow-dragons-add.md
+++ b/.changeset/slow-dragons-add.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-transport-http': patch
+---
+
+Add `fromJson` and `toJson` options to the HTTP transport

--- a/packages/rpc-transport-http/README.md
+++ b/packages/rpc-transport-http/README.md
@@ -82,6 +82,10 @@ const balances = await Promise.allSettled(
 );
 ```
 
+##### `fromJson`
+
+An optional function that takes the response as a JSON string and converts it to a JSON value. The request payload is also provided as a second argument. When not provided, the JSON value will be accessed via the `response.json()` method of the fetch API.
+
 ##### `headers`
 
 An object of headers to set on the request. Avoid [forbidden headers](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name). Additionally, the headers `Accept`, `Content-Length`, and `Content-Type` are disallowed.
@@ -97,6 +101,10 @@ const transport = createHttpTransport({
     url: 'https://several-neat-iguana.quiknode.pro',
 });
 ```
+
+##### `toJson`
+
+An optional function that takes the request payload and converts it to a JSON string. When not provided, `JSON.stringify` will be used.
 
 ##### `url`
 

--- a/packages/rpc-transport-http/src/__tests__/http-transport-from-json-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-from-json-test.ts
@@ -1,0 +1,29 @@
+import { RpcTransport } from '@solana/rpc-spec';
+
+describe('createHttpTransport and `fromJson` function', () => {
+    let fromJson: jest.Mock;
+    let fetchSpy: jest.SpyInstance;
+    let makeHttpRequest: RpcTransport;
+    beforeEach(async () => {
+        await jest.isolateModulesAsync(async () => {
+            fromJson = jest.fn();
+            fetchSpy = jest.spyOn(globalThis, 'fetch');
+            fetchSpy.mockResolvedValue({ ok: true, text: () => '{"ok":true}' });
+            const { createHttpTransport } =
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                await import('../http-transport');
+            makeHttpRequest = createHttpTransport({ fromJson, url: 'http://localhost' });
+        });
+    });
+    it('uses the `fromJson` function to parse the response from a JSON string', async () => {
+        expect.assertions(1);
+        await makeHttpRequest({ payload: { foo: 123 } });
+        expect(fromJson).toHaveBeenCalledWith('{"ok":true}', { foo: 123 });
+    });
+    it('returns the value parsed by `fromJson`', async () => {
+        expect.assertions(1);
+        fromJson.mockReturnValueOnce({ result: 456 });
+        await expect(makeHttpRequest({ payload: { foo: 123 } })).resolves.toEqual({ result: 456 });
+    });
+});

--- a/packages/rpc-transport-http/src/__tests__/http-transport-to-json-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-to-json-test.ts
@@ -1,0 +1,33 @@
+import { RpcTransport } from '@solana/rpc-spec';
+
+describe('createHttpTransport and `toJson` function', () => {
+    let toJson: jest.Mock;
+    let fetchSpy: jest.SpyInstance;
+    let makeHttpRequest: RpcTransport;
+    beforeEach(async () => {
+        await jest.isolateModulesAsync(async () => {
+            toJson = jest.fn(value => JSON.stringify(value));
+            fetchSpy = jest.spyOn(globalThis, 'fetch');
+            fetchSpy.mockResolvedValue({ json: () => ({ ok: true }), ok: true });
+            const { createHttpTransport } =
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                await import('../http-transport');
+            makeHttpRequest = createHttpTransport({ toJson, url: 'http://localhost' });
+        });
+    });
+    it('uses the `toJson` function to transform the payload to a JSON string', () => {
+        makeHttpRequest({ payload: { foo: 123 } });
+        expect(toJson).toHaveBeenCalledWith({ foo: 123 });
+    });
+    it('uses passes the JSON string to the fetch API', () => {
+        toJson.mockReturnValueOnce('{"someAugmented":"jsonString"}');
+        makeHttpRequest({ payload: { foo: 123 } });
+        expect(fetchSpy).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                body: '{"someAugmented":"jsonString"}',
+            }),
+        );
+    });
+});


### PR DESCRIPTION
This PR adds two new optional functions to the `createHttpTransport` configs.

- `fromJson`: When provided, replaces the logic that transforms the response from a JSON string into a JSON value.
- `toJson`: When provided, replaces the logic that transforms the request payload from a JSON value into a JSON string.

This will enable us to wrap this transport and create a new Solana-RPC-specific HTTP transport that do not loose range/precision when `bigint` values are transmitted over the wire.