### PR TITLE
Make API plans return payloads

### DIFF
--- a/.changeset/small-cougars-smoke.md
+++ b/.changeset/small-cougars-smoke.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-spec': patch
+---
+
+Make API plans return payloads

--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -72,8 +72,7 @@ This is a marker interface that all RPC method definitions must extend to be acc
 
 This type allows an `RpcApi` to describe how a particular request should be issued to the JSON RPC server. Given a function that was called on a `Rpc`, this object gives you the opportunity to:
 
--   customize the JSON RPC method name in the case that it's different than the name of that function
--   define the shape of the JSON RPC params in case they are different than the arguments provided to that function
+-   provide a `payload` from the requested method name and parameters.
 -   provide a function to transform the JSON RPC server's response, in case it does not match the `TResponse` specified by the `PendingRpcRequest<TResponse>` returned from that function.
 
 ### `RpcSendOptions`
@@ -106,8 +105,7 @@ A config object with the following properties:
 
 Creates a JavaScript proxy that converts _any_ function call called on it to a `RpcApiRequestPlan` by:
 
--   setting `methodName` to the name of the function called, optionally transformed by `config.requestTransformer`.
--   setting `params` to the arguments supplied to that function, optionally transformed by `config.requestTransformer`.
+-   setting `payload` to a JSON RPC v2 payload object with the requested `methodName` and `params` properties, optionally transformed by `config.requestTransformer`.
 -   setting `responseTransformer` to `config.responseTransformer`, if provided.
 
 ```ts
@@ -123,8 +121,7 @@ rpcApi.foo('bar', { baz: 'bat' });
 // ...will produce the following `RpcApiRequestPlan` object:
 //
 //     {
-//         methodName: 'foo',
-//         params: [{ baz: 'bat' }, 'bar'],
+//         payload: { id: 1, jsonrpc: '2.0', method: 'foo', params: ['bar', { baz: 'bat' }] },
 //         responseTransformer: (response) => response.result,
 //     }
 ```

--- a/packages/rpc-spec/src/__tests__/rpc-api-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-api-test.ts
@@ -8,7 +8,7 @@ type DummyApi = {
 };
 
 describe('createRpcApi', () => {
-    it('returns a plan containing the method name and parameters provided', () => {
+    it('returns a plan containing the payload to send to the transport', () => {
         // Given a dummy API.
         const api = createRpcApi<DummyApi>();
 
@@ -16,8 +16,8 @@ describe('createRpcApi', () => {
         const plan = api.someMethod(1, 'two', { three: [4] });
 
         // Then we expect the plan to contain the method name and the provided parameters.
-        expect(plan).toEqual({
-            methodName: 'someMethod',
+        expect(plan.payload).toMatchObject({
+            method: 'someMethod',
             params: [1, 'two', { three: [4] }],
         });
     });
@@ -34,7 +34,7 @@ describe('createRpcApi', () => {
         const plan = api.someMethod();
 
         // Then we expect the plan to contain the transformed method name.
-        expect(plan.methodName).toBe('someMethodTransformed');
+        expect(plan.payload).toMatchObject({ method: 'someMethodTransformed' });
     });
     it('applies the request transformer to the provided params', () => {
         // Given a dummy API with a request transformer that doubles the provided params.
@@ -49,7 +49,7 @@ describe('createRpcApi', () => {
         const plan = api.someMethod(1, 2, 3);
 
         // Then we expect the plan to contain the transformed params.
-        expect(plan.params).toEqual([2, 4, 6]);
+        expect(plan.payload).toMatchObject({ params: [2, 4, 6] });
     });
     it('includes the provided response transformer in the plan', () => {
         // Given a dummy API with a response transformer.

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -51,8 +51,7 @@ describe('JSON-RPC 2.0', () => {
                 api: {
                     someMethod(...params: unknown[]): RpcApiRequestPlan<unknown> {
                         return {
-                            methodName: 'someMethodAugmented',
-                            params: [...params, 'augmented', 'params'],
+                            payload: createRpcMessage('someMethodAugmented', [...params, 'augmented', 'params']),
                         };
                     },
                 } as RpcApi<TestRpcMethods>,
@@ -78,8 +77,7 @@ describe('JSON-RPC 2.0', () => {
                 api: {
                     someMethod(...params: unknown[]): RpcApiRequestPlan<unknown> {
                         return {
-                            methodName: 'someMethod',
-                            params,
+                            payload: createRpcMessage('someMethod', params),
                             responseTransformer,
                         };
                     },

--- a/packages/rpc-spec/src/rpc-api.ts
+++ b/packages/rpc-spec/src/rpc-api.ts
@@ -1,13 +1,14 @@
-import { Callable } from '@solana/rpc-spec-types';
+import { Callable, createRpcMessage } from '@solana/rpc-spec-types';
 
-import { RpcRequest, RpcRequestTransformer, RpcResponse, RpcResponseTransformer } from './rpc-shared';
+import { RpcRequestTransformer, RpcResponse, RpcResponseTransformer } from './rpc-shared';
 
 export type RpcApiConfig = Readonly<{
     requestTransformer?: RpcRequestTransformer;
     responseTransformer?: RpcResponseTransformer;
 }>;
 
-export type RpcApiRequestPlan<TResponse> = RpcRequest & {
+export type RpcApiRequestPlan<TResponse> = {
+    payload: unknown;
     responseTransformer?: (response: RpcResponse) => RpcResponse<TResponse>;
 };
 
@@ -46,7 +47,7 @@ export function createRpcApi<TRpcMethods extends RpcApiMethods>(config?: RpcApiC
                 const rawRequest = Object.freeze({ methodName, params: rawParams });
                 const request = config?.requestTransformer ? config?.requestTransformer(rawRequest) : rawRequest;
                 return Object.freeze({
-                    ...request,
+                    payload: createRpcMessage(request.methodName, request.params),
                     ...(config?.responseTransformer
                         ? {
                               responseTransformer: (response: RpcResponse) => {

--- a/packages/rpc-spec/src/rpc.ts
+++ b/packages/rpc-spec/src/rpc.ts
@@ -60,7 +60,7 @@ function makeProxy<TRpcMethods, TRpcTransport extends RpcTransport>(
                 const createRpcRequest = Reflect.get(target, methodName, receiver);
                 const newRequest = createRpcRequest
                     ? createRpcRequest(...rawParams)
-                    : { methodName, params: rawParams };
+                    : { payload: createRpcMessage(methodName, rawParams) };
                 return createPendingRpcRequest(rpcConfig, newRequest);
             };
         },
@@ -73,11 +73,8 @@ function createPendingRpcRequest<TRpcMethods, TRpcTransport extends RpcTransport
 ): PendingRpcRequest<TResponse> {
     return {
         async send(options?: RpcSendOptions): Promise<TResponse> {
-            const { methodName, params, responseTransformer } = apiPlan;
-            const rawResponse = await rpcConfig.transport<TResponse>({
-                payload: createRpcMessage(methodName, params),
-                signal: options?.abortSignal,
-            });
+            const { payload, responseTransformer } = apiPlan;
+            const rawResponse = await rpcConfig.transport<TResponse>({ payload, signal: options?.abortSignal });
             return responseTransformer ? responseTransformer(rawResponse) : rawResponse;
         },
     };


### PR DESCRIPTION
This PR alters the boundaries of the RPC API layer by making the `RpcApiRequestPlan` return a `payload` of type `unknown` instead of `methodName` and `params`. This means, it is now the responsibility of the RPC API to crunch the request into a payload. The outer RPC layer now simply need to forward that `payload` to the RPC transport.