### PR TITLE
Add JSON channel decorator with BigInt support

### DIFF
--- a/.changeset/rotten-sloths-raise.md
+++ b/.changeset/rotten-sloths-raise.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-subscriptions': patch
+---
+
+Add a \`getRpcSubscriptionsChannelWithBigIntJSONSerialization\` helper function that parses and stringifies JSON messages with support for \`BigInt\` values. Any integer value is parsed as a \`BigInt\` in order to safely handle numbers that exceed the JavaScript \`Number.MAX_SAFE_INTEGER\` value.

--- a/packages/rpc-subscriptions/README.md
+++ b/packages/rpc-subscriptions/README.md
@@ -45,6 +45,10 @@ Given a channel creator, will return a new channel creator with the following be
 
 Given an `RpcSubscriptionsChannel`, will return a new channel that parses data published to the `'message'` channel as JSON, and JSON-stringifies messages sent via the `send(message)` method.
 
+### `getRpcSubscriptionsChannelWithBigIntJSONSerialization(channel)`
+
+Similarly, to `getRpcSubscriptionsChannelWithJSONSerialization`, this function will stringify and parse JSON message to and from the given `string` channel. However, this function parses any integer value as a `BigInt` in order to safely handle numbers that exceed the JavaScript `Number.MAX_SAFE_INTEGER` value.
+
 ### `getRpcSubscriptionsChannelWithAutoping(channel)`
 
 Given an `RpcSubscriptionsChannel`, will return a new channel that sends a ping message to the inner channel if a message has not been sent or received in the last `intervalMs`. In web browsers, this implementation sends no ping when the network is down, and sends a ping immediately upon the network coming back up.

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -75,6 +75,7 @@
         "@solana/fast-stable-stringify": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/promises": "workspace:*",
+        "@solana/rpc-spec-types": "workspace:*",
         "@solana/rpc-subscriptions-api": "workspace:*",
         "@solana/rpc-subscriptions-channel-websocket": "workspace:*",
         "@solana/rpc-subscriptions-spec": "workspace:*",

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-json-bigint-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-json-bigint-test.ts
@@ -1,0 +1,32 @@
+import { RpcSubscriptionsChannel } from '@solana/rpc-subscriptions-spec';
+
+import { getRpcSubscriptionsChannelWithBigIntJSONSerialization } from '../rpc-subscriptions-json-bigint';
+
+const MAX_SAFE_INTEGER_PLUS_ONE = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
+
+describe('getRpcSubscriptionsChannelWithBigIntJSONSerialization', () => {
+    let mockOn: jest.Mock;
+    let mockChannel: RpcSubscriptionsChannel<string, string>;
+    function receiveMessage(message: unknown) {
+        mockOn.mock.calls.filter(([type]) => type === 'message').forEach(([_, listener]) => listener(message));
+    }
+    beforeEach(() => {
+        mockOn = jest.fn();
+        mockChannel = {
+            on: mockOn,
+            send: jest.fn().mockResolvedValue(void 0),
+        };
+    });
+    it('forwards JSON-serialized large integers to the underlying channel', () => {
+        const channel = getRpcSubscriptionsChannelWithBigIntJSONSerialization(mockChannel);
+        channel.send({ value: MAX_SAFE_INTEGER_PLUS_ONE }).catch(() => {});
+        expect(mockChannel.send).toHaveBeenCalledWith(`{"value":${MAX_SAFE_INTEGER_PLUS_ONE}}`);
+    });
+    it('deserializes large integers received from the underlying channel as JSON', () => {
+        const channel = getRpcSubscriptionsChannelWithBigIntJSONSerialization(mockChannel);
+        const messageListener = jest.fn();
+        channel.on('message', messageListener);
+        receiveMessage(`{"value":${MAX_SAFE_INTEGER_PLUS_ONE}}`);
+        expect(messageListener).toHaveBeenCalledWith({ value: MAX_SAFE_INTEGER_PLUS_ONE });
+    });
+});

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-json-bigint.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-json-bigint.ts
@@ -1,0 +1,17 @@
+import { pipe } from '@solana/functional';
+import { parseJsonWithBigInts, stringifyJsonWithBigints } from '@solana/rpc-spec-types';
+import {
+    RpcSubscriptionsChannel,
+    transformChannelInboundMessages,
+    transformChannelOutboundMessages,
+} from '@solana/rpc-subscriptions-spec';
+
+export function getRpcSubscriptionsChannelWithBigIntJSONSerialization(
+    channel: RpcSubscriptionsChannel<string, string>,
+): RpcSubscriptionsChannel<unknown, unknown> {
+    return pipe(
+        channel,
+        c => transformChannelInboundMessages(c, parseJsonWithBigInts),
+        c => transformChannelOutboundMessages(c, stringifyJsonWithBigints),
+    );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,6 +880,9 @@ importers:
       '@solana/promises':
         specifier: workspace:*
         version: link:../promises
+      '@solana/rpc-spec-types':
+        specifier: workspace:*
+        version: link:../rpc-spec-types
       '@solana/rpc-subscriptions-api':
         specifier: workspace:*
         version: link:../rpc-subscriptions-api


### PR DESCRIPTION
This PR adds a new `getRpcSubscriptionsChannelWithBigIntJSONSerialization` function that acts the same as the existing `getRpcSubscriptionsChannelWithJSONSerialization` function except that it uses the `parseJsonWithBigints` and `stringifyJsonWithBigints` function internally instead of the native `JSON.parse` and `JSON.stringify`.