### PR TITLE
Use RpcRequest in PlanExecutor configs

### DIFF
--- a/packages/rpc-subscriptions-api/src/index.ts
+++ b/packages/rpc-subscriptions-api/src/index.ts
@@ -56,11 +56,10 @@ function createSolanaRpcSubscriptionsApi_INTERNAL<TApi extends RpcSubscriptionsA
         allowedNumericKeyPaths: getAllowedNumericKeypaths(),
     });
     return createRpcSubscriptionsApi<TApi>({
-        getSubscriptionConfigurationHash({ notificationName, params }) {
-            return fastStableStringify([notificationName, params]);
+        getSubscriptionConfigurationHash(request) {
+            return fastStableStringify([request.methodName, request.params]);
         },
-        planExecutor({ notificationName, params, ...rest }) {
-            const request = { methodName: notificationName, params };
+        planExecutor({ request, ...rest }) {
             const transformedRequest = requestTransformer(request);
             return executeRpcPubSubSubscriptionPlan({
                 ...rest,

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-api-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-api-test.ts
@@ -23,8 +23,7 @@ describe('createRpcSubscriptionsApi', () => {
                 .catch(() => {});
             expect(mockPlanExecutor).toHaveBeenCalledWith({
                 channel: mockChannel,
-                notificationName: 'foo',
-                params: expectedParams,
+                request: { methodName: 'foo', params: expectedParams },
                 signal: expectedSignal,
             });
         });
@@ -48,7 +47,7 @@ describe('createRpcSubscriptionsApi', () => {
             const result = api.foo('hi');
             result.subscriptionConfigurationHash;
             expect(mockGetSubscriptionConfigurationHash).toHaveBeenCalledWith({
-                notificationName: 'foo',
+                methodName: 'foo',
                 params: ['hi'],
             });
         });


### PR DESCRIPTION
This PR replaces the `notificationName` and `params` arguments of the `RpcSubscriptionsPlanExecutor` function by a single `request` argument of type `RpcRequest`. This request argument is meant to represent the user intent to request a subscription from the RPC Subscriptions packages.

Note: A changeset for this PR is included in https://github.com/solana-labs/solana-web3.js/pull/3407.