### PR TITLE
Rename `executeSubscriptionPlan` to `execute` in `RpcSubscriptionsPlan`

### DIFF
--- a/.changeset/tricky-walls-doubt.md
+++ b/.changeset/tricky-walls-doubt.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-subscriptions-spec': patch
+---
+
+Rename `executeSubscriptionPlan` to `execute` in `RpcSubscriptionsPlan`

--- a/packages/rpc-subscriptions-api/src/__tests__/__setup__.ts
+++ b/packages/rpc-subscriptions-api/src/__tests__/__setup__.ts
@@ -12,7 +12,7 @@ export function createLocalhostSolanaRpcSubscriptions(): RpcSubscriptions<
 > {
     return createSubscriptionRpc({
         api: createSolanaRpcSubscriptionsApi_UNSTABLE(),
-        async transport({ executeSubscriptionPlan, signal }) {
+        async transport({ execute, signal }) {
             const webSocketChannel = await createWebSocketChannel({
                 sendBufferHighWatermark: Number.POSITIVE_INFINITY,
                 signal,
@@ -38,7 +38,7 @@ export function createLocalhostSolanaRpcSubscriptions(): RpcSubscriptions<
                     return webSocketChannel.send(serializedMessage);
                 },
             } as RpcSubscriptionsChannel<unknown, unknown>;
-            return await executeSubscriptionPlan({ channel, signal });
+            return await execute({ channel, signal });
         },
     });
 }

--- a/packages/rpc-subscriptions-api/src/__tests__/index-test.ts
+++ b/packages/rpc-subscriptions-api/src/__tests__/index-test.ts
@@ -21,8 +21,8 @@ describe('createSolanaRpcSubscriptionsApi', () => {
         api = createSolanaRpcSubscriptionsApi();
     });
     it('creates a subscription plan that synthesizes the correct subscribe/unsubscribe method names from the name of the notification', () => {
-        const { executeSubscriptionPlan } = api.thingNotifications();
-        void executeSubscriptionPlan({
+        const { execute } = api.thingNotifications();
+        void execute({
             channel: {
                 on: jest.fn(),
                 send: jest.fn(),

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-api-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-api-test.ts
@@ -6,17 +6,17 @@ describe('createRpcSubscriptionsApi', () => {
     beforeEach(() => {
         mockChannel = { on: jest.fn(), send: jest.fn() };
     });
-    describe('executeSubscriptionPlan', () => {
+    describe('execute', () => {
         it('calls the plan executor with the expected params', () => {
             const mockPlanExecutor = jest.fn().mockResolvedValue({
-                executeSubscriptionPlan: jest.fn(),
+                execute: jest.fn(),
                 request: { methodName: 'foo', params: [] },
             } as RpcSubscriptionsPlan<unknown>);
             const api = createRpcSubscriptionsApi({ planExecutor: mockPlanExecutor });
             const expectedParams = [1, 'hi', 3];
             const expectedSignal = new AbortController().signal;
             api.foo(...expectedParams)
-                .executeSubscriptionPlan({
+                .execute({
                     channel: mockChannel,
                     signal: expectedSignal,
                 })

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions-api.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions-api.ts
@@ -21,7 +21,7 @@ export type RpcSubscriptionsPlan<TNotification> = Readonly<{
     /**
      * This method may be called with a newly-opened channel or a pre-established channel.
      */
-    executeSubscriptionPlan: (
+    execute: (
         config: Readonly<{
             channel: RpcSubscriptionsChannel<unknown, unknown>;
             signal: AbortSignal;
@@ -76,7 +76,7 @@ export function createRpcSubscriptionsApi<TRpcSubscriptionsApiMethods extends Rp
                 const rawRequest = { methodName, params };
                 const request = config.requestTransformer ? config.requestTransformer(rawRequest) : rawRequest;
                 return {
-                    executeSubscriptionPlan(planConfig) {
+                    execute(planConfig) {
                         return config.planExecutor({ ...planConfig, request });
                     },
                     request,

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
@@ -19,29 +19,29 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         const expectedDataPublisher = { on: mockOn };
         mockInnerTransport.mockResolvedValue(expectedDataPublisher);
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
         };
         const transportPromise = coalescedTransport(config);
         await expect(transportPromise).resolves.toBe(expectedDataPublisher);
     });
-    it('passes the `executeSubscriptionPlan` config to the inner transport', () => {
+    it('passes the `execute` config to the inner transport', () => {
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
         };
         coalescedTransport(config).catch(() => {});
         expect(mockInnerTransport).toHaveBeenCalledWith(
             expect.objectContaining({
-                executeSubscriptionPlan: config.executeSubscriptionPlan,
+                execute: config.execute,
             }),
         );
     });
     it('passes the `rpcRequest` config to the inner transport', () => {
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
         };
@@ -54,7 +54,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     });
     it('calls the inner transport once per subscriber whose hashes do not match, in the same runloop', () => {
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             signal: new AbortController().signal,
         };
         coalescedTransport({
@@ -70,7 +70,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     it('calls the inner transport once per subscriber whose hashes do not match, in different runloops', async () => {
         expect.assertions(1);
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             signal: new AbortController().signal,
         };
         await coalescedTransport({ ...config, request: { methodName: 'methodA', params: [] } });
@@ -79,7 +79,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     });
     it('only calls the inner transport once, in the same runloop', () => {
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
         };
@@ -90,7 +90,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     it('only calls the inner transport once, in different runloops', async () => {
         expect.assertions(1);
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
         };
@@ -101,7 +101,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     it('delivers the same value to each subscriber, in the same runloop', async () => {
         expect.assertions(1);
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
         };
@@ -111,7 +111,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     it('delivers the same value to each subscriber, in different runloops', async () => {
         expect.assertions(1);
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
         };
@@ -122,7 +122,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     it('does not fire the inner abort signal if fewer than all subscribers abort, in the same runloop', () => {
         jest.useFakeTimers();
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
         };
         const abortControllerB = new AbortController();
@@ -135,7 +135,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     it('fires the inner abort signal if all subscribers abort, in the same runloop', () => {
         jest.useFakeTimers();
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
         };
         const abortControllerA = new AbortController();
@@ -150,7 +150,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     it('fires the inner abort signal if all subscribers abort, in different runloops', async () => {
         expect.assertions(1);
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
         };
         const abortControllerA = new AbortController();
@@ -166,7 +166,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
     });
     it('does not fire the inner abort signal if the subscriber count is non zero at the end of the runloop, despite having aborted all in the middle of it', () => {
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
         };
         const abortControllerA = new AbortController();
@@ -180,7 +180,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         expect.assertions(1);
         jest.useFakeTimers();
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
         };
         coalescedTransport({ ...config, signal: new AbortController().signal }).catch(() => {});
@@ -193,7 +193,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         expect.assertions(2);
         jest.useFakeTimers();
         const config = {
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
         };
         const abortControllerA = new AbortController();

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-transport-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-transport-test.ts
@@ -9,40 +9,40 @@ describe('createRpcSubscriptionsTransportFromChannelCreator', () => {
         const creator = createRpcSubscriptionsTransportFromChannelCreator(mockCreateChannel);
         const abortSignal = new AbortController().signal;
         creator({
-            executeSubscriptionPlan: jest.fn(),
+            execute: jest.fn(),
             request: { methodName: 'foo', params: [] },
             signal: abortSignal,
         }).catch(() => {});
         expect(mockCreateChannel).toHaveBeenCalledWith({ abortSignal });
     });
-    it('creates a function that calls `executeSubscriptionPlan` with the created channel', async () => {
+    it('creates a function that calls `execute` with the created channel', async () => {
         expect.assertions(1);
         const creator = createRpcSubscriptionsTransportFromChannelCreator(jest.fn().mockResolvedValue('MOCK_CHANNEL'));
-        const mockExecuteSubscriptionPlan = jest.fn();
+        const mockExecute = jest.fn();
         creator({
-            executeSubscriptionPlan: mockExecuteSubscriptionPlan,
+            execute: mockExecute,
             request: { methodName: 'foo', params: [] },
             signal: new AbortController().signal,
         }).catch(() => {});
         await jest.runAllTimersAsync();
-        expect(mockExecuteSubscriptionPlan).toHaveBeenCalledWith(
+        expect(mockExecute).toHaveBeenCalledWith(
             expect.objectContaining({
                 channel: 'MOCK_CHANNEL',
             }),
         );
     });
-    it('creates a function that calls `executeSubscriptionPlan` with the abort signal', async () => {
+    it('creates a function that calls `execute` with the abort signal', async () => {
         expect.assertions(1);
         const creator = createRpcSubscriptionsTransportFromChannelCreator(jest.fn());
-        const mockExecuteSubscriptionPlan = jest.fn();
+        const mockExecute = jest.fn();
         const signal = new AbortController().signal;
         creator({
-            executeSubscriptionPlan: mockExecuteSubscriptionPlan,
+            execute: mockExecute,
             request: { methodName: 'foo', params: [] },
             signal,
         }).catch(() => {});
         await jest.runAllTimersAsync();
-        expect(mockExecuteSubscriptionPlan).toHaveBeenCalledWith(
+        expect(mockExecute).toHaveBeenCalledWith(
             expect.objectContaining({
                 signal,
             }),

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-transport.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-transport.ts
@@ -34,9 +34,9 @@ export function createRpcSubscriptionsTransportFromChannelCreator<
     TInboundMessage,
     TOutboundMessage,
 >(createChannel: TChannelCreator) {
-    return (async ({ executeSubscriptionPlan, signal }) => {
+    return (async ({ execute, signal }) => {
         const channel = await createChannel({ abortSignal: signal });
-        return await executeSubscriptionPlan({ channel, signal });
+        return await execute({ channel, signal });
     }) as TChannelCreator extends RpcSubscriptionsChannelCreatorDevnet<TOutboundMessage, TInboundMessage>
         ? RpcSubscriptionsTransportDevnet
         : TChannelCreator extends RpcSubscriptionsChannelCreatorTestnet<TOutboundMessage, TInboundMessage>


### PR DESCRIPTION
This PR renames the `executeSubscriptionPlan` function of the `RpcSubscriptionsPlan` type to `execute` to be consistent with the `RpcPlan`. This means we can now call the plan by running `subscriptionsPlan.execute(...)` instead of the more redundant `subscriptionsPlan.executeSubscriptionPlan(...)`.