### PR TITLE
Update `isAddress` to not throw

### DIFF
--- a/packages/addresses/src/__tests__/address-test.ts
+++ b/packages/addresses/src/__tests__/address-test.ts
@@ -48,7 +48,7 @@ describe('Address', () => {
                 }).not.toThrow();
             });
             it('returns false when supplied a non-base58 string', () => {
-                expect(isAddress('not-a-base-58-encoded-string')).toEqual(false);
+                expect(isAddress('not-a-base-58-encoded-string')).toBe(false);
             });
             it('returns false when the decoded byte array has a length other than 32 bytes', () => {
                 expect(
@@ -56,10 +56,10 @@ describe('Address', () => {
                         // 31 bytes [128, ..., 128]
                         '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM',
                     ),
-                ).toEqual(false);
+                ).toBe(false);
             });
             it('returns true when supplied a base-58 encoded address', () => {
-                expect(isAddress('11111111111111111111111111111111')).toEqual(true);
+                expect(isAddress('11111111111111111111111111111111')).toBe(true);
             });
         });
         describe('using a mock base58 implementation', () => {

--- a/packages/addresses/src/__tests__/address-test.ts
+++ b/packages/addresses/src/__tests__/address-test.ts
@@ -44,20 +44,22 @@ describe('Address', () => {
             });
             it('does not throw when supplied a non-base58 address', () => {
                 expect(() => {
-                    isAddress('not-a-base-58-encoded-string')
+                    isAddress('not-a-base-58-encoded-string');
                 }).not.toThrow();
             });
             it('returns false when supplied a non-base58 string', () => {
                 expect(isAddress('not-a-base-58-encoded-string')).toEqual(false);
             });
             it('returns false when the decoded byte array has a length other than 32 bytes', () => {
-                expect(isAddress(
-                    // 31 bytes [128, ..., 128]
-                    '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM',
-                )).toEqual(false)
+                expect(
+                    isAddress(
+                        // 31 bytes [128, ..., 128]
+                        '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM',
+                    ),
+                ).toEqual(false);
             });
             it('returns true when supplied a base-58 encoded address', () => {
-                expect(isAddress('11111111111111111111111111111111')).toEqual(true)
+                expect(isAddress('11111111111111111111111111111111')).toEqual(true);
             });
         });
         describe('using a mock base58 implementation', () => {
@@ -75,7 +77,7 @@ describe('Address', () => {
                     try {
                         isAddress('1'.repeat(len));
                         // eslint-disable-next-line no-empty
-                    } catch { }
+                    } catch {}
                     expect(mockEncode).toHaveBeenCalled();
                 });
             });
@@ -86,7 +88,7 @@ describe('Address', () => {
                         '1111111111111111111111111111111', // 31 characters
                     );
                     // eslint-disable-next-line no-empty
-                } catch { }
+                } catch {}
                 expect(mockEncode).not.toHaveBeenCalled();
             });
             it('does not attempt to decode too-long input strings', () => {
@@ -96,18 +98,18 @@ describe('Address', () => {
                         '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG', // 45 characters
                     );
                     // eslint-disable-next-line no-empty
-                } catch { }
+                } catch {}
                 expect(mockEncode).not.toHaveBeenCalled();
             });
             it('memoizes getBase58Encoder when called multiple times', () => {
                 try {
                     isAddress('1'.repeat(32));
                     // eslint-disable-next-line no-empty
-                } catch { }
+                } catch {}
                 try {
                     isAddress('1'.repeat(32));
                     // eslint-disable-next-line no-empty
-                } catch { }
+                } catch {}
                 expect(jest.mocked(getBase58Encoder)).toHaveBeenCalledTimes(1);
             });
         });
@@ -176,7 +178,7 @@ describe('Address', () => {
                     try {
                         assertIsAddress('1'.repeat(len));
                         // eslint-disable-next-line no-empty
-                    } catch { }
+                    } catch {}
                     expect(mockEncode).toHaveBeenCalled();
                 });
             });
@@ -187,7 +189,7 @@ describe('Address', () => {
                         '1111111111111111111111111111111', // 31 characters
                     );
                     // eslint-disable-next-line no-empty
-                } catch { }
+                } catch {}
                 expect(mockEncode).not.toHaveBeenCalled();
             });
             it('does not attempt to decode too-long input strings', () => {
@@ -197,18 +199,18 @@ describe('Address', () => {
                         '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG', // 45 characters
                     );
                     // eslint-disable-next-line no-empty
-                } catch { }
+                } catch {}
                 expect(mockEncode).not.toHaveBeenCalled();
             });
             it('memoizes getBase58Encoder when called multiple times', () => {
                 try {
                     assertIsAddress('1'.repeat(32));
                     // eslint-disable-next-line no-empty
-                } catch { }
+                } catch {}
                 try {
                     assertIsAddress('1'.repeat(32));
                     // eslint-disable-next-line no-empty
-                } catch { }
+                } catch {}
                 expect(jest.mocked(getBase58Encoder)).toHaveBeenCalledTimes(1);
             });
         });

--- a/packages/addresses/src/__tests__/address-test.ts
+++ b/packages/addresses/src/__tests__/address-test.ts
@@ -24,6 +24,95 @@ const originalGetBase58Encoder = originalBase58Module.getBase58Encoder();
 const originalGetBase58Decoder = originalBase58Module.getBase58Decoder();
 
 describe('Address', () => {
+    describe('isAddress()', () => {
+        let isAddress: typeof import('../address').isAddress;
+        // Reload `isAddress` before each test to reset memoized state
+        beforeEach(async () => {
+            await jest.isolateModulesAsync(async () => {
+                const base58ModulePromise =
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    import('../address');
+                isAddress = (await base58ModulePromise).isAddress;
+            });
+        });
+
+        describe('using the real base58 implementation', () => {
+            beforeEach(() => {
+                // use real implementation
+                jest.mocked(getBase58Encoder).mockReturnValue(originalGetBase58Encoder);
+            });
+            it('does not throw when supplied a non-base58 address', () => {
+                expect(() => {
+                    isAddress('not-a-base-58-encoded-string')
+                }).not.toThrow();
+            });
+            it('returns false when supplied a non-base58 string', () => {
+                expect(isAddress('not-a-base-58-encoded-string')).toEqual(false);
+            });
+            it('returns false when the decoded byte array has a length other than 32 bytes', () => {
+                expect(isAddress(
+                    // 31 bytes [128, ..., 128]
+                    '2xea9jWJ9eca3dFiefTeSPP85c6qXqunCqL2h2JNffM',
+                )).toEqual(false)
+            });
+            it('returns true when supplied a base-58 encoded address', () => {
+                expect(isAddress('11111111111111111111111111111111')).toEqual(true)
+            });
+        });
+        describe('using a mock base58 implementation', () => {
+            const mockEncode = jest.fn();
+            beforeEach(() => {
+                // use mock implementation
+                mockEncode.mockClear();
+                jest.mocked(getBase58Encoder).mockReturnValue({
+                    encode: mockEncode,
+                } as unknown as VariableSizeEncoder<string>);
+            });
+
+            [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44].forEach(len => {
+                it(`attempts to encode input strings of exactly ${len} characters`, () => {
+                    try {
+                        isAddress('1'.repeat(len));
+                        // eslint-disable-next-line no-empty
+                    } catch { }
+                    expect(mockEncode).toHaveBeenCalled();
+                });
+            });
+            it('does not attempt to decode too-short input strings', () => {
+                try {
+                    isAddress(
+                        // 31 bytes [0, ..., 0]
+                        '1111111111111111111111111111111', // 31 characters
+                    );
+                    // eslint-disable-next-line no-empty
+                } catch { }
+                expect(mockEncode).not.toHaveBeenCalled();
+            });
+            it('does not attempt to decode too-long input strings', () => {
+                try {
+                    isAddress(
+                        // 33 bytes [0, 255, ..., 255]
+                        '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG', // 45 characters
+                    );
+                    // eslint-disable-next-line no-empty
+                } catch { }
+                expect(mockEncode).not.toHaveBeenCalled();
+            });
+            it('memoizes getBase58Encoder when called multiple times', () => {
+                try {
+                    isAddress('1'.repeat(32));
+                    // eslint-disable-next-line no-empty
+                } catch { }
+                try {
+                    isAddress('1'.repeat(32));
+                    // eslint-disable-next-line no-empty
+                } catch { }
+                expect(jest.mocked(getBase58Encoder)).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+
     describe('assertIsAddress()', () => {
         let assertIsAddress: typeof import('../address').assertIsAddress;
         // Reload `assertIsAddress` before each test to reset memoized state
@@ -87,7 +176,7 @@ describe('Address', () => {
                     try {
                         assertIsAddress('1'.repeat(len));
                         // eslint-disable-next-line no-empty
-                    } catch {}
+                    } catch { }
                     expect(mockEncode).toHaveBeenCalled();
                 });
             });
@@ -98,7 +187,7 @@ describe('Address', () => {
                         '1111111111111111111111111111111', // 31 characters
                     );
                     // eslint-disable-next-line no-empty
-                } catch {}
+                } catch { }
                 expect(mockEncode).not.toHaveBeenCalled();
             });
             it('does not attempt to decode too-long input strings', () => {
@@ -108,18 +197,18 @@ describe('Address', () => {
                         '1JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG', // 45 characters
                     );
                     // eslint-disable-next-line no-empty
-                } catch {}
+                } catch { }
                 expect(mockEncode).not.toHaveBeenCalled();
             });
             it('memoizes getBase58Encoder when called multiple times', () => {
                 try {
                     assertIsAddress('1'.repeat(32));
                     // eslint-disable-next-line no-empty
-                } catch {}
+                } catch { }
                 try {
                     assertIsAddress('1'.repeat(32));
                     // eslint-disable-next-line no-empty
-                } catch {}
+                } catch { }
                 expect(jest.mocked(getBase58Encoder)).toHaveBeenCalledTimes(1);
             });
         });

--- a/packages/addresses/src/address.ts
+++ b/packages/addresses/src/address.ts
@@ -46,14 +46,10 @@ export function isAddress(putativeAddress: string): putativeAddress is Address<t
     // Slow-path; actually attempt to decode the input string.
     const base58Encoder = getMemoizedBase58Encoder();
     try {
-        const bytes = base58Encoder.encode(putativeAddress);
-        const numBytes = bytes.byteLength;
-        if (numBytes !== 32) {
-            return false;
-        }
-        return true;
-    } catch (e) {
-        return false
+        return base58Encoder.encode(putativeAddress).byteLength === 32;
+    } catch {
+        return false;
+    }
     }
 }
 

--- a/packages/addresses/src/address.ts
+++ b/packages/addresses/src/address.ts
@@ -45,12 +45,16 @@ export function isAddress(putativeAddress: string): putativeAddress is Address<t
     }
     // Slow-path; actually attempt to decode the input string.
     const base58Encoder = getMemoizedBase58Encoder();
-    const bytes = base58Encoder.encode(putativeAddress);
-    const numBytes = bytes.byteLength;
-    if (numBytes !== 32) {
-        return false;
+    try {
+        const bytes = base58Encoder.encode(putativeAddress);
+        const numBytes = bytes.byteLength;
+        if (numBytes !== 32) {
+            return false;
+        }
+        return true;
+    } catch (e) {
+        return false
     }
-    return true;
 }
 
 export function assertIsAddress(putativeAddress: string): asserts putativeAddress is Address<typeof putativeAddress> {

--- a/packages/addresses/src/address.ts
+++ b/packages/addresses/src/address.ts
@@ -50,7 +50,6 @@ export function isAddress(putativeAddress: string): putativeAddress is Address<t
     } catch {
         return false;
     }
-    }
 }
 
 export function assertIsAddress(putativeAddress: string): asserts putativeAddress is Address<typeof putativeAddress> {


### PR DESCRIPTION
When supplied with a non-base58 encoded string the function would unexpectedly throw. 

This PR updates it to return `false` instead and adds similar tests as `assertIsAddress`