### PR TITLE
Replace abuse of promises with the `queueMicrotask` API in the RPC request coalescer

### DIFF
--- a/packages/rpc/src/rpc-request-coalescer.ts
+++ b/packages/rpc/src/rpc-request-coalescer.ts
@@ -39,8 +39,7 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
             return await transport(request);
         }
         if (!coalescedRequestsByDeduplicationKey) {
-            // FIXME: Probably replace this with `queueMicrotask()`
-            void Promise.resolve().then(() => {
+            queueMicrotask(() => {
                 coalescedRequestsByDeduplicationKey = undefined;
             });
             coalescedRequestsByDeduplicationKey = {};
@@ -77,8 +76,7 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
                 const handleAbort = (e: AbortSignalEventMap['abort']) => {
                     signal.removeEventListener('abort', handleAbort);
                     coalescedRequest.numConsumers -= 1;
-                    // FIXME: Probably replace this with `queueMicrotask()`
-                    void Promise.resolve().then(() => {
+                    queueMicrotask(() => {
                         if (coalescedRequest.numConsumers === 0) {
                             const abortController = coalescedRequest.abortController;
                             abortController.abort((EXPLICIT_ABORT_TOKEN ||= createExplicitAbortToken()));


### PR DESCRIPTION
# Summary

The `queueMicrotask` API is well-supported enough now to use for this use case. https://caniuse.com/mdn-api_queuemicrotask