### PR TITLE
Temporarily disable Node 23 CI tests

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -31,7 +31,7 @@ jobs:
           # FIXME: This is a temporary workaround until Jest work nicely with Node 23.
           # Currently, we get `No tests found, exiting with code 1` errors when running
           # Jest unit tests on Node 23.
-          # - 'current'
+          - 22.x # 'current'
           - 'lts/*'
 
     name: Build & Test on Node ${{ matrix.node }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -28,7 +28,10 @@ jobs:
     strategy:
       matrix:
         node:
-          - 'current'
+          # FIXME: This is a temporary workaround until Jest work nicely with Node 23.
+          # Currently, we get `No tests found, exiting with code 1` errors when running
+          # Jest unit tests on Node 23.
+          # - 'current'
           - 'lts/*'
 
     name: Build & Test on Node ${{ matrix.node }}


### PR DESCRIPTION
**Context**: Two days ago Node officially released version 23 and updated the `Current` alias to point to this new stable version.

**Problem**: This is causing our CI to fail in the following way: when running Jest unit tests, we get `No tests found, exiting with code 1`.

![CleanShot 2024-10-18 at 09.51.17@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/kTNWsdvmzyPPLaKihnPF/0c2a367a-0c45-4095-a97a-87389560bcee.png)

It looks like `testMatch` gets some matches but `testRegex` no longer does. The reason this only starts failing in PRs (and not on the `master` branch) is because of Turbo caching. I tested this by created a new PR that only adds a comment to a package and that package CI now fails.

**Workaround**: One temporary workaround is to comment out the current version on the CI Node matrix until Node v23 and Jest learn how to play nicely with each other. This is what this PR does.