### PR TITLE
The default RPC transport now requests wire compression in Node

### DIFF
--- a/.changeset/six-olives-hang.md
+++ b/.changeset/six-olives-hang.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc': patch
+---
+
+Enabled Brotli, gzip, and Deflate compression by default when running in Node.js, where compression headers are not added by the runtime like they are in browsers

--- a/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
@@ -17,7 +17,6 @@ describe('assertIsAllowedHttpRequestHeader', () => {
         'Accept-charset',
         'accept-charset',
         'ACCEPT-CHARSET',
-        'Accept-Encoding',
         'Access-Control-Request-Headers',
         'Access-Control-Request-Method',
         'Connection',
@@ -54,6 +53,17 @@ describe('assertIsAllowedHttpRequestHeader', () => {
             );
         });
     });
+    if (!__NODEJS__) {
+        it('throws when called with the `Accept-Encoding` header', () => {
+            expect(() => {
+                assertIsAllowedHttpRequestHeaders({ 'Accept-Encoding': 'zstd' });
+            }).toThrow(
+                new SolanaError(SOLANA_ERROR__RPC__TRANSPORT_HTTP_HEADER_FORBIDDEN, {
+                    headers: ['Accept-Encoding'],
+                }),
+            );
+        });
+    }
     ['Authorization', 'Content-Language', 'Solana-Client'].forEach(allowedHeader => {
         it('does not throw when called with the header `' + allowedHeader + '`', () => {
             expect(() => {

--- a/packages/rpc-transport-http/src/http-transport-headers.ts
+++ b/packages/rpc-transport-http/src/http-transport-headers.ts
@@ -18,7 +18,13 @@ export type AllowedHttpRequestHeaders = Readonly<
 type DisallowedHeaders = 'Accept' | 'Content-Length' | 'Content-Type' | 'Solana-Client';
 type ForbiddenHeaders =
     | 'Accept-Charset'
-    | 'Accept-Encoding'
+    /**
+     * Though technically forbidden in non-Node environments, we don't have a way to target
+     * TypeScript types depending on which platform you are authoring for. `Accept-Encoding` is
+     * therefore omitted from the forbidden headers type, but is still a runtime error in dev mode
+     * when supplied in a non-Node context.
+     */
+    // | 'Accept-Encoding'
     | 'Access-Control-Request-Headers'
     | 'Access-Control-Request-Method'
     | 'Connection'
@@ -47,31 +53,33 @@ const DISALLOWED_HEADERS: Record<string, boolean> = {
     'content-type': true,
 };
 // https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
-const FORBIDDEN_HEADERS: Record<string, boolean> = {
-    'accept-charset': true,
-    'accept-encoding': true,
-    'access-control-request-headers': true,
-    'access-control-request-method': true,
-    connection: true,
-    'content-length': true,
-    cookie: true,
-    date: true,
-    dnt: true,
-    expect: true,
-    host: true,
-    'keep-alive': true,
-    origin: true,
-    'permissions-policy': true,
-    // Prefix matching is implemented in code, below.
-    // 'proxy-': true,
-    // 'sec-': true,
-    referer: true,
-    te: true,
-    trailer: true,
-    'transfer-encoding': true,
-    upgrade: true,
-    via: true,
-};
+const FORBIDDEN_HEADERS: Record<string, boolean> = /* @__PURE__ */ Object.assign(
+    {
+        'accept-charset': true,
+        'access-control-request-headers': true,
+        'access-control-request-method': true,
+        connection: true,
+        'content-length': true,
+        cookie: true,
+        date: true,
+        dnt: true,
+        expect: true,
+        host: true,
+        'keep-alive': true,
+        origin: true,
+        'permissions-policy': true,
+        // Prefix matching is implemented in code, below.
+        // 'proxy-': true,
+        // 'sec-': true,
+        referer: true,
+        te: true,
+        trailer: true,
+        'transfer-encoding': true,
+        upgrade: true,
+        via: true,
+    },
+    __NODEJS__ ? undefined : { 'accept-encoding': true },
+);
 
 export function assertIsAllowedHttpRequestHeaders(
     headers: Record<string, string>,

--- a/packages/rpc/src/__tests__/rpc-transport-header-config-test.ts
+++ b/packages/rpc/src/__tests__/rpc-transport-header-config-test.ts
@@ -5,6 +5,31 @@ import { createDefaultRpcTransport } from '../rpc-transport';
 jest.mock('@solana/rpc-transport-http');
 
 describe('createDefaultRpcTransport', () => {
+    if (__NODEJS__) {
+        it('adds default compression headers', () => {
+            createDefaultRpcTransport({ url: 'fake://url' });
+            expect(createHttpTransportForSolanaRpc).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'accept-encoding': 'br,gzip,deflate',
+                    }),
+                }),
+            );
+        });
+        it('allows the override of the default compression headers', () => {
+            createDefaultRpcTransport({
+                headers: { 'aCcEpT-eNcOdInG': 'zstd' },
+                url: 'fake://url',
+            });
+            expect(createHttpTransportForSolanaRpc).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'accept-encoding': 'zstd',
+                    }),
+                }),
+            );
+        });
+    }
     it('adds configured headers to each request with downcased property names', () => {
         createDefaultRpcTransport({
             headers: { aUtHoRiZaTiOn: 'Picard, 4 7 Alpha Tango' },

--- a/packages/rpc/src/rpc-transport.ts
+++ b/packages/rpc/src/rpc-transport.ts
@@ -31,6 +31,13 @@ export function createDefaultRpcTransport<TClusterUrl extends ClusterUrl>(
         createHttpTransportForSolanaRpc({
             ...config,
             headers: {
+                ...(__NODEJS__ &&
+                    ({
+                        // Keep these headers lowercase so they will be overriden by any user-supplied headers below.
+                        'accept-encoding':
+                            // Natively supported by Node LTS v20.18.0 and above.
+                            'br,gzip,deflate', // Brotli, gzip, and Deflate, in that order.
+                    } as { [overrideHeader: string]: string })),
                 ...(config.headers ? normalizeHeaders(config.headers) : undefined),
                 ...({
                     // Keep these headers lowercase so they will override any user-supplied headers above.


### PR DESCRIPTION
# Summary

The `fetch` API in browsers automatically requests the wire compression encoding that the browser supports, in the order it wants it. Node's `fetch` API does not.

In this PR we add all of the default algorithms supported by Node LTS at the time of writing.

Closes #3338.

# Test Plan

1. Install Node LTS (`n lts`)
2. Test that it actually supports these

```
> await (await fetch('https://httpbin.org/deflate', {headers:{'Accept-Encoding': 'deflate', 'Content-Type': 'application/json'}})).json()
{
  deflated: true,
  headers: {
    Accept: '*/*',
    'Accept-Encoding': 'deflate',
    'Accept-Language': '*',
    'Content-Type': 'application/json',
    Host: 'httpbin.org',
    'Sec-Fetch-Mode': 'cors',
    'User-Agent': 'node',
    'X-Amzn-Trace-Id': 'Root=1-67020914-22d36c347b3b8b0f356d9a98'
  },
  method: 'GET',
  origin: '145.40.88.235'
}
> await (await fetch('https://httpbin.org/gzip', {headers:{'Accept-Encoding': 'gzip', 'Content-Type': 'application/json'}})).json()
{
  gzipped: true,
  headers: {
    Accept: '*/*',
    'Accept-Encoding': 'gzip',
    'Accept-Language': '*',
    'Content-Type': 'application/json',
    Host: 'httpbin.org',
    'Sec-Fetch-Mode': 'cors',
    'User-Agent': 'node',
    'X-Amzn-Trace-Id': 'Root=1-67020916-28ed8e6b0b8c612f3be0f76f'
  },
  method: 'GET',
  origin: '145.40.88.235'
}
> await (await fetch('https://httpbin.org/brotli', {headers:{'Accept-Encoding': 'br', 'Content-Type': 'application/json'}})).json()
{
  brotli: true,
  headers: {
    Accept: '*/*',
    'Accept-Encoding': 'br',
    'Accept-Language': '*',
    'Content-Type': 'application/json',
    Host: 'httpbin.org',
    'Sec-Fetch-Mode': 'cors',
    'User-Agent': 'node',
    'X-Amzn-Trace-Id': 'Root=1-6702091a-1a5970103512353b1eafdfcf'
  },
  method: 'GET',
  origin: '145.40.88.235'
}
```
