### PR TITLE
A channel augmenter that autopings the channel

### DIFF
--- a/packages/rpc-subscriptions/README.md
+++ b/packages/rpc-subscriptions/README.md
@@ -31,3 +31,7 @@ Given a channel creator, will return a new channel creator with the following be
 ### `getRpcSubscriptionsChannelWithJSONSerialization(channel)`
 
 Given an `RpcSubscriptionsChannel`, will return a new channel that parses data published to the `'message'` channel as JSON, and JSON-stringifies messages sent via the `send(message)` method.
+
+### `getRpcSubscriptionsChannelWithAutoping(channel)`
+
+Given an `RpcSubscriptionsChannel`, will return a new channel that sends a ping message to the inner channel if a message has not been sent or received in the last `intervalMs`. In web browsers, this implementation sends no ping when the network is down, and sends a ping immediately upon the network coming back up.


### PR DESCRIPTION
# Summary

RPC web socket channels will go down if there hasn't been any chatter over the wire in a while. This higher-order function wraps a channel, and sends a ping message if there has been no activity in `intervalMs`.
