### PR TITLE
fix: cover logs error for ws message

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6251,13 +6251,15 @@ export class Connection {
                   serverSubscriptionId
                 ] = subscription.callbacks;
                 await this._updateSubscriptions();
-              } catch (e) {
+              } catch (e: any) {
                 if (e instanceof Error) {
                   console.error(
                     `${method} error for argument`,
                     args,
                     e.message,
                   );
+                } else if (typeof e === 'object' && e.code) {
+                  console.log(`${method} error for argument`, args, e.message);
                 }
                 if (!isCurrentConnectionStillActive()) {
                   return;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6251,16 +6251,14 @@ export class Connection {
                   serverSubscriptionId
                 ] = subscription.callbacks;
                 await this._updateSubscriptions();
-              } catch (e: any) {
-                if (e instanceof Error) {
-                  console.error(
-                    `${method} error for argument`,
+              } catch (e) {
+                console.error(
+                  `Received ${e instanceof Error ? '' : 'JSON-RPC '}error calling \`${method}\``,
+                  {
                     args,
-                    e.message,
-                  );
-                } else if (typeof e === 'object' && e.code) {
-                  console.log(`${method} error for argument`, args, e.message);
-                }
+                    error: e,
+                  },
+                );
                 if (!isCurrentConnectionStillActive()) {
                   return;
                 }


### PR DESCRIPTION
Some message from websocket contain error 
```json
{
  "id": 59,
  "jsonrpc": "2.0",
  "error": {
    "code": -32601,
    "message": "Subscriptions unsupported for this network"
  }
}
```
Which not present any where, just add console log for represent error for developer