### PR TITLE
Update `@solana/eslint-config-solana` and repair all the unresolved promise lint errors

### DIFF
--- a/.changeset/olive-shrimps-lick.md
+++ b/.changeset/olive-shrimps-lick.md
@@ -1,0 +1,5 @@
+---
+'@solana/assertions': patch
+---
+
+Fixed a bug where calls to `isEd25519CurveSupported()` might have resulted in uncaught rejections bubbling up through the app, in cases where Ed25519 is not supported

--- a/examples/react-app/src/components/SolanaSignAndSendTransactionFeaturePanel.tsx
+++ b/examples/react-app/src/components/SolanaSignAndSendTransactionFeaturePanel.tsx
@@ -92,8 +92,8 @@ export function SolanaSignAndSendTransactionFeaturePanel({ account }: Props) {
                         );
                         assertIsTransactionMessageWithSingleSendingSigner(message);
                         const signature = await signAndSendTransactionMessageWithSigners(message);
-                        mutate({ address: transactionSendingSigner.address, chain: currentChain });
-                        mutate({ address: recipientAccount.address, chain: currentChain });
+                        void mutate({ address: transactionSendingSigner.address, chain: currentChain });
+                        void mutate({ address: recipientAccount.address, chain: currentChain });
                         setLastSignature(signature);
                         setSolQuantityString('');
                     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.9",
         "@solana/build-scripts": "workspace:*",
-        "@solana/eslint-config-solana": "^3.0.5",
+        "@solana/eslint-config-solana": "^3.0.6",
         "@solana/prettier-config-solana": "0.0.5",
         "@solana/test-config": "workspace:*",
         "@solana/test-matchers": "workspace:*",

--- a/packages/accounts/src/__typetests__/fetch-account-typetest.ts
+++ b/packages/accounts/src/__typetests__/fetch-account-typetest.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
 import type { Address } from '@solana/addresses';
 import type { Rpc } from '@solana/rpc-spec';
 

--- a/packages/assertions/src/subtle-crypto.ts
+++ b/packages/assertions/src/subtle-crypto.ts
@@ -21,11 +21,11 @@ async function isEd25519CurveSupported(subtle: SubtleCrypto): Promise<boolean> {
         cachedEd25519Decision = new Promise(resolve => {
             subtle
                 .generateKey('Ed25519', /* extractable */ false, ['sign', 'verify'])
-                .catch(() => {
-                    resolve((cachedEd25519Decision = false));
-                })
                 .then(() => {
                     resolve((cachedEd25519Decision = true));
+                })
+                .catch(() => {
+                    resolve((cachedEd25519Decision = false));
                 });
         });
     }

--- a/packages/codecs-core/src/__benchmarks__/run.ts
+++ b/packages/codecs-core/src/__benchmarks__/run.ts
@@ -46,7 +46,7 @@ bench
         { beforeEach: randomizeBytes },
     );
 
-(async () => {
+void (async () => {
     await bench.warmup();
     await bench.run();
 

--- a/packages/codecs-strings/src/__benchmarks__/run.ts
+++ b/packages/codecs-strings/src/__benchmarks__/run.ts
@@ -55,7 +55,7 @@ bench
         },
     );
 
-(async () => {
+void (async () => {
     await bench.warmup();
     await bench.run();
 

--- a/packages/fetch-impl/src/__benchmarks__/run.ts
+++ b/packages/fetch-impl/src/__benchmarks__/run.ts
@@ -90,7 +90,7 @@ bench
         beforeEach: createDispatcher.bind(null, { connections: 64, pipelining: 2 }),
     });
 
-(async () => {
+void (async () => {
     await bench.run();
 
     console.table(bench.table());

--- a/packages/keys/src/__benchmarks__/run.ts
+++ b/packages/keys/src/__benchmarks__/run.ts
@@ -40,7 +40,7 @@ bench
         },
     });
 
-(async () => {
+void (async () => {
     await bench.run();
     console.table(bench.table());
 })();

--- a/packages/keys/src/__typetests__/key-pair-typetests.ts
+++ b/packages/keys/src/__typetests__/key-pair-typetests.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 
 import { createKeyPairFromBytes, createKeyPairFromPrivateKeyBytes } from '../key-pair';

--- a/packages/keys/src/__typetests__/private-key-typetests.ts
+++ b/packages/keys/src/__typetests__/private-key-typetests.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 
 import { createPrivateKeyFromBytes } from '../private-key';

--- a/packages/keys/src/__typetests__/public-key-typetests.ts
+++ b/packages/keys/src/__typetests__/public-key-typetests.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { getPublicKeyFromPrivateKey } from '../public-key';
 
 getPublicKeyFromPrivateKey(new CryptoKey()) satisfies Promise<CryptoKey>;

--- a/packages/library/src/__tests__/airdrop-internal-test.ts
+++ b/packages/library/src/__tests__/airdrop-internal-test.ts
@@ -33,7 +33,7 @@ describe('requestAndConfirmAirdrop', () => {
             lamports: lamports(1n),
             recipientAddress: '123' as Address,
             rpc,
-        });
+        }).catch(() => {});
         expect(sendAirdropRequest).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: false }),
         });
@@ -53,7 +53,7 @@ describe('requestAndConfirmAirdrop', () => {
             lamports: lamports(1n),
             recipientAddress: '123' as Address,
             rpc,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(confirmSignatureOnlyTransaction).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -76,7 +76,7 @@ describe('requestAndConfirmAirdrop', () => {
             lamports: lamports(1n),
             recipientAddress: '123' as Address,
             rpc,
-        });
+        }).catch(() => {});
         expect(requestAirdrop).toHaveBeenCalledWith('123', 1n, { commitment: 'finalized' });
     });
     it('passes the expected input to the transaction confirmer', async () => {
@@ -89,7 +89,7 @@ describe('requestAndConfirmAirdrop', () => {
             lamports: lamports(1n),
             recipientAddress: '123' as Address,
             rpc,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(confirmSignatureOnlyTransaction).toHaveBeenCalledWith({
             abortSignal: expect.any(AbortSignal),

--- a/packages/library/src/__tests__/compute-limit-internal-test.ts
+++ b/packages/library/src/__tests__/compute-limit-internal-test.ts
@@ -47,7 +47,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
                 ...mockTransactionMessage,
                 lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME_CONSTRAINT,
             },
-        });
+        }).catch(() => {});
         expect(sendSimulateTransactionRequest).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: false }),
         });
@@ -66,7 +66,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
             minContextSlot: 42n,
             rpc,
             transactionMessage,
-        });
+        }).catch(() => {});
         expect(simulateTransaction).toHaveBeenCalledWith(
             expect.any(String),
             expect.objectContaining({
@@ -99,7 +99,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
             getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT({
                 rpc,
                 transactionMessage,
-            });
+            }).catch(() => {});
             expect(compileTransaction).toHaveBeenCalledWith({
                 ...transactionMessage,
                 instructions: [
@@ -152,7 +152,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
             getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT({
                 rpc,
                 transactionMessage,
-            });
+            }).catch(() => {});
             expect(compileTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
                     instructions: [
@@ -196,7 +196,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
                     nonce: 'BzAqD6382v5r1pcELoi8HWrBDV4dSL9NGemMn2JYAhxc' as Nonce,
                 },
             },
-        });
+        }).catch(() => {});
         expect(simulateTransaction).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({ replaceRecentBlockhash: false }),
@@ -209,7 +209,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
                 ...mockTransactionMessage,
                 lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME_CONSTRAINT,
             },
-        });
+        }).catch(() => {});
         expect(simulateTransaction).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({ replaceRecentBlockhash: true }),
@@ -219,7 +219,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
         getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT({
             rpc,
             transactionMessage: mockTransactionMessage,
-        });
+        }).catch(() => {});
         expect(simulateTransaction).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({ replaceRecentBlockhash: true }),

--- a/packages/library/src/__tests__/send-transaction-internal-test.ts
+++ b/packages/library/src/__tests__/send-transaction-internal-test.ts
@@ -45,7 +45,7 @@ describe('sendAndConfirmTransaction', () => {
             confirmRecentTransaction,
             rpc,
             transaction: MOCK_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_TRANSACTION);
         expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', expect.anything());
     });
@@ -63,7 +63,7 @@ describe('sendAndConfirmTransaction', () => {
             confirmRecentTransaction,
             rpc,
             transaction: MOCK_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_TRANSACTION);
         expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', {
             ...sendTransactionConfig,
@@ -87,7 +87,7 @@ describe('sendAndConfirmTransaction', () => {
             confirmRecentTransaction,
             rpc,
             transaction: MOCK_TRANSACTION,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(confirmRecentTransaction).toHaveBeenCalledWith({
             abortSignal,
@@ -108,7 +108,7 @@ describe('sendAndConfirmTransaction', () => {
                 confirmRecentTransaction,
                 rpc,
                 transaction: MOCK_TRANSACTION,
-            });
+            }).catch(() => {});
             expect(createPendingRequest).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
@@ -138,7 +138,7 @@ describe('sendAndConfirmTransaction', () => {
                 preflightCommitment,
                 rpc,
                 transaction: MOCK_TRANSACTION,
-            });
+            }).catch(() => {});
             expect(createPendingRequest).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
@@ -155,7 +155,7 @@ describe('sendAndConfirmTransaction', () => {
             confirmRecentTransaction,
             rpc,
             transaction: MOCK_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(createPendingRequest.mock.lastCall![1]).not.toHaveProperty('preflightCommitment');
     });
     it('returns the signature of the transaction', async () => {
@@ -200,7 +200,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
             confirmDurableNonceTransaction,
             rpc,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_DURABLE_NONCE_TRANSACTION);
         expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', expect.anything());
     });
@@ -218,7 +218,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
             confirmDurableNonceTransaction,
             rpc,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(getBase64EncodedWireTransaction).toHaveBeenCalledWith(MOCK_DURABLE_NONCE_TRANSACTION);
         expect(createPendingRequest).toHaveBeenCalledWith('MOCK_WIRE_TRANSACTION', {
             ...sendTransactionConfig,
@@ -242,7 +242,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
             confirmDurableNonceTransaction,
             rpc,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(confirmDurableNonceTransaction).toHaveBeenCalledWith({
             abortSignal,
@@ -263,7 +263,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
                 confirmDurableNonceTransaction,
                 rpc,
                 transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-            });
+            }).catch(() => {});
             expect(createPendingRequest).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
@@ -293,7 +293,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
                 preflightCommitment,
                 rpc,
                 transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-            });
+            }).catch(() => {});
             expect(createPendingRequest).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
@@ -310,7 +310,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
             confirmDurableNonceTransaction,
             rpc,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(createPendingRequest.mock.lastCall![1]).not.toHaveProperty('preflightCommitment');
     });
     it('returns the signature of the transaction', async () => {

--- a/packages/react/src/__tests__/useSignAndSendTransaction-test.ts
+++ b/packages/react/src/__tests__/useSignAndSendTransaction-test.ts
@@ -110,12 +110,12 @@ describe('useSignAndSendTransaction', () => {
                 signAndSendTransaction({
                     options: { minContextSlot: 123n },
                     transaction: new Uint8Array([1, 2, 3]),
-                });
+                }).catch(() => {});
                 await jest.runAllTimersAsync();
                 signAndSendTransaction({
                     options: { minContextSlot: 123n },
                     transaction: new Uint8Array([1, 2, 3]),
-                });
+                }).catch(() => {});
                 // eslint-disable-next-line jest/no-conditional-expect
                 expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(2);
                 // eslint-disable-next-line jest/no-conditional-expect

--- a/packages/react/src/__tests__/useSignIn-test.ts
+++ b/packages/react/src/__tests__/useSignIn-test.ts
@@ -123,9 +123,9 @@ describe('useSignIn', () => {
         describe('the function returned', () => {
             it("calls the wallet's `signIn` implementation", async () => {
                 expect.assertions(2);
-                signIn({ statement: 'You will really like being signed in' });
+                signIn({ statement: 'You will really like being signed in' }).catch(() => {});
                 await jest.runAllTimersAsync();
-                signIn({ statement: 'You will really like being signed in' });
+                signIn({ statement: 'You will really like being signed in' }).catch(() => {});
                 // eslint-disable-next-line jest/no-conditional-expect
                 expect(mockSignIn).toHaveBeenCalledTimes(2);
                 // eslint-disable-next-line jest/no-conditional-expect
@@ -153,9 +153,9 @@ describe('useSignIn', () => {
         describe('the function returned', () => {
             it("calls the wallet's `signIn` implementation", async () => {
                 expect.assertions(2);
-                signIn({ statement: 'You will really like being signed in' });
+                signIn({ statement: 'You will really like being signed in' }).catch(() => {});
                 await jest.runAllTimersAsync();
-                signIn({ statement: 'You will really like being signed in' });
+                signIn({ statement: 'You will really like being signed in' }).catch(() => {});
                 // eslint-disable-next-line jest/no-conditional-expect
                 expect(mockSignIn).toHaveBeenCalledTimes(2);
                 // eslint-disable-next-line jest/no-conditional-expect
@@ -168,7 +168,7 @@ describe('useSignIn', () => {
                 signIn({
                     // @ts-expect-error Not allowed by TypeScript, but what if supplied anyway?
                     address: '123',
-                });
+                }).catch(() => {});
                 // eslint-disable-next-line jest/no-conditional-expect
                 expect(mockSignIn).toHaveBeenCalledWith({ address: 'abc' });
             });

--- a/packages/react/src/__tests__/useSignMessage-test.ts
+++ b/packages/react/src/__tests__/useSignMessage-test.ts
@@ -83,9 +83,9 @@ describe('useSignMessage', () => {
                 throw result.current;
             } else {
                 const signMessage = result.current;
-                signMessage({ message: new Uint8Array([1, 2, 3]) });
+                signMessage({ message: new Uint8Array([1, 2, 3]) }).catch(() => {});
                 await jest.runAllTimersAsync();
-                signMessage({ message: new Uint8Array([1, 2, 3]) });
+                signMessage({ message: new Uint8Array([1, 2, 3]) }).catch(() => {});
                 // eslint-disable-next-line jest/no-conditional-expect
                 expect(mockSignMessage).toHaveBeenCalledTimes(2);
                 // eslint-disable-next-line jest/no-conditional-expect

--- a/packages/react/src/__tests__/useSignTransaction-test.ts
+++ b/packages/react/src/__tests__/useSignTransaction-test.ts
@@ -110,12 +110,12 @@ describe('useSignTransaction', () => {
                 signTransaction({
                     options: { minContextSlot: 123n },
                     transaction: new Uint8Array([1, 2, 3]),
-                });
+                }).catch(() => {});
                 await jest.runAllTimersAsync();
                 signTransaction({
                     options: { minContextSlot: 123n },
                     transaction: new Uint8Array([1, 2, 3]),
-                });
+                }).catch(() => {});
                 // eslint-disable-next-line jest/no-conditional-expect
                 expect(mockSignTransaction).toHaveBeenCalledTimes(2);
                 // eslint-disable-next-line jest/no-conditional-expect

--- a/packages/react/src/__tests__/useWalletAccountTransactionSendingSigner-test.ts
+++ b/packages/react/src/__tests__/useWalletAccountTransactionSendingSigner-test.ts
@@ -115,7 +115,7 @@ describe('useWalletAccountTransactionSendingSigner', () => {
                     '11111111111111111111111111111114': new Uint8Array(64).fill(2) as SignatureBytes,
                 },
             };
-            signAndSendTransactions([inputTransaction]);
+            signAndSendTransactions([inputTransaction]).catch(() => {});
             // eslint-disable-next-line jest/no-conditional-expect
             expect(mockEncodeTransaction).toHaveBeenCalledWith(inputTransaction);
             // eslint-disable-next-line jest/no-conditional-expect
@@ -163,7 +163,7 @@ describe('useWalletAccountTransactionSendingSigner', () => {
             signAndSendTransactions([inputTransaction], {
                 abortSignal: AbortSignal.timeout(1_000_000),
                 ...mockOptions,
-            });
+            }).catch(() => {});
             // eslint-disable-next-line jest/no-conditional-expect
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(mockOptions);
         }

--- a/packages/react/src/__tests__/useWalletAccountTransactionSigner-test.ts
+++ b/packages/react/src/__tests__/useWalletAccountTransactionSigner-test.ts
@@ -111,7 +111,7 @@ describe('useWalletAccountTransactionSigner', () => {
                     '11111111111111111111111111111114': new Uint8Array(64).fill(2) as SignatureBytes,
                 },
             };
-            modifyAndSignTransactions([inputTransaction]);
+            modifyAndSignTransactions([inputTransaction]).catch(() => {});
             // eslint-disable-next-line jest/no-conditional-expect
             expect(mockEncodeTransaction).toHaveBeenCalledWith(inputTransaction);
             // eslint-disable-next-line jest/no-conditional-expect
@@ -161,7 +161,7 @@ describe('useWalletAccountTransactionSigner', () => {
             modifyAndSignTransactions([inputTransaction], {
                 abortSignal: AbortSignal.timeout(1_000_000),
                 ...mockOptions,
-            });
+            }).catch(() => {});
             // eslint-disable-next-line jest/no-conditional-expect
             expect(mockSignTransaction).toHaveBeenCalledWith(mockOptions);
         }

--- a/packages/react/src/__typetests__/useSignIn-typetest.ts
+++ b/packages/react/src/__typetests__/useSignIn-typetest.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import { address } from '@solana/addresses';

--- a/packages/react/src/test-renderer.tsx
+++ b/packages/react/src/test-renderer.tsx
@@ -56,12 +56,12 @@ export function renderHook<THookReturn>(executor: () => THookReturn): {
 } {
     const result = { __type: 'result' } as Result<THookReturn>;
     let testRenderer: ReactTestRenderer;
-    act(() => {
+    void act(() => {
         testRenderer = create(<TestComponent executor={executor} resultRef={result} />);
     });
     return {
         rerenderHook(nextExecutor) {
-            act(() => {
+            void act(() => {
                 testRenderer.update(<TestComponent executor={nextExecutor} resultRef={result} />);
             });
         },

--- a/packages/rpc-graphql/src/loaders/__tests__/account-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/account-loader-test.ts
@@ -56,7 +56,7 @@ describe('account loader', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source, { address });
+            rpcGraphQL.query(source, { address }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
         });
@@ -70,8 +70,8 @@ describe('account loader', () => {
                 }
             `;
             // Call the query twice
-            rpcGraphQL.query(source, { address });
-            rpcGraphQL.query(source, { address });
+            rpcGraphQL.query(source, { address }).catch(() => {});
+            rpcGraphQL.query(source, { address }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
         });
@@ -95,7 +95,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' });
+                rpcGraphQL.query(source, { address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -115,7 +115,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' });
+                rpcGraphQL.query(source, { address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -138,7 +138,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' });
+                rpcGraphQL.query(source, { address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr' }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
                 expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -174,7 +174,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
@@ -252,7 +252,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
@@ -366,7 +366,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
                 expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
@@ -508,7 +508,7 @@ describe('account loader', () => {
                     }
                 `;
 
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
 
                 // Evaluate layer 1
                 await jest.advanceTimersToNextTimerAsync();
@@ -588,7 +588,7 @@ describe('account loader', () => {
                     }
                 `;
 
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
 
                 await jest.runAllTimersAsync();
                 expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
@@ -619,7 +619,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -636,7 +636,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -653,7 +653,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -670,7 +670,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -689,7 +689,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -708,7 +708,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -727,7 +727,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -746,7 +746,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -767,7 +767,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -792,7 +792,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                 expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -812,7 +812,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
                 expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -841,7 +841,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(3);
                 expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -871,7 +871,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                     expect(rpc.getAccountInfo).toHaveBeenLastCalledWith(
@@ -893,7 +893,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                     expect(rpc.getAccountInfo).toHaveBeenLastCalledWith(
@@ -916,7 +916,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
                     expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -945,7 +945,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getAccountInfo).toHaveBeenCalledTimes(3);
                     expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -976,7 +976,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
                     expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -995,7 +995,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
                     expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -1027,7 +1027,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getAccountInfo).toHaveBeenCalledTimes(4);
                     expect(rpc.getAccountInfo).toHaveBeenCalledWith('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr', {
@@ -1074,7 +1074,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
                     expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
@@ -1108,7 +1108,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
                     expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(
@@ -1147,7 +1147,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
@@ -1200,7 +1200,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
@@ -1234,7 +1234,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
@@ -1302,7 +1302,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source, { maxDataSliceByteRange });
+                    rpcGraphQL.query(source, { maxDataSliceByteRange }).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
@@ -1372,7 +1372,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source);
+                    rpcGraphQL.query(source).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(4);
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
@@ -1479,7 +1479,7 @@ describe('account loader', () => {
                             }
                         }
                     `;
-                    rpcGraphQL.query(source, { maxDataSliceByteRange });
+                    rpcGraphQL.query(source, { maxDataSliceByteRange }).catch(() => {});
                     await jest.runAllTimersAsync();
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(4);
                     expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(

--- a/packages/rpc-graphql/src/loaders/__tests__/block-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/block-loader-test.ts
@@ -47,7 +47,7 @@ describe('account loader', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source, { slot });
+            rpcGraphQL.query(source, { slot }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getBlock).toHaveBeenCalledTimes(1);
         });
@@ -62,8 +62,8 @@ describe('account loader', () => {
                 }
             `;
             // Call the query twice
-            rpcGraphQL.query(source, { slot });
-            rpcGraphQL.query(source, { slot });
+            rpcGraphQL.query(source, { slot }).catch(() => {});
+            rpcGraphQL.query(source, { slot }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getBlock).toHaveBeenCalledTimes(2);
         });
@@ -85,7 +85,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -106,7 +106,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -130,7 +130,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(2);
                 expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
@@ -155,7 +155,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -175,7 +175,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -196,7 +196,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -219,7 +219,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -241,7 +241,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -263,7 +263,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -291,7 +291,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -325,7 +325,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -360,7 +360,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(2);
                 expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
@@ -388,7 +388,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(2);
                 expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
@@ -415,7 +415,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -435,7 +435,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(1);
                 expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -459,7 +459,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { slot });
+                rpcGraphQL.query(source, { slot }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getBlock).toHaveBeenCalledTimes(3);
                 expect(rpc.getBlock).toHaveBeenCalledWith(slot, {

--- a/packages/rpc-graphql/src/loaders/__tests__/program-accounts-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/program-accounts-loader-test.ts
@@ -46,7 +46,7 @@ describe('account loader', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source, { programAddress });
+            rpcGraphQL.query(source, { programAddress }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
         });
@@ -61,8 +61,8 @@ describe('account loader', () => {
                 }
             `;
             // Call the query twice
-            rpcGraphQL.query(source, { programAddress });
-            rpcGraphQL.query(source, { programAddress });
+            rpcGraphQL.query(source, { programAddress }).catch(() => {});
+            rpcGraphQL.query(source, { programAddress }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
         });
@@ -86,7 +86,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { address: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj' });
+                rpcGraphQL.query(source, { address: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj' }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -109,7 +109,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { address: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj' });
+                rpcGraphQL.query(source, { address: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj' }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -135,7 +135,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, { address: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj' });
+                rpcGraphQL.query(source, { address: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj' }).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
                 expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
@@ -158,7 +158,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -178,7 +178,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -198,7 +198,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -218,7 +218,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -240,7 +240,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -262,7 +262,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -284,7 +284,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -306,7 +306,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -330,7 +330,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -358,7 +358,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -381,7 +381,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
                 expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
@@ -413,7 +413,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(4);
                 expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
@@ -446,7 +446,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -468,7 +468,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith(
@@ -491,7 +491,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
                 expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
@@ -517,7 +517,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(3);
                 expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
@@ -548,7 +548,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
                 expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
@@ -567,7 +567,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
                 expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {
@@ -593,7 +593,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(4);
                 expect(rpc.getProgramAccounts).toHaveBeenCalledWith('DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj', {

--- a/packages/rpc-graphql/src/loaders/__tests__/transaction-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/transaction-loader-test.ts
@@ -46,7 +46,7 @@ describe('account loader', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source, { signature });
+            rpcGraphQL.query(source, { signature }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
         });
@@ -60,8 +60,8 @@ describe('account loader', () => {
                 }
             `;
             // Call the query twice
-            rpcGraphQL.query(source, { signature });
-            rpcGraphQL.query(source, { signature });
+            rpcGraphQL.query(source, { signature }).catch(() => {});
+            rpcGraphQL.query(source, { signature }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getTransaction).toHaveBeenCalledTimes(2);
         });
@@ -92,10 +92,12 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, {
-                    signature:
-                        '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
-                });
+                rpcGraphQL
+                    .query(source, {
+                        signature:
+                            '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    })
+                    .catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -118,10 +120,12 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, {
-                    signature:
-                        '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
-                });
+                rpcGraphQL
+                    .query(source, {
+                        signature:
+                            '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    })
+                    .catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -147,10 +151,12 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source, {
-                    signature:
-                        '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
-                });
+                rpcGraphQL
+                    .query(source, {
+                        signature:
+                            '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk',
+                    })
+                    .catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(2);
                 expect(rpc.getTransaction).toHaveBeenCalledWith(
@@ -181,7 +187,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -203,7 +209,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -225,7 +231,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -256,7 +262,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -280,7 +286,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -304,7 +310,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -335,7 +341,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -376,7 +382,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
                 expect(rpc.getTransaction).toHaveBeenLastCalledWith(
@@ -408,7 +414,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(2);
                 expect(rpc.getTransaction).toHaveBeenCalledWith(
@@ -452,7 +458,7 @@ describe('account loader', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getTransaction).toHaveBeenCalledTimes(3);
                 expect(rpc.getTransaction).toHaveBeenCalledWith(

--- a/packages/rpc-graphql/src/resolvers/__tests__/account-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/account-resolver-test.ts
@@ -56,7 +56,7 @@ describe('account resolver', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).not.toHaveBeenCalled();
             });
@@ -71,7 +71,7 @@ describe('account resolver', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).not.toHaveBeenCalled();
             });
@@ -87,7 +87,7 @@ describe('account resolver', () => {
                         address
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).not.toHaveBeenCalled();
             });
@@ -105,7 +105,7 @@ describe('account resolver', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             });
@@ -123,7 +123,7 @@ describe('account resolver', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             });
@@ -142,7 +142,7 @@ describe('account resolver', () => {
                         address
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).not.toHaveBeenCalled();
             });
@@ -163,7 +163,7 @@ describe('account resolver', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.advanceTimersToNextTimerAsync(); // Advance past layer 1
                 await jest.advanceTimersToNextTimerAsync(); // Advance past layer 2
                 await jest.runAllTimersAsync();
@@ -186,7 +186,7 @@ describe('account resolver', () => {
                         }
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             });
@@ -208,7 +208,7 @@ describe('account resolver', () => {
                         address
                     }
                 `;
-                rpcGraphQL.query(source);
+                rpcGraphQL.query(source).catch(() => {});
                 await jest.runAllTimersAsync();
                 expect(rpc.getAccountInfo).not.toHaveBeenCalled();
             });
@@ -226,7 +226,7 @@ describe('account resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -246,7 +246,7 @@ describe('account resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
             expect(rpc.getAccountInfo).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -271,7 +271,7 @@ describe('account resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -297,7 +297,7 @@ describe('account resolver', () => {
                     lamports
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -321,7 +321,7 @@ describe('account resolver', () => {
                     data(encoding: BASE_64_ZSTD)
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -344,7 +344,7 @@ describe('account resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -367,7 +367,7 @@ describe('account resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(2);
             expect(rpc.getAccountInfo).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -394,7 +394,7 @@ describe('account resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getAccountInfo).toHaveBeenCalledTimes(1);
             expect(rpc.getAccountInfo).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {

--- a/packages/rpc-graphql/src/resolvers/__tests__/block-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/block-resolver-test.ts
@@ -44,7 +44,7 @@ describe('block resolver', () => {
                     blockhash
                 }
             `;
-            rpcGraphQL.query(source, { slot });
+            rpcGraphQL.query(source, { slot }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getBlock).toHaveBeenCalledTimes(1);
             expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -69,7 +69,7 @@ describe('block resolver', () => {
                     parentSlot
                 }
             `;
-            rpcGraphQL.query(source, { slot });
+            rpcGraphQL.query(source, { slot }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getBlock).toHaveBeenCalledTimes(1);
             expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -98,7 +98,7 @@ describe('block resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source, { slot });
+            rpcGraphQL.query(source, { slot }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getBlock).toHaveBeenCalledTimes(1);
             expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {
@@ -129,7 +129,7 @@ describe('block resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source, { slot });
+            rpcGraphQL.query(source, { slot }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getBlock).toHaveBeenCalledTimes(2);
             expect(rpc.getBlock).toHaveBeenCalledWith(slot, {
@@ -159,7 +159,7 @@ describe('block resolver', () => {
                     transactionData: data(encoding: BASE_58)
                 }
             `;
-            rpcGraphQL.query(source, { slot });
+            rpcGraphQL.query(source, { slot }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getBlock).toHaveBeenCalledTimes(1);
             expect(rpc.getBlock).toHaveBeenLastCalledWith(slot, {

--- a/packages/rpc-graphql/src/resolvers/__tests__/program-accounts-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/program-accounts-resolver-test.ts
@@ -39,7 +39,7 @@ describe('program accounts resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
             expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -59,7 +59,7 @@ describe('program accounts resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
             expect(rpc.getProgramAccounts).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -84,7 +84,7 @@ describe('program accounts resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
             expect(rpc.getProgramAccounts).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -110,7 +110,7 @@ describe('program accounts resolver', () => {
                     lamports
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
             expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -134,7 +134,7 @@ describe('program accounts resolver', () => {
                     data(encoding: BASE_64_ZSTD)
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
             expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -157,7 +157,7 @@ describe('program accounts resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
             expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -180,7 +180,7 @@ describe('program accounts resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(2);
             expect(rpc.getProgramAccounts).toHaveBeenCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {
@@ -207,7 +207,7 @@ describe('program accounts resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source);
+            rpcGraphQL.query(source).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getProgramAccounts).toHaveBeenCalledTimes(1);
             expect(rpc.getProgramAccounts).toHaveBeenLastCalledWith('AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca', {

--- a/packages/rpc-graphql/src/resolvers/__tests__/transaction-resolver-test.ts
+++ b/packages/rpc-graphql/src/resolvers/__tests__/transaction-resolver-test.ts
@@ -42,7 +42,7 @@ describe('transaction resolver', () => {
                     blockTime
                 }
             `;
-            rpcGraphQL.query(source, { signature });
+            rpcGraphQL.query(source, { signature }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
             expect(rpc.getTransaction).toHaveBeenLastCalledWith(signature, {
@@ -66,7 +66,7 @@ describe('transaction resolver', () => {
                     data(encoding: BASE_64)
                 }
             `;
-            rpcGraphQL.query(source, { signature });
+            rpcGraphQL.query(source, { signature }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
             expect(rpc.getTransaction).toHaveBeenLastCalledWith(signature, {
@@ -92,7 +92,7 @@ describe('transaction resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source, { signature });
+            rpcGraphQL.query(source, { signature }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
             expect(rpc.getTransaction).toHaveBeenLastCalledWith(signature, {
@@ -119,7 +119,7 @@ describe('transaction resolver', () => {
                     }
                 }
             `;
-            rpcGraphQL.query(source, { signature });
+            rpcGraphQL.query(source, { signature }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getTransaction).toHaveBeenCalledTimes(2);
             expect(rpc.getTransaction).toHaveBeenCalledWith(signature, {
@@ -143,7 +143,7 @@ describe('transaction resolver', () => {
                     transactionData: data(encoding: BASE_58)
                 }
             `;
-            rpcGraphQL.query(source, { signature });
+            rpcGraphQL.query(source, { signature }).catch(() => {});
             await jest.runAllTimersAsync();
             expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
             expect(rpc.getTransaction).toHaveBeenLastCalledWith(signature, {

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -51,7 +51,9 @@ describe('JSON-RPC 2.0', () => {
             });
         });
         it('sends a request to the transport', () => {
-            rpc.someMethod(123).send();
+            rpc.someMethod(123)
+                .send()
+                .catch(() => {});
             expect(makeHttpRequest).toHaveBeenCalledWith({
                 payload: { ...createRpcMessage('someMethod', [123]), id: expect.any(Number) },
             });
@@ -85,7 +87,9 @@ describe('JSON-RPC 2.0', () => {
             });
         });
         it('converts the returned request to a JSON-RPC 2.0 message and sends it to the transport', () => {
-            rpc.someMethod(123).send();
+            rpc.someMethod(123)
+                .send()
+                .catch(() => {});
             expect(makeHttpRequest).toHaveBeenCalledWith({
                 payload: {
                     ...createRpcMessage('someMethodAugmented', [123, 'augmented', 'params']),

--- a/packages/rpc-subscriptions-api/src/__tests__/index-test.ts
+++ b/packages/rpc-subscriptions-api/src/__tests__/index-test.ts
@@ -22,7 +22,7 @@ describe('createSolanaRpcSubscriptionsApi', () => {
     });
     it('creates a subscription plan that synthesizes the correct subscribe/unsubscribe method names from the name of the notification', () => {
         const { executeSubscriptionPlan } = api.thingNotifications();
-        executeSubscriptionPlan({
+        void executeSubscriptionPlan({
             channel: {
                 on: jest.fn(),
                 send: jest.fn(),

--- a/packages/rpc-subscriptions-api/src/__typetests__/account-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/account-notifications-type-test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import type { Address } from '@solana/addresses';
 import type { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
 import type {

--- a/packages/rpc-subscriptions-api/src/__typetests__/block-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/block-notifications-type-test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import type { Address } from '@solana/addresses';
 import type { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
 import type {

--- a/packages/rpc-subscriptions-api/src/__typetests__/logs-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/logs-notifications-type-test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import type { Address } from '@solana/addresses';
 import type { Signature } from '@solana/keys';
 import type { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';

--- a/packages/rpc-subscriptions-api/src/__typetests__/program-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/program-notifications-type-test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import type { Address } from '@solana/addresses';
 import type { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
 import type {

--- a/packages/rpc-subscriptions-api/src/__typetests__/root-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/root-notifications-type-test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import type { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
 import type { Slot } from '@solana/rpc-types';
 

--- a/packages/rpc-subscriptions-api/src/__typetests__/signature-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/signature-notifications-type-test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import type { Signature } from '@solana/keys';
 import type { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
 import type { SolanaRpcResponse, TransactionError } from '@solana/rpc-types';

--- a/packages/rpc-subscriptions-api/src/__typetests__/slots-updates-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/slots-updates-notifications-type-test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import type { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
 import type { Slot, U64UnsafeBeyond2Pow53Minus1 } from '@solana/rpc-types';
 

--- a/packages/rpc-subscriptions-api/src/__typetests__/vote-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/vote-notifications-type-test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import type { Address } from '@solana/addresses';
 import type { Signature } from '@solana/keys';
 import type { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';

--- a/packages/rpc-subscriptions-channel-websocket/src/__tests__/websocket-channel-test.ts
+++ b/packages/rpc-subscriptions-channel-websocket/src/__tests__/websocket-channel-test.ts
@@ -152,7 +152,7 @@ describe('a websocket channel', () => {
         });
         it('sends a message to the websocket', async () => {
             expect.assertions(1);
-            channel.send('message');
+            channel.send('message').catch(() => {});
             await expect(ws).toReceiveMessage('message');
         });
         it('throws when sending a message to a closing channel', async () => {
@@ -190,9 +190,12 @@ describe('a websocket channel', () => {
             it('queues messages until the buffer falls to the high watermark', async () => {
                 expect.assertions(2);
                 let resolved = false;
-                channel.send('message').then(() => {
-                    resolved = true;
-                });
+                channel
+                    .send('message')
+                    .then(() => {
+                        resolved = true;
+                    })
+                    .catch(() => {});
                 await Promise.resolve(); // Flush Promise queue.
                 expect(resolved).toBe(false);
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -203,7 +206,7 @@ describe('a websocket channel', () => {
                 expect.assertions(1);
                 const message = new Uint8Array(1) satisfies ArrayBufferView;
                 message[0] = 42;
-                channel.send(message);
+                channel.send(message).catch(() => {});
                 message[0] = 255; // Some modification
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (client as any).bufferedAmount = MOCK_SEND_BUFFER_HIGH_WATERMARK;

--- a/packages/rpc-subscriptions-channel-websocket/src/__typetests__/websocket-channel-typetest.ts
+++ b/packages/rpc-subscriptions-channel-websocket/src/__typetests__/websocket-channel-typetest.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
 import { RpcSubscriptionsChannel } from '@solana/rpc-subscriptions-spec';
 
 import { createWebSocketChannel } from '../websocket-channel';

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-api-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-api-test.ts
@@ -1,4 +1,4 @@
-import { createRpcSubscriptionsApi } from '../rpc-subscriptions-api';
+import { createRpcSubscriptionsApi, RpcSubscriptionsPlan } from '../rpc-subscriptions-api';
 import { RpcSubscriptionsChannel } from '../rpc-subscriptions-channel';
 
 describe('createRpcSubscriptionsApi', () => {
@@ -8,14 +8,19 @@ describe('createRpcSubscriptionsApi', () => {
     });
     describe('executeSubscriptionPlan', () => {
         it('calls the plan executor with the expected params', () => {
-            const mockPlanExecutor = jest.fn();
+            const mockPlanExecutor = jest.fn().mockResolvedValue({
+                executeSubscriptionPlan: jest.fn(),
+                subscriptionConfigurationHash: 'MOCK_HASH',
+            } as RpcSubscriptionsPlan<unknown>);
             const api = createRpcSubscriptionsApi({ planExecutor: mockPlanExecutor });
             const expectedParams = [1, 'hi', 3];
             const expectedSignal = new AbortController().signal;
-            api.foo(...expectedParams).executeSubscriptionPlan({
-                channel: mockChannel,
-                signal: expectedSignal,
-            });
+            api.foo(...expectedParams)
+                .executeSubscriptionPlan({
+                    channel: mockChannel,
+                    signal: expectedSignal,
+                })
+                .catch(() => {});
             expect(mockPlanExecutor).toHaveBeenCalledWith({
                 channel: mockChannel,
                 notificationName: 'foo',

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-pubsub-plan-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-pubsub-plan-test.ts
@@ -59,7 +59,7 @@ describe('executeRpcPubSubSubscriptionPlan', () => {
             subscribeMethodName: 'thingSubscribe',
             subscribeParams: [],
             unsubscribeMethodName: 'thingUnsubscribe',
-        });
+        }).catch(() => {});
         expect(mockChannel.on).toHaveBeenCalledWith('error', expect.any(Function), {
             signal: abortController.signal,
         });
@@ -72,7 +72,7 @@ describe('executeRpcPubSubSubscriptionPlan', () => {
             subscribeMethodName: 'thingSubscribe',
             subscribeParams: expectedParams,
             unsubscribeMethodName: 'thingUnsubscribe',
-        });
+        }).catch(() => {});
         expect(mockSend).toHaveBeenCalledWith(
             expect.objectContaining({
                 id: expect.any(Number),
@@ -288,7 +288,7 @@ describe('executeRpcPubSubSubscriptionPlan', () => {
                     subscribeMethodName: 'thingSubscribe',
                     subscribeParams: [],
                     unsubscribeMethodName: 'thingUnsubscribe',
-                });
+                }).catch(() => {});
                 await jest.runAllTimersAsync();
                 receiveMessage({ id: lastMessageId, jsonrpc: '2.0', result: (expectedSubscriptionId = 123) });
             });

--- a/packages/rpc-subscriptions/src/__tests__/cached-abortable-iterable-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/cached-abortable-iterable-test.ts
@@ -196,7 +196,7 @@ describe('getCachedAbortableIterableFactory', () => {
                     resolve = r;
                 }),
         );
-        Promise.all([factory('A'), factory('B')]);
+        Promise.all([factory('A'), factory('B')]).catch(() => {});
         expect(onCacheHit).not.toHaveBeenCalled();
         await jest.runAllTimersAsync();
         const iterable = getAsyncIterable();
@@ -210,7 +210,7 @@ describe('getCachedAbortableIterableFactory', () => {
     it('calls `onCacheHit` in the same runloop when the cached iterable is already resolved', () => {
         const iterable = getAsyncIterable();
         onCreateIterable.mockReturnValue(iterable);
-        Promise.all([factory('A'), factory('B')]);
+        Promise.all([factory('A'), factory('B')]).catch(() => {});
         expect(onCacheHit).toHaveBeenCalledWith(iterable, 'B');
     });
     it('does not call `onCacheHit` in different runloops until the cached iterable is resolved', async () => {
@@ -222,9 +222,9 @@ describe('getCachedAbortableIterableFactory', () => {
                     resolve = r;
                 }),
         );
-        factory('A');
+        factory('A').catch(() => {});
         await jest.runAllTimersAsync();
-        factory('B');
+        factory('B').catch(() => {});
         await jest.runAllTimersAsync();
         expect(onCacheHit).not.toHaveBeenCalled();
         const iterable = getAsyncIterable();

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-autopinger-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-autopinger-test.ts
@@ -99,11 +99,11 @@ describe('getRpcSubscriptionsChannelWithAutoping', () => {
             channel: mockChannel,
             intervalMs: MOCK_INTERVAL_MS,
         });
-        autopingChannel.send('hi');
+        autopingChannel.send('hi').catch(() => {});
         mockSend.mockClear();
         await jest.advanceTimersByTimeAsync(500);
         expect(mockSend).not.toHaveBeenCalled();
-        autopingChannel.send('hi');
+        autopingChannel.send('hi').catch(() => {});
         mockSend.mockClear();
         await jest.advanceTimersByTimeAsync(MOCK_INTERVAL_MS - 1);
         expect(mockSend).not.toHaveBeenCalled();

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-channel-pool-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-channel-pool-test.ts
@@ -44,8 +44,8 @@ describe('getChannelPoolingChannelCreator', () => {
             maxSubscriptionsPerChannel: Number.POSITIVE_INFINITY,
             minChannels: 1,
         });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
         expect(channelPool).toMatchObject({
             entries: [{ channel: newChannel, subscriptionCount: 2 }],
             freeChannelIndex: 0,
@@ -59,8 +59,8 @@ describe('getChannelPoolingChannelCreator', () => {
             maxSubscriptionsPerChannel: 1,
             minChannels: 1,
         });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
         expect(channelPool).toMatchObject({
             entries: [
                 { channel: newChannelA, subscriptionCount: 1 },
@@ -78,7 +78,7 @@ describe('getChannelPoolingChannelCreator', () => {
             minChannels: 1,
         });
         const abortController = new AbortController();
-        poolingChannelCreator({ abortSignal: abortController.signal });
+        poolingChannelCreator({ abortSignal: abortController.signal }).catch(() => {});
         expect(channelPool).toMatchObject({
             entries: [{ channel: newChannelA, subscriptionCount: 1 }],
             freeChannelIndex: 0,
@@ -97,7 +97,7 @@ describe('getChannelPoolingChannelCreator', () => {
             minChannels: 1,
         });
         const abortController = new AbortController();
-        poolingChannelCreator({ abortSignal: abortController.signal });
+        poolingChannelCreator({ abortSignal: abortController.signal }).catch(() => {});
         channelPool.entries = [
             { subscriptionCount: 2 },
             ...channelPool.entries,
@@ -122,8 +122,8 @@ describe('getChannelPoolingChannelCreator', () => {
             minChannels: 1,
         });
         const abortController = new AbortController();
-        poolingChannelCreator({ abortSignal: abortController.signal });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
+        poolingChannelCreator({ abortSignal: abortController.signal }).catch(() => {});
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
         channelPool.entries = [...channelPool.entries, { subscriptionCount: 1 }] as ChannelPoolEntry[];
         channelPool.freeChannelIndex = 1;
         expect(channelPool).toMatchObject({
@@ -144,9 +144,9 @@ describe('getChannelPoolingChannelCreator', () => {
             minChannels: 2,
         });
         const abortController = new AbortController();
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
-        poolingChannelCreator({ abortSignal: abortController.signal });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
+        poolingChannelCreator({ abortSignal: abortController.signal }).catch(() => {});
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
         expect(channelPool).toMatchObject({
             entries: [{ subscriptionCount: 2 }, { subscriptionCount: 1 }],
             freeChannelIndex: 1,
@@ -196,7 +196,7 @@ describe('getChannelPoolingChannelCreator', () => {
             minChannels: 1,
         });
         const abortController = new AbortController();
-        poolingChannelCreator({ abortSignal: abortController.signal });
+        poolingChannelCreator({ abortSignal: abortController.signal }).catch(() => {});
         abortController.abort();
         expect(createChannel.mock.lastCall?.[0].abortSignal).toHaveProperty('aborted', true);
     });
@@ -206,9 +206,9 @@ describe('getChannelPoolingChannelCreator', () => {
             maxSubscriptionsPerChannel: 2,
             minChannels: 1,
         });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
         expect(channelPool).toMatchObject({
             entries: [{ subscriptionCount: 2 }, { subscriptionCount: 1 }],
             freeChannelIndex: 1,
@@ -247,8 +247,8 @@ describe('getChannelPoolingChannelCreator', () => {
             },
             send: jest.fn(),
         });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
-        poolingChannelCreator({ abortSignal: new AbortController().signal });
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
+        poolingChannelCreator({ abortSignal: new AbortController().signal }).catch(() => {});
         expect(channelPool).toMatchObject({
             entries: [{ subscriptionCount: 2 }],
             freeChannelIndex: 0,

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
@@ -32,7 +32,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             signal: new AbortController().signal,
             subscriptionConfigurationHash: 'MOCK_HASH',
         };
-        coalescedTransport(config);
+        coalescedTransport(config).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledWith(
             expect.objectContaining({
                 executeSubscriptionPlan: config.executeSubscriptionPlan,
@@ -45,7 +45,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             signal: new AbortController().signal,
             subscriptionConfigurationHash: 'MOCK_HASH',
         };
-        coalescedTransport(config);
+        coalescedTransport(config).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledWith(
             expect.objectContaining({
                 subscriptionConfigurationHash: 'MOCK_HASH',
@@ -57,8 +57,14 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             executeSubscriptionPlan: jest.fn(),
             signal: new AbortController().signal,
         };
-        coalescedTransport({ ...config, subscriptionConfigurationHash: 'MOCK_HASH_A' });
-        coalescedTransport({ ...config, subscriptionConfigurationHash: 'MOCK_HASH_B' });
+        coalescedTransport({
+            subscriptionConfigurationHash: 'MOCK_HASH_A',
+            ...config,
+        }).catch(() => {});
+        coalescedTransport({
+            subscriptionConfigurationHash: 'MOCK_HASH_B',
+            ...config,
+        }).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledTimes(2);
     });
     it('calls the inner transport once per subscriber whose hashes do not match, in different runloops', async () => {
@@ -76,8 +82,14 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             executeSubscriptionPlan: jest.fn(),
             signal: new AbortController().signal,
         };
-        coalescedTransport({ ...config, subscriptionConfigurationHash: undefined });
-        coalescedTransport({ ...config, subscriptionConfigurationHash: undefined });
+        coalescedTransport({
+            subscriptionConfigurationHash: undefined,
+            ...config,
+        }).catch(() => {});
+        coalescedTransport({
+            subscriptionConfigurationHash: undefined,
+            ...config,
+        }).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledTimes(2);
     });
     it("calls the inner transport once per subscriber when both subscribers' hashes are `undefined`, in different runloops", async () => {
@@ -86,8 +98,14 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             executeSubscriptionPlan: jest.fn(),
             signal: new AbortController().signal,
         };
-        await coalescedTransport({ ...config, subscriptionConfigurationHash: undefined });
-        await coalescedTransport({ ...config, subscriptionConfigurationHash: undefined });
+        await coalescedTransport({
+            subscriptionConfigurationHash: undefined,
+            ...config,
+        });
+        await coalescedTransport({
+            subscriptionConfigurationHash: undefined,
+            ...config,
+        });
         expect(mockInnerTransport).toHaveBeenCalledTimes(2);
     });
     it('only calls the inner transport once, in the same runloop', () => {
@@ -96,8 +114,8 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             signal: new AbortController().signal,
             subscriptionConfigurationHash: 'MOCK_HASH',
         };
-        coalescedTransport(config);
-        coalescedTransport(config);
+        coalescedTransport(config).catch(() => {});
+        coalescedTransport(config).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledTimes(1);
     });
     it('only calls the inner transport once, in different runloops', async () => {
@@ -139,8 +157,8 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             subscriptionConfigurationHash: 'MOCK_HASH',
         };
         const abortControllerB = new AbortController();
-        coalescedTransport({ ...config, signal: new AbortController().signal });
-        coalescedTransport({ ...config, signal: abortControllerB.signal });
+        coalescedTransport({ ...config, signal: new AbortController().signal }).catch(() => {});
+        coalescedTransport({ ...config, signal: abortControllerB.signal }).catch(() => {});
         abortControllerB.abort();
         jest.runAllTicks();
         expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', false);
@@ -153,8 +171,8 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         };
         const abortControllerA = new AbortController();
         const abortControllerB = new AbortController();
-        coalescedTransport({ ...config, signal: abortControllerA.signal });
-        coalescedTransport({ ...config, signal: abortControllerB.signal });
+        coalescedTransport({ ...config, signal: abortControllerA.signal }).catch(() => {});
+        coalescedTransport({ ...config, signal: abortControllerB.signal }).catch(() => {});
         abortControllerA.abort();
         abortControllerB.abort();
         jest.runAllTicks();
@@ -168,9 +186,9 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         };
         const abortControllerA = new AbortController();
         const abortControllerB = new AbortController();
-        coalescedTransport({ ...config, signal: abortControllerA.signal });
+        coalescedTransport({ ...config, signal: abortControllerA.signal }).catch(() => {});
         await jest.runAllTimersAsync();
-        coalescedTransport({ ...config, signal: abortControllerB.signal });
+        coalescedTransport({ ...config, signal: abortControllerB.signal }).catch(() => {});
         await jest.runAllTimersAsync();
         abortControllerA.abort();
         abortControllerB.abort();
@@ -183,9 +201,9 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             subscriptionConfigurationHash: 'MOCK_HASH',
         };
         const abortControllerA = new AbortController();
-        coalescedTransport({ ...config, signal: abortControllerA.signal });
+        coalescedTransport({ ...config, signal: abortControllerA.signal }).catch(() => {});
         abortControllerA.abort();
-        coalescedTransport({ ...config, signal: new AbortController().signal });
+        coalescedTransport({ ...config, signal: new AbortController().signal }).catch(() => {});
         jest.runAllTicks();
         expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', false);
     });
@@ -196,10 +214,10 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             executeSubscriptionPlan: jest.fn(),
             subscriptionConfigurationHash: 'MOCK_HASH',
         };
-        coalescedTransport({ ...config, signal: new AbortController().signal });
+        coalescedTransport({ ...config, signal: new AbortController().signal }).catch(() => {});
         await jest.runAllTimersAsync();
         receiveError('o no');
-        coalescedTransport({ ...config, signal: new AbortController().signal });
+        coalescedTransport({ ...config, signal: new AbortController().signal }).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledTimes(2);
     });
     it('does not cancel a newly-coalesced transport when an old errored one is aborted', async () => {

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-json-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-json-test.ts
@@ -12,12 +12,12 @@ describe('getRpcSubscriptionsChannelWithJSONSerialization', () => {
         mockOn = jest.fn();
         channel = {
             on: mockOn,
-            send: jest.fn(),
+            send: jest.fn().mockResolvedValue(void 0),
         };
     });
     it('forwards JSON-serialized messages to the underlying channel', () => {
         const channelWithJSONSerialization = getRpcSubscriptionsChannelWithJSONSerialization(channel);
-        channelWithJSONSerialization.send('hello');
+        channelWithJSONSerialization.send('hello').catch(() => {});
         expect(channel.send).toHaveBeenCalledWith(JSON.stringify('hello'));
     });
     it('deserializes messages received from the underlying channel as JSON', () => {

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-transport-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-transport-test.ts
@@ -12,7 +12,7 @@ describe('createRpcSubscriptionsTransportFromChannelCreator', () => {
             executeSubscriptionPlan: jest.fn(),
             signal: abortSignal,
             subscriptionConfigurationHash: undefined,
-        });
+        }).catch(() => {});
         expect(mockCreateChannel).toHaveBeenCalledWith({ abortSignal });
     });
     it('creates a function that calls `executeSubscriptionPlan` with the created channel', async () => {
@@ -23,7 +23,7 @@ describe('createRpcSubscriptionsTransportFromChannelCreator', () => {
             executeSubscriptionPlan: mockExecuteSubscriptionPlan,
             signal: new AbortController().signal,
             subscriptionConfigurationHash: undefined,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(mockExecuteSubscriptionPlan).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -40,7 +40,7 @@ describe('createRpcSubscriptionsTransportFromChannelCreator', () => {
             executeSubscriptionPlan: mockExecuteSubscriptionPlan,
             signal,
             subscriptionConfigurationHash: undefined,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(mockExecuteSubscriptionPlan).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/packages/rpc-subscriptions/src/cached-abortable-iterable.ts
+++ b/packages/rpc-subscriptions/src/cached-abortable-iterable.ts
@@ -21,7 +21,7 @@ type Config<TInput extends unknown[], TIterable extends AsyncIterable<unknown>> 
 }>;
 
 function registerIterableCleanup(iterable: AsyncIterable<unknown>, cleanupFn: CallableFunction) {
-    (async () => {
+    void (async () => {
         try {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             for await (const _ of iterable);

--- a/packages/rpc-transport-http/src/__benchmarks__/run.ts
+++ b/packages/rpc-transport-http/src/__benchmarks__/run.ts
@@ -93,7 +93,7 @@ bench
         beforeEach: createDispatcher.bind(null, { connections: 64, pipelining: 2 }),
     });
 
-(async () => {
+void (async () => {
     const validatorPromise = $`../../scripts/start-shared-test-validator.sh`;
     await $`wget --output-document=/dev/null --waitretry=1 --tries=100 --retry-connrefused ${VALIDATOR_URL.replace(
         /^(\w+:\/\/[^\\/]+)\/.*$/,
@@ -101,5 +101,5 @@ bench
     )}/health -nv`;
     await bench.run();
     console.table(bench.table());
-    validatorPromise.kill('SIGINT');
+    await validatorPromise.kill('SIGINT');
 })();

--- a/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
@@ -91,7 +91,7 @@ describe('createHttpRequest with custom headers', () => {
             headers: { aCcEpT: 'text/html' },
             url: 'http://localhost',
         });
-        makeHttpRequest({ payload: 123 });
+        makeHttpRequest({ payload: 123 }).catch(() => {});
         expect(fetchSpy).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({
@@ -106,7 +106,7 @@ describe('createHttpRequest with custom headers', () => {
             headers: { 'cOnTeNt-LeNgTh': '420' },
             url: 'http://localhost',
         });
-        makeHttpRequest({ payload: 123 });
+        makeHttpRequest({ payload: 123 }).catch(() => {});
         expect(fetchSpy).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({
@@ -121,7 +121,7 @@ describe('createHttpRequest with custom headers', () => {
             headers: { 'cOnTeNt-TyPe': 'text/html' },
             url: 'http://localhost',
         });
-        makeHttpRequest({ payload: 123 });
+        makeHttpRequest({ payload: 123 }).catch(() => {});
         expect(fetchSpy).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({

--- a/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
@@ -54,11 +54,11 @@ describe('createHttpTransport', () => {
             });
         });
         it('calls fetch with the specified URL', () => {
-            makeHttpRequest({ payload: 123 });
+            makeHttpRequest({ payload: 123 }).catch(() => {});
             expect(fetchSpy).toHaveBeenCalledWith('http://localhost', expect.anything());
         });
         it('sets the `body` to a stringfied version of the payload', () => {
-            makeHttpRequest({ payload: { ok: true } });
+            makeHttpRequest({ payload: { ok: true } }).catch(() => {});
             expect(fetchSpy).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
@@ -67,7 +67,7 @@ describe('createHttpTransport', () => {
             );
         });
         it('sets the accept header to `application/json`', () => {
-            makeHttpRequest({ payload: 123 });
+            makeHttpRequest({ payload: 123 }).catch(() => {});
             expect(fetchSpy).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
@@ -78,7 +78,7 @@ describe('createHttpTransport', () => {
             );
         });
         it('sets the content type header to `application/json; charset=utf-8`', () => {
-            makeHttpRequest({ payload: 123 });
+            makeHttpRequest({ payload: 123 }).catch(() => {});
             expect(fetchSpy).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
@@ -99,7 +99,7 @@ describe('createHttpTransport', () => {
                     ' ' +
                     // https://tinyurl.com/bdemuf3r
                     '\u{1F469}\u{1F3FB}\u200D\u2764\uFE0F\u200D\u{1F469}\u{1F3FF}',
-            });
+            }).catch(() => {});
             expect(fetchSpy).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
@@ -110,7 +110,7 @@ describe('createHttpTransport', () => {
             );
         });
         it('sets the `method` to `POST`', () => {
-            makeHttpRequest({ payload: 123 });
+            makeHttpRequest({ payload: 123 }).catch(() => {});
             expect(fetchSpy).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({

--- a/packages/rpc-transport-http/src/__tests__/http-transport-to-json-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-to-json-test.ts
@@ -17,12 +17,12 @@ describe('createHttpTransport and `toJson` function', () => {
         });
     });
     it('uses the `toJson` function to transform the payload to a JSON string', () => {
-        makeHttpRequest({ payload: { foo: 123 } });
+        makeHttpRequest({ payload: { foo: 123 } }).catch(() => {});
         expect(toJson).toHaveBeenCalledWith({ foo: 123 });
     });
     it('uses passes the JSON string to the fetch API', () => {
         toJson.mockReturnValueOnce('{"someAugmented":"jsonString"}');
-        makeHttpRequest({ payload: { foo: 123 } });
+        makeHttpRequest({ payload: { foo: 123 } }).catch(() => {});
         expect(fetchSpy).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({

--- a/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
+++ b/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
@@ -17,15 +17,15 @@ describe('RPC request coalescer', () => {
             hashFn.mockReturnValue('samehash');
         });
         it('multiple requests in the same tick produce a single transport request', () => {
-            coalescedTransport({ payload: null });
-            coalescedTransport({ payload: null });
+            coalescedTransport({ payload: null }).catch(() => {});
+            coalescedTransport({ payload: null }).catch(() => {});
             expect(mockTransport).toHaveBeenCalledTimes(1);
         });
         it('multiple requests in different ticks each produce their own transport request', async () => {
             expect.assertions(1);
-            coalescedTransport({ payload: null });
+            coalescedTransport({ payload: null }).catch(() => {});
             await jest.runOnlyPendingTimersAsync();
-            coalescedTransport({ payload: null });
+            coalescedTransport({ payload: null }).catch(() => {});
             expect(mockTransport).toHaveBeenCalledTimes(2);
         });
         it('multiple requests in the same tick receive the same response', async () => {
@@ -89,7 +89,7 @@ describe('RPC request coalescer', () => {
             abortControllerA.abort('o no A');
             abortControllerB.abort('o no B');
             // New request comes in at the last moment before the end of the runloop.
-            coalescedTransport({ payload: null });
+            coalescedTransport({ payload: null }).catch(() => {});
             await jest.runOnlyPendingTimersAsync();
             expect(mockTransport).toHaveBeenCalledTimes(1);
             const transportAbortSignal = mockTransport.mock.lastCall![0].signal!;
@@ -186,8 +186,8 @@ describe('RPC request coalescer', () => {
                 hashFn.mockImplementation(getHashFn());
             });
             it('multiple requests in the same tick produce one transport request each', () => {
-                coalescedTransport({ payload: null });
-                coalescedTransport({ payload: null });
+                coalescedTransport({ payload: null }).catch(() => {});
+                coalescedTransport({ payload: null }).catch(() => {});
                 expect(mockTransport).toHaveBeenCalledTimes(2);
             });
             it('multiple requests in the same tick receive different responses', async () => {

--- a/packages/rpc/src/rpc-request-coalescer.ts
+++ b/packages/rpc/src/rpc-request-coalescer.ts
@@ -39,7 +39,8 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
             return await transport(request);
         }
         if (!coalescedRequestsByDeduplicationKey) {
-            Promise.resolve().then(() => {
+            // FIXME: Probably replace this with `queueMicrotask()`
+            void Promise.resolve().then(() => {
                 coalescedRequestsByDeduplicationKey = undefined;
             });
             coalescedRequestsByDeduplicationKey = {};
@@ -76,7 +77,8 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
                 const handleAbort = (e: AbortSignalEventMap['abort']) => {
                     signal.removeEventListener('abort', handleAbort);
                     coalescedRequest.numConsumers -= 1;
-                    Promise.resolve().then(() => {
+                    // FIXME: Probably replace this with `queueMicrotask()`
+                    void Promise.resolve().then(() => {
                         if (coalescedRequest.numConsumers === 0) {
                             const abortController = coalescedRequest.abortController;
                             abortController.abort((EXPLICIT_ABORT_TOKEN ||= createExplicitAbortToken()));

--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { SignatureBytes } from '@solana/keys';
 import {
     CompilableTransactionMessage,

--- a/packages/sysvars/src/__typetests__/sysvar-typetest.ts
+++ b/packages/sysvars/src/__typetests__/sysvar-typetest.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import type { MaybeAccount, MaybeEncodedAccount } from '@solana/accounts';
 import type { Address } from '@solana/addresses';
 import type { JsonParsedSysvarAccount } from '@solana/rpc-parsed-types';

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-blockheight-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-blockheight-test.ts
@@ -156,22 +156,16 @@ describe('createBlockHeightExceedencePromiseFactory', () => {
                 abortSignal: new AbortController().signal,
                 commitment,
                 lastValidBlockHeight: 100n,
-            });
+            }).catch(() => {});
             expect(getEpochInfoMock).toHaveBeenCalledWith({ commitment });
         },
     );
     it('calls the abort signal passed to the epoch info fetcher when aborted', () => {
         const abortController = new AbortController();
-        (async () => {
-            try {
-                await getBlockHeightExceedencePromise({
-                    abortSignal: abortController.signal,
-                    lastValidBlockHeight: 100n,
-                });
-            } catch {
-                /* empty */
-            }
-        })();
+        getBlockHeightExceedencePromise({
+            abortSignal: abortController.signal,
+            lastValidBlockHeight: 100n,
+        }).catch(() => {});
         expect(getEpochInfoRequestSender).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: false }),
         });
@@ -182,16 +176,10 @@ describe('createBlockHeightExceedencePromiseFactory', () => {
     });
     it('calls the abort signal passed to the slot subscription when aborted', () => {
         const abortController = new AbortController();
-        (async () => {
-            try {
-                await getBlockHeightExceedencePromise({
-                    abortSignal: abortController.signal,
-                    lastValidBlockHeight: 100n,
-                });
-            } catch {
-                /* empty */
-            }
-        })();
+        getBlockHeightExceedencePromise({
+            abortSignal: abortController.signal,
+            lastValidBlockHeight: 100n,
+        }).catch(() => {});
         expect(createSubscriptionIterable).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: false }),
         });

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
@@ -58,7 +58,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
             commitment: 'finalized',
             currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(getAccountInfoMock).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: false }),
@@ -75,7 +75,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
             commitment: 'finalized',
             currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
-        });
+        }).catch(() => {});
         expect(createSubscriptionIterable).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: false }),
         });
@@ -91,7 +91,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
             commitment: 'finalized',
             currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(createPendingSubscription).toHaveBeenCalledWith('9'.repeat(44), {
             commitment: 'finalized',
@@ -112,7 +112,7 @@ describe('createNonceInvalidationPromiseFactory', () => {
             commitment: 'finalized',
             currentNonceValue: '4'.repeat(44) as Nonce,
             nonceAccountAddress: '9'.repeat(44) as Address,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(getAccountInfoMock).not.toHaveBeenCalled();
         // FIXME: https://github.com/microsoft/TypeScript/issues/11498

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-racer-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-racer-test.ts
@@ -22,7 +22,7 @@ describe('raceStrategies', () => {
             function getSpecificStrategiesForRace() {
                 return [];
             },
-        );
+        ).catch(() => {});
         expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith(
             expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: false }) }),
         );
@@ -44,7 +44,7 @@ describe('raceStrategies', () => {
             function getSpecificStrategiesForRace() {
                 return [];
             },
-        );
+        ).catch(() => {});
         expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith(
             expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: false }) }),
         );
@@ -63,7 +63,7 @@ describe('raceStrategies', () => {
                 getRecentSignatureConfirmationPromise: jest.fn(),
             },
             getSpecificStrategiesForRace,
-        );
+        ).catch(() => {});
         expect(getSpecificStrategiesForRace).toHaveBeenCalledWith(
             expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: false }) }),
         );
@@ -83,7 +83,7 @@ describe('raceStrategies', () => {
                 getRecentSignatureConfirmationPromise: jest.fn().mockReturnValue(FOREVER_PROMISE),
             },
             getSpecificStrategiesForRace,
-        );
+        ).catch(() => {});
         expect(getSpecificStrategiesForRace).toHaveBeenCalledWith(
             expect.objectContaining({ abortSignal: expect.objectContaining({ aborted: false }) }),
         );

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
@@ -39,7 +39,7 @@ describe('createSignatureConfirmationPromiseFactory', () => {
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             signature: 'abc' as Signature,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(createPendingSubscription).toHaveBeenCalledWith('abc', {
             commitment: 'finalized',
@@ -58,7 +58,7 @@ describe('createSignatureConfirmationPromiseFactory', () => {
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             signature: 'abc' as Signature,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(getSignatureStatusesMock).not.toHaveBeenCalled();
         // FIXME: https://github.com/microsoft/TypeScript/issues/11498
@@ -148,7 +148,7 @@ describe('createSignatureConfirmationPromiseFactory', () => {
             abortSignal: abortController.signal,
             commitment: 'finalized',
             signature: 'abc' as Signature,
-        });
+        }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(getSignatureStatusesMock).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: false }),
@@ -164,7 +164,7 @@ describe('createSignatureConfirmationPromiseFactory', () => {
             abortSignal: abortController.signal,
             commitment: 'finalized',
             signature: 'abc' as Signature,
-        });
+        }).catch(() => {});
         expect(createSubscriptionIterable).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: false }),
         });

--- a/packages/transaction-confirmation/src/__tests__/waiters-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/waiters-test.ts
@@ -54,7 +54,7 @@ describe('waitForDurableNonceTransactionConfirmation', () => {
             getNonceInvalidationPromise,
             getRecentSignatureConfirmationPromise,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(getNonceInvalidationPromise).toHaveBeenCalledWith({
             abortSignal: expect.any(AbortSignal),
             commitment: 'finalized',
@@ -75,7 +75,7 @@ describe('waitForDurableNonceTransactionConfirmation', () => {
             getNonceInvalidationPromise,
             getRecentSignatureConfirmationPromise,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-        });
+        }).catch(() => {});
         abortController.abort();
         expect(handleAbortOnBlockHeightExceedencePromise).toHaveBeenCalled();
     });
@@ -92,7 +92,7 @@ describe('waitForDurableNonceTransactionConfirmation', () => {
             getNonceInvalidationPromise,
             getRecentSignatureConfirmationPromise,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-        });
+        }).catch(() => {});
         abortController.abort();
         expect(handleAbortOnSignatureConfirmationPromise).toHaveBeenCalled();
     });
@@ -103,7 +103,7 @@ describe('waitForDurableNonceTransactionConfirmation', () => {
             getNonceInvalidationPromise,
             getRecentSignatureConfirmationPromise,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith({
             abortSignal: expect.any(AbortSignal),
             commitment: 'finalized',
@@ -203,7 +203,7 @@ describe('waitForRecentTransactionConfirmation', () => {
             getBlockHeightExceedencePromise,
             getRecentSignatureConfirmationPromise,
             transaction: MOCK_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(getBlockHeightExceedencePromise).toHaveBeenCalledWith({
             abortSignal: expect.any(AbortSignal),
             commitment: 'finalized',
@@ -217,7 +217,7 @@ describe('waitForRecentTransactionConfirmation', () => {
             getBlockHeightExceedencePromise,
             getRecentSignatureConfirmationPromise,
             transaction: MOCK_TRANSACTION,
-        });
+        }).catch(() => {});
         expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith({
             abortSignal: expect.any(AbortSignal),
             commitment: 'finalized',
@@ -294,7 +294,7 @@ describe('waitForRecentTransactionConfirmation', () => {
             getBlockHeightExceedencePromise,
             getRecentSignatureConfirmationPromise,
             transaction: MOCK_TRANSACTION,
-        });
+        }).catch(() => {});
         abortController.abort();
         expect(handleAbortOnBlockHeightExceedencePromise).toHaveBeenCalled();
     });
@@ -311,7 +311,7 @@ describe('waitForRecentTransactionConfirmation', () => {
             getBlockHeightExceedencePromise,
             getRecentSignatureConfirmationPromise,
             transaction: MOCK_TRANSACTION,
-        });
+        }).catch(() => {});
         abortController.abort();
         expect(handleAbortOnSignatureConfirmationPromise).toHaveBeenCalled();
     });
@@ -345,7 +345,7 @@ describe('waitForRecentTransactionConfirmationUntilTimeout', () => {
             getRecentSignatureConfirmationPromise,
             getTimeoutPromise,
             signature: MOCK_SIGNATURE,
-        });
+        }).catch(() => {});
         expect(getTimeoutPromise).toHaveBeenCalledWith({
             abortSignal: expect.any(AbortSignal),
             commitment: 'finalized',
@@ -358,7 +358,7 @@ describe('waitForRecentTransactionConfirmationUntilTimeout', () => {
             getRecentSignatureConfirmationPromise,
             getTimeoutPromise,
             signature: MOCK_SIGNATURE,
-        });
+        }).catch(() => {});
         expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith({
             abortSignal: expect.any(AbortSignal),
             commitment: 'finalized',
@@ -415,7 +415,7 @@ describe('waitForRecentTransactionConfirmationUntilTimeout', () => {
             getRecentSignatureConfirmationPromise,
             getTimeoutPromise,
             signature: MOCK_SIGNATURE,
-        });
+        }).catch(() => {});
         abortController.abort();
         expect(handleAbortOnTimeoutPromise).toHaveBeenCalled();
     });
@@ -432,7 +432,7 @@ describe('waitForRecentTransactionConfirmationUntilTimeout', () => {
             getRecentSignatureConfirmationPromise,
             getTimeoutPromise,
             signature: MOCK_SIGNATURE,
-        });
+        }).catch(() => {});
         abortController.abort();
         expect(handleAbortOnSignatureConfirmationPromise).toHaveBeenCalled();
     });

--- a/packages/transactions/src/__typetests__/signatures-typetests.ts
+++ b/packages/transactions/src/__typetests__/signatures-typetests.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { Signature } from '@solana/keys';
 
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: workspace:*
         version: link:packages/build-scripts
       '@solana/eslint-config-solana':
-        specifier: ^3.0.5
-        version: 3.0.5(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@30.0.0-alpha.6(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.11))(@types/node@22.7.5)(typescript@5.6.3)))(typescript@5.6.3))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-simple-import-sort@12.1.1(eslint@8.57.1))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
+        specifier: ^3.0.6
+        version: 3.0.6(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@30.0.0-alpha.6(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.11))(@types/node@22.7.5)(typescript@5.6.3)))(typescript@5.6.3))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-simple-import-sort@12.1.1(eslint@8.57.1))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
       '@solana/prettier-config-solana':
         specifier: 0.0.5
         version: 0.0.5(prettier@3.3.3)
@@ -3384,8 +3384,8 @@ packages:
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
 
-  '@solana/eslint-config-solana@3.0.5':
-    resolution: {integrity: sha512-/8nD6Wm6dy6p2ED3k4mPduxeM8DPtwmv6z3iSbB51eR5qR65bQQUt8MyJ6gItylEwO7EiESoT0GRl1VU7GVOhg==}
+  '@solana/eslint-config-solana@3.0.6':
+    resolution: {integrity: sha512-3u024DkukJCfzUfOgN1EmWzVZLaZtgRLJ52FEdQmIG8NYOzLpaIJFgQvjYXWQlnK6ycIcSn/MesHG6sbKkMtTQ==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^7.0.0
       '@typescript-eslint/parser': ^7.0.0
@@ -9303,7 +9303,7 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@solana/eslint-config-solana@3.0.5(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@30.0.0-alpha.6(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.11))(@types/node@22.7.5)(typescript@5.6.3)))(typescript@5.6.3))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-simple-import-sort@12.1.1(eslint@8.57.1))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
+  '@solana/eslint-config-solana@3.0.6(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@30.0.0-alpha.6(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.11))(@types/node@22.7.5)(typescript@5.6.3)))(typescript@5.6.3))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-simple-import-sort@12.1.1(eslint@8.57.1))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.6.3)


### PR DESCRIPTION
# Summary

In this PR we get strict about creating promises that are resolved neither through `await` nor `then()` nor `catch()`. This new lint rule actually found some bugs that we were able to fix in PRs earlier in the stack.

You might be thinking, ‘are you serious, a `catch()` in every test where I don't care about the result?’ This will actually help make test failures more clear because {the thing you're actually testing} will no longer be accompanied by {unhandled rejection}.