### PR TITLE
Remove request arg in API plan's response transformer

### DIFF
--- a/packages/rpc-spec/src/__tests__/rpc-api-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-api-test.ts
@@ -60,7 +60,7 @@ describe('createRpcApi', () => {
         const plan = api.someMethod(1, 2, 3);
 
         // Then we expect the plan to contain the response transformer.
-        expect(plan.responseTransformer).toBe(responseTransformer);
+        expect(typeof plan.responseTransformer).toBe('function');
     });
     it('returns a frozen object', () => {
         // Given a dummy API.

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -92,7 +92,7 @@ describe('JSON-RPC 2.0', () => {
             const rawResponse = 123;
             (makeHttpRequest as jest.Mock).mockResolvedValueOnce(rawResponse);
             await rpc.someMethod().send();
-            expect(responseTransformer).toHaveBeenCalledWith(rawResponse, { methodName: 'someMethod', params: [] });
+            expect(responseTransformer).toHaveBeenCalledWith(rawResponse);
         });
         it('returns the processed response', async () => {
             expect.assertions(1);

--- a/packages/rpc-spec/src/rpc.ts
+++ b/packages/rpc-spec/src/rpc.ts
@@ -69,17 +69,16 @@ function makeProxy<TRpcMethods, TRpcTransport extends RpcTransport>(
 
 function createPendingRpcRequest<TRpcMethods, TRpcTransport extends RpcTransport, TResponse>(
     rpcConfig: RpcConfig<TRpcMethods, TRpcTransport>,
-    pendingRequest: RpcApiRequestPlan<TResponse>,
+    apiPlan: RpcApiRequestPlan<TResponse>,
 ): PendingRpcRequest<TResponse> {
     return {
         async send(options?: RpcSendOptions): Promise<TResponse> {
-            const { methodName, params, responseTransformer } = pendingRequest;
-            const request = Object.freeze({ methodName, params });
+            const { methodName, params, responseTransformer } = apiPlan;
             const rawResponse = await rpcConfig.transport<TResponse>({
                 payload: createRpcMessage(methodName, params),
                 signal: options?.abortSignal,
             });
-            return responseTransformer ? responseTransformer(rawResponse, request) : rawResponse;
+            return responseTransformer ? responseTransformer(rawResponse) : rawResponse;
         },
     };
 }


### PR DESCRIPTION
This PR removes the unnecessary `request` argument from the API plan's `responseTransformer` function. This is because the plan already knows the `request` so it can inject it to the `responseTransformer` provided in its config.