### PR TITLE
Update `getClusterNodes` response

### DIFF
--- a/.changeset/ten-buckets-search.md
+++ b/.changeset/ten-buckets-search.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-api': patch
+---
+
+Update the response type of the `getClusterNodes` RPC method

--- a/packages/rpc-api/src/__tests__/get-cluster-nodes-test.ts
+++ b/packages/rpc-api/src/__tests__/get-cluster-nodes-test.ts
@@ -77,9 +77,14 @@ describe('getClusterNodes', () => {
                 pubkey,
                 pubsub: expect.stringMatching(/127.0.0.1(:\d+)?/),
                 rpc,
+                serveRepair: expect.stringMatching(/127.0.0.1(:\d+)?/),
                 shredVersion,
                 tpu: expect.stringMatching(/127.0.0.1(:\d+)?/),
+                tpuForwards: expect.stringMatching(/127.0.0.1(:\d+)?/),
+                tpuForwardsQuic: expect.stringMatching(/127.0.0.1(:\d+)?/),
                 tpuQuic: expect.stringMatching(/127.0.0.1(:\d+)?/),
+                tpuVote: expect.stringMatching(/127.0.0.1(:\d+)?/),
+                tvu: expect.stringMatching(/127.0.0.1(:\d+)?/),
                 version,
             });
         });

--- a/packages/rpc-api/src/getClusterNodes.ts
+++ b/packages/rpc-api/src/getClusterNodes.ts
@@ -8,15 +8,29 @@ type ClusterNode = Readonly<{
     gossip: string | null;
     /** Node public key, as base-58 encoded string */
     pubkey: Address;
+    /** WebSocket PubSub network address for the node */
+    pubsub: string | null;
     /**
      * JSON RPC network address for the node,
      * or `null` if the JSON RPC service is not enabled
      */
     rpc: string | null;
+    /** Server repair UDP network address for the node */
+    serveRepair: string | null;
     /** The shred version the node has been configured to use */
     shredVersion: number | null;
     /** TPU network address for the node */
     tpu: string | null;
+    /** Tpu UDP forwards network address for the node */
+    tpuForwards: string | null;
+    /** Tpu QUIC forwards network address for the node */
+    tpuForwardsQuic: string | null;
+    /** Tpu QUIC network address for the node */
+    tpuQuic: string | null;
+    /** Tpu UDP vote network address for the node */
+    tpuVote: string | null;
+    /** Tvu UDP network address for the node */
+    tvu: string | null;
     /**
      * The software version of the node,
      * or `null` if the version information is not available


### PR DESCRIPTION
This PR updates the response's type and test expectations of the `getClusterNodes` RPC method to keep it in sync with the latest RPC changes.

See https://github.com/anza-xyz/agave/pull/1637