### PR TITLE
Add helpers to transform channel messages

### DIFF
--- a/.changeset/late-ravens-cross.md
+++ b/.changeset/late-ravens-cross.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-subscriptions-spec': patch
+---
+
+Add `transformChannelInboundMessages` and `transformChannelOutboundMessages` helper functions to transform incoming and outgoing messages on a given channel.

--- a/packages/rpc-subscriptions-spec/README.md
+++ b/packages/rpc-subscriptions-spec/README.md
@@ -66,3 +66,23 @@ Given a channel, this function executes the particular subscription plan require
 2. Waits for a response containing the subscription id
 3. Returns a `DataPublisher` that publishes notifications related to that subscriptions id, filtering out all others
 4. Calls the `unsubscribeMethodName` on the remote RPC when the abort signal is fired.
+
+### `transformChannelInboundMessages(channel, transform)`
+
+Given a channel with inbound messages of type `T` and a function of type `T => U`, returns a new channel with inbound messages of type `U`. Note that this only affects messages of type `"message"` and thus, does not affect incoming error messages.
+
+For instance, it can be used to parse incoming JSON messages:
+
+```ts
+const transformedChannel = transformChannelInboundMessages(channel, JSON.parse);
+```
+
+### `transformChannelOutboundMessages(channel, transform)`
+
+Given a channel with outbound messages of type `T` and a function of type `U => T`, returns a new channel with outbound messages of type `U`.
+
+For instance, it can be used to stringify JSON messages before sending them over the wire:
+
+```ts
+const transformedChannel = transformChannelOutboundMessages(channel, JSON.stringify);
+```

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-channel-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-channel-test.ts
@@ -1,0 +1,133 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import {
+    RpcSubscriptionsChannel,
+    transformChannelInboundMessages,
+    transformChannelOutboundMessages,
+} from '../rpc-subscriptions-channel';
+
+type Irrelevant = { readonly brand: unique symbol };
+
+function createMockChannel<TOutboundMessage, TInboundMessage>(): RpcSubscriptionsChannel<
+    TOutboundMessage,
+    TInboundMessage
+> {
+    return {
+        on: jest.fn().mockReturnValue(() => {}),
+        send: jest.fn().mockResolvedValue(void 0),
+    };
+}
+
+function getMockReceive<TOutboundMessage, TInboundMessage>(
+    mockChannel: RpcSubscriptionsChannel<TOutboundMessage, TInboundMessage>,
+) {
+    return (type: 'error' | 'message', value: unknown) => {
+        (mockChannel.on as jest.Mock).mock.calls
+            .filter(([t]) => t === type)
+            .forEach(([_, subscriber]) => subscriber(value));
+    };
+}
+
+describe('transformChannelInboundMessages', () => {
+    it('transforms the incoming messages of a channel', () => {
+        // Given a mock channel receiving strings.
+        const mockChannel = createMockChannel<Irrelevant, string>();
+        const mockReceive = getMockReceive(mockChannel);
+
+        // When we transform incoming string messages to their length.
+        const channel = transformChannelInboundMessages(mockChannel, (message: string) => message.length);
+        channel satisfies RpcSubscriptionsChannel<Irrelevant, number>;
+
+        // Then the transformed channel should receive the length of the incoming messages.
+        const listener = jest.fn();
+        channel.on('message', listener);
+        mockReceive('message', 'Hello World!');
+        expect(listener).toHaveBeenCalledWith(12);
+    });
+
+    it('can be used to parse JSON messages', () => {
+        // Given a mock channel receiving JSON strings.
+        const mockChannel = createMockChannel<Irrelevant, string>();
+        const mockReceive = getMockReceive(mockChannel);
+
+        // When we transform incoming JSON strings to their parsed values.
+        const channel = transformChannelInboundMessages(mockChannel, JSON.parse);
+        channel satisfies RpcSubscriptionsChannel<Irrelevant, unknown>;
+
+        // Then the transformed channel should receive JSON parsed values of incoming messages.
+        const listener = jest.fn();
+        channel.on('message', listener);
+        mockReceive('message', '{"hello": "world"}');
+        expect(listener).toHaveBeenCalledWith({ hello: 'world' });
+    });
+
+    it('does not affect error messages', () => {
+        // Given a mock channel receiving strings.
+        const mockChannel = createMockChannel<Irrelevant, string>();
+        const mockReceive = getMockReceive(mockChannel);
+
+        // When we transform incoming string messages to their length.
+        const channel = transformChannelInboundMessages(mockChannel, (message: string) => message.length);
+        channel satisfies RpcSubscriptionsChannel<Irrelevant, number>;
+
+        // Then error messages are not affected by the transformation.
+        const listener = jest.fn();
+        channel.on('error', listener);
+        mockReceive('error', 'Hello Errors!');
+        expect(listener).toHaveBeenCalledWith('Hello Errors!');
+    });
+
+    it('returns a frozen channel', () => {
+        // Given a mock channel receiving strings.
+        const mockChannel = createMockChannel<Irrelevant, string>();
+
+        // When we transform incoming string messages to their length.
+        const channel = transformChannelInboundMessages(mockChannel, (message: string) => message.length);
+
+        // Then we expect the transformed channel to be a frozen object.
+        expect(channel).toBeFrozenObject();
+    });
+});
+
+describe('transformChannelOutboundMessages', () => {
+    it('transforms the outgoing messages of a channel', async () => {
+        expect.assertions(1);
+
+        // Given a mock channel receiving numbers.
+        const mockChannel = createMockChannel<number, Irrelevant>();
+
+        // When we transform outgoing string messages to their length.
+        const channel = transformChannelOutboundMessages(mockChannel, (message: string) => message.length);
+        channel satisfies RpcSubscriptionsChannel<string, Irrelevant>;
+
+        // Then the transformed channel should send the length of the outgoing messages.
+        await channel.send('Hello World!');
+        expect(mockChannel.send).toHaveBeenCalledWith(12);
+    });
+
+    it('can be used to stringify JSON messages', async () => {
+        expect.assertions(1);
+
+        // Given a mock channel sending JSON strings.
+        const mockChannel = createMockChannel<string, Irrelevant>();
+
+        // When we transform outgoing JSON messages to their stringified values.
+        const channel = transformChannelOutboundMessages(mockChannel, JSON.stringify);
+        channel satisfies RpcSubscriptionsChannel<unknown, Irrelevant>;
+
+        // Then the transformed channel should send JSON stringified values of outgoing messages.
+        await channel.send({ hello: 'world' });
+        expect(mockChannel.send).toHaveBeenCalledWith('{"hello":"world"}');
+    });
+
+    it('returns a frozen channel', () => {
+        // Given a mock channel.
+        const mockChannel = createMockChannel<number, Irrelevant>();
+
+        // When we get a new channel that transforms outgoing messages.
+        const channel = transformChannelOutboundMessages(mockChannel, (message: string) => message.length);
+
+        // Then we expect the transformed channel to be a frozen object.
+        expect(channel).toBeFrozenObject();
+    });
+});


### PR DESCRIPTION
This PR adds the following two helper functions for `RpcSubscriptionsChannels`:

- `transformChannelInboundMessages(channel, transform)`: returns a new channel such that incoming messages are going through the provided transform function. Note that this does not affect incoming error messages.
- `transformChannelOutboundMessages(channel, transform)`: returns a new channel such that outgoing messages are going through the provided transform function.

These helper functions will be used in a follow-up refactoring.