### PR TITLE
Remove `payload` and `responseTransformer` from `RpcPlan`

### DIFF
--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -87,10 +87,10 @@ A config object with the following properties:
 
 ### `createJsonRpcApi(config)`
 
-Creates a JavaScript proxy that converts _any_ function call called on it to a `RpcPlan` by:
+Creates a JavaScript proxy that converts _any_ function call called on it to a `RpcPlan` by creating an `execute` function that:
 
--   setting `payload` to a JSON RPC v2 payload object with the requested `methodName` and `params` properties, optionally transformed by `config.requestTransformer`.
--   setting `responseTransformer` to `config.responseTransformer`, if provided.
+-   sets the transport payload to a JSON RPC v2 payload object with the requested `methodName` and `params` properties, optionally transformed by `config.requestTransformer`.
+-   transforms the transport's response using the `config.responseTransformer` function, if provided.
 
 ```ts
 // For example, given this `RpcApi`:
@@ -102,12 +102,9 @@ const rpcApi = createJsonRpcApi({
 // ...the following function call:
 rpcApi.foo('bar', { baz: 'bat' });
 
-// ...will produce the following `RpcPlan` object:
-//
-//     {
-//         payload: { id: 1, jsonrpc: '2.0', method: 'foo', params: ['bar', { baz: 'bat' }] },
-//         responseTransformer: (response) => response.result,
-//     }
+// ...will produce an `RpcPlan` that:
+// -   Uses the following payload: { id: 1, jsonrpc: '2.0', method: 'foo', params: ['bar', { baz: 'bat' }] }.
+// -   Returns the "result" attribute of the RPC response.
 ```
 
 #### Arguments

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -48,7 +48,6 @@ describe('JSON-RPC 2.0', () => {
                                     payload: createRpcMessage({ methodName: methodName.toString(), params }),
                                     signal,
                                 }),
-                            payload: createRpcMessage({ methodName: methodName.toString(), params }),
                         });
                     },
                 }),
@@ -87,7 +86,7 @@ describe('JSON-RPC 2.0', () => {
                             methodName: 'someMethodAugmented',
                             params: [...params, 'augmented', 'params'],
                         });
-                        return { execute: ({ signal, transport }) => transport({ payload, signal }), payload };
+                        return { execute: ({ signal, transport }) => transport({ payload, signal }) };
                     },
                 } as RpcApi<TestRpcMethods>,
                 transport: makeHttpRequest,
@@ -103,39 +102,6 @@ describe('JSON-RPC 2.0', () => {
                     id: expect.any(Number),
                 },
             });
-        });
-    });
-    describe('when calling a method whose concrete implementation returns a response processor', () => {
-        let responseTransformer: jest.Mock;
-        let rpc: Rpc<TestRpcMethods>;
-        beforeEach(() => {
-            responseTransformer = jest.fn(json => `${json} processed response`);
-            rpc = createRpc({
-                api: {
-                    someMethod(...params: unknown[]): RpcPlan<unknown> {
-                        const payload = createRpcMessage({ methodName: 'someMethod', params });
-                        return {
-                            execute: ({ signal, transport }) => transport({ payload, signal }),
-                            payload,
-                            responseTransformer,
-                        };
-                    },
-                } as RpcApi<TestRpcMethods>,
-                transport: makeHttpRequest,
-            });
-        });
-        it('calls the response transformer with the response from the JSON-RPC 2.0 endpoint', async () => {
-            expect.assertions(1);
-            const rawResponse = 123;
-            (makeHttpRequest as jest.Mock).mockResolvedValueOnce(rawResponse);
-            await rpc.someMethod().send();
-            expect(responseTransformer).toHaveBeenCalledWith(rawResponse);
-        });
-        it('returns the processed response', async () => {
-            expect.assertions(1);
-            (makeHttpRequest as jest.Mock).mockResolvedValueOnce(123);
-            const result = await rpc.someMethod().send();
-            expect(result).toBe('123 processed response');
         });
     });
 });

--- a/packages/rpc-spec/src/rpc-api.ts
+++ b/packages/rpc-spec/src/rpc-api.ts
@@ -20,8 +20,6 @@ export type RpcPlan<TResponse> = {
             transport: RpcTransport;
         }>,
     ) => Promise<RpcResponse<TResponse>>;
-    payload: unknown;
-    responseTransformer?: (response: RpcResponse) => RpcResponse<TResponse>;
 };
 
 export type RpcApi<TRpcMethods> = {
@@ -67,17 +65,6 @@ export function createJsonRpcApi<TRpcMethods extends RpcApiMethods>(config?: Rpc
                         }
                         return config.responseTransformer(response, request);
                     },
-                    payload: createRpcMessage(request),
-                    ...(config?.responseTransformer
-                        ? {
-                              responseTransformer: (response: RpcResponse) => {
-                                  const configTransformer = config.responseTransformer as RpcResponseTransformer<
-                                      ReturnType<TRpcMethods[TMethodName]>
-                                  >;
-                                  return configTransformer(response, request);
-                              },
-                          }
-                        : {}),
                 });
             };
         },

--- a/packages/rpc-spec/src/rpc.ts
+++ b/packages/rpc-spec/src/rpc.ts
@@ -67,14 +67,12 @@ function makeProxy<TRpcMethods, TRpcTransport extends RpcTransport>(
 }
 
 function createPendingRpcRequest<TRpcMethods, TRpcTransport extends RpcTransport, TResponse>(
-    rpcConfig: RpcConfig<TRpcMethods, TRpcTransport>,
-    apiPlan: RpcPlan<TResponse>,
+    { transport }: RpcConfig<TRpcMethods, TRpcTransport>,
+    plan: RpcPlan<TResponse>,
 ): PendingRpcRequest<TResponse> {
     return {
         async send(options?: RpcSendOptions): Promise<TResponse> {
-            const { payload, responseTransformer } = apiPlan;
-            const rawResponse = await rpcConfig.transport<TResponse>({ payload, signal: options?.abortSignal });
-            return responseTransformer ? responseTransformer(rawResponse) : rawResponse;
+            return await plan.execute({ signal: options?.abortSignal, transport });
         },
     };
 }


### PR DESCRIPTION
This PR replaces the usage of `payload` and `responseTransformer` in favour of the new `execute` function.

Note that, this PR removes some `responseTransformer`-specific tests from the RPC tests since the outer RPC layer no longer cares about transformers. This is fine since we’re already got `responseTransformer` tests for the `createJsonRpcApi` function.

Also note that a follow-up PR will add a changeset for these changes.