### PR TITLE
Allow extending numeric keypaths when extending Solana RPC API

### DIFF
--- a/.changeset/tricky-flies-brush.md
+++ b/.changeset/tricky-flies-brush.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-api': patch
+---
+
+Allow extending numeric keypaths when extending Solana RPC API

--- a/packages/rpc-api/src/__tests__/create-solana-rpc-api.test.ts
+++ b/packages/rpc-api/src/__tests__/create-solana-rpc-api.test.ts
@@ -1,0 +1,48 @@
+import { getDefaultResponseTransformerForSolanaRpc } from '@solana/rpc-transformers';
+
+import { createSolanaRpcApi, SolanaRpcApi } from '..';
+
+jest.mock('@solana/rpc-transformers');
+
+describe('createSolanaRpcApi', () => {
+    describe('when extending allowedNumericKeyPaths', () => {
+        it('should create a response transformer including the new paths', () => {
+            type TestApi = SolanaRpcApi & {
+                someNewFunction(): void;
+                someOtherFunction(): void;
+            };
+
+            createSolanaRpcApi<TestApi>({
+                extendAllowedNumericKeypaths: {
+                    someNewFunction: [['someNewKeyPath']],
+                    someOtherFunction: [['someOtherKeyPath']],
+                },
+            });
+
+            expect(getDefaultResponseTransformerForSolanaRpc as jest.Mock).toHaveBeenCalledWith({
+                allowedNumericKeyPaths: expect.objectContaining({
+                    someNewFunction: [['someNewKeyPath']],
+                    someOtherFunction: [['someOtherKeyPath']],
+                }),
+            });
+        });
+
+        it('should include the default paths', () => {
+            type TestApi = SolanaRpcApi & {
+                someNewFunction(): void;
+            };
+
+            createSolanaRpcApi<TestApi>({
+                extendAllowedNumericKeypaths: {
+                    someNewFunction: [['someNewKeyPath']],
+                },
+            });
+
+            expect(getDefaultResponseTransformerForSolanaRpc as jest.Mock).toHaveBeenCalledWith({
+                allowedNumericKeyPaths: expect.objectContaining({
+                    getAccountInfo: expect.any(Array),
+                }),
+            });
+        });
+    });
+});

--- a/packages/rpc-api/src/__typetests__/create-solana-rpc-api-type-test.ts.ts
+++ b/packages/rpc-api/src/__typetests__/create-solana-rpc-api-type-test.ts.ts
@@ -1,0 +1,46 @@
+import { createSolanaRpcApi, SolanaRpcApi } from '..';
+
+type TestApi = SolanaRpcApi & {
+    someNewFunction(): void;
+    someOtherFunction(): void;
+};
+
+createSolanaRpcApi<TestApi>();
+createSolanaRpcApi<TestApi>({
+    extendAllowedNumericKeypaths: {},
+});
+createSolanaRpcApi<TestApi>({
+    extendAllowedNumericKeypaths: {
+        someNewFunction: [['someNewKeyPath']],
+    },
+});
+createSolanaRpcApi<TestApi>({
+    extendAllowedNumericKeypaths: {
+        someNewFunction: [['someNewKeyPath']],
+        someOtherFunction: [['someOtherKeyPath']],
+    },
+});
+
+createSolanaRpcApi<TestApi>({
+    extendAllowedNumericKeypaths: {
+        // @ts-expect-error getAccountInfo is a SolanaRpcApi method
+        getAccountInfo: [],
+    },
+});
+
+createSolanaRpcApi<SolanaRpcApi>();
+createSolanaRpcApi<SolanaRpcApi>({
+    extendAllowedNumericKeypaths: {},
+});
+createSolanaRpcApi<SolanaRpcApi>({
+    extendAllowedNumericKeypaths: {
+        // @ts-expect-error getAccountInfo is a SolanaRpcApi method
+        getAccountInfo: [],
+    },
+});
+createSolanaRpcApi<SolanaRpcApi>({
+    extendAllowedNumericKeypaths: {
+        // @ts-expect-error someNewMethod is not a method on the RPC API
+        someNewMethod: [['someNewKeyPath']],
+    },
+});

--- a/packages/rpc/src/rpc-default-config.ts
+++ b/packages/rpc/src/rpc-default-config.ts
@@ -2,9 +2,9 @@ import type { createSolanaRpcApi } from '@solana/rpc-api';
 
 import { createSolanaJsonRpcIntegerOverflowError } from './rpc-integer-overflow-error';
 
-export const DEFAULT_RPC_CONFIG: Partial<NonNullable<Parameters<typeof createSolanaRpcApi>[0]>> = {
+export const DEFAULT_RPC_CONFIG = {
     defaultCommitment: 'confirmed',
     onIntegerOverflow(request, keyPath, value) {
         throw createSolanaJsonRpcIntegerOverflowError(request.methodName, keyPath, value);
     },
-};
+} as const satisfies Partial<NonNullable<Parameters<typeof createSolanaRpcApi>[0]>>;


### PR DESCRIPTION
This PR adds additional optional config to `createSolanaRpcApi` that allows defining numeric keypaths for additional methods.

This means that if you use `createSolanaRpcApi` to define an API that extends ours ([as in our example](https://github.com/solana-labs/solana-web3.js/blob/02cefa7cc98463e602f78a8acc10d85c37f03481/examples/rpc-custom-api/src/example.ts#L48)), then you can add numeric keypaths to the default response transformer for the additional methods.

Eg

```ts
const heliusRpc = createSolanaRpcApi<HeliusRpcMethods>({
   ...DEFAULT_RPC_CONFIG,
   extendAllowedNumericKeypaths: {
     getAsset: [["token_info", "decimals"]]
  }
})
```

Without this you inherit our bigint upcasting (since this is on the default response transformer from `createSolanaRpcApi`), but have no way to exempt certain fields on your own methods.

Note that the semantics here are that you're extending the default allowed keypaths, so you can't override those included in the default, ie the Solana RPC methods. It's assumed that if you're extending our API using this opinionated method then you've implemented our API as-is. So the extended keypaths are typed to exclude the methods in `SolanaRpcApi`. 