### PR TITLE
Repair documentation site after Microsoft's breaking change to `upload-artifact`

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -43,6 +43,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: ghpages-deploy-artifacts-v1-docs
           path: .ghpages-deploy
           retention-days: 1
@@ -68,6 +69,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: ghpages-deploy-artifacts
           path: .ghpages-deploy
           retention-days: 1

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -59,6 +59,7 @@ jobs:
         if: matrix.node == 'current'
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: library-dist
           path: |
             ./packages/library/dist/


### PR DESCRIPTION
See discussion at https://github.com/actions/upload-artifact/issues/602.
