### PR TITLE
Add `execute` function to `RpcPlan`

### DIFF
--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -51,10 +51,13 @@ This is a marker interface that all RPC method definitions must extend to be acc
 
 ### `RpcPlan`
 
-This type allows an `RpcApi` to describe how a particular request should be issued to the JSON RPC server. Given a function that was called on a `Rpc`, this object gives you the opportunity to:
+This type allows an `RpcApi` to describe how a particular request should be issued to the JSON RPC server. Given a function that was called on a `Rpc`, this object returns an `execute` function that dictates which request will be sent, how the underlying transport will be used and how the responses will be transformed.
 
--   provide a `payload` from the requested method name and parameters.
--   provide a function to transform the JSON RPC server's response, in case it does not match the `TResponse` specified by the `PendingRpcRequest<TResponse>` returned from that function.
+This function accepts an `RpcTransport` and an `AbortSignal` and asynchronously returns an `RpcResponse`. This gives us the opportunity to:
+
+-   define the `payload` from the requested method name and parameters before passing it to the transport.
+-   call the underlying transport zero, one or multiple times depending on the use-case (e.g. caching or aggregating multiple responses).
+-   transform the response from the JSON RPC server, in case it does not match the `TResponse` specified by the `PendingRpcRequest<TResponse>` returned from that function.
 
 ### `RpcSendOptions`
 

--- a/packages/rpc-spec/src/__tests__/rpc-api-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-api-test.ts
@@ -1,28 +1,33 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
-import type { RpcRequest, RpcResponse } from '@solana/rpc-spec-types';
+import type { RpcRequest } from '@solana/rpc-spec-types';
 
 import { createJsonRpcApi } from '../rpc-api';
+import type { RpcTransport } from '../rpc-transport';
 
 type DummyApi = {
     someMethod(...args: unknown[]): unknown;
 };
 
 describe('createJsonRpcApi', () => {
-    it('returns a plan containing the payload to send to the transport', () => {
+    let transport: jest.Mock & RpcTransport;
+    beforeEach(() => {
+        transport = jest.fn();
+    });
+    it('returns a plan containing a function to execute the plan', () => {
         // Given a dummy API.
         const api = createJsonRpcApi<DummyApi>();
 
         // When we call a method on the API.
         const plan = api.someMethod(1, 'two', { three: [4] });
 
-        // Then we expect the plan to contain the method name and the provided parameters.
-        expect(plan.payload).toMatchObject({
-            method: 'someMethod',
-            params: [1, 'two', { three: [4] }],
-        });
+        // Then we expect the plan to contain an `execute` function.
+        expect(plan).toHaveProperty('execute');
+        expect(typeof plan.execute).toBe('function');
     });
-    it('applies the request transformer to the provided method name', () => {
+    it('applies the request transformer to the provided method name', async () => {
+        expect.assertions(1);
+
         // Given a dummy API with a request transformer that appends 'Transformed' to the method name.
         const api = createJsonRpcApi<DummyApi>({
             requestTransformer: (request: RpcRequest) => ({
@@ -34,10 +39,19 @@ describe('createJsonRpcApi', () => {
         // When we call a method on the API.
         const plan = api.someMethod();
 
-        // Then we expect the plan to contain the transformed method name.
-        expect(plan.payload).toMatchObject({ method: 'someMethodTransformed' });
+        // Then we expect the plan executor to pass the transformed method name to the transport.
+        await plan.execute({ transport });
+        expect(transport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({
+                    method: 'someMethodTransformed',
+                }),
+            }),
+        );
     });
-    it('applies the request transformer to the provided params', () => {
+    it('applies the request transformer to the provided params', async () => {
+        expect.assertions(1);
+
         // Given a dummy API with a request transformer that doubles the provided params.
         const api = createJsonRpcApi<DummyApi>({
             requestTransformer: (request: RpcRequest) => ({
@@ -49,19 +63,32 @@ describe('createJsonRpcApi', () => {
         // When we call a method on the API.
         const plan = api.someMethod(1, 2, 3);
 
-        // Then we expect the plan to contain the transformed params.
-        expect(plan.payload).toMatchObject({ params: [2, 4, 6] });
+        // Then we expect the plan executor to pass the transformed params to the transport.
+        await plan.execute({ transport });
+        expect(transport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({
+                    params: [2, 4, 6],
+                }),
+            }),
+        );
     });
-    it('includes the provided response transformer in the plan', () => {
-        // Given a dummy API with a response transformer.
-        const responseTransformer = <T>(response: RpcResponse) => response as RpcResponse<T>;
+    it("applies the response transformer to the transport's response", async () => {
+        expect.assertions(1);
+
+        // Given a dummy API with a response transformer that doubles the response.
+        const responseTransformer = (response: unknown) => (response as number) * 2;
         const api = createJsonRpcApi<DummyApi>({ responseTransformer });
+
+        // And given a transport that returns a mock response.
+        transport.mockResolvedValue(42);
 
         // When we call a method on the API.
         const plan = api.someMethod(1, 2, 3);
 
-        // Then we expect the plan to contain the response transformer.
-        expect(typeof plan.responseTransformer).toBe('function');
+        // Then we expect the plan to use the response transformer.
+        const response = await plan.execute({ transport });
+        expect(response).toBe(84);
     });
     it('returns a frozen object', () => {
         // Given a dummy API.


### PR DESCRIPTION
Now we're getting in the fun bit.

This PR adds an `execute` function to the `RpcPlan` type whose entire purpose is to dictate how the request should be forwarded to the transport and how its response should be transformed.

Note that the following PR will remove the `payload` and `responseTransformer` attributes from the plan as they are no longer necessary.

Also note that a follow-up PR will add a changeset for these changes.