### PR TITLE
Use RpcRequest in createRpcMessage helper

### DIFF
--- a/.changeset/wet-colts-exist.md
+++ b/.changeset/wet-colts-exist.md
@@ -1,0 +1,7 @@
+---
+'@solana/rpc-subscriptions-spec': patch
+'@solana/rpc-spec-types': patch
+'@solana/rpc-spec': patch
+---
+
+Use RpcRequest in createRpcMessage helper

--- a/packages/rpc-spec-types/src/__tests__/rpc-message-test.ts
+++ b/packages/rpc-spec-types/src/__tests__/rpc-message-test.ts
@@ -2,17 +2,18 @@ import { createRpcMessage } from '../rpc-message';
 
 describe('createRpcMessage', () => {
     it('auto-increments ids with each new message', () => {
-        const { id: firstId } = createRpcMessage('foo', 'bar');
-        const { id: secondId } = createRpcMessage('foo', 'bar');
+        const request = { methodName: 'foo', params: 'bar' };
+        const { id: firstId } = createRpcMessage(request);
+        const { id: secondId } = createRpcMessage(request);
         expect(secondId - firstId).toBe(1);
     });
     it('returns a well-formed JSON-RPC 2.0 message', () => {
-        const params = [1, 2, 3];
-        expect(createRpcMessage('someMethod', params)).toStrictEqual({
+        const request = { methodName: 'someMethod', params: [1, 2, 3] };
+        expect(createRpcMessage(request)).toStrictEqual({
             id: expect.any(Number),
             jsonrpc: '2.0',
             method: 'someMethod',
-            params,
+            params: [1, 2, 3],
         });
     });
 });

--- a/packages/rpc-spec-types/src/rpc-message.ts
+++ b/packages/rpc-spec-types/src/rpc-message.ts
@@ -1,3 +1,5 @@
+import { RpcRequest } from './rpc-request';
+
 let _nextMessageId = 0;
 function getNextMessageId() {
     const id = _nextMessageId;
@@ -5,11 +7,11 @@ function getNextMessageId() {
     return id;
 }
 
-export function createRpcMessage<TParams>(method: string, params: TParams) {
+export function createRpcMessage<TParams>(request: RpcRequest<TParams>) {
     return {
         id: getNextMessageId(),
         jsonrpc: '2.0',
-        method,
-        params,
+        method: request.methodName,
+        params: request.params,
     };
 }

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -43,7 +43,7 @@ describe('JSON-RPC 2.0', () => {
                 api: new Proxy({} as RpcApi<TestRpcMethods>, {
                     get(_, methodName) {
                         return (...params: unknown[]) => ({
-                            payload: createRpcMessage(methodName.toString(), params),
+                            payload: createRpcMessage({ methodName: methodName.toString(), params }),
                         });
                     },
                 }),
@@ -55,7 +55,7 @@ describe('JSON-RPC 2.0', () => {
                 .send()
                 .catch(() => {});
             expect(makeHttpRequest).toHaveBeenCalledWith({
-                payload: { ...createRpcMessage('someMethod', [123]), id: expect.any(Number) },
+                payload: { ...createRpcMessage({ methodName: 'someMethod', params: [123] }), id: expect.any(Number) },
             });
         });
         it('returns results from the transport', async () => {
@@ -79,7 +79,10 @@ describe('JSON-RPC 2.0', () => {
                 api: {
                     someMethod(...params: unknown[]): RpcApiRequestPlan<unknown> {
                         return {
-                            payload: createRpcMessage('someMethodAugmented', [...params, 'augmented', 'params']),
+                            payload: createRpcMessage({
+                                methodName: 'someMethodAugmented',
+                                params: [...params, 'augmented', 'params'],
+                            }),
                         };
                     },
                 } as RpcApi<TestRpcMethods>,
@@ -92,7 +95,7 @@ describe('JSON-RPC 2.0', () => {
                 .catch(() => {});
             expect(makeHttpRequest).toHaveBeenCalledWith({
                 payload: {
-                    ...createRpcMessage('someMethodAugmented', [123, 'augmented', 'params']),
+                    ...createRpcMessage({ methodName: 'someMethodAugmented', params: [123, 'augmented', 'params'] }),
                     id: expect.any(Number),
                 },
             });
@@ -107,7 +110,7 @@ describe('JSON-RPC 2.0', () => {
                 api: {
                     someMethod(...params: unknown[]): RpcApiRequestPlan<unknown> {
                         return {
-                            payload: createRpcMessage('someMethod', params),
+                            payload: createRpcMessage({ methodName: 'someMethod', params }),
                             responseTransformer,
                         };
                     },

--- a/packages/rpc-spec/src/rpc-api.ts
+++ b/packages/rpc-spec/src/rpc-api.ts
@@ -51,7 +51,7 @@ export function createJsonRpcApi<TRpcMethods extends RpcApiMethods>(config?: Rpc
                 const rawRequest = Object.freeze({ methodName, params: rawParams });
                 const request = config?.requestTransformer ? config?.requestTransformer(rawRequest) : rawRequest;
                 return Object.freeze({
-                    payload: createRpcMessage(request.methodName, request.params),
+                    payload: createRpcMessage(request),
                     ...(config?.responseTransformer
                         ? {
                               responseTransformer: (response: RpcResponse) => {

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions-pubsub-plan.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions-pubsub-plan.ts
@@ -128,7 +128,10 @@ export async function executeRpcPubSubSubscriptionPlan<TNotification>({
              * must be careful not to send the unsubscribe message until the last subscriber aborts.
              */
             if (decrementSubscriberCountAndReturnNewCount(channel, subscriptionId) === 0) {
-                const unsubscribePayload = createRpcMessage(unsubscribeMethodName, [subscriptionId]);
+                const unsubscribePayload = createRpcMessage({
+                    methodName: unsubscribeMethodName,
+                    params: [subscriptionId],
+                });
                 subscriptionId = undefined;
                 channel.send(unsubscribePayload).catch(() => {});
             }
@@ -144,7 +147,7 @@ export async function executeRpcPubSubSubscriptionPlan<TNotification>({
      * STEP 2
      * Send the subscription request.
      */
-    const subscribePayload = createRpcMessage(subscribeMethodName, subscribeParams);
+    const subscribePayload = createRpcMessage({ methodName: subscribeMethodName, params: subscribeParams });
     await channel.send(subscribePayload);
     /**
      * STEP 3


### PR DESCRIPTION
This PR changes the arguments of the `createRpcMessage` helper function so that it accepts an `RpcRequest` directly instead of accepting all the components inside a request (i.e. `methodName` and `params`).

We discussed this a little while ago with @mcintyre94 as, without this change, you sometimes need to express a request as an object and sometimes as its deconstructed version. This PR stack aims to embrace the `RpcRequest` object wherever applicable.