### PR TITLE
Specify Node LTS as the miniumum version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 auto-install-peers=true
+engine-strict=true
 workspaces-update=false

--- a/packages/accounts/.npmrc
+++ b/packages/accounts/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -88,5 +88,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -89,5 +89,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -86,5 +86,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/build-scripts/.npmrc
+++ b/packages/build-scripts/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/build-scripts/package.json
+++ b/packages/build-scripts/package.json
@@ -11,5 +11,8 @@
         "@types/jscodeshift": "^0.12.0",
         "browserslist-to-esbuild": "^2.1.1",
         "jscodeshift": "^17.0.0"
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -90,5 +90,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -91,5 +91,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -87,5 +87,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -94,5 +94,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/codecs/.npmrc
+++ b/packages/codecs/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -85,5 +85,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -94,5 +94,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/crypto-impl/.npmrc
+++ b/packages/crypto-impl/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/crypto-impl/package.json
+++ b/packages/crypto-impl/package.json
@@ -52,6 +52,6 @@
         "maintained node versions"
     ],
     "engines": {
-        "node": ">=18"
+        "node": ">=20.18.0"
     }
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -88,5 +88,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/fast-stable-stringify/.npmrc
+++ b/packages/fast-stable-stringify/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/fast-stable-stringify/package.json
+++ b/packages/fast-stable-stringify/package.json
@@ -87,5 +87,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/fetch-impl/.npmrc
+++ b/packages/fetch-impl/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/fetch-impl/package.json
+++ b/packages/fetch-impl/package.json
@@ -8,5 +8,8 @@
     "devDependencies": {
         "tinybench": "^2.9.0",
         "undici": "^6.20.0"
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/functional/.npmrc
+++ b/packages/functional/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -80,5 +80,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/instructions/.npmrc
+++ b/packages/instructions/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -86,5 +86,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -93,5 +93,8 @@
     },
     "devDependencies": {
         "tinybench": "^2.9.0"
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/library/.npmrc
+++ b/packages/library/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -102,5 +102,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -90,5 +90,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/programs/.npmrc
+++ b/packages/programs/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -88,5 +88,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/promises/.npmrc
+++ b/packages/promises/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/promises/package.json
+++ b/packages/promises/package.json
@@ -80,5 +80,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -104,5 +104,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-api/.npmrc
+++ b/packages/rpc-api/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -97,5 +97,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-graphql/.npmrc
+++ b/packages/rpc-graphql/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -94,5 +94,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-parsed-types/.npmrc
+++ b/packages/rpc-parsed-types/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -82,5 +82,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-spec-types/.npmrc
+++ b/packages/rpc-spec-types/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -80,5 +80,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-spec/.npmrc
+++ b/packages/rpc-spec/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -84,5 +84,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-subscriptions-api/.npmrc
+++ b/packages/rpc-subscriptions-api/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -93,5 +93,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-subscriptions-channel-websocket/.npmrc
+++ b/packages/rpc-subscriptions-channel-websocket/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-subscriptions-channel-websocket/package.json
+++ b/packages/rpc-subscriptions-channel-websocket/package.json
@@ -91,5 +91,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-subscriptions-spec/.npmrc
+++ b/packages/rpc-subscriptions-spec/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -86,5 +86,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-subscriptions/.npmrc
+++ b/packages/rpc-subscriptions/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -91,5 +91,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-transformers/.npmrc
+++ b/packages/rpc-transformers/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -87,5 +87,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-transport-http/.npmrc
+++ b/packages/rpc-transport-http/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -91,5 +91,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc-types/.npmrc
+++ b/packages/rpc-types/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -87,5 +87,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/rpc/.npmrc
+++ b/packages/rpc/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -90,5 +90,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -96,5 +96,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/subscribable/package.json
+++ b/packages/subscribable/package.json
@@ -86,5 +86,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -96,5 +96,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/test-config/.npmrc
+++ b/packages/test-config/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/test-config/package.json
+++ b/packages/test-config/package.json
@@ -15,5 +15,8 @@
         "@jest/types": "^29.6.3",
         "undici": "^6.20.0",
         "whatwg-fetch": "^3.6.20"
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/test-matchers/.npmrc
+++ b/packages/test-matchers/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/test-matchers/package.json
+++ b/packages/test-matchers/package.json
@@ -4,5 +4,8 @@
     "private": true,
     "files": [
         "toBeFrozenObject.ts"
-    ]
+    ],
+    "engines": {
+        "node": ">=20.18.0"
+    }
 }

--- a/packages/text-encoding-impl/.npmrc
+++ b/packages/text-encoding-impl/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/text-encoding-impl/package.json
+++ b/packages/text-encoding-impl/package.json
@@ -55,5 +55,8 @@
     },
     "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22"
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -98,5 +98,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/transaction-messages/.npmrc
+++ b/packages/transaction-messages/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -93,5 +93,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/transactions/.npmrc
+++ b/packages/transactions/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -93,5 +93,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/tsconfig/.npmrc
+++ b/packages/tsconfig/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -4,5 +4,8 @@
     "private": true,
     "files": [
         "base.json"
-    ]
+    ],
+    "engines": {
+        "node": ">=20.18.0"
+    }
 }

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -86,5 +86,8 @@
                 "path": "./dist/index*.js"
             }
         ]
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }

--- a/packages/ws-impl/.npmrc
+++ b/packages/ws-impl/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/ws-impl/package.json
+++ b/packages/ws-impl/package.json
@@ -56,5 +56,8 @@
     },
     "peerDependencies": {
         "ws": "^8.18.0"
+    },
+    "engines": {
+        "node": ">=20.18.0"
     }
 }


### PR DESCRIPTION
This is not a panacea, but at least it draws a line in the sand. In particular, this won't prevent people who _install_ these npm packages from having a lower Node version, but it will prevent development on the packages themselves on a Node version lower than LTS.

LTS at the time of writing was 20.18.0.

Closes #1680.
