### PR TITLE
Rename `createRpcApi` to `createJsonRpcApi`

### DIFF
--- a/.changeset/warm-dolls-yell.md
+++ b/.changeset/warm-dolls-yell.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-spec': patch
+---
+
+Rename `createRpcApi` to `createJsonRpcApi`

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ const transport = createDefaultRpcTransport({ url: 'http:127.0.0.1:8899' });
 const rpc = createRpc({ api, transport });
 ```
 
-Note that the `createSolanaRpcApi` function is a wrapper on top of the `createRpcApi` function which adds some Solana-specific transformers such as setting a default commitment on all methods or throwing an error when an integer overflow is detected.
+Note that the `createSolanaRpcApi` function is a wrapper on top of the `createJsonRpcApi` function which adds some Solana-specific transformers such as setting a default commitment on all methods or throwing an error when an integer overflow is detected.
 
 #### Creating Your Own API Methods
 
@@ -393,7 +393,7 @@ type GetAssetApiResponse = Readonly<{
 type GetAssetApi = {
     // Define the method's name, parameters and response type
     getAsset(args: { id: Address }): GetAssetApiResponse;
-}
+};
 
 // Export the type spec for downstream users.
 export type MetaplexDASApi = GetAssetApi;
@@ -402,10 +402,10 @@ export type MetaplexDASApi = GetAssetApi;
 Here’s how a developer might use it:
 
 ```ts
-import { createDefaultRpcTransport, createRpc, createRpcApi } from '@solana/web3.js';
+import { createDefaultRpcTransport, createRpc, createJsonRpcApi } from '@solana/web3.js';
 
 // Create the custom API.
-const api = createRpcApi<MetaplexDASApi>();
+const api = createJsonRpcApi<MetaplexDASApi>();
 
 // Set up an HTTP transport to a server that supports the custom API.
 const transport = createDefaultRpcTransport({

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -1,4 +1,4 @@
-import { createRpcApi, RpcApi } from '@solana/rpc-spec';
+import { createJsonRpcApi, RpcApi } from '@solana/rpc-spec';
 import {
     AllowedNumericKeypaths,
     getDefaultRequestTransformerForSolanaRpc,
@@ -184,7 +184,7 @@ type Config = RequestTransformerConfig;
 export function createSolanaRpcApi<
     TRpcMethods extends SolanaRpcApi | SolanaRpcApiDevnet | SolanaRpcApiMainnet | SolanaRpcApiTestnet = SolanaRpcApi,
 >(config?: Config): RpcApi<TRpcMethods> {
-    return createRpcApi<TRpcMethods>({
+    return createJsonRpcApi<TRpcMethods>({
         requestTransformer: getDefaultRequestTransformerForSolanaRpc(config),
         responseTransformer: getDefaultResponseTransformerForSolanaRpc({
             allowedNumericKeyPaths: getAllowedNumericKeypaths(),

--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -101,7 +101,7 @@ A config object with the following properties:
 -   `api`: An instance of `RpcApi`
 -   `transport`: A function that implements the `RpcTransport` interface
 
-### `createRpcApi(config)`
+### `createJsonRpcApi(config)`
 
 Creates a JavaScript proxy that converts _any_ function call called on it to a `RpcApiRequestPlan` by:
 
@@ -110,7 +110,7 @@ Creates a JavaScript proxy that converts _any_ function call called on it to a `
 
 ```ts
 // For example, given this `RpcApi`:
-const rpcApi = createRpcApi({
+const rpcApi = createJsonRpcApi({
     requestTransformer: (...rawParams) => rawParams.reverse(),
     responseTransformer: response => response.result,
 });

--- a/packages/rpc-spec/src/__tests__/rpc-api-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-api-test.ts
@@ -1,16 +1,16 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
-import { createRpcApi } from '../rpc-api';
+import { createJsonRpcApi } from '../rpc-api';
 import { RpcRequest, RpcResponse } from '../rpc-shared';
 
 type DummyApi = {
     someMethod(...args: unknown[]): unknown;
 };
 
-describe('createRpcApi', () => {
+describe('createJsonRpcApi', () => {
     it('returns a plan containing the payload to send to the transport', () => {
         // Given a dummy API.
-        const api = createRpcApi<DummyApi>();
+        const api = createJsonRpcApi<DummyApi>();
 
         // When we call a method on the API.
         const plan = api.someMethod(1, 'two', { three: [4] });
@@ -23,7 +23,7 @@ describe('createRpcApi', () => {
     });
     it('applies the request transformer to the provided method name', () => {
         // Given a dummy API with a request transformer that appends 'Transformed' to the method name.
-        const api = createRpcApi<DummyApi>({
+        const api = createJsonRpcApi<DummyApi>({
             requestTransformer: (request: RpcRequest) => ({
                 ...request,
                 methodName: `${request.methodName}Transformed`,
@@ -38,7 +38,7 @@ describe('createRpcApi', () => {
     });
     it('applies the request transformer to the provided params', () => {
         // Given a dummy API with a request transformer that doubles the provided params.
-        const api = createRpcApi<DummyApi>({
+        const api = createJsonRpcApi<DummyApi>({
             requestTransformer: (request: RpcRequest) => ({
                 ...request,
                 params: (request.params as number[]).map(x => x * 2),
@@ -54,7 +54,7 @@ describe('createRpcApi', () => {
     it('includes the provided response transformer in the plan', () => {
         // Given a dummy API with a response transformer.
         const responseTransformer = <T>(response: RpcResponse) => response as RpcResponse<T>;
-        const api = createRpcApi<DummyApi>({ responseTransformer });
+        const api = createJsonRpcApi<DummyApi>({ responseTransformer });
 
         // When we call a method on the API.
         const plan = api.someMethod(1, 2, 3);
@@ -64,7 +64,7 @@ describe('createRpcApi', () => {
     });
     it('returns a frozen object', () => {
         // Given a dummy API.
-        const api = createRpcApi<DummyApi>();
+        const api = createJsonRpcApi<DummyApi>();
 
         // When we call a method on the API.
         const plan = api.someMethod();
@@ -74,7 +74,7 @@ describe('createRpcApi', () => {
     });
     it('also returns a frozen object with a request transformer', () => {
         // Given a dummy API with a request transformer.
-        const api = createRpcApi<DummyApi>({
+        const api = createJsonRpcApi<DummyApi>({
             requestTransformer: (request: RpcRequest) => ({ ...request, methodName: 'transformed' }),
         });
 

--- a/packages/rpc-spec/src/__typetests__/rpc-api-typetest.ts
+++ b/packages/rpc-spec/src/__typetests__/rpc-api-typetest.ts
@@ -1,4 +1,4 @@
-import { createRpcApi, RpcApi } from '../rpc-api';
+import { createJsonRpcApi, RpcApi } from '../rpc-api';
 
 type NftCollectionDetailsApiResponse = Readonly<{
     address: string;
@@ -18,4 +18,4 @@ type NftCollectionDetailsApi = {
 
 type QuickNodeRpcMethods = NftCollectionDetailsApi;
 
-createRpcApi<QuickNodeRpcMethods>() satisfies RpcApi<QuickNodeRpcMethods>;
+createJsonRpcApi<QuickNodeRpcMethods>() satisfies RpcApi<QuickNodeRpcMethods>;

--- a/packages/rpc-spec/src/__typetests__/rpc-typetest.ts
+++ b/packages/rpc-spec/src/__typetests__/rpc-typetest.ts
@@ -1,5 +1,5 @@
 import { createRpc, Rpc } from '../rpc';
-import { createRpcApi } from '../rpc-api';
+import { createJsonRpcApi } from '../rpc-api';
 import { RpcTransport } from '../rpc-transport';
 
 type MyApiMethods = {
@@ -7,7 +7,7 @@ type MyApiMethods = {
     foo(): number;
 };
 
-const api = createRpcApi<MyApiMethods>();
+const api = createJsonRpcApi<MyApiMethods>();
 const transport = null as unknown as RpcTransport;
 
 createRpc({ api, transport }) satisfies Rpc<MyApiMethods>;

--- a/packages/rpc-spec/src/rpc-api.ts
+++ b/packages/rpc-spec/src/rpc-api.ts
@@ -26,7 +26,7 @@ interface RpcApiMethods {
     [methodName: string]: RpcApiMethod;
 }
 
-export function createRpcApi<TRpcMethods extends RpcApiMethods>(config?: RpcApiConfig): RpcApi<TRpcMethods> {
+export function createJsonRpcApi<TRpcMethods extends RpcApiMethods>(config?: RpcApiConfig): RpcApi<TRpcMethods> {
     return new Proxy({} as RpcApi<TRpcMethods>, {
         defineProperty() {
             return false;


### PR DESCRIPTION
This PR renames `createRpcApi` to `createJsonRpcApi` since this function is now responsible for converting the `RpcRequest` into a `payload` compatible with the JSON RPC v2 spec.