### PR TITLE
Add `isSolanaRequest` helper

### DIFF
--- a/packages/rpc-transport-http/src/__tests__/is-solana-request-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/is-solana-request-test.ts
@@ -1,0 +1,12 @@
+import { isSolanaRequest } from '../is-solana-request';
+
+describe('isSolanaRequest', () => {
+    it('returns true if the method name is from the Solana RPC API', () => {
+        const payload = { jsonrpc: '2.0', method: 'getBalance', params: ['1234..5678'] };
+        expect(isSolanaRequest(payload)).toBe(true);
+    });
+    it('returns false if the method name is not from the Solana RPC API', () => {
+        const payload = { jsonrpc: '2.0', method: 'getAssetsByAuthority', params: ['1234..5678'] };
+        expect(isSolanaRequest(payload)).toBe(false);
+    });
+});

--- a/packages/rpc-transport-http/src/is-solana-request.ts
+++ b/packages/rpc-transport-http/src/is-solana-request.ts
@@ -1,0 +1,69 @@
+import { isJsonRpcPayload } from '@solana/rpc-spec';
+
+const SOLANA_RPC_METHODS = [
+    'getAccountInfo',
+    'getBalance',
+    'getBlock',
+    'getBlockCommitment',
+    'getBlockHeight',
+    'getBlockProduction',
+    'getBlocks',
+    'getBlocksWithLimit',
+    'getBlockTime',
+    'getClusterNodes',
+    'getEpochInfo',
+    'getEpochSchedule',
+    'getFeeForMessage',
+    'getFirstAvailableBlock',
+    'getGenesisHash',
+    'getHealth',
+    'getHighestSnapshotSlot',
+    'getIdentity',
+    'getInflationGovernor',
+    'getInflationRate',
+    'getInflationReward',
+    'getLargestAccounts',
+    'getLatestBlockhash',
+    'getLeaderSchedule',
+    'getMaxRetransmitSlot',
+    'getMaxShredInsertSlot',
+    'getMinimumBalanceForRentExemption',
+    'getMultipleAccounts',
+    'getProgramAccounts',
+    'getRecentPerformanceSamples',
+    'getRecentPrioritizationFees',
+    'getSignaturesForAddress',
+    'getSignatureStatuses',
+    'getSlot',
+    'getSlotLeader',
+    'getSlotLeaders',
+    'getStakeActivation',
+    'getStakeMinimumDelegation',
+    'getSupply',
+    'getTokenAccountBalance',
+    'getTokenAccountsByDelegate',
+    'getTokenAccountsByOwner',
+    'getTokenLargestAccounts',
+    'getTokenSupply',
+    'getTransaction',
+    'getTransactionCount',
+    'getVersion',
+    'getVoteAccounts',
+    'index',
+    'isBlockhashValid',
+    'minimumLedgerSlot',
+    'requestAirdrop',
+    'sendTransaction',
+    'simulateTransaction',
+] as const;
+
+/**
+ * Helper function that checks if a given `RpcRequest` comes from the Solana RPC API.
+ */
+export function isSolanaRequest(payload: unknown): payload is Readonly<{
+    jsonrpc: '2.0';
+    method: (typeof SOLANA_RPC_METHODS)[number];
+    params: unknown;
+}> {
+    return isJsonRpcPayload(payload) && (SOLANA_RPC_METHODS as readonly string[]).includes(payload.method);
+}


### PR DESCRIPTION
This PR adds a new `isSolanaRequest` helper function that checks if a given `RpcRequest` comes from the Solana RPC API.

This will be used — in a subsequent PR — to create a new Solana-RPC-specific HTTP transport that prevents loss of precision for large integers.