### PR TITLE
Rename `RpcApiRequestPlan` to `RpcPlan`

### DIFF
--- a/.changeset/flat-ways-love.md
+++ b/.changeset/flat-ways-love.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-spec': patch
+---
+
+Rename `RpcApiRequestPlan` to `RpcPlan` to stay consistent with the `RpcSusbscriptionsPlan` of the RPC Subscription architecture.

--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -43,13 +43,13 @@ An object that exposes all of the functions described by `TRpcMethods`, and fulf
 
 ### `RpcApi<TRpcMethods>`
 
-For each of `TRpcMethods` this object exposes a method with the same name that maps between its input arguments and a `RpcApiRequestPlan<TResponse>` that describes how to prepare a JSON RPC request to fetch `TResponse`.
+For each of `TRpcMethods` this object exposes a method with the same name that maps between its input arguments and a `RpcPlan<TResponse>` that describes how to prepare a JSON RPC request to fetch `TResponse`.
 
 ### `RpcApiMethods`
 
 This is a marker interface that all RPC method definitions must extend to be accepted for use with the `RpcApi` creator.
 
-### `RpcApiRequestPlan`
+### `RpcPlan`
 
 This type allows an `RpcApi` to describe how a particular request should be issued to the JSON RPC server. Given a function that was called on a `Rpc`, this object gives you the opportunity to:
 
@@ -84,7 +84,7 @@ A config object with the following properties:
 
 ### `createJsonRpcApi(config)`
 
-Creates a JavaScript proxy that converts _any_ function call called on it to a `RpcApiRequestPlan` by:
+Creates a JavaScript proxy that converts _any_ function call called on it to a `RpcPlan` by:
 
 -   setting `payload` to a JSON RPC v2 payload object with the requested `methodName` and `params` properties, optionally transformed by `config.requestTransformer`.
 -   setting `responseTransformer` to `config.responseTransformer`, if provided.
@@ -99,7 +99,7 @@ const rpcApi = createJsonRpcApi({
 // ...the following function call:
 rpcApi.foo('bar', { baz: 'bat' });
 
-// ...will produce the following `RpcApiRequestPlan` object:
+// ...will produce the following `RpcPlan` object:
 //
 //     {
 //         payload: { id: 1, jsonrpc: '2.0', method: 'foo', params: ['bar', { baz: 'bat' }] },

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -2,7 +2,7 @@ import { SOLANA_ERROR__RPC__API_PLAN_MISSING_FOR_RPC_METHOD, SolanaError } from 
 import { createRpcMessage } from '@solana/rpc-spec-types';
 
 import { createRpc, Rpc } from '../rpc';
-import { RpcApi, RpcApiRequestPlan } from '../rpc-api';
+import { RpcApi, RpcPlan } from '../rpc-api';
 import { RpcTransport } from '../rpc-transport';
 
 interface TestRpcMethods {
@@ -77,7 +77,7 @@ describe('JSON-RPC 2.0', () => {
         beforeEach(() => {
             rpc = createRpc({
                 api: {
-                    someMethod(...params: unknown[]): RpcApiRequestPlan<unknown> {
+                    someMethod(...params: unknown[]): RpcPlan<unknown> {
                         return {
                             payload: createRpcMessage({
                                 methodName: 'someMethodAugmented',
@@ -108,7 +108,7 @@ describe('JSON-RPC 2.0', () => {
             responseTransformer = jest.fn(json => `${json} processed response`);
             rpc = createRpc({
                 api: {
-                    someMethod(...params: unknown[]): RpcApiRequestPlan<unknown> {
+                    someMethod(...params: unknown[]): RpcPlan<unknown> {
                         return {
                             payload: createRpcMessage({ methodName: 'someMethod', params }),
                             responseTransformer,

--- a/packages/rpc-spec/src/rpc-api.ts
+++ b/packages/rpc-spec/src/rpc-api.ts
@@ -11,7 +11,7 @@ export type RpcApiConfig = Readonly<{
     responseTransformer?: RpcResponseTransformer;
 }>;
 
-export type RpcApiRequestPlan<TResponse> = {
+export type RpcPlan<TResponse> = {
     payload: unknown;
     responseTransformer?: (response: RpcResponse) => RpcResponse<TResponse>;
 };
@@ -21,7 +21,7 @@ export type RpcApi<TRpcMethods> = {
 };
 
 type RpcReturnTypeMapper<TRpcMethod> = TRpcMethod extends Callable
-    ? (...rawParams: unknown[]) => RpcApiRequestPlan<ReturnType<TRpcMethod>>
+    ? (...rawParams: unknown[]) => RpcPlan<ReturnType<TRpcMethod>>
     : never;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -47,7 +47,7 @@ export function createJsonRpcApi<TRpcMethods extends RpcApiMethods>(config?: Rpc
                 ...rawParams: Parameters<
                     TRpcMethods[TMethodName] extends CallableFunction ? TRpcMethods[TMethodName] : never
                 >
-            ): RpcApiRequestPlan<ReturnType<TRpcMethods[TMethodName]>> {
+            ): RpcPlan<ReturnType<TRpcMethods[TMethodName]>> {
                 const rawRequest = Object.freeze({ methodName, params: rawParams });
                 const request = config?.requestTransformer ? config?.requestTransformer(rawRequest) : rawRequest;
                 return Object.freeze({

--- a/packages/rpc-spec/src/rpc.ts
+++ b/packages/rpc-spec/src/rpc.ts
@@ -1,7 +1,7 @@
 import { SOLANA_ERROR__RPC__API_PLAN_MISSING_FOR_RPC_METHOD, SolanaError } from '@solana/errors';
 import { Callable, Flatten, OverloadImplementations, UnionToIntersection } from '@solana/rpc-spec-types';
 
-import { RpcApi, RpcApiRequestPlan } from './rpc-api';
+import { RpcApi, RpcPlan } from './rpc-api';
 import { RpcTransport } from './rpc-transport';
 
 export type RpcConfig<TRpcMethods, TRpcTransport extends RpcTransport> = Readonly<{
@@ -68,7 +68,7 @@ function makeProxy<TRpcMethods, TRpcTransport extends RpcTransport>(
 
 function createPendingRpcRequest<TRpcMethods, TRpcTransport extends RpcTransport, TResponse>(
     rpcConfig: RpcConfig<TRpcMethods, TRpcTransport>,
-    apiPlan: RpcApiRequestPlan<TResponse>,
+    apiPlan: RpcPlan<TResponse>,
 ): PendingRpcRequest<TResponse> {
     return {
         async send(options?: RpcSendOptions): Promise<TResponse> {


### PR DESCRIPTION
This PR renames the `RpcApiRequestPlan` type to `RpcPlan` in order to stay consistent with the `RpcSubscriptionsPlan` of the RPC Subscriptions architecture.