### PR TITLE
chore: update `blockTime` doc

### DIFF
--- a/packages/rpc-api/src/getBlock.ts
+++ b/packages/rpc-api/src/getBlock.ts
@@ -19,7 +19,7 @@ import type { TransactionVersion } from '@solana/transaction-messages';
 type GetBlockApiResponseBase = Readonly<{
     /** The number of blocks beneath this block */
     blockHeight: U64UnsafeBeyond2Pow53Minus1;
-    /** The number of blocks beneath this block */
+    /** Estimated production time, as Unix timestamp */
     blockTime: UnixTimestampUnsafeBeyond2Pow53Minus1;
     /** the blockhash of this block */
     blockhash: Blockhash;

--- a/packages/rpc-subscriptions-api/src/block-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/block-notifications.ts
@@ -31,7 +31,7 @@ type BlockNotificationsNotificationBase = Readonly<{
 type BlockNotificationsNotificationBlock = Readonly<{
     /** The number of blocks beneath this block */
     blockHeight: U64UnsafeBeyond2Pow53Minus1;
-    /** The number of blocks beneath this block */
+    /** Estimated production time, as Unix timestamp */
     blockTime: UnixTimestampUnsafeBeyond2Pow53Minus1;
     /** the blockhash of this block */
     blockhash: Blockhash;


### PR DESCRIPTION
#### Problem
The documentation for `blockTime` is a duplicate of `blockHeight`.

#### Summary of Changes
Change it to the correct documentation from the [RPC docs](https://solana.com/docs/rpc/http/getblock).

Closes #3228