### PR TITLE
Clean up SolanaRpcSubscriptionsApi: no longer extend RpcApiSubscriptionsMethods 

### DIFF
--- a/.changeset/beige-files-travel.md
+++ b/.changeset/beige-files-travel.md
@@ -1,0 +1,6 @@
+---
+'@solana/rpc-subscriptions-spec': patch
+'@solana/rpc-subscriptions-api': patch
+---
+
+Clean up SolanaRpcSubscriptionsApi: no longer extend RpcApiSubscriptionsMethods

--- a/packages/rpc-subscriptions-api/src/__tests__/index-test.ts
+++ b/packages/rpc-subscriptions-api/src/__tests__/index-test.ts
@@ -1,10 +1,10 @@
-import type { RpcSubscriptionsApi, RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
+import type { RpcSubscriptionsApi } from '@solana/rpc-subscriptions-spec';
 
 import { createSolanaRpcSubscriptionsApi } from '..';
 
-interface TestRpcSubscriptionNotifications extends RpcSubscriptionsApiMethods {
+type TestRpcSubscriptionNotifications = {
     thingNotifications(...args: unknown[]): unknown;
-}
+};
 
 describe('RpcSubscriptionsApi', () => {
     let api: RpcSubscriptionsApi<TestRpcSubscriptionNotifications>;

--- a/packages/rpc-subscriptions-api/src/__typetests__/rpc-subscriptions-api-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/rpc-subscriptions-api-type-test.ts
@@ -1,0 +1,21 @@
+import { SolanaRpcSubscriptionsApi, SolanaRpcSubscriptionsApiUnstable } from '..';
+
+'accountNotifications' satisfies keyof SolanaRpcSubscriptionsApi;
+// @ts-expect-error RPC subscriptions API does not have this method
+'someMadeUpNotifications' satisfies keyof SolanaRpcSubscriptionsApi;
+
+// if we extend the RPC API with additional methods, we can access them on keyof
+type testRpcSubscriptionsApi = SolanaRpcSubscriptionsApi & {
+    someMadeUpNotifications: () => void;
+};
+'someMadeUpNotifications' satisfies keyof testRpcSubscriptionsApi;
+
+// slots updates notifications are available on unstable API only
+'slotsUpdatesNotifications' satisfies keyof SolanaRpcSubscriptionsApiUnstable;
+// @ts-expect-error RPC subscriptions API does not have this method
+'slotsUpdatesNotifications' satisfies keyof SolanaRpcSubscriptionsApi;
+
+// vote notifications are available on unstable API only
+'voteNotifications' satisfies keyof SolanaRpcSubscriptionsApiUnstable;
+// @ts-expect-error RPC subscriptions API does not have this method
+'voteNotifications' satisfies keyof SolanaRpcSubscriptionsApi;

--- a/packages/rpc-subscriptions-api/src/account-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/account-notifications.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58Bytes,
@@ -15,7 +14,7 @@ type AccountNotificationsApiCommonConfig = Readonly<{
     commitment?: Commitment;
 }>;
 
-export interface AccountNotificationsApi extends RpcSubscriptionsApiMethods {
+export type AccountNotificationsApi = {
     /**
      * Subscribe to an account to receive notifications when the lamports or data for
      * a given account public key changes.
@@ -55,4 +54,4 @@ export interface AccountNotificationsApi extends RpcSubscriptionsApiMethods {
         address: Address,
         config?: AccountNotificationsApiCommonConfig,
     ): SolanaRpcResponse<AccountInfoBase & AccountInfoWithBase58Bytes>;
-}
+};

--- a/packages/rpc-subscriptions-api/src/block-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/block-notifications.ts
@@ -1,4 +1,3 @@
-import type { RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
 import type {
     Base58EncodedBytes,
     Blockhash,
@@ -80,7 +79,7 @@ type BlockNotificationsEncoding = 'base58' | 'base64' | 'json' | 'jsonParsed';
 // - These rules apply to both "accounts" and "full" transaction details.
 type BlockNotificationsMaxSupportedTransactionVersion = Exclude<TransactionVersion, 'legacy'>;
 
-export interface BlockNotificationsApi extends RpcSubscriptionsApiMethods {
+export type BlockNotificationsApi = {
     /**
      * Subscribe to receive notification anytime a new block is Confirmed or Finalized.
      *
@@ -555,4 +554,4 @@ export interface BlockNotificationsApi extends RpcSubscriptionsApiMethods {
                     | null;
             }>
     >;
-}
+};

--- a/packages/rpc-subscriptions-api/src/logs-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/logs-notifications.ts
@@ -1,6 +1,5 @@
 import type { Address } from '@solana/addresses';
 import type { Signature } from '@solana/keys';
-import type { RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
 import type { Commitment, SolanaRpcResponse, TransactionError } from '@solana/rpc-types';
 
 type LogsNotificationsApiNotification = SolanaRpcResponse<
@@ -24,7 +23,7 @@ type LogsNotificationsApiConfig = Readonly<{
     commitment?: Commitment;
 }>;
 
-export interface LogsNotificationsApi extends RpcSubscriptionsApiMethods {
+export type LogsNotificationsApi = {
     /**
      * Subscribe to a transaction logs to receive notification when a given transaction is committed.
      * On `logsNotification` - the subscription is automatically cancelled.
@@ -34,4 +33,4 @@ export interface LogsNotificationsApi extends RpcSubscriptionsApiMethods {
         filter: LogsNotificationsApiFilter,
         config?: LogsNotificationsApiConfig,
     ): LogsNotificationsApiNotification;
-}
+};

--- a/packages/rpc-subscriptions-api/src/program-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/program-notifications.ts
@@ -1,5 +1,4 @@
 import type { Address } from '@solana/addresses';
-import type { RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
 import type {
     AccountInfoBase,
     AccountInfoWithBase58Bytes,
@@ -44,7 +43,7 @@ type ProgramNotificationsApiCommonConfig = Readonly<{
     >[];
 }>;
 
-export interface ProgramNotificationsApi extends RpcSubscriptionsApiMethods {
+export type ProgramNotificationsApi = {
     /**
      * Subscribe to a program to receive notifications when the lamports or data for an account
      * owned by the given program changes
@@ -81,4 +80,4 @@ export interface ProgramNotificationsApi extends RpcSubscriptionsApiMethods {
         programId: Address,
         config?: ProgramNotificationsApiCommonConfig,
     ): ProgramNotificationsApiNotificationBase<AccountInfoWithBase58Bytes>;
-}
+};

--- a/packages/rpc-subscriptions-api/src/root-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/root-notifications.ts
@@ -1,9 +1,8 @@
-import type { RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
 import type { Slot } from '@solana/rpc-types';
 
 type RootNotificationsApiNotification = Slot;
 
-export interface RootNotificationsApi extends RpcSubscriptionsApiMethods {
+export type RootNotificationsApi = {
     /**
      * Subscribe to receive notification anytime a new root is set by the validator
      */
@@ -11,4 +10,4 @@ export interface RootNotificationsApi extends RpcSubscriptionsApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): RootNotificationsApiNotification;
-}
+};

--- a/packages/rpc-subscriptions-api/src/signature-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/signature-notifications.ts
@@ -1,5 +1,4 @@
 import type { Signature } from '@solana/keys';
-import type { RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
 import type { Commitment, SolanaRpcResponse, TransactionError } from '@solana/rpc-types';
 
 type SignatureNotificationsApiNotificationReceived = SolanaRpcResponse<Readonly<string>>;
@@ -15,7 +14,7 @@ type SignatureNotificationsApiConfigBase = Readonly<{
     commitment?: Commitment;
 }>;
 
-export interface SignatureNotificationsApi extends RpcSubscriptionsApiMethods {
+export type SignatureNotificationsApi = {
     /**
      * Subscribe to a transaction signature to receive notification when a given transaction is committed.
      * On `signatureNotification` - the subscription is automatically cancelled.
@@ -38,4 +37,4 @@ export interface SignatureNotificationsApi extends RpcSubscriptionsApiMethods {
         }> &
             SignatureNotificationsApiConfigBase,
     ): SignatureNotificationsApiNotificationProcessed;
-}
+};

--- a/packages/rpc-subscriptions-api/src/slot-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/slot-notifications.ts
@@ -1,4 +1,3 @@
-import type { RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
 import type { Slot } from '@solana/rpc-types';
 
 type SlotNotificationsApiNotification = Readonly<{
@@ -7,7 +6,7 @@ type SlotNotificationsApiNotification = Readonly<{
     slot: Slot;
 }>;
 
-export interface SlotNotificationsApi extends RpcSubscriptionsApiMethods {
+export type SlotNotificationsApi = {
     /**
      * Subscribe to receive notification anytime a slot is processed by the validator
      */
@@ -15,4 +14,4 @@ export interface SlotNotificationsApi extends RpcSubscriptionsApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): SlotNotificationsApiNotification;
-}
+};

--- a/packages/rpc-subscriptions-api/src/slots-updates-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/slots-updates-notifications.ts
@@ -1,4 +1,3 @@
-import type { RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
 import type { Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type SlotsUpdatesNotificationsApiNotificationBase = Readonly<{
@@ -36,7 +35,7 @@ type SlotsUpdatesNotificationsApiNotification =
     | SlotsUpdatesNotificationsApiNotificationDead
     | SlotsUpdatesNotificationsApiNotificationFrozen;
 
-export interface SlotsUpdatesNotificationsApi extends RpcSubscriptionsApiMethods {
+export type SlotsUpdatesNotificationsApi = {
     /**
      * Subscribe to receive a notification from the validator on a variety of updates on every slot
      */
@@ -44,4 +43,4 @@ export interface SlotsUpdatesNotificationsApi extends RpcSubscriptionsApiMethods
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): SlotsUpdatesNotificationsApiNotification;
-}
+};

--- a/packages/rpc-subscriptions-api/src/vote-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/vote-notifications.ts
@@ -1,6 +1,5 @@
 import type { Address } from '@solana/addresses';
 import type { Signature } from '@solana/keys';
-import type { RpcSubscriptionsApiMethods } from '@solana/rpc-subscriptions-spec';
 import type { Blockhash, Slot, UnixTimestampUnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 
 type VoteNotificationsApiNotification = Readonly<{
@@ -11,7 +10,7 @@ type VoteNotificationsApiNotification = Readonly<{
     votePubkey: Address;
 }>;
 
-export interface VoteNotificationsApi extends RpcSubscriptionsApiMethods {
+export type VoteNotificationsApi = {
     /**
      * Subscribe to receive a notification from the validator on a variety of updates on every slot
      */
@@ -19,4 +18,4 @@ export interface VoteNotificationsApi extends RpcSubscriptionsApiMethods {
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
         NO_CONFIG?: Record<string, never>,
     ): VoteNotificationsApiNotification;
-}
+};

--- a/packages/rpc-subscriptions-spec/src/__typetests__/rpc-subscriptions-api-typetest.ts
+++ b/packages/rpc-subscriptions-spec/src/__typetests__/rpc-subscriptions-api-typetest.ts
@@ -1,4 +1,4 @@
-import { createRpcSubscriptionsApi, RpcSubscriptionsApi, RpcSubscriptionsApiMethods } from '../rpc-subscriptions-api';
+import { createRpcSubscriptionsApi, RpcSubscriptionsApi } from '../rpc-subscriptions-api';
 
 type NftCollectionDetailsApiResponse = Readonly<{
     address: string;
@@ -12,9 +12,9 @@ type NftCollectionDetailsApiResponse = Readonly<{
     totalSupply: number;
 }>;
 
-interface NftCollectionDetailsApi extends RpcSubscriptionsApiMethods {
+type NftCollectionDetailsApi = {
     qn_fetchNFTCollectionDetails(args: { contracts: string[] }): NftCollectionDetailsApiResponse;
-}
+};
 
 type QuickNodeRpcMethods = NftCollectionDetailsApi;
 

--- a/packages/rpc-subscriptions-spec/src/__typetests__/rpc-subscriptions-typetest.ts
+++ b/packages/rpc-subscriptions-spec/src/__typetests__/rpc-subscriptions-typetest.ts
@@ -1,11 +1,11 @@
 import { createSubscriptionRpc, RpcSubscriptions } from '../rpc-subscriptions';
-import { createRpcSubscriptionsApi, RpcSubscriptionsApiMethods } from '../rpc-subscriptions-api';
+import { createRpcSubscriptionsApi } from '../rpc-subscriptions-api';
 import { RpcSubscriptionsTransport } from '../rpc-subscriptions-transport';
 
-interface MySubscriptionApiMethods extends RpcSubscriptionsApiMethods {
+type MySubscriptionApiMethods = {
     bar(): string;
     foo(): number;
-}
+};
 
 const api = createRpcSubscriptionsApi<MySubscriptionApiMethods>();
 const transport = null as unknown as RpcSubscriptionsTransport;


### PR DESCRIPTION
Same idea as #3213 but for subscriptions

Also added a typetest to verify that keys of RpcSubscriptions are now correctly typed 