### PR TITLE
Use `createHttpTransportForSolanaRpc` in default transport

### DIFF
--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -441,7 +441,7 @@ export type SolanaErrorContext = DefaultUnspecifiedErrorContextToUndefined<
             __serverMessage: string;
         };
         [SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED]: {
-            contextSlot: number;
+            contextSlot: bigint;
         };
         [SOLANA_ERROR__JSON_RPC__SERVER_ERROR_NODE_UNHEALTHY]: {
             numSlotsBehind?: number;

--- a/packages/rpc-api/src/__tests__/__setup__.ts
+++ b/packages/rpc-api/src/__tests__/__setup__.ts
@@ -1,11 +1,11 @@
 import { createRpc, Rpc } from '@solana/rpc-spec';
-import { createHttpTransport } from '@solana/rpc-transport-http';
+import { createHttpTransportForSolanaRpc } from '@solana/rpc-transport-http';
 
 import { createSolanaRpcApi, SolanaRpcApi } from '..';
 
 export function createLocalhostSolanaRpc(): Rpc<SolanaRpcApi> {
     return createRpc({
         api: createSolanaRpcApi(),
-        transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        transport: createHttpTransportForSolanaRpc({ url: 'http://127.0.0.1:8899' }),
     });
 }

--- a/packages/rpc-api/src/__tests__/get-account-info-test.ts
+++ b/packages/rpc-api/src/__tests__/get-account-info-test.ts
@@ -37,7 +37,7 @@ describe('getAccountInfo', () => {
                         executable: false,
                         lamports: 5000000n,
                         owner: '11111111111111111111111111111111',
-                        rentEpoch: 18446744073709551616n, // TODO: This number loses precision
+                        rentEpoch: 18446744073709551615n,
                         space: 9n,
                     },
                 });
@@ -61,7 +61,7 @@ describe('getAccountInfo', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-balance-test.ts
+++ b/packages/rpc-api/src/__tests__/get-balance-test.ts
@@ -53,7 +53,7 @@ describe('getBalance', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-block-height.ts
+++ b/packages/rpc-api/src/__tests__/get-block-height.ts
@@ -40,7 +40,7 @@ describe('getBlockHeight', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-epoch-info-test.ts
+++ b/packages/rpc-api/src/__tests__/get-epoch-info-test.ts
@@ -42,7 +42,7 @@ describe('getEpochInfo', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(epochInfoPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(epochInfoPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-fee-for-message-test.ts
+++ b/packages/rpc-api/src/__tests__/get-fee-for-message-test.ts
@@ -136,7 +136,7 @@ describe('getFeeForMessage', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-inflation-reward-test.ts
+++ b/packages/rpc-api/src/__tests__/get-inflation-reward-test.ts
@@ -64,7 +64,7 @@ describe('getInflationReward', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-latest-blockhash-test.ts
+++ b/packages/rpc-api/src/__tests__/get-latest-blockhash-test.ts
@@ -45,7 +45,7 @@ describe('getLatestBlockhash', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-multiple-accounts-test.ts
+++ b/packages/rpc-api/src/__tests__/get-multiple-accounts-test.ts
@@ -43,7 +43,7 @@ describe('getMultipleAccounts', () => {
                             executable: false,
                             lamports: 5000000n,
                             owner: '11111111111111111111111111111111',
-                            rentEpoch: 18446744073709551616n, // TODO: This number loses precision
+                            rentEpoch: 18446744073709551615n,
                             space: 9n,
                         },
                         {
@@ -51,7 +51,7 @@ describe('getMultipleAccounts', () => {
                             executable: false,
                             lamports: 5000000n,
                             owner: '11111111111111111111111111111111',
-                            rentEpoch: 18446744073709551616n, // TODO: This number loses precision
+                            rentEpoch: 18446744073709551615n,
                             space: 0n,
                         },
                     ],
@@ -76,7 +76,7 @@ describe('getMultipleAccounts', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });
@@ -114,7 +114,7 @@ describe('getMultipleAccounts', () => {
                         executable: false,
                         lamports: 5000000n,
                         owner: '11111111111111111111111111111111',
-                        rentEpoch: 18446744073709551616n,
+                        rentEpoch: 18446744073709551615n,
                         space: 9n,
                     },
                     null,

--- a/packages/rpc-api/src/__tests__/get-program-accounts-test.ts
+++ b/packages/rpc-api/src/__tests__/get-program-accounts-test.ts
@@ -65,7 +65,7 @@ describe('getProgramAccounts', () => {
                                 executable: false,
                                 lamports: 5000000n,
                                 owner: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
-                                rentEpoch: 18446744073709551616n, // TODO: This number loses precision
+                                rentEpoch: 18446744073709551615n,
                                 space: 9n,
                             },
                             pubkey: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
@@ -92,7 +92,7 @@ describe('getProgramAccounts', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });
@@ -126,7 +126,7 @@ describe('getProgramAccounts', () => {
                             executable: false,
                             lamports: 5000000n,
                             owner: 'AmtpVzo6H6qQCP9dH9wfu5hfa8kKaAFpTJ4aamPYR6V6',
-                            rentEpoch: 18446744073709551616n, // TODO: This number loses precision
+                            rentEpoch: 18446744073709551615n,
                             space: 9n,
                         },
                         pubkey: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
@@ -137,7 +137,7 @@ describe('getProgramAccounts', () => {
                             executable: false,
                             lamports: 5000000n,
                             owner: 'AmtpVzo6H6qQCP9dH9wfu5hfa8kKaAFpTJ4aamPYR6V6',
-                            rentEpoch: 18446744073709551616n, // TODO: This number loses precision
+                            rentEpoch: 18446744073709551615n,
                             space: 9n,
                         },
                         pubkey: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',

--- a/packages/rpc-api/src/__tests__/get-signatures-for-address-test.ts
+++ b/packages/rpc-api/src/__tests__/get-signatures-for-address-test.ts
@@ -52,7 +52,7 @@ describe('getSignaturesForAddress', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-slot-leader-test.ts
+++ b/packages/rpc-api/src/__tests__/get-slot-leader-test.ts
@@ -73,7 +73,7 @@ describe('getSlotLeader', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-slot-test.ts
+++ b/packages/rpc-api/src/__tests__/get-slot-test.ts
@@ -40,7 +40,7 @@ describe('getSlot', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-stake-activation-test.ts
+++ b/packages/rpc-api/src/__tests__/get-stake-activation-test.ts
@@ -64,7 +64,7 @@ describe('getStakeActivation', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(stakeActivationPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(stakeActivationPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-token-accounts-by-delegate-test.ts
+++ b/packages/rpc-api/src/__tests__/get-token-accounts-by-delegate-test.ts
@@ -92,7 +92,7 @@ describe('getTokenAccountsByDelegate', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(accountInfoPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(accountInfoPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-token-accounts-by-owner-test.ts
+++ b/packages/rpc-api/src/__tests__/get-token-accounts-by-owner-test.ts
@@ -92,7 +92,7 @@ describe('getTokenAccountsByOwner', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(accountInfoPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(accountInfoPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/get-transaction-count-test.ts
+++ b/packages/rpc-api/src/__tests__/get-transaction-count-test.ts
@@ -40,7 +40,7 @@ describe('getTransactionCount', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(sendPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/send-transaction-test.ts
+++ b/packages/rpc-api/src/__tests__/send-transaction-test.ts
@@ -359,7 +359,7 @@ describe('sendTransaction', () => {
                     'context.__code',
                     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 ),
-                expect(resultPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+                expect(resultPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
             ]);
         });
     });

--- a/packages/rpc-api/src/__tests__/simulate-transaction-test.ts
+++ b/packages/rpc-api/src/__tests__/simulate-transaction-test.ts
@@ -216,7 +216,7 @@ describe('simulateTransaction', () => {
                 'context.__code',
                 SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
             ),
-            expect(resultPromise).rejects.toHaveProperty('context.contextSlot', expect.any(Number)),
+            expect(resultPromise).rejects.toHaveProperty('context.contextSlot', expect.any(BigInt)),
         ]);
     });
 

--- a/packages/rpc-transformers/src/response-transformer-bigint-upcast.ts
+++ b/packages/rpc-transformers/src/response-transformer-bigint-upcast.ts
@@ -6,17 +6,16 @@ export function getBigIntUpcastResponseTransformer(allowedNumericKeyPaths: reado
 
 export function getBigIntUpcastVisitor(allowedNumericKeyPaths: readonly KeyPath[]) {
     return function upcastNodeToBigIntIfNumber(value: unknown, { keyPath }: TraversalState) {
-        if (
-            typeof value === 'number' &&
-            Number.isInteger(value) &&
-            !keyPathIsAllowedToBeNumeric(keyPath, allowedNumericKeyPaths)
-        ) {
-            // FIXME(solana-labs/solana/issues/30341) Create a data type to represent u64 in the
-            // Solana JSON RPC implementation so that we can throw away this entire patcher instead
-            // of unsafely upcasting `numbers` to `bigints`.
-            return BigInt(value);
+        const isInteger = (typeof value === 'number' && Number.isInteger(value)) || typeof value === 'bigint';
+        if (!isInteger) return value;
+
+        // FIXME(solana-labs/solana/issues/30341) Create a data type to represent u64 in the
+        // Solana JSON RPC implementation so that we can throw away this entire patcher instead
+        // of unsafely upcasting `numbers` to `bigints`.
+        if (keyPathIsAllowedToBeNumeric(keyPath, allowedNumericKeyPaths)) {
+            return Number(value);
         } else {
-            return value;
+            return BigInt(value);
         }
     };
 }

--- a/packages/rpc/src/__tests__/rpc-transport-header-config-test.ts
+++ b/packages/rpc/src/__tests__/rpc-transport-header-config-test.ts
@@ -1,4 +1,4 @@
-import { createHttpTransport } from '@solana/rpc-transport-http';
+import { createHttpTransportForSolanaRpc } from '@solana/rpc-transport-http';
 
 import { createDefaultRpcTransport } from '../rpc-transport';
 
@@ -10,7 +10,7 @@ describe('createDefaultRpcTransport', () => {
             headers: { aUtHoRiZaTiOn: 'Picard, 4 7 Alpha Tango' },
             url: 'fake://url',
         });
-        expect(createHttpTransport).toHaveBeenCalledWith(
+        expect(createHttpTransportForSolanaRpc).toHaveBeenCalledWith(
             expect.objectContaining({
                 headers: expect.objectContaining({
                     authorization: 'Picard, 4 7 Alpha Tango',
@@ -20,7 +20,7 @@ describe('createDefaultRpcTransport', () => {
     });
     it('adds a `solana-client` header with the current NPM package version by default', () => {
         createDefaultRpcTransport({ url: 'fake://url' });
-        expect(createHttpTransport).toHaveBeenCalledWith(
+        expect(createHttpTransportForSolanaRpc).toHaveBeenCalledWith(
             expect.objectContaining({
                 headers: expect.objectContaining({
                     // Version is defined in `setup-define-version-constant.ts`
@@ -34,7 +34,7 @@ describe('createDefaultRpcTransport', () => {
             headers: { 'sOlAnA-cLiEnT': 'fakeversion' },
             url: 'fake://url',
         });
-        expect(createHttpTransport).toHaveBeenCalledWith(
+        expect(createHttpTransportForSolanaRpc).toHaveBeenCalledWith(
             expect.objectContaining({
                 headers: expect.objectContaining({
                     // Version is defined in `setup-define-version-constant.ts`
@@ -42,7 +42,7 @@ describe('createDefaultRpcTransport', () => {
                 }),
             }),
         );
-        expect(createHttpTransport).toHaveBeenCalledWith(
+        expect(createHttpTransportForSolanaRpc).toHaveBeenCalledWith(
             expect.objectContaining({
                 headers: expect.not.objectContaining({
                     'sOlAnA-cLiEnT': 'fakeversion',

--- a/packages/rpc/src/rpc-transport.ts
+++ b/packages/rpc/src/rpc-transport.ts
@@ -1,5 +1,5 @@
 import { pipe } from '@solana/functional';
-import { createHttpTransport } from '@solana/rpc-transport-http';
+import { createHttpTransport, createHttpTransportForSolanaRpc } from '@solana/rpc-transport-http';
 import type { ClusterUrl } from '@solana/rpc-types';
 
 import { RpcTransportFromClusterUrl } from './rpc-clusters';
@@ -28,7 +28,7 @@ export function createDefaultRpcTransport<TClusterUrl extends ClusterUrl>(
     config: DefaultRpcTransportConfig<TClusterUrl>,
 ): RpcTransportFromClusterUrl<TClusterUrl> {
     return pipe(
-        createHttpTransport({
+        createHttpTransportForSolanaRpc({
             ...config,
             headers: {
                 ...(config.headers ? normalizeHeaders(config.headers) : undefined),


### PR DESCRIPTION
This PR uses the brand new `createHttpTransportForSolanaRpc` function within the default transport for Solana RPCs.