### PR TITLE
Configure the channel pool to open a new channel when all of the currently open channels reach 100 subscriptions each

### DIFF
--- a/packages/rpc-subscriptions/README.md
+++ b/packages/rpc-subscriptions/README.md
@@ -27,7 +27,7 @@ Creates a function that returns new subscription channels when called.
 A config object with the following properties:
 
 -   `intervalMs`: The number of milliseconds to wait since the last message sent or received over the channel before sending a ping message to keep the channel open.
--   `maxSubscriptionsPerChannel`: The number of subscribers that may share a channel before a new channel must be created. Set this to the maximum number of subscriptions that your RPC provider recommends making over a single connection.
+-   `maxSubscriptionsPerChannel`: The number of subscribers that may share a channel before a new channel must be created (default: 100). It is important that you set this to the maximum number of subscriptions that your RPC provider recommends making over a single connection; the default is set deliberately low, so as to comply with the restrictive limits of the public mainnet RPC node.
 -   `minChannels`: The number of channels to create before reusing a channel for a new subscription.
 -   `sendBufferHighWatermark`: The number of bytes of data to admint into the `WebSocket` buffer before buffering data on the client. -`url`: The URL of the web socket server. Must use the `ws` or `wss` protocols.
 

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-channel.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-channel.ts
@@ -48,8 +48,15 @@ export function createDefaultRpcSubscriptionsChannelCreator<TClusterUrl extends 
     return getChannelPoolingChannelCreator(createDefaultRpcSubscriptionsChannel, {
         maxSubscriptionsPerChannel:
             config.maxSubscriptionsPerChannel ??
-            // TODO: Determine this experimentally
-            1_000,
+            /**
+             * A note about this default. The idea here is that, because some RPC providers impose
+             * an upper limit on the number of subscriptions you can make per channel, we must
+             * choose a number low enough to avoid hitting that limit. Without knowing what provider
+             * a given person is using, or what their limit is, we have to choose the lowest of all
+             * known limits. As of this writing (October 2024) that is the public mainnet RPC node
+             * (api.mainnet-beta.solana.com) at 100 subscriptions.
+             */
+            100,
         minChannels: config.minChannels ?? 1,
     });
 }


### PR DESCRIPTION
# Summary

When you make ‘too many’ subscriptions over a single channel/connection/socket, RPC providers will throw errors. The idea behind this PR is to set the default subscriptions-per-channel low enough so as to avoid running afoul of even the most restrictive provider's limit.

This was determined experimentally by hitting various nodes with [this script](https://gist.github.com/steveluscher/717d3ac535e862314ae3f9f4d0310c14).

- Triton Public Mainnet (`api.mainnet-beta.solana.com`): 100
- Helius: ~1450
- QuickNode: ~4500

The ground truth is this:

1. Some nodes have definite limits set, like the public Triton mainnet node.
2. Some nodes _don't_ have limits set, but unceremoniously close the connection _roughly_ around the same number of subscriptions.

The right thing to do here would be for providers _not_ to kill the channels, but rather to _respond_ to the suscription request with a JSON-RPC response, of the form:

```json
{
  "error": {
    "code": ???,
    "message": "OK, that's enough subscriptions for now.",
  },
  "id": 123,
  "jsonrpc": "2.0"
}
```

If everyone did that, and we all decided on an error code in the range -32000 to -32099, as demanded by what the JSON-RPC spec says about errors, then the channel pool could _catch_ that error to know when a new channel needed to be added to the pool. Because they don't, we have to participate in this tragedy of the commons, and hardcode the limit to 100 so that people using the public endpoint will not get caught off-guard by the limit.

> [!NOTE]
> There might actually be two kinds of errors: ‘I can't give you this subscription over this channel, open a new one’ and ‘I can't give you this subscription over any channel, please stop opening subscriptions.’ 

cc/ @linuskendall, @WilfredAlmeida, @vovkman