### PR TITLE
Clean up SolanaRpcApi: no longer extend RpcApiMethods

### DIFF
--- a/.changeset/green-eels-applaud.md
+++ b/.changeset/green-eels-applaud.md
@@ -1,0 +1,8 @@
+---
+'@solana/rpc-graphql': patch
+'@solana/accounts': patch
+'@solana/rpc-spec': patch
+'@solana/rpc-api': patch
+---
+
+Clean up SolanaRpcApi: no longer extend RpcApiMethods + remove export

--- a/README.md
+++ b/README.md
@@ -389,8 +389,8 @@ type GetAssetApiResponse = Readonly<{
     /* ...etc... */
 }>;
 
-// Set up an interface for the request method.
-interface GetAssetApi extends RpcApiMethods {
+// Set up a type spec for the request method.
+type GetAssetApi = {
     // Define the method's name, parameters and response type
     getAsset(args: { id: Address }): GetAssetApiResponse;
 }

--- a/examples/rpc-custom-api/src/example.ts
+++ b/examples/rpc-custom-api/src/example.ts
@@ -14,7 +14,6 @@ import {
     DEFAULT_RPC_CONFIG,
     mainnet,
     RpcApi,
-    RpcApiMethods,
     SolanaRpcApiMainnet,
 } from '@solana/web3.js';
 
@@ -31,13 +30,13 @@ type AssetMetadata = Readonly<{
     name: string;
     symbol: string;
 }>;
-interface TritonGetAssetApi extends RpcApiMethods {
+type TritonGetAssetApi = {
     /**
      * Define the ideal developer-facing API as a TypeScript type. Doing so will enable typechecking
      * and autocompletion for it on the RPC instance.
      */
     getAssetMetadata(address: Address): AssetMetadata;
-}
+};
 
 /**
  * STEP 2: CUSTOM JSON RPC API IMPLEMENTATION

--- a/packages/accounts/src/rpc-api/getAccountInfo.ts
+++ b/packages/accounts/src/rpc-api/getAccountInfo.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58Bytes,
@@ -31,7 +30,7 @@ type GetAccountInfoApiSliceableCommonConfig = Readonly<{
     dataSlice?: DataSlice;
 }>;
 
-export interface GetAccountInfoApi extends RpcApiMethods {
+export type GetAccountInfoApi = {
     /**
      * Returns all information associated with the account of provided public key
      */
@@ -70,4 +69,4 @@ export interface GetAccountInfoApi extends RpcApiMethods {
         address: Address,
         config?: GetAccountInfoApiCommonConfig,
     ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase58Bytes>;
-}
+};

--- a/packages/accounts/src/rpc-api/getMultipleAccounts.ts
+++ b/packages/accounts/src/rpc-api/getMultipleAccounts.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58EncodedData,
@@ -26,7 +25,7 @@ type GetMultipleAccountsApiSliceableCommonConfig = Readonly<{
     dataSlice?: DataSlice;
 }>;
 
-export interface GetMultipleAccountsApi extends RpcApiMethods {
+export type GetMultipleAccountsApi = {
     /**
      * Returns the account information for a list of Pubkeys.
      */
@@ -72,4 +71,4 @@ export interface GetMultipleAccountsApi extends RpcApiMethods {
         addresses: Address[],
         config?: GetMultipleAccountsApiCommonConfig,
     ): SolanaRpcResponse<(GetMultipleAccountsApiResponseBase & (AccountInfoWithBase64EncodedData | null))[]>;
-}
+};

--- a/packages/rpc-api/README.md
+++ b/packages/rpc-api/README.md
@@ -16,12 +16,12 @@
 
 This package contains types that describe the [methods](https://solana.com/docs/rpc/http) of the Solana JSON RPC API, and utilities for creating a `RpcApi` implementation with sensible defaults. It can be used standalone, but it is also exported as part of the Solana JavaScript SDK [`@solana/web3.js@rc`](https://github.com/solana-labs/solana-web3.js/tree/master/packages/library).
 
-Each RPC method is described in terms of a TypeScript interface of the following form:
+Each RPC method is described in terms of a TypeScript type of the following form:
 
 ```ts
-interface ExampleApi extends RpcApiMethods {
+type ExampleApi = {
     getSomething(address: Address): Something;
-}
+};
 ```
 
 A `RpcApi` that implements `ExampleApi` will ultimately expose its defined methods on any `Rpc` that uses it.

--- a/packages/rpc-api/src/__tests__/get-slot-leaders-test.ts
+++ b/packages/rpc-api/src/__tests__/get-slot-leaders-test.ts
@@ -6,7 +6,7 @@ import { SOLANA_ERROR__JSON_RPC__INVALID_PARAMS, SolanaError } from '@solana/err
 import type { Rpc } from '@solana/rpc-spec';
 import path from 'path';
 
-import { GetSlotLeadersApi } from '../index';
+import { GetSlotLeadersApi, MinimumLedgerSlotApi } from '../index';
 import { createLocalhostSolanaRpc } from './__setup__';
 
 const validatorKeypairPath = path.resolve(__dirname, '../../../../test-ledger/validator-keypair.json');
@@ -31,7 +31,7 @@ async function getValidatorAddress() {
 }
 
 describe('getSlotLeaders', () => {
-    let rpc: Rpc<GetSlotLeadersApi>;
+    let rpc: Rpc<GetSlotLeadersApi & MinimumLedgerSlotApi>;
     beforeEach(() => {
         rpc = createLocalhostSolanaRpc();
     });

--- a/packages/rpc-api/src/__tests__/get-token-largest-accounts-test.ts
+++ b/packages/rpc-api/src/__tests__/get-token-largest-accounts-test.ts
@@ -3,7 +3,7 @@ import { SOLANA_ERROR__JSON_RPC__INVALID_PARAMS, SolanaError } from '@solana/err
 import type { Rpc } from '@solana/rpc-spec';
 import type { Commitment } from '@solana/rpc-types';
 
-import { GetTokenLargestAccountsApi } from '../index';
+import { GetTokenLargestAccountsApi, GetTokenSupplyApi } from '../index';
 import { createLocalhostSolanaRpc } from './__setup__';
 
 const CONTEXT_MATCHER = expect.objectContaining({
@@ -11,7 +11,7 @@ const CONTEXT_MATCHER = expect.objectContaining({
 });
 
 describe('getTokenLargestAccounts', () => {
-    let rpc: Rpc<GetTokenLargestAccountsApi>;
+    let rpc: Rpc<GetTokenLargestAccountsApi & GetTokenSupplyApi>;
     beforeEach(() => {
         rpc = createLocalhostSolanaRpc();
     });

--- a/packages/rpc-api/src/__typetests__/rpc-api-type-test.ts
+++ b/packages/rpc-api/src/__typetests__/rpc-api-type-test.ts
@@ -1,0 +1,18 @@
+import { SolanaRpcApi, SolanaRpcApiDevnet, SolanaRpcApiMainnet, SolanaRpcApiTestnet } from '..';
+
+'getAccountInfo' satisfies keyof SolanaRpcApi;
+// @ts-expect-error RPC API does not have this method
+'someMadeUpMethod' satisfies keyof SolanaRpcApi;
+
+// if we extend the RPC API with additional methods, we can access them on keyof
+type TestRpcApi = SolanaRpcApi & {
+    someMadeUpMethod: () => void;
+};
+'someMadeUpMethod' satisfies keyof TestRpcApi;
+
+// request airdrop is available on test networks, but not mainnet
+'requestAirdrop' satisfies keyof SolanaRpcApiDevnet;
+'requestAirdrop' satisfies keyof SolanaRpcApiTestnet;
+'requestAirdrop' satisfies keyof SolanaRpcApi;
+// @ts-expect-error requestAirdrop is not available on mainnet
+'requestAirdrop' satisfies keyof SolanaRpcApiMainnet;

--- a/packages/rpc-api/src/getAccountInfo.ts
+++ b/packages/rpc-api/src/getAccountInfo.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58Bytes,
@@ -27,7 +26,7 @@ type GetAccountInfoApiSliceableCommonConfig = Readonly<{
     dataSlice?: DataSlice;
 }>;
 
-export interface GetAccountInfoApi extends RpcApiMethods {
+export type GetAccountInfoApi = {
     /**
      * Returns all information associated with the account of provided public key
      */
@@ -66,4 +65,4 @@ export interface GetAccountInfoApi extends RpcApiMethods {
         address: Address,
         config?: GetAccountInfoApiCommonConfig,
     ): SolanaRpcResponse<GetAccountInfoApiResponse<AccountInfoWithBase58Bytes>>;
-}
+};

--- a/packages/rpc-api/src/getBalance.ts
+++ b/packages/rpc-api/src/getBalance.ts
@@ -1,10 +1,9 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, LamportsUnsafeBeyond2Pow53Minus1, Slot, SolanaRpcResponse } from '@solana/rpc-types';
 
 type GetBalanceApiResponse = SolanaRpcResponse<LamportsUnsafeBeyond2Pow53Minus1>;
 
-export interface GetBalanceApi extends RpcApiMethods {
+export type GetBalanceApi = {
     /**
      * Returns the balance of the account of provided Pubkey
      */
@@ -15,4 +14,4 @@ export interface GetBalanceApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): GetBalanceApiResponse;
-}
+};

--- a/packages/rpc-api/src/getBlock.ts
+++ b/packages/rpc-api/src/getBlock.ts
@@ -1,4 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     Base58EncodedBytes,
     Blockhash,
@@ -62,7 +61,7 @@ type GetBlockEncoding = 'base58' | 'base64' | 'json' | 'jsonParsed';
 // - These rules apply to both "accounts" and "full" transaction details.
 type GetBlockMaxSupportedTransactionVersion = Exclude<TransactionVersion, 'legacy'>;
 
-export interface GetBlockApi extends RpcApiMethods {
+export type GetBlockApi = {
     /**
      * Returns identity and transaction information about a confirmed block in the ledger
      */
@@ -375,4 +374,4 @@ export interface GetBlockApi extends RpcApiMethods {
               GetBlockApiResponseWithRewards &
               GetBlockApiResponseWithTransactions<TransactionForFullJson<void>>)
         | null;
-}
+};

--- a/packages/rpc-api/src/getBlockCommitment.ts
+++ b/packages/rpc-api/src/getBlockCommitment.ts
@@ -1,4 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { LamportsUnsafeBeyond2Pow53Minus1, Slot } from '@solana/rpc-types';
 
 type GetBlockCommitmentApiResponse = Readonly<{
@@ -6,10 +5,10 @@ type GetBlockCommitmentApiResponse = Readonly<{
     totalStake: LamportsUnsafeBeyond2Pow53Minus1;
 }>;
 
-export interface GetBlockCommitmentApi extends RpcApiMethods {
+export type GetBlockCommitmentApi = {
     /**
      * Returns the amount of cluster stake in lamports that has voted on
      * a particular block, as well as the stake attributed to each vote account
      */
     getBlockCommitment(slot: Slot): GetBlockCommitmentApiResponse;
-}
+};

--- a/packages/rpc-api/src/getBlockHeight.ts
+++ b/packages/rpc-api/src/getBlockHeight.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetBlockHeightApiResponse = U64UnsafeBeyond2Pow53Minus1;
 
-export interface GetBlockHeightApi extends RpcApiMethods {
+export type GetBlockHeightApi = {
     /**
      * Returns the current block height of the node
      */
@@ -15,4 +14,4 @@ export interface GetBlockHeightApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): GetBlockHeightApiResponse;
-}
+};

--- a/packages/rpc-api/src/getBlockProduction.ts
+++ b/packages/rpc-api/src/getBlockProduction.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot, SolanaRpcResponse, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type NumberOfLeaderSlots = U64UnsafeBeyond2Pow53Minus1;
@@ -32,7 +31,7 @@ type GetBlockProductionApiResponse<T> = Readonly<{
     range: SlotRange;
 }>;
 
-export interface GetBlockProductionApi extends RpcApiMethods {
+export type GetBlockProductionApi = {
     /**
      * Returns recent block production information from the current or previous epoch.
      */
@@ -45,4 +44,4 @@ export interface GetBlockProductionApi extends RpcApiMethods {
     getBlockProduction(
         config?: GetBlockProductionApiConfigBase,
     ): SolanaRpcResponse<GetBlockProductionApiResponse<BlockProductionWithAllIdentities>>;
-}
+};

--- a/packages/rpc-api/src/getBlockTime.ts
+++ b/packages/rpc-api/src/getBlockTime.ts
@@ -1,10 +1,9 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Slot, UnixTimestampUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 /** Estimated production time, as Unix timestamp (seconds since the Unix epoch) */
 type GetBlockTimeApiResponse = UnixTimestampUnsafeBeyond2Pow53Minus1;
 
-export interface GetBlockTimeApi extends RpcApiMethods {
+export type GetBlockTimeApi = {
     /**
      * Returns the estimated production time of a block.
      */
@@ -12,4 +11,4 @@ export interface GetBlockTimeApi extends RpcApiMethods {
         /** block number, identified by Slot */
         blockNumber: Slot,
     ): GetBlockTimeApiResponse;
-}
+};

--- a/packages/rpc-api/src/getBlocks.ts
+++ b/packages/rpc-api/src/getBlocks.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot } from '@solana/rpc-types';
 
 type GetBlocksApiResponse = Slot[];
 
-export interface GetBlocksApi extends RpcApiMethods {
+export type GetBlocksApi = {
     /**
      * Returns a list of confirmed blocks between two slots
      */
@@ -15,4 +14,4 @@ export interface GetBlocksApi extends RpcApiMethods {
             commitment?: Exclude<Commitment, 'processed'>;
         }>,
     ): GetBlocksApiResponse;
-}
+};

--- a/packages/rpc-api/src/getBlocksWithLimit.ts
+++ b/packages/rpc-api/src/getBlocksWithLimit.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot } from '@solana/rpc-types';
 
 type GetBlocksWithLimitApiResponse = Slot[];
 
-export interface GetBlocksWithLimitApi extends RpcApiMethods {
+export type GetBlocksWithLimitApi = {
     /**
      * Returns a list of confirmed blocks starting at the given slot
      * for up to `limit` blocks
@@ -18,4 +17,4 @@ export interface GetBlocksWithLimitApi extends RpcApiMethods {
             commitment?: Exclude<Commitment, 'processed'>;
         }>,
     ): GetBlocksWithLimitApiResponse;
-}
+};

--- a/packages/rpc-api/src/getClusterNodes.ts
+++ b/packages/rpc-api/src/getClusterNodes.ts
@@ -1,5 +1,4 @@
 import { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 
 type ClusterNode = Readonly<{
     /** The unique identifier of the node's feature set */
@@ -40,7 +39,7 @@ type ClusterNode = Readonly<{
 
 type GetClusterNodesApiResponse = readonly ClusterNode[];
 
-export interface GetClusterNodesApi extends RpcApiMethods {
+export type GetClusterNodesApi = {
     /**
      * Returns information about all the nodes participating in the cluster
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
@@ -49,4 +48,4 @@ export interface GetClusterNodesApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetClusterNodesApiResponse;
-}
+};

--- a/packages/rpc-api/src/getEpochInfo.ts
+++ b/packages/rpc-api/src/getEpochInfo.ts
@@ -1,4 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetEpochInfoApiResponse = Readonly<{
@@ -16,7 +15,7 @@ type GetEpochInfoApiResponse = Readonly<{
     transactionCount: U64UnsafeBeyond2Pow53Minus1 | null;
 }>;
 
-export interface GetEpochInfoApi extends RpcApiMethods {
+export type GetEpochInfoApi = {
     /**
      * Returns the balance of the account of provided Pubkey
      */
@@ -26,4 +25,4 @@ export interface GetEpochInfoApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): GetEpochInfoApiResponse;
-}
+};

--- a/packages/rpc-api/src/getEpochSchedule.ts
+++ b/packages/rpc-api/src/getEpochSchedule.ts
@@ -1,4 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetEpochScheduleApiResponse = Readonly<{
@@ -14,7 +13,7 @@ type GetEpochScheduleApiResponse = Readonly<{
     warmup: boolean;
 }>;
 
-export interface GetEpochScheduleApi extends RpcApiMethods {
+export type GetEpochScheduleApi = {
     /**
      * Returns the epoch schedule information from this cluster's genesis config
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
@@ -23,4 +22,4 @@ export interface GetEpochScheduleApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetEpochScheduleApiResponse;
-}
+};

--- a/packages/rpc-api/src/getFeeForMessage.ts
+++ b/packages/rpc-api/src/getFeeForMessage.ts
@@ -1,11 +1,10 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot, SolanaRpcResponse, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 import type { TransactionMessageBytesBase64 } from '@solana/transactions';
 
 /** Fee corresponding to the message at the specified blockhash */
 type GetFeeForMessageApiResponse = U64UnsafeBeyond2Pow53Minus1 | null;
 
-export interface GetFeeForMessageApi extends RpcApiMethods {
+export type GetFeeForMessageApi = {
     /**
      * Returns the fee the network will charge for a particular Message
      */
@@ -16,4 +15,4 @@ export interface GetFeeForMessageApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): SolanaRpcResponse<GetFeeForMessageApiResponse>;
-}
+};

--- a/packages/rpc-api/src/getFirstAvailableBlock.ts
+++ b/packages/rpc-api/src/getFirstAvailableBlock.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Slot } from '@solana/rpc-types';
 
 type GetFirstAvailableBlockApiResponse = Slot;
 
-export interface GetFirstAvailableBlockApi extends RpcApiMethods {
+export type GetFirstAvailableBlockApi = {
     /**
      * Returns the slot of the lowest confirmed block that has not been purged from the ledger
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
@@ -12,4 +11,4 @@ export interface GetFirstAvailableBlockApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetFirstAvailableBlockApiResponse;
-}
+};

--- a/packages/rpc-api/src/getGenesisHash.ts
+++ b/packages/rpc-api/src/getGenesisHash.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Blockhash } from '@solana/rpc-types';
 
 type GetGenesisHashApiResponse = Blockhash;
 
-export interface GetGenesisHashApi extends RpcApiMethods {
+export type GetGenesisHashApi = {
     /**
      * Returns the genesis hash
      */
@@ -11,4 +10,4 @@ export interface GetGenesisHashApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetGenesisHashApiResponse;
-}
+};

--- a/packages/rpc-api/src/getHealth.ts
+++ b/packages/rpc-api/src/getHealth.ts
@@ -1,8 +1,6 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
-
 type GetHealthApiResponse = 'ok';
 
-export interface GetHealthApi extends RpcApiMethods {
+export type GetHealthApi = {
     /**
      * Returns the health status of the node ("ok" if healthy).
      */
@@ -10,4 +8,4 @@ export interface GetHealthApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetHealthApiResponse;
-}
+};

--- a/packages/rpc-api/src/getHighestSnapshotSlot.ts
+++ b/packages/rpc-api/src/getHighestSnapshotSlot.ts
@@ -1,4 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Slot } from '@solana/rpc-types';
 
 type GetHighestSnapshotSlotApiResponse = Readonly<{
@@ -6,7 +5,7 @@ type GetHighestSnapshotSlotApiResponse = Readonly<{
     incremental: Slot | null;
 }>;
 
-export interface GetHighestSnapshotSlotApi extends RpcApiMethods {
+export type GetHighestSnapshotSlotApi = {
     /**
      * Returns the highest slot information that the node has snapshots for.
      *
@@ -18,4 +17,4 @@ export interface GetHighestSnapshotSlotApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetHighestSnapshotSlotApiResponse;
-}
+};

--- a/packages/rpc-api/src/getIdentity.ts
+++ b/packages/rpc-api/src/getIdentity.ts
@@ -1,11 +1,10 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 
 type GetIdentityApiResponse = Readonly<{
     identity: Address;
 }>;
 
-export interface GetIdentityApi extends RpcApiMethods {
+export type GetIdentityApi = {
     /**
      * Returns the identity pubkey for the current node
      */
@@ -13,4 +12,4 @@ export interface GetIdentityApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetIdentityApiResponse;
-}
+};

--- a/packages/rpc-api/src/getInflationGovernor.ts
+++ b/packages/rpc-api/src/getInflationGovernor.ts
@@ -1,4 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, F64UnsafeSeeDocumentation } from '@solana/rpc-types';
 
 type GetInflationGovernorApiResponse = Readonly<{
@@ -18,7 +17,7 @@ type GetInflationGovernorApiResponse = Readonly<{
     terminal: F64UnsafeSeeDocumentation;
 }>;
 
-export interface GetInflationGovernorApi extends RpcApiMethods {
+export type GetInflationGovernorApi = {
     /**
      * Returns the current inflation governor
      */
@@ -28,4 +27,4 @@ export interface GetInflationGovernorApi extends RpcApiMethods {
             commitment?: Commitment;
         }>,
     ): GetInflationGovernorApiResponse;
-}
+};

--- a/packages/rpc-api/src/getInflationRate.ts
+++ b/packages/rpc-api/src/getInflationRate.ts
@@ -1,4 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { F64UnsafeSeeDocumentation, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetInflationRateApiResponse = Readonly<{
@@ -12,7 +11,7 @@ type GetInflationRateApiResponse = Readonly<{
     validator: F64UnsafeSeeDocumentation;
 }>;
 
-export interface GetInflationRateApi extends RpcApiMethods {
+export type GetInflationRateApi = {
     /**
      * Returns the current block height of the node
      */
@@ -20,4 +19,4 @@ export interface GetInflationRateApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetInflationRateApiResponse;
-}
+};

--- a/packages/rpc-api/src/getInflationReward.ts
+++ b/packages/rpc-api/src/getInflationReward.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     Commitment,
     LamportsUnsafeBeyond2Pow53Minus1,
@@ -32,9 +31,9 @@ type InflationReward = Readonly<{
 
 type GetInflationRewardApiResponse = readonly (InflationReward | null)[];
 
-export interface GetInflationRewardApi extends RpcApiMethods {
+export type GetInflationRewardApi = {
     /**
      * Returns the current block height of the node
      */
     getInflationReward(addresses: Address[], config?: GetInflationRewardApiConfig): GetInflationRewardApiResponse;
-}
+};

--- a/packages/rpc-api/src/getLargestAccounts.ts
+++ b/packages/rpc-api/src/getLargestAccounts.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, LamportsUnsafeBeyond2Pow53Minus1, SolanaRpcResponse } from '@solana/rpc-types';
 
 type GetLargestAccountsResponseItem = Readonly<{
@@ -11,7 +10,7 @@ type GetLargestAccountsResponseItem = Readonly<{
 
 type GetLargestAccountsApiResponse = readonly GetLargestAccountsResponseItem[];
 
-export interface GetLargestAccountsApi extends RpcApiMethods {
+export type GetLargestAccountsApi = {
     /**
      * Returns the 20 largest accounts, by lamport balance
      * (results may be cached up to two hours)
@@ -23,4 +22,4 @@ export interface GetLargestAccountsApi extends RpcApiMethods {
             filter?: 'circulating' | 'nonCirculating';
         }>,
     ): SolanaRpcResponse<GetLargestAccountsApiResponse>;
-}
+};

--- a/packages/rpc-api/src/getLatestBlockhash.ts
+++ b/packages/rpc-api/src/getLatestBlockhash.ts
@@ -1,4 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Blockhash, Commitment, Slot, SolanaRpcResponse, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetLatestBlockhashApiResponse = Readonly<{
@@ -8,7 +7,7 @@ type GetLatestBlockhashApiResponse = Readonly<{
     lastValidBlockHeight: U64UnsafeBeyond2Pow53Minus1;
 }>;
 
-export interface GetLatestBlockhashApi extends RpcApiMethods {
+export type GetLatestBlockhashApi = {
     /**
      * Returns the latest blockhash
      */
@@ -18,4 +17,4 @@ export interface GetLatestBlockhashApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): SolanaRpcResponse<GetLatestBlockhashApiResponse>;
-}
+};

--- a/packages/rpc-api/src/getLeaderSchedule.ts
+++ b/packages/rpc-api/src/getLeaderSchedule.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot } from '@solana/rpc-types';
 
 type GetLeaderScheduleApiConfigBase = Readonly<{
@@ -28,7 +27,7 @@ type GetLeaderScheduleApiResponseWithSingleIdentity<TIdentity extends string> = 
     [TAddress in TIdentity]?: Slot[];
 }>;
 
-export interface GetLeaderScheduleApi extends RpcApiMethods {
+export type GetLeaderScheduleApi = {
     /**
      * Fetch the leader schedule for the epoch that corresponds to the provided slot.
      * If unspecified, the leader schedule for the current epoch is fetched
@@ -64,4 +63,4 @@ export interface GetLeaderScheduleApi extends RpcApiMethods {
         slot: null,
         config?: GetLeaderScheduleApiConfigBase,
     ): GetLeaderScheduleApiResponseWithAllIdentities;
-}
+};

--- a/packages/rpc-api/src/getMaxRetransmitSlot.ts
+++ b/packages/rpc-api/src/getMaxRetransmitSlot.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Slot } from '@solana/rpc-types';
 
 type GetMaxRetransmitSlotApiResponse = Slot;
 
-export interface GetMaxRetransmitSlotApi extends RpcApiMethods {
+export type GetMaxRetransmitSlotApi = {
     /**
      * Get the max slot seen from retransmit stage.
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
@@ -12,4 +11,4 @@ export interface GetMaxRetransmitSlotApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetMaxRetransmitSlotApiResponse;
-}
+};

--- a/packages/rpc-api/src/getMaxShredInsertSlot.ts
+++ b/packages/rpc-api/src/getMaxShredInsertSlot.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Slot } from '@solana/rpc-types';
 
 type GetMaxShredInsertSlotApiResponse = Slot;
 
-export interface GetMaxShredInsertSlotApi extends RpcApiMethods {
+export type GetMaxShredInsertSlotApi = {
     /**
      * Get the max slot seen from after shred insert.
      * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
@@ -12,4 +11,4 @@ export interface GetMaxShredInsertSlotApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetMaxShredInsertSlotApiResponse;
-}
+};

--- a/packages/rpc-api/src/getMinimumBalanceForRentExemption.ts
+++ b/packages/rpc-api/src/getMinimumBalanceForRentExemption.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, LamportsUnsafeBeyond2Pow53Minus1, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetMinimumBalanceForRentExemptionApiResponse = LamportsUnsafeBeyond2Pow53Minus1;
 
-export interface GetMinimumBalanceForRentExemptionApi extends RpcApiMethods {
+export type GetMinimumBalanceForRentExemptionApi = {
     /**
      * Returns the minimum balance to exempt an account of a certain size from rent
      */
@@ -13,4 +12,4 @@ export interface GetMinimumBalanceForRentExemptionApi extends RpcApiMethods {
             commitment?: Commitment;
         }>,
     ): GetMinimumBalanceForRentExemptionApiResponse;
-}
+};

--- a/packages/rpc-api/src/getMultipleAccounts.ts
+++ b/packages/rpc-api/src/getMultipleAccounts.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58EncodedData,
@@ -26,7 +25,7 @@ type GetMultipleAccountsApiSliceableCommonConfig = Readonly<{
     dataSlice?: DataSlice;
 }>;
 
-export interface GetMultipleAccountsApi extends RpcApiMethods {
+export type GetMultipleAccountsApi = {
     /**
      * Returns the account information for a list of Pubkeys.
      */
@@ -72,4 +71,4 @@ export interface GetMultipleAccountsApi extends RpcApiMethods {
         addresses: Address[],
         config?: GetMultipleAccountsApiCommonConfig,
     ): SolanaRpcResponse<(GetMultipleAccountsApiResponseBase & (AccountInfoWithBase64EncodedData | null))[]>;
-}
+};

--- a/packages/rpc-api/src/getProgramAccounts.ts
+++ b/packages/rpc-api/src/getProgramAccounts.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58Bytes,
@@ -29,7 +28,7 @@ type GetProgramAccountsApiSliceableCommonConfig = Readonly<{
     /** Limit the returned account data */
     dataSlice?: DataSlice;
 }>;
-export interface GetProgramAccountsApi extends RpcApiMethods {
+export type GetProgramAccountsApi = {
     /**
      * Returns the account information for a list of Pubkeys.
      */
@@ -128,4 +127,4 @@ export interface GetProgramAccountsApi extends RpcApiMethods {
                 withContext?: boolean;
             }>,
     ): AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58Bytes>[];
-}
+};

--- a/packages/rpc-api/src/getRecentPerformanceSamples.ts
+++ b/packages/rpc-api/src/getRecentPerformanceSamples.ts
@@ -1,4 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type PerformanceSample = Readonly<{
@@ -16,7 +15,7 @@ type PerformanceSample = Readonly<{
 
 type GetRecentPerformanceSamplesApiResponse = readonly PerformanceSample[];
 
-export interface GetRecentPerformanceSamplesApi extends RpcApiMethods {
+export type GetRecentPerformanceSamplesApi = {
     /**
      * Returns a list of recent performance samples, in reverse slot order. Performance samples are taken every 60 seconds and include the number of transactions and slots that occur in a given time window.
      */
@@ -24,4 +23,4 @@ export interface GetRecentPerformanceSamplesApi extends RpcApiMethods {
         /** number of samples to return (maximum 720) */
         limit?: number,
     ): GetRecentPerformanceSamplesApiResponse;
-}
+};

--- a/packages/rpc-api/src/getRecentPrioritizationFees.ts
+++ b/packages/rpc-api/src/getRecentPrioritizationFees.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { MicroLamportsUnsafeBeyond2Pow53Minus1, Slot } from '@solana/rpc-types';
 
 type RecentPrioritizationFee = Readonly<{
@@ -15,7 +14,7 @@ type RecentPrioritizationFee = Readonly<{
 
 type GetRecentPrioritizationFeesApiResponse = readonly RecentPrioritizationFee[];
 
-export interface GetRecentPrioritizationFeesApi extends RpcApiMethods {
+export type GetRecentPrioritizationFeesApi = {
     /**
      * Returns the balance of the account of provided Pubkey
      */
@@ -30,4 +29,4 @@ export interface GetRecentPrioritizationFeesApi extends RpcApiMethods {
          */
         addresses?: Address[],
     ): GetRecentPrioritizationFeesApiResponse;
-}
+};

--- a/packages/rpc-api/src/getSignatureStatuses.ts
+++ b/packages/rpc-api/src/getSignatureStatuses.ts
@@ -1,5 +1,4 @@
 import type { Signature } from '@solana/keys';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     Commitment,
     Slot,
@@ -41,7 +40,7 @@ type SignatureStatusResult = Readonly<{
 
 type GetSignatureStatusesApiResponse = readonly (SignatureStatusResult | null)[];
 
-export interface GetSignatureStatusesApi extends RpcApiMethods {
+export type GetSignatureStatusesApi = {
     /**
      * Returns the statuses of a list of signatures.
      * Each signature must be a txid, the first signature of a transaction.
@@ -65,4 +64,4 @@ export interface GetSignatureStatusesApi extends RpcApiMethods {
             searchTransactionHistory?: boolean;
         }>,
     ): SolanaRpcResponse<GetSignatureStatusesApiResponse>;
-}
+};

--- a/packages/rpc-api/src/getSignaturesForAddress.ts
+++ b/packages/rpc-api/src/getSignaturesForAddress.ts
@@ -1,6 +1,5 @@
 import type { Address } from '@solana/addresses';
 import type { Signature } from '@solana/keys';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot, TransactionError, UnixTimestampUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetSignaturesForAddressTransaction = Readonly<{
@@ -34,7 +33,7 @@ type GetSignaturesForAddressConfig = Readonly<{
     until?: Signature;
 }>;
 
-export interface GetSignaturesForAddressApi extends RpcApiMethods {
+export type GetSignaturesForAddressApi = {
     /**
      * Returns signatures for confirmed transactions that include the given address in their accountKeys list.
      * Returns signatures backwards in time from the provided signature or most recent confirmed block
@@ -43,4 +42,4 @@ export interface GetSignaturesForAddressApi extends RpcApiMethods {
         address: Address,
         config?: GetSignaturesForAddressConfig,
     ): GetSignaturesForAddressApiResponse;
-}
+};

--- a/packages/rpc-api/src/getSlot.ts
+++ b/packages/rpc-api/src/getSlot.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot } from '@solana/rpc-types';
 
 type GetSlotApiResponse = Slot;
 
-export interface GetSlotApi extends RpcApiMethods {
+export type GetSlotApi = {
     /**
      * Returns the slot that has reached the given or default commitment level
      */
@@ -13,4 +12,4 @@ export interface GetSlotApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): GetSlotApiResponse;
-}
+};

--- a/packages/rpc-api/src/getSlotLeader.ts
+++ b/packages/rpc-api/src/getSlotLeader.ts
@@ -1,10 +1,9 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot } from '@solana/rpc-types';
 
 type GetSlotLeaderApiResponse = Address;
 
-export interface GetSlotLeaderApi extends RpcApiMethods {
+export type GetSlotLeaderApi = {
     /**
      * Returns the current slot leader
      */
@@ -14,4 +13,4 @@ export interface GetSlotLeaderApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): GetSlotLeaderApiResponse;
-}
+};

--- a/packages/rpc-api/src/getSlotLeaders.ts
+++ b/packages/rpc-api/src/getSlotLeaders.ts
@@ -1,11 +1,10 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Slot } from '@solana/rpc-types';
 
 /** array of Node identity public keys as base-58 encoded strings */
 type GetSlotLeadersApiResponse = Address[];
 
-export interface GetSlotLeadersApi extends RpcApiMethods {
+export type GetSlotLeadersApi = {
     /**
      * Returns the slot leaders for a given slot range
      */
@@ -15,4 +14,4 @@ export interface GetSlotLeadersApi extends RpcApiMethods {
         /** Limit (between 1 and 5000) */
         limit: number,
     ): GetSlotLeadersApiResponse;
-}
+};

--- a/packages/rpc-api/src/getStakeActivation.ts
+++ b/packages/rpc-api/src/getStakeActivation.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetStakeActivationApiResponse = Readonly<{
@@ -11,7 +10,7 @@ type GetStakeActivationApiResponse = Readonly<{
     state: 'activating' | 'active' | 'deactivating' | 'inactive';
 }>;
 
-export interface GetStakeActivationApi extends RpcApiMethods {
+export type GetStakeActivationApi = {
     /**
      * Returns epoch activation information for a stake account
      *
@@ -26,4 +25,4 @@ export interface GetStakeActivationApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): GetStakeActivationApiResponse;
-}
+};

--- a/packages/rpc-api/src/getStakeMinimumDelegation.ts
+++ b/packages/rpc-api/src/getStakeMinimumDelegation.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, LamportsUnsafeBeyond2Pow53Minus1, SolanaRpcResponse } from '@solana/rpc-types';
 
 type GetStakeMinimumDelegationApiResponse = LamportsUnsafeBeyond2Pow53Minus1;
 
-export interface GetStakeMinimumDelegationApi extends RpcApiMethods {
+export type GetStakeMinimumDelegationApi = {
     /**
      * Returns the stake minimum delegation, in lamports.
      */
@@ -12,4 +11,4 @@ export interface GetStakeMinimumDelegationApi extends RpcApiMethods {
             commitment?: Commitment;
         }>,
     ): SolanaRpcResponse<GetStakeMinimumDelegationApiResponse>;
-}
+};

--- a/packages/rpc-api/src/getSupply.ts
+++ b/packages/rpc-api/src/getSupply.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, LamportsUnsafeBeyond2Pow53Minus1, SolanaRpcResponse } from '@solana/rpc-types';
 
 type GetSupplyConfig = Readonly<{
@@ -30,7 +29,7 @@ type GetSupplyApiResponseWithoutNonCirculatingAccounts = GetSupplyApiResponseBas
         nonCirculatingAccounts: never[];
     }>;
 
-export interface GetSupplyApi extends RpcApiMethods {
+export type GetSupplyApi = {
     /**
      * Returns information about the current supply.
      */
@@ -46,4 +45,4 @@ export interface GetSupplyApi extends RpcApiMethods {
                 excludeNonCirculatingAccountsList?: false;
             }>,
     ): SolanaRpcResponse<GetSupplyApiResponseWithNonCirculatingAccounts>;
-}
+};

--- a/packages/rpc-api/src/getTokenAccountBalance.ts
+++ b/packages/rpc-api/src/getTokenAccountBalance.ts
@@ -1,10 +1,9 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, SolanaRpcResponse, TokenAmount } from '@solana/rpc-types';
 
 type GetTokenAccountBalanceApiResponse = TokenAmount;
 
-export interface GetTokenAccountBalanceApi extends RpcApiMethods {
+export type GetTokenAccountBalanceApi = {
     /**
      * Returns the token balance of an SPL Token account
      */
@@ -15,4 +14,4 @@ export interface GetTokenAccountBalanceApi extends RpcApiMethods {
             commitment?: Commitment;
         }>,
     ): SolanaRpcResponse<GetTokenAccountBalanceApiResponse>;
-}
+};

--- a/packages/rpc-api/src/getTokenAccountsByDelegate.ts
+++ b/packages/rpc-api/src/getTokenAccountsByDelegate.ts
@@ -1,6 +1,5 @@
 import type { Address } from '@solana/addresses';
 import type { JsonParsedTokenAccount } from '@solana/rpc-parsed-types';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58Bytes,
@@ -53,7 +52,7 @@ type GetTokenAccountsByDelegateApiSliceableCommonConfig = Readonly<{
     dataSlice?: DataSlice;
 }>;
 
-export interface GetTokenAccountsByDelegateApi extends RpcApiMethods {
+export type GetTokenAccountsByDelegateApi = {
     /**
      * Returns all SPL Token accounts by approved Delegate.
      */
@@ -101,4 +100,4 @@ export interface GetTokenAccountsByDelegateApi extends RpcApiMethods {
         filter: AccountsFilter,
         config?: GetTokenAccountsByDelegateApiCommonConfig & GetTokenAccountsByDelegateApiSliceableCommonConfig,
     ): SolanaRpcResponse<GetTokenAccountsByDelegateResponse<AccountInfoWithBase58Bytes>>;
-}
+};

--- a/packages/rpc-api/src/getTokenAccountsByOwner.ts
+++ b/packages/rpc-api/src/getTokenAccountsByOwner.ts
@@ -1,6 +1,5 @@
 import type { Address } from '@solana/addresses';
 import type { JsonParsedTokenAccount } from '@solana/rpc-parsed-types';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58Bytes,
@@ -52,7 +51,7 @@ type GetTokenAccountsByOwnerApiSliceableCommonConfig = Readonly<{
     /** Limit the returned account data */
     dataSlice?: DataSlice;
 }>;
-export interface GetTokenAccountsByOwnerApi extends RpcApiMethods {
+export type GetTokenAccountsByOwnerApi = {
     /**
      * Returns all SPL Token accounts by token owner.
      */
@@ -100,4 +99,4 @@ export interface GetTokenAccountsByOwnerApi extends RpcApiMethods {
         filter: AccountsFilter,
         config?: GetTokenAccountsByOwnerApiCommonConfig & GetTokenAccountsByOwnerApiSliceableCommonConfig,
     ): SolanaRpcResponse<GetTokenAccountsByOwnerResponse<AccountInfoWithBase58Bytes>>;
-}
+};

--- a/packages/rpc-api/src/getTokenLargestAccounts.ts
+++ b/packages/rpc-api/src/getTokenLargestAccounts.ts
@@ -1,12 +1,11 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, SolanaRpcResponse, TokenAmount } from '@solana/rpc-types';
 
 type TokenLargestAccount = Readonly<{ address: Address }> & TokenAmount;
 
 type GetTokenLargestAccountsApiResponse = readonly TokenLargestAccount[];
 
-export interface GetTokenLargestAccountsApi extends RpcApiMethods {
+export type GetTokenLargestAccountsApi = {
     /**
      * Returns the 20 largest accounts of a particular SPL Token type.
      */
@@ -16,4 +15,4 @@ export interface GetTokenLargestAccountsApi extends RpcApiMethods {
             commitment?: Commitment;
         }>,
     ): SolanaRpcResponse<GetTokenLargestAccountsApiResponse>;
-}
+};

--- a/packages/rpc-api/src/getTokenSupply.ts
+++ b/packages/rpc-api/src/getTokenSupply.ts
@@ -1,10 +1,9 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, SolanaRpcResponse, TokenAmount } from '@solana/rpc-types';
 
 type GetTokenSupplyApiResponse = TokenAmount;
 
-export interface GetTokenSupplyApi extends RpcApiMethods {
+export type GetTokenSupplyApi = {
     /**
      * Returns the total supply of an SPL Token mint
      */
@@ -15,4 +14,4 @@ export interface GetTokenSupplyApi extends RpcApiMethods {
             commitment?: Commitment;
         }>,
     ): SolanaRpcResponse<GetTokenSupplyApiResponse>;
-}
+};

--- a/packages/rpc-api/src/getTransaction.ts
+++ b/packages/rpc-api/src/getTransaction.ts
@@ -1,6 +1,5 @@
 import type { Address } from '@solana/addresses';
 import type { Signature } from '@solana/keys';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     Base58EncodedBytes,
     Base58EncodedDataResponse,
@@ -161,7 +160,7 @@ type TransactionAddressTableLookups = Readonly<{
     }>;
 }>;
 
-export interface GetTransactionApi extends RpcApiMethods {
+export type GetTransactionApi = {
     /**
      * Returns transaction details for a confirmed transaction
      */
@@ -249,4 +248,4 @@ export interface GetTransactionApi extends RpcApiMethods {
                           : TransactionAddressTableLookups);
               })
         | null;
-}
+};

--- a/packages/rpc-api/src/getTransactionCount.ts
+++ b/packages/rpc-api/src/getTransactionCount.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type GetTransactionCountApiResponse = U64UnsafeBeyond2Pow53Minus1;
 
-export interface GetTransactionCountApi extends RpcApiMethods {
+export type GetTransactionCountApi = {
     /**
      * Returns the current Transaction count from the ledger
      */
@@ -15,4 +14,4 @@ export interface GetTransactionCountApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): GetTransactionCountApiResponse;
-}
+};

--- a/packages/rpc-api/src/getVersion.ts
+++ b/packages/rpc-api/src/getVersion.ts
@@ -1,5 +1,3 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
-
 type GetVersionApiResponse = Readonly<{
     /** Unique identifier of the current software's feature set */
     'feature-set': number; // `u32`
@@ -7,7 +5,7 @@ type GetVersionApiResponse = Readonly<{
     'solana-core': string;
 }>;
 
-export interface GetVersionApi extends RpcApiMethods {
+export type GetVersionApi = {
     /**
      * Returns the current Solana version running on the node
      */
@@ -15,4 +13,4 @@ export interface GetVersionApi extends RpcApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): GetVersionApiResponse;
-}
+};

--- a/packages/rpc-api/src/getVoteAccounts.ts
+++ b/packages/rpc-api/src/getVoteAccounts.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type Epoch = U64UnsafeBeyond2Pow53Minus1;
@@ -42,9 +41,9 @@ type GetVoteAccountsConfig<TVotePubkey extends Address> = Readonly<{
     votePubkey?: TVotePubkey;
 }>;
 
-export interface GetVoteAccountsApi extends RpcApiMethods {
+export type GetVoteAccountsApi = {
     /** Returns the account info and associated stake for all the voting accounts in the current bank. */
     getVoteAccounts<TVoteAccount extends Address>(
         config?: GetVoteAccountsConfig<TVoteAccount>,
     ): GetVoteAccountsApiResponse<TVoteAccount>;
-}
+};

--- a/packages/rpc-api/src/isBlockhashValid.ts
+++ b/packages/rpc-api/src/isBlockhashValid.ts
@@ -1,9 +1,8 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Blockhash, Commitment, Slot, SolanaRpcResponse } from '@solana/rpc-types';
 
 type IsBlockhashValidApiResponse = boolean;
 
-export interface IsBlockhashValidApi extends RpcApiMethods {
+export type IsBlockhashValidApi = {
     /**
      * Returns whether a blockhash is still valid or not
      */
@@ -17,4 +16,4 @@ export interface IsBlockhashValidApi extends RpcApiMethods {
             minContextSlot?: Slot;
         }>,
     ): SolanaRpcResponse<IsBlockhashValidApiResponse>;
-}
+};

--- a/packages/rpc-api/src/minimumLedgerSlot.ts
+++ b/packages/rpc-api/src/minimumLedgerSlot.ts
@@ -1,12 +1,11 @@
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Slot } from '@solana/rpc-types';
 
 type MinimumLedgerSlotApiResponse = Slot;
 
-export interface MinimumLedgerSlotApi extends RpcApiMethods {
+export type MinimumLedgerSlotApi = {
     /**
      * Returns the lowest slot that the node has information about in its ledger.
      * This value may increase over time if the node is configured to purge older ledger data.
      */
     minimumLedgerSlot(): MinimumLedgerSlotApiResponse;
-}
+};

--- a/packages/rpc-api/src/requestAirdrop.ts
+++ b/packages/rpc-api/src/requestAirdrop.ts
@@ -1,6 +1,5 @@
 import type { Address } from '@solana/addresses';
 import type { Signature } from '@solana/keys';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, LamportsUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type RequestAirdropConfig = Readonly<{
@@ -9,7 +8,7 @@ type RequestAirdropConfig = Readonly<{
 
 type RequestAirdropResponse = Signature;
 
-export interface RequestAirdropApi extends RpcApiMethods {
+export type RequestAirdropApi = {
     /**
      * Requests an airdrop of lamports to a Pubkey
      */
@@ -18,4 +17,4 @@ export interface RequestAirdropApi extends RpcApiMethods {
         lamports: LamportsUnsafeBeyond2Pow53Minus1,
         config?: RequestAirdropConfig,
     ): RequestAirdropResponse;
-}
+};

--- a/packages/rpc-api/src/sendTransaction.ts
+++ b/packages/rpc-api/src/sendTransaction.ts
@@ -1,5 +1,4 @@
 import type { Signature } from '@solana/keys';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type { Commitment, Slot } from '@solana/rpc-types';
 import type { Base64EncodedWireTransaction } from '@solana/transactions';
 
@@ -12,7 +11,7 @@ type SendTransactionConfig = Readonly<{
 
 type SendTransactionResponse = Signature;
 
-export interface SendTransactionApi extends RpcApiMethods {
+export type SendTransactionApi = {
     /** @deprecated Set `encoding` to `'base64'` when calling this method */
     sendTransaction(
         base64EncodedWireTransaction: Base64EncodedWireTransaction,
@@ -49,4 +48,4 @@ export interface SendTransactionApi extends RpcApiMethods {
         base64EncodedWireTransaction: Base64EncodedWireTransaction,
         config?: SendTransactionConfig & { encoding: 'base64' },
     ): SendTransactionResponse;
-}
+};

--- a/packages/rpc-api/src/simulateTransaction.ts
+++ b/packages/rpc-api/src/simulateTransaction.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcApiMethods } from '@solana/rpc-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase64EncodedData,
@@ -117,7 +116,7 @@ type SimulateTransactionApiResponseWithInnerInstructions = Readonly<
     TransactionForFullMetaInnerInstructionsParsed | TransactionForFullMetaInnerInstructionsUnparsed
 >;
 
-export interface SimulateTransactionApi extends RpcApiMethods {
+export type SimulateTransactionApi = {
     /** @deprecated Set `encoding` to `'base64'` when calling this method */
     simulateTransaction(
         base58EncodedWireTransaction: Base58EncodedBytes,
@@ -299,4 +298,4 @@ export interface SimulateTransactionApi extends RpcApiMethods {
         base64EncodedWireTransaction: Base64EncodedWireTransaction,
         config: SigVerifyAndReplaceRecentBlockhashConfig & SimulateTransactionConfigBase & { encoding: 'base64' },
     ): SolanaRpcResponse<Readonly<{ readonly accounts: null }> & SimulateTransactionApiResponseBase>;
-}
+};

--- a/packages/rpc-graphql/src/__tests__/block-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/block-tests.ts
@@ -30,6 +30,7 @@ describe('block', () => {
             get(target, p) {
                 if (!target[p as keyof GraphQLCompliantRpc]) {
                     const pendingRpcRequest = { send: mockRpcTransport };
+                    // @ts-expect-error - Mocking RPC methods
                     target[p as keyof GraphQLCompliantRpc] = jest
                         .fn()
                         .mockReturnValue(pendingRpcRequest) as GraphQLCompliantRpc[keyof GraphQLCompliantRpc];

--- a/packages/rpc-graphql/src/__tests__/transaction-tests.ts
+++ b/packages/rpc-graphql/src/__tests__/transaction-tests.ts
@@ -41,6 +41,7 @@ describe('transaction', () => {
             get(target, p) {
                 if (!target[p as keyof GraphQLCompliantRpc]) {
                     const pendingRpcRequest = { send: mockRpcTransport };
+                    // @ts-expect-error - Mocking RPC methods
                     target[p as keyof GraphQLCompliantRpc] = jest
                         .fn()
                         .mockReturnValue(pendingRpcRequest) as GraphQLCompliantRpc[keyof GraphQLCompliantRpc];

--- a/packages/rpc-graphql/src/resolvers/__tests__/block-inputs-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/block-inputs-test.ts
@@ -27,6 +27,7 @@ describe('block inputs', () => {
             get(target, p) {
                 if (!target[p as keyof GraphQLCompliantRpc]) {
                     const pendingRpcRequest = { send: mockRpcTransport };
+                    // @ts-expect-error - Mocking RPC methods
                     target[p as keyof GraphQLCompliantRpc] = jest
                         .fn()
                         .mockReturnValue(pendingRpcRequest) as GraphQLCompliantRpc[keyof GraphQLCompliantRpc];

--- a/packages/rpc-spec/src/__typetests__/rpc-api-typetest.ts
+++ b/packages/rpc-spec/src/__typetests__/rpc-api-typetest.ts
@@ -1,4 +1,4 @@
-import { createRpcApi, RpcApi, RpcApiMethods } from '../rpc-api';
+import { createRpcApi, RpcApi } from '../rpc-api';
 
 type NftCollectionDetailsApiResponse = Readonly<{
     address: string;
@@ -12,9 +12,9 @@ type NftCollectionDetailsApiResponse = Readonly<{
     totalSupply: number;
 }>;
 
-interface NftCollectionDetailsApi extends RpcApiMethods {
+type NftCollectionDetailsApi = {
     qn_fetchNFTCollectionDetails(args: { contracts: string[] }): NftCollectionDetailsApiResponse;
-}
+};
 
 type QuickNodeRpcMethods = NftCollectionDetailsApi;
 

--- a/packages/rpc-spec/src/__typetests__/rpc-typetest.ts
+++ b/packages/rpc-spec/src/__typetests__/rpc-typetest.ts
@@ -1,11 +1,11 @@
 import { createRpc, Rpc } from '../rpc';
-import { createRpcApi, RpcApiMethods } from '../rpc-api';
+import { createRpcApi } from '../rpc-api';
 import { RpcTransport } from '../rpc-transport';
 
-interface MyApiMethods extends RpcApiMethods {
+type MyApiMethods = {
     bar(): string;
     foo(): number;
-}
+};
 
 const api = createRpcApi<MyApiMethods>();
 const transport = null as unknown as RpcTransport;

--- a/packages/rpc-spec/src/rpc-api.ts
+++ b/packages/rpc-spec/src/rpc-api.ts
@@ -21,7 +21,7 @@ type RpcReturnTypeMapper<TRpcMethod> = TRpcMethod extends Callable
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RpcApiMethod = (...args: any) => any;
-export interface RpcApiMethods {
+interface RpcApiMethods {
     [methodName: string]: RpcApiMethod;
 }
 


### PR DESCRIPTION
Extending `RpcApiMethods` removes the ability to access typed keys on `SolanaRpcApi` etc, because it's typed as `[method: string]: RpcApiMethod`. 

In this PR we change from:
```ts
interface GetAssetApi extends RpcApiMethods {
```

To:
```ts
type GetAssetApi = {
```

(Thanks @lorisleiva!)

This allows `createRpcApi` to maintain its typing, meaning that it still constrains any API methods we attempt to build an RPC for. But we now have typesafe `keyof SolanaRpcApi` etc. 

I've also removed the export of `RpcApiMethods`, since this should now be used only as a constraint internally and not a type externally.

I've added a typetest with a bit more detail, but this basically makes this work:
```ts
'getAccountInfo' satisfies keyof SolanaRpcApi;
// @ts-expect-error RPC API does not have this method
'someMadeUpMethod' satisfies keyof SolanaRpcApi;
```

Previously `someMadeUpMethod` would satisfy it, because `keyof SolanaRpcApi` was just string. 