### PR TITLE
feat: Agave v2 RPC: replace `getConfirmedTransaction` with `getTransaction`

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -5353,7 +5353,7 @@ export class Connection {
     commitment?: Finality,
   ): Promise<ConfirmedTransaction | null> {
     const args = this._buildArgsAtLeastConfirmed([signature], commitment);
-    const unsafeRes = await this._rpcRequest('getConfirmedTransaction', args);
+    const unsafeRes = await this._rpcRequest('getTransaction', args);
     const res = create(unsafeRes, GetTransactionRpcResult);
     if ('error' in res) {
       throw new SolanaJSONRPCError(res.error, 'failed to get transaction');
@@ -5384,7 +5384,7 @@ export class Connection {
       commitment,
       'jsonParsed',
     );
-    const unsafeRes = await this._rpcRequest('getConfirmedTransaction', args);
+    const unsafeRes = await this._rpcRequest('getTransaction', args);
     const res = create(unsafeRes, GetParsedTransactionRpcResult);
     if ('error' in res) {
       throw new SolanaJSONRPCError(
@@ -5411,7 +5411,7 @@ export class Connection {
         'jsonParsed',
       );
       return {
-        methodName: 'getConfirmedTransaction',
+        methodName: 'getTransaction',
         args,
       };
     });

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -2712,7 +2712,7 @@ describe('Connection', function () {
     await mockRpcBatchResponse({
       batch: [
         {
-          methodName: 'getConfirmedTransaction',
+          methodName: 'getTransaction',
           args: [],
         },
       ],
@@ -3364,7 +3364,7 @@ describe('Connection', function () {
     }
 
     await mockRpcResponse({
-      method: 'getConfirmedTransaction',
+      method: 'getTransaction',
       params: [confirmedTransaction],
       value: {
         slot,
@@ -3430,7 +3430,7 @@ describe('Connection', function () {
     });
 
     await mockRpcResponse({
-      method: 'getConfirmedTransaction',
+      method: 'getTransaction',
       params: [recentSignature],
       value: null,
     });
@@ -3622,7 +3622,7 @@ describe('Connection', function () {
       }
 
       await mockRpcResponse({
-        method: 'getConfirmedTransaction',
+        method: 'getTransaction',
         params: [confirmedTransaction, {encoding: 'jsonParsed'}],
         value: getMockData({
           parsed: {},
@@ -3641,7 +3641,7 @@ describe('Connection', function () {
       }
 
       await mockRpcResponse({
-        method: 'getConfirmedTransaction',
+        method: 'getTransaction',
         params: [confirmedTransaction, {encoding: 'jsonParsed'}],
         value: getMockData({
           accounts: [


### PR DESCRIPTION
#### Problem
With the upcoming upgrade from 1.18 to 2.0 on Solana mainnet-beta, deprecated RPC methods have been removed, therefore they will no longer be available through Web3.js client requests.

The [Agave 2.0 Migration Guide](https://github.com/anza-xyz/agave/wiki/Agave-v2.0-Transition-Guide) lists semi-equivalent RPC method counterparts for each of the removed methods.

#### Summary of Changes
Replace `getConfirmedTransaction` with `getTransaction`. This method was already requiring a confirmation level of `confirmed` or `finalized`, so the behavior should be unchanged.