### PR TITLE
Use BigInt JSON serialization in Solana RPC Subscriptions

### DIFF
--- a/.changeset/orange-squids-think.md
+++ b/.changeset/orange-squids-think.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-subscriptions': patch
+---
+
+Adds a channel creator function called `createDefaultSolanaRpcSubscriptionsChannelCreator`. This function works similarly to `createDefaultRpcSubscriptionsChannelCreator` but with some Solana-specific defaults. For instance, it safely handles `BigInt` values in JSON messages since Solana RPC servers accept and return integers larger than `Number.MAX_SAFE_INTEGER`.

--- a/README.md
+++ b/README.md
@@ -671,7 +671,7 @@ If your app needs access to [unstable RPC Subscriptions](https://docs.solana.com
 
 ```ts
 import {
-    createDefaultRpcSubscriptionsChannelCreator,
+    createDefaultSolanaRpcSubscriptionsChannelCreator,
     createDefaultRpcSubscriptionsTransport,
     createSolanaRpcSubscriptions_UNSTABLE,
     createSolanaRpcSubscriptionsFromTransport_UNSTABLE,
@@ -683,7 +683,7 @@ const rpcSubscriptions = createSolanaRpcSubscriptions_UNSTABLE('ws://127.0.0.1:8
 
 // Using a custom transport.
 const transport = createDefaultRpcSubscriptionsTransport({
-    createChannel: createDefaultRpcSubscriptionsChannelCreator({
+    createChannel: createDefaultSolanaRpcSubscriptionsChannelCreator({
         url: 'ws://127.0.0.1:8900',
     }),
 });
@@ -712,7 +712,7 @@ Alternatively, you may explicitly create the RPC Subscriptions API using the `cr
 
 ```ts
 import {
-    createDefaultRpcSubscriptionsChannelCreator,
+    createDefaultSolanaRpcSubscriptionsChannelCreator,
     createDefaultRpcSubscriptionsTransport,
     createSubscriptionRpc,
     createSolanaRpcSubscriptionsApi,
@@ -723,7 +723,7 @@ import {
 
 const api = createSolanaRpcSubscriptionsApi<AccountNotificationsApi & SlotNotificationsApi>(DEFAULT_RPC_CONFIG);
 const transport = createDefaultRpcSubscriptionsTransport({
-    createChannel: createDefaultRpcSubscriptionsChannelCreator({
+    createChannel: createDefaultSolanaRpcSubscriptionsChannelCreator({
         url: 'ws://127.0.0.1:8900',
     }),
 });

--- a/packages/rpc-subscriptions/README.md
+++ b/packages/rpc-subscriptions/README.md
@@ -22,6 +22,10 @@ This package contains types that implement RPC subscriptions as required by the 
 
 Creates a function that returns new subscription channels when called.
 
+### `createDefaultSolanaRpcSubscriptionsChannelCreator(config)`
+
+Similar to `createDefaultRpcSubscriptionsChannelCreator` with some Solana-specific defaults. For instance, it safely handles `BigInt` values in JSON messages since Solana RPC servers accept and return integers larger than `Number.MAX_SAFE_INTEGER`.
+
 #### Arguments
 
 A config object with the following properties:

--- a/packages/rpc-subscriptions/src/rpc-subscriptions.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions.ts
@@ -9,7 +9,7 @@ import { ClusterUrl } from '@solana/rpc-types';
 
 import { DEFAULT_RPC_SUBSCRIPTIONS_CONFIG } from './rpc-default-config';
 import {
-    createDefaultRpcSubscriptionsChannelCreator,
+    createDefaultSolanaRpcSubscriptionsChannelCreator,
     DefaultRpcSubscriptionsChannelConfig,
 } from './rpc-subscriptions-channel';
 import type { RpcSubscriptionsFromTransport } from './rpc-subscriptions-clusters';
@@ -23,7 +23,7 @@ function createSolanaRpcSubscriptionsImpl<TClusterUrl extends ClusterUrl, TApi e
     config?: Omit<DefaultRpcSubscriptionsConfig<TClusterUrl>, 'url'>,
 ) {
     const transport = createDefaultRpcSubscriptionsTransport({
-        createChannel: createDefaultRpcSubscriptionsChannelCreator({ ...config, url: clusterUrl }),
+        createChannel: createDefaultSolanaRpcSubscriptionsChannelCreator({ ...config, url: clusterUrl }),
     });
     return createSolanaRpcSubscriptionsFromTransport<typeof transport, TApi>(transport);
 }


### PR DESCRIPTION
This PR offers a new `createDefaultSolanaRpcSubscriptionsChannelCreator` function that works similarly to `createDefaultRpcSubscriptionsChannelCreator` but with some Solana-specific defaults.

Namely, it uses the brand new `getRpcSubscriptionsChannelWithBigIntJSONSerialization` function to stringify and parse messages to and from the server. 