### PR TITLE
feat: Agave v2 RPC: replace `getRecentBlockhash` with `getLatestBlockhash`

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -5353,7 +5353,7 @@ export class Connection {
     commitment?: Finality,
   ): Promise<ConfirmedTransaction | null> {
     const args = this._buildArgsAtLeastConfirmed([signature], commitment);
-    const unsafeRes = await this._rpcRequest('getConfirmedTransaction', args);
+    const unsafeRes = await this._rpcRequest('getTransaction', args);
     const res = create(unsafeRes, GetTransactionRpcResult);
     if ('error' in res) {
       throw new SolanaJSONRPCError(res.error, 'failed to get transaction');
@@ -5384,7 +5384,7 @@ export class Connection {
       commitment,
       'jsonParsed',
     );
-    const unsafeRes = await this._rpcRequest('getConfirmedTransaction', args);
+    const unsafeRes = await this._rpcRequest('getTransaction', args);
     const res = create(unsafeRes, GetParsedTransactionRpcResult);
     if ('error' in res) {
       throw new SolanaJSONRPCError(
@@ -5411,7 +5411,7 @@ export class Connection {
         'jsonParsed',
       );
       return {
-        methodName: 'getConfirmedTransaction',
+        methodName: 'getTransaction',
         args,
       };
     });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -5225,7 +5225,7 @@ export class Connection {
     commitment?: Finality,
   ): Promise<ConfirmedBlock> {
     const args = this._buildArgsAtLeastConfirmed([slot], commitment);
-    const unsafeRes = await this._rpcRequest('getConfirmedBlock', args);
+    const unsafeRes = await this._rpcRequest('getBlock', args);
     const res = create(unsafeRes, GetConfirmedBlockRpcResult);
 
     if ('error' in res) {
@@ -5331,7 +5331,7 @@ export class Connection {
         rewards: false,
       },
     );
-    const unsafeRes = await this._rpcRequest('getConfirmedBlock', args);
+    const unsafeRes = await this._rpcRequest('getBlock', args);
     const res = create(unsafeRes, GetBlockSignaturesRpcResult);
     if ('error' in res) {
       throw new SolanaJSONRPCError(res.error, 'failed to get confirmed block');

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4557,19 +4557,23 @@ export class Connection {
       context,
       value: {blockhash},
     } = await this.getLatestBlockhashAndContext(commitment);
+    const feeCalculator = {
+      get lamportsPerSignature(): number {
+        throw new Error(
+          'The capability to fetch `lamportsPerSignature` using the `getRecentBlockhash` API is ' +
+            'no longer offered by the network. Use the `getFeeForMessage` API to obtain the fee ' +
+            'for a given message.',
+        );
+      },
+      toJSON() {
+        return {};
+      },
+    };
     return {
       context,
       value: {
         blockhash,
-        feeCalculator: {
-          get lamportsPerSignature(): number {
-            throw new Error(
-              'The capability to fetch `lamportsPerSignature` using the `getRecentBlockhash` API is ' +
-                'no longer offered by the network. Use the `getFeeForMessage` API to obtain the fee ' +
-                'for a given message.',
-            );
-          },
-        },
+        feeCalculator,
       },
     };
   }

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -2712,7 +2712,7 @@ describe('Connection', function () {
     await mockRpcBatchResponse({
       batch: [
         {
-          methodName: 'getConfirmedTransaction',
+          methodName: 'getTransaction',
           args: [],
         },
       ],
@@ -3364,7 +3364,7 @@ describe('Connection', function () {
     }
 
     await mockRpcResponse({
-      method: 'getConfirmedTransaction',
+      method: 'getTransaction',
       params: [confirmedTransaction],
       value: {
         slot,
@@ -3430,7 +3430,7 @@ describe('Connection', function () {
     });
 
     await mockRpcResponse({
-      method: 'getConfirmedTransaction',
+      method: 'getTransaction',
       params: [recentSignature],
       value: null,
     });
@@ -3622,7 +3622,7 @@ describe('Connection', function () {
       }
 
       await mockRpcResponse({
-        method: 'getConfirmedTransaction',
+        method: 'getTransaction',
         params: [confirmedTransaction, {encoding: 'jsonParsed'}],
         value: getMockData({
           parsed: {},
@@ -3641,7 +3641,7 @@ describe('Connection', function () {
       }
 
       await mockRpcResponse({
-        method: 'getConfirmedTransaction',
+        method: 'getTransaction',
         params: [confirmedTransaction, {encoding: 'jsonParsed'}],
         value: getMockData({
           accounts: [

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -2351,7 +2351,7 @@ describe('Connection', function () {
     await waitForSlot.call(this, connection, 1);
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [1],
       value: {
         blockTime: 1614281964,
@@ -2433,7 +2433,7 @@ describe('Connection', function () {
     const mockSignature =
       '5SHZ9NwpnS9zYnauN7pnuborKf39zGMr11XpMC59VvRSeDJNcnYLecmdxXCVuBFPNQLdCBBjyZiNCL4KoHKr3tvz';
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [slot, {transactionDetails: 'signatures', rewards: false}],
       value: {
         blockTime: 1614281964,
@@ -2449,7 +2449,7 @@ describe('Connection', function () {
       value: 123,
     });
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [slot + 2, {transactionDetails: 'signatures', rewards: false}],
       value: {
         blockTime: 1614281964,
@@ -2482,7 +2482,7 @@ describe('Connection', function () {
 
     const badSlot = Number.MAX_SAFE_INTEGER - 1;
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [badSlot - 1, {transactionDetails: 'signatures', rewards: false}],
       error: {message: 'Block not available for slot ' + badSlot},
     });
@@ -2531,7 +2531,7 @@ describe('Connection', function () {
     await waitForSlot.call(this, connection, 1);
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [1],
       value: {
         blockTime: 1614281964,
@@ -2640,7 +2640,7 @@ describe('Connection', function () {
     await waitForSlot.call(this, connection, 1);
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [1],
       value: {
         blockTime: 1614281964,
@@ -3294,7 +3294,7 @@ describe('Connection', function () {
     await waitForSlot.call(this, connection, 1);
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [1],
       value: {
         blockTime: 1614281964,
@@ -4252,7 +4252,7 @@ describe('Connection', function () {
 
     it('gets the genesis block', async function () {
       await mockRpcResponse({
-        method: 'getConfirmedBlock',
+        method: 'getBlock',
         params: [0],
         value: {
           blockHeight: 0,
@@ -4290,7 +4290,7 @@ describe('Connection', function () {
     it('gets a block having a parent', async function () {
       // Mock parent of block with transaction.
       await mockRpcResponse({
-        method: 'getConfirmedBlock',
+        method: 'getBlock',
         params: [0],
         value: {
           blockHeight: 0,
@@ -4303,7 +4303,7 @@ describe('Connection', function () {
       });
       // Mock block with transaction.
       await mockRpcResponse({
-        method: 'getConfirmedBlock',
+        method: 'getBlock',
         params: [1],
         value: {
           blockTime: 1614281964,
@@ -4390,7 +4390,7 @@ describe('Connection', function () {
         .null;
 
       await mockRpcResponse({
-        method: 'getConfirmedBlock',
+        method: 'getBlock',
         params: [Number.MAX_SAFE_INTEGER],
         error: {
           message: `Block not available for slot ${Number.MAX_SAFE_INTEGER}`,

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -4625,6 +4625,19 @@ describe('Connection', function () {
     }
   });
 
+  it('get recent blockhash can stringify', async () => {
+    const commitments: Commitment[] = ['processed', 'confirmed', 'finalized'];
+    for (const commitment of commitments) {
+      const response = await helpers.recentBlockhash({
+        connection,
+        commitment,
+      });
+      expect(JSON.stringify(response)).to.match(
+        /{"blockhash":"\w+","feeCalculator":{}}/,
+      );
+    }
+  });
+
   it('get recent blockhash LPS field throws', async () => {
     const commitments: Commitment[] = ['processed', 'confirmed', 'finalized'];
     for (const commitment of commitments) {

--- a/test/mocks/rpc-http.ts
+++ b/test/mocks/rpc-http.ts
@@ -3,7 +3,13 @@ import BN from 'bn.js';
 import * as mockttp from 'mockttp';
 
 import {mockRpcMessage} from './rpc-websocket';
-import {Connection, PublicKey, Transaction, Signer} from '../../src';
+import {
+  Connection,
+  PublicKey,
+  Transaction,
+  Signer,
+  VersionedMessage,
+} from '../../src';
 import invariant from '../../src/utils/assert';
 import type {Commitment, HttpHeaders, RpcParams} from '../../src/connection';
 
@@ -146,6 +152,30 @@ const latestBlockhash = async ({
   return await connection.getLatestBlockhash(commitment);
 };
 
+const getFeeForMessage = async ({
+  connection,
+  commitment,
+  message,
+}: {
+  connection: Connection;
+  commitment?: Commitment;
+  message: VersionedMessage;
+}) => {
+  const params: Array<Object> = [];
+  if (commitment) {
+    params.push({commitment});
+  }
+
+  await mockRpcResponse({
+    method: 'getFeeForMessage',
+    params,
+    value: 42,
+    withContext: true,
+  });
+
+  return await connection.getFeeForMessage(message, commitment);
+};
+
 const recentBlockhash = async ({
   connection,
   commitment,
@@ -160,13 +190,11 @@ const recentBlockhash = async ({
   }
 
   await mockRpcResponse({
-    method: 'getRecentBlockhash',
+    method: 'getLatestBlockhash',
     params,
     value: {
       blockhash,
-      feeCalculator: {
-        lamportsPerSignature: 42,
-      },
+      lastValidBlockHeight: 100,
     },
     withContext: true,
   });
@@ -267,7 +295,8 @@ const airdrop = async ({
 
 export const helpers = {
   airdrop,
+  getFeeForMessage,
+  latestBlockhash,
   processTransaction,
   recentBlockhash,
-  latestBlockhash,
 };


### PR DESCRIPTION
#### Problem
With the upcoming upgrade from 1.18 to 2.0 on Solana mainnet-beta, deprecated RPC methods have been removed, therefore they will no longer be available through Web3.js client requests.

The [Agave 2.0 Migration Guide](https://github.com/anza-xyz/agave/wiki/Agave-v2.0-Transition-Guide) lists semi-equivalent RPC method counterparts for each of the removed methods.

#### Summary of Changes
Replace `getRecentBlockhash` with `getLatestBlockhash`. This method still vends a blockhash, but the field `lamportsPerSignature` cannot be served, so accessing it throws an error. However, if apps use the deprecated `getRecentBlockhash` method and only access the `blockhash` field, they will not see an error, and the request is served by `getLatestBlockhash`.