### PR TITLE
Repair benchmarks

### DIFF
--- a/packages/build-scripts/package.json
+++ b/packages/build-scripts/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.0",
     "private": true,
     "files": [
+        "register-node-globals.mjs",
         "tsup.config.library.ts",
         "tsup.config.package.ts"
     ],

--- a/packages/build-scripts/register-node-globals.cjs
+++ b/packages/build-scripts/register-node-globals.cjs
@@ -1,0 +1,4 @@
+globalThis.__DEV__ = false;
+globalThis.__BROWSER = false;
+globalThis.__NODEJS__ = true;
+globalThis.__REACTNATIVE__ = false;

--- a/packages/codecs-core/src/__benchmarks__/run.ts
+++ b/packages/codecs-core/src/__benchmarks__/run.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pnpm dlx tsx
+#!/usr/bin/env -S pnpm dlx tsx -r ../build-scripts/register-node-globals.cjs
 
 import { webcrypto as crypto } from 'node:crypto';
 

--- a/packages/codecs-strings/src/__benchmarks__/run.ts
+++ b/packages/codecs-strings/src/__benchmarks__/run.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pnpm dlx tsx
+#!/usr/bin/env -S pnpm dlx tsx -r ../build-scripts/register-node-globals.cjs
 
 import { webcrypto as crypto } from 'node:crypto';
 

--- a/packages/fetch-impl/src/__benchmarks__/run.ts
+++ b/packages/fetch-impl/src/__benchmarks__/run.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pnpm dlx tsx
+#!/usr/bin/env -S pnpm dlx tsx -r ../build-scripts/register-node-globals.cjs
 
 import { ok } from 'node:assert';
 import process from 'node:process';

--- a/packages/keys/src/__benchmarks__/run.ts
+++ b/packages/keys/src/__benchmarks__/run.ts
@@ -1,15 +1,8 @@
-#!/usr/bin/env -S pnpm dlx tsx --
+#!/usr/bin/env -S pnpm dlx tsx -r ../build-scripts/register-node-globals.cjs
 
 import { Bench } from 'tinybench';
 
 import { generateKeyPair, SignatureBytes, signBytes, verifySignature } from '../index';
-
-Object.assign(globalThis, {
-    __BROWSER__: false,
-    __DEV__: false,
-    __NODEJS__: true,
-    __REACTNATIVE____: false,
-});
 
 const bench = new Bench({
     throws: true,

--- a/packages/rpc-transport-http/src/__benchmarks__/run.ts
+++ b/packages/rpc-transport-http/src/__benchmarks__/run.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pnpm dlx tsx --
+#!/usr/bin/env -S pnpm dlx tsx -r ../build-scripts/register-node-globals.cjs
 
 import { ok } from 'node:assert';
 
@@ -14,13 +14,6 @@ ok(
     'You must supply the URL of a rate-limit-free Solana JSON-RPC server as the first argument to this script',
 );
 VALIDATOR_URL ??= 'http://127.0.0.1:8899';
-
-Object.assign(globalThis, {
-    __BROWSER__: false,
-    __DEV__: false,
-    __NODEJS__: true,
-    __REACTNATIVE____: false,
-});
 
 const NUM_CONCURRENT_REQUESTS = 1024;
 


### PR DESCRIPTION
# Summary

Because we moved a build-time contstant to the top level in #3340, we can no longer run these scripts without replacing the build time constants. That means that running this with `tsx` will yield a `__NODEJS__ is not defined` error.

In this PR, we change the benchmarks to run on the built source, and teach Turborepo to build it beforehand. You now run benchmarks with `pnpm turbo benchmark`.
