### PR TITLE
Rename internal `RpcTransportRequest` type to `Config`

### DIFF
--- a/packages/rpc-spec/src/rpc-transport.ts
+++ b/packages/rpc-spec/src/rpc-transport.ts
@@ -1,12 +1,12 @@
 import { RpcResponse } from '@solana/rpc-spec-types';
 
-type RpcTransportRequest = Readonly<{
+type Config = Readonly<{
     payload: unknown;
     signal?: AbortSignal;
 }>;
 
 export type RpcTransport = {
-    <TResponse>(request: RpcTransportRequest): Promise<RpcResponse<TResponse>>;
+    <TResponse>(config: Config): Promise<RpcResponse<TResponse>>;
 };
 
 export function isJsonRpcPayload(payload: unknown): payload is Readonly<{


### PR DESCRIPTION
This stack aims to change the interfaces of the RPC API layer in a way that not only simplifies the RPC API boundaries but also allows the RPC API to do more than it currently can.

This change was inspired by the new RPC Subscriptions API design which offers a plan executor function instead of a data object. As such, this stack will make the RPC architecture more consistent with the RPC Subscriptions architecture.

Here are two diagrams showing the current state of the RPC architecture and the proposed state implemented by this stack.

### Current state
![Rpc Current@2x](https://github.com/user-attachments/assets/37df3406-2303-48df-9c19-f110c71a0b97)

### Proposed state
![Rpc Proposed@2x](https://github.com/user-attachments/assets/e9d4046d-e5f5-4b2a-bb6e-951a848fcf24)

As you can see, the new implementation simplifies the interfaces by wrapping the RPC Transport layer inside the RPC API layer. This enables the RPC API do things like: not calling the transport at all for caching purposes or calling the transport multiple times for retries or even for aggregating responses from multiple RPC calls.

Additionally, the outer RPC layer no longer need to care about things like `responseTransformers` since this logic is now abstracted by the `execute` function of the `RpcPlan`.

---

Now, for the first few PRs of this stack, we do a little bit of housekeeping before getting into the fun bit.

This first PR is a bit of a nit but the `RpcTransportRequest` name is confusing and is actually just here to define the inputs of the `RpcTransport` function. Using `Config` is more consistent with the rest of the RPC architecture.