### PR TITLE
Replace subscriptionConfigurationHash with RpcRequest in RpcSubscriptionsPlan

### DIFF
--- a/.changeset/silly-wombats-switch.md
+++ b/.changeset/silly-wombats-switch.md
@@ -1,0 +1,7 @@
+---
+'@solana/rpc-subscriptions-spec': patch
+'@solana/rpc-subscriptions-api': patch
+'@solana/rpc-subscriptions': patch
+---
+
+Replace subscriptionConfigurationHash with RpcRequest in RpcSubscriptionPlan

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -72,7 +72,6 @@
     ],
     "dependencies": {
         "@solana/addresses": "workspace:*",
-        "@solana/fast-stable-stringify": "workspace:*",
         "@solana/keys": "workspace:*",
         "@solana/rpc-subscriptions-spec": "workspace:*",
         "@solana/rpc-transformers": "workspace:*",

--- a/packages/rpc-subscriptions-api/src/index.ts
+++ b/packages/rpc-subscriptions-api/src/index.ts
@@ -1,4 +1,3 @@
-import fastStableStringify from '@solana/fast-stable-stringify';
 import {
     createRpcSubscriptionsApi,
     executeRpcPubSubSubscriptionPlan,
@@ -56,21 +55,15 @@ function createSolanaRpcSubscriptionsApi_INTERNAL<TApi extends RpcSubscriptionsA
         allowedNumericKeyPaths: getAllowedNumericKeypaths(),
     });
     return createRpcSubscriptionsApi<TApi>({
-        getSubscriptionConfigurationHash(request) {
-            return fastStableStringify([request.methodName, request.params]);
-        },
         planExecutor({ request, ...rest }) {
-            const transformedRequest = requestTransformer(request);
             return executeRpcPubSubSubscriptionPlan({
                 ...rest,
                 responseTransformer,
-                subscribeRequest: {
-                    ...transformedRequest,
-                    methodName: transformedRequest.methodName.replace(/Notifications$/, 'Subscribe'),
-                },
-                unsubscribeMethodName: transformedRequest.methodName.replace(/Notifications$/, 'Unsubscribe'),
+                subscribeRequest: { ...request, methodName: request.methodName.replace(/Notifications$/, 'Subscribe') },
+                unsubscribeMethodName: request.methodName.replace(/Notifications$/, 'Unsubscribe'),
             });
         },
+        requestTransformer,
     });
 }
 

--- a/packages/rpc-subscriptions/README.md
+++ b/packages/rpc-subscriptions/README.md
@@ -51,4 +51,4 @@ Given an `RpcSubscriptionsChannel`, will return a new channel that sends a ping 
 
 ### `getRpcSubscriptionsTransportWithSubscriptionCoalescing(transport)`
 
-Given an `RpcSubscriptionsTransport`, will return a new transport that coalesces identical subscriptions into a single subscription request to the server. The determination of whether a subscription is the same as another is based on the `subscriptionConfigurationHash` returned by its `RpcSubscriptionsPlan`. The subscription will only be aborted once all subscribers abort, or there is an error.
+Given an `RpcSubscriptionsTransport`, will return a new transport that coalesces identical subscriptions into a single subscription request to the server. The determination of whether a subscription is the same as another is based on the `rpcRequest` returned by its `RpcSubscriptionsPlan`. The subscription will only be aborted once all subscribers abort, or there is an error.

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -72,6 +72,7 @@
     ],
     "dependencies": {
         "@solana/errors": "workspace:*",
+        "@solana/fast-stable-stringify": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/promises": "workspace:*",
         "@solana/rpc-subscriptions-api": "workspace:*",

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
@@ -20,8 +20,8 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         mockInnerTransport.mockResolvedValue(expectedDataPublisher);
         const config = {
             executeSubscriptionPlan: jest.fn(),
+            request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
-            subscriptionConfigurationHash: 'MOCK_HASH',
         };
         const transportPromise = coalescedTransport(config);
         await expect(transportPromise).resolves.toBe(expectedDataPublisher);
@@ -29,8 +29,8 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     it('passes the `executeSubscriptionPlan` config to the inner transport', () => {
         const config = {
             executeSubscriptionPlan: jest.fn(),
+            request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
-            subscriptionConfigurationHash: 'MOCK_HASH',
         };
         coalescedTransport(config).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledWith(
@@ -39,16 +39,16 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             }),
         );
     });
-    it('passes the `subscriptionConfigurationHash` config to the inner transport', () => {
+    it('passes the `rpcRequest` config to the inner transport', () => {
         const config = {
             executeSubscriptionPlan: jest.fn(),
+            request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
-            subscriptionConfigurationHash: 'MOCK_HASH',
         };
         coalescedTransport(config).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledWith(
             expect.objectContaining({
-                subscriptionConfigurationHash: 'MOCK_HASH',
+                request: { methodName: 'foo', params: [] },
             }),
         );
     });
@@ -58,11 +58,11 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             signal: new AbortController().signal,
         };
         coalescedTransport({
-            subscriptionConfigurationHash: 'MOCK_HASH_A',
+            request: { methodName: 'methodA', params: [] },
             ...config,
         }).catch(() => {});
         coalescedTransport({
-            subscriptionConfigurationHash: 'MOCK_HASH_B',
+            request: { methodName: 'methodB', params: [] },
             ...config,
         }).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledTimes(2);
@@ -73,46 +73,15 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
             executeSubscriptionPlan: jest.fn(),
             signal: new AbortController().signal,
         };
-        await coalescedTransport({ ...config, subscriptionConfigurationHash: 'MOCK_HASH_A' });
-        await coalescedTransport({ ...config, subscriptionConfigurationHash: 'MOCK_HASH_B' });
-        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
-    });
-    it("calls the inner transport once per subscriber when both subscribers' hashes are `undefined`, in the same runloop", () => {
-        const config = {
-            executeSubscriptionPlan: jest.fn(),
-            signal: new AbortController().signal,
-        };
-        coalescedTransport({
-            subscriptionConfigurationHash: undefined,
-            ...config,
-        }).catch(() => {});
-        coalescedTransport({
-            subscriptionConfigurationHash: undefined,
-            ...config,
-        }).catch(() => {});
-        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
-    });
-    it("calls the inner transport once per subscriber when both subscribers' hashes are `undefined`, in different runloops", async () => {
-        expect.assertions(1);
-        const config = {
-            executeSubscriptionPlan: jest.fn(),
-            signal: new AbortController().signal,
-        };
-        await coalescedTransport({
-            subscriptionConfigurationHash: undefined,
-            ...config,
-        });
-        await coalescedTransport({
-            subscriptionConfigurationHash: undefined,
-            ...config,
-        });
+        await coalescedTransport({ ...config, request: { methodName: 'methodA', params: [] } });
+        await coalescedTransport({ ...config, request: { methodName: 'methodB', params: [] } });
         expect(mockInnerTransport).toHaveBeenCalledTimes(2);
     });
     it('only calls the inner transport once, in the same runloop', () => {
         const config = {
             executeSubscriptionPlan: jest.fn(),
+            request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
-            subscriptionConfigurationHash: 'MOCK_HASH',
         };
         coalescedTransport(config).catch(() => {});
         coalescedTransport(config).catch(() => {});
@@ -122,8 +91,8 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         expect.assertions(1);
         const config = {
             executeSubscriptionPlan: jest.fn(),
+            request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
-            subscriptionConfigurationHash: 'MOCK_HASH',
         };
         await coalescedTransport(config);
         await coalescedTransport(config);
@@ -133,8 +102,8 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         expect.assertions(1);
         const config = {
             executeSubscriptionPlan: jest.fn(),
+            request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
-            subscriptionConfigurationHash: 'MOCK_HASH',
         };
         const [publisherA, publisherB] = await Promise.all([coalescedTransport(config), coalescedTransport(config)]);
         expect(publisherA).toBe(publisherB);
@@ -143,8 +112,8 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         expect.assertions(1);
         const config = {
             executeSubscriptionPlan: jest.fn(),
+            request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
-            subscriptionConfigurationHash: 'MOCK_HASH',
         };
         const publisherA = await coalescedTransport(config);
         const publisherB = await coalescedTransport(config);
@@ -154,7 +123,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         jest.useFakeTimers();
         const config = {
             executeSubscriptionPlan: jest.fn(),
-            subscriptionConfigurationHash: 'MOCK_HASH',
+            request: { methodName: 'foo', params: [] },
         };
         const abortControllerB = new AbortController();
         coalescedTransport({ ...config, signal: new AbortController().signal }).catch(() => {});
@@ -167,7 +136,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         jest.useFakeTimers();
         const config = {
             executeSubscriptionPlan: jest.fn(),
-            subscriptionConfigurationHash: 'MOCK_HASH',
+            request: { methodName: 'foo', params: [] },
         };
         const abortControllerA = new AbortController();
         const abortControllerB = new AbortController();
@@ -182,7 +151,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         expect.assertions(1);
         const config = {
             executeSubscriptionPlan: jest.fn(),
-            subscriptionConfigurationHash: 'MOCK_HASH',
+            request: { methodName: 'foo', params: [] },
         };
         const abortControllerA = new AbortController();
         const abortControllerB = new AbortController();
@@ -198,7 +167,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     it('does not fire the inner abort signal if the subscriber count is non zero at the end of the runloop, despite having aborted all in the middle of it', () => {
         const config = {
             executeSubscriptionPlan: jest.fn(),
-            subscriptionConfigurationHash: 'MOCK_HASH',
+            request: { methodName: 'foo', params: [] },
         };
         const abortControllerA = new AbortController();
         coalescedTransport({ ...config, signal: abortControllerA.signal }).catch(() => {});
@@ -212,7 +181,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         jest.useFakeTimers();
         const config = {
             executeSubscriptionPlan: jest.fn(),
-            subscriptionConfigurationHash: 'MOCK_HASH',
+            request: { methodName: 'foo', params: [] },
         };
         coalescedTransport({ ...config, signal: new AbortController().signal }).catch(() => {});
         await jest.runAllTimersAsync();
@@ -225,7 +194,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         jest.useFakeTimers();
         const config = {
             executeSubscriptionPlan: jest.fn(),
-            subscriptionConfigurationHash: 'MOCK_HASH',
+            request: { methodName: 'foo', params: [] },
         };
         const abortControllerA = new AbortController();
         /**

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-transport-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-transport-test.ts
@@ -10,8 +10,8 @@ describe('createRpcSubscriptionsTransportFromChannelCreator', () => {
         const abortSignal = new AbortController().signal;
         creator({
             executeSubscriptionPlan: jest.fn(),
+            request: { methodName: 'foo', params: [] },
             signal: abortSignal,
-            subscriptionConfigurationHash: undefined,
         }).catch(() => {});
         expect(mockCreateChannel).toHaveBeenCalledWith({ abortSignal });
     });
@@ -21,8 +21,8 @@ describe('createRpcSubscriptionsTransportFromChannelCreator', () => {
         const mockExecuteSubscriptionPlan = jest.fn();
         creator({
             executeSubscriptionPlan: mockExecuteSubscriptionPlan,
+            request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
-            subscriptionConfigurationHash: undefined,
         }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(mockExecuteSubscriptionPlan).toHaveBeenCalledWith(
@@ -38,8 +38,8 @@ describe('createRpcSubscriptionsTransportFromChannelCreator', () => {
         const signal = new AbortController().signal;
         creator({
             executeSubscriptionPlan: mockExecuteSubscriptionPlan,
+            request: { methodName: 'foo', params: [] },
             signal,
-            subscriptionConfigurationHash: undefined,
         }).catch(() => {});
         await jest.runAllTimersAsync();
         expect(mockExecuteSubscriptionPlan).toHaveBeenCalledWith(

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-coalescer.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-coalescer.ts
@@ -1,3 +1,4 @@
+import fastStableStringify from '@solana/fast-stable-stringify';
 import { RpcSubscriptionsTransport } from '@solana/rpc-subscriptions-spec';
 import { DataPublisher } from '@solana/subscribable';
 
@@ -12,10 +13,9 @@ export function getRpcSubscriptionsTransportWithSubscriptionCoalescing<TTranspor
 ): TTransport {
     const cache = new Map<string, CacheEntry>();
     return function rpcSubscriptionsTransportWithSubscriptionCoalescing(config) {
-        const { subscriptionConfigurationHash, signal } = config;
-        if (subscriptionConfigurationHash === undefined) {
-            return transport(config);
-        }
+        const { request, signal } = config;
+        const subscriptionConfigurationHash = fastStableStringify([request.methodName, request.params]);
+
         let cachedDataPublisherPromise = cache.get(subscriptionConfigurationHash);
         if (!cachedDataPublisherPromise) {
             const abortController = new AbortController();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -865,6 +865,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      '@solana/fast-stable-stringify':
+        specifier: workspace:*
+        version: link:../fast-stable-stringify
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional
@@ -898,9 +901,6 @@ importers:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
-      '@solana/fast-stable-stringify':
-        specifier: workspace:*
-        version: link:../fast-stable-stringify
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys


### PR DESCRIPTION
This PR replaces the `subscriptionConfigurationHash` attribute from the `RpcSubscriptionsPlan` type by a `request` attribute of type `RpcRequest` representing the user intent to request to an RPC Subscription.

The main issue with having a `subscriptionConfigurationHash` attribute defined in the interfaces of RPC Subscriptions is that it is mainly useful to create a coalescer transport decorator and, therefore, is application-specific. By providing the full `RpcRequest` instead, transports can decide to use this information however they see fit. For instance, a coalescer transport may hash all of the request data whereas a sharding transport may only use the method name of the request. Notice how the `@solana/fast-stable-stringify` package has now moved from the API package to the package that defines the coalescer transport.

Additionally, this PR replaces the `getSubscriptionConfigurationHash` function of the `RpcSubscriptionsApiConfig` type by an `RpcRequestTransformer`. That way, the `createRpcSubscriptionsApi` function can prepare the raw request (from the proxy), transform it using the provided request transformer and pass the transformed request into the plan executor.