### PR TITLE
Revert "Temporarily disable Node 23 CI tests"

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -28,10 +28,7 @@ jobs:
     strategy:
       matrix:
         node:
-          # FIXME: This is a temporary workaround until Jest work nicely with Node 23.
-          # Currently, we get `No tests found, exiting with code 1` errors when running
-          # Jest unit tests on Node 23.
-          - 22.x # 'current'
+          - 'current'
           - 'lts/*'
 
     name: Build & Test on Node ${{ matrix.node }}


### PR DESCRIPTION
Node 23.1.0 is out.

Reverts solana-labs/solana-web3.js#3395