### PR TITLE
Remove unused RpcSubscriptionsRequest type

### DIFF
--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
@@ -1,10 +1,3 @@
-export type RpcSubscriptionsRequest<TResponse> = {
-    params: unknown[];
-    responseTransformer?: (response: unknown, notificationName: string) => TResponse;
-    subscribeMethodName: string;
-    unsubscribeMethodName: string;
-};
-
 export type PendingRpcSubscriptionsRequest<TNotification> = {
     subscribe(options: RpcSubscribeOptions): Promise<AsyncIterable<TNotification>>;
 };


### PR DESCRIPTION
This PR removes the `RpcSubscriptionsRequest` which was used in the previous implementation of RPC Subscriptions but no longer is.