### PR TITLE
Prevent false blockheight exceedence errors when transaction confirmations are aborted

### DIFF
--- a/.changeset/forty-bananas-bow.md
+++ b/.changeset/forty-bananas-bow.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-confirmation': patch
+---
+
+Fixed a bug that could result in the transaction confirmer claiming that the blockheight had been exceeded, when the fact of the matter was that the confirmation was aborted by an `AbortSignal`

--- a/packages/transaction-confirmation/src/confirmation-strategy-blockheight.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-blockheight.ts
@@ -36,7 +36,8 @@ export function createBlockHeightExceedencePromiseFactory<
         abortSignal: callerAbortSignal,
         commitment,
         lastValidBlockHeight,
-    }) {
+    }): Promise<never> {
+        callerAbortSignal.throwIfAborted();
         const abortController = new AbortController();
         const handleAbort = () => {
             abortController.abort();
@@ -57,6 +58,7 @@ export function createBlockHeightExceedencePromiseFactory<
                     rpcSubscriptions.slotNotifications().subscribe({ abortSignal: abortController.signal }),
                     getBlockHeightAndDifferenceBetweenSlotHeightAndBlockHeight(),
                 ]);
+            callerAbortSignal.throwIfAborted();
             let currentBlockHeight = initialBlockHeight;
             if (currentBlockHeight <= lastValidBlockHeight) {
                 let lastKnownDifferenceBetweenSlotHeightAndBlockHeight = differenceBetweenSlotHeightAndBlockHeight;
@@ -83,6 +85,7 @@ export function createBlockHeightExceedencePromiseFactory<
                     }
                 }
             }
+            callerAbortSignal.throwIfAborted();
             throw new SolanaError(SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED, {
                 currentBlockHeight,
                 lastValidBlockHeight,


### PR DESCRIPTION
# Summary

I noticed that my application was getting blockheight exceedence errors when there definitely was not one. Turns out the reason was because my application was aborting the confirmation, which would cause all of this code to fall through to the `BLOCKHEIGHT_EXCEEDENCE` exception.

This PR introduces a throw of the abort after every `await`. After this change, this existing text becomes consequential:

https://github.com/solana-labs/solana-web3.js/blob/e9d137651792172e16548ec9e8bbd6824c9e7189/packages/transaction-confirmation/src/__tests__/waiters-test.ts#L146-L157
