### PR TITLE
Fixing misnamed field in `PerformanceSample` return type

### DIFF
--- a/.changeset/plenty-eyes-kick.md
+++ b/.changeset/plenty-eyes-kick.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-api': patch
+---
+
+PerformanceSample return type field numNonVoteTransaction corrected to numNonVoteTransactions

--- a/packages/rpc-api/src/getRecentPerformanceSamples.ts
+++ b/packages/rpc-api/src/getRecentPerformanceSamples.ts
@@ -3,7 +3,7 @@ import type { Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type PerformanceSample = Readonly<{
     /** Number of non-vote transactions in sample. */
-    numNonVoteTransaction: U64UnsafeBeyond2Pow53Minus1;
+    numNonVoteTransactions: U64UnsafeBeyond2Pow53Minus1;
     /** Number of slots in sample */
     numSlots: U64UnsafeBeyond2Pow53Minus1;
     /** Number of transactions in sample */


### PR DESCRIPTION
`PerformanceSample` type, used to define the return values from the `getRecentPerformanceSamples` RPC Method incorrectly includes a `numNonVoteTransaction` field but the RPC call itself returns `numNonVoteTransactions` (with an "s").

In the core the fields called [`num_non_vote_transactions`](https://github.com/solana-labs/solana/blob/master/core/src/sample_performance_service.rs#L84) but you can see it should be mapped to `numNonVoteTransactions`, as [tested here](https://github.com/solana-labs/solana/blob/master/rpc-client-api/src/response.rs#L614). The pluralise spelling is also consistent with the other fields (`numSlots`, `numTransactions`, etc.).

And, of course, `numNonVoteTransactions` is what's actually being returned. See for yourself:

```sh
curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -s \
  -d '{"jsonrpc":"2.0", "id":1,"method": "getRecentPerformanceSamples","params": [1]}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "result": [
    {
      "numNonVoteTransactions": 850,
      "numSlots": 163,
      "numTransactions": 2792,
      "samplePeriodSecs": 60,
      "slot": 323584907
    }
  ],
  "id": 1
}
````

The [docs](https://solana.com/docs/rpc/http/getrecentperformancesamples) are also wrong. I'll PR that too.