### PR TITLE
Put `types` before `require` and `import` in `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prettier": "^3.3",
         "ts-node": "^10.9.2",
         "tsup": "^8.3.4",
-        "turbo": "^2.2.1",
+        "turbo": "^2.2.3",
         "typescript": "^5.6.3"
     },
     "engineStrict": true,

--- a/packages/crypto-impl/package.json
+++ b/packages/crypto-impl/package.json
@@ -4,24 +4,24 @@
     "private": true,
     "exports": {
         "edge-light": {
+            "types": "./dist/types/index.browser.d.ts",
             "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs",
-            "types": "./dist/types/index.browser.d.ts"
+            "require": "./dist/index.node.cjs"
         },
         "workerd": {
+            "types": "./dist/types/index.browser.d.ts",
             "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs",
-            "types": "./dist/types/index.browser.d.ts"
+            "require": "./dist/index.node.cjs"
         },
         "browser": {
+            "types": "./dist/types/index.browser.d.ts",
             "import": "./dist/index.browser.mjs",
-            "require": "./dist/index.browser.cjs",
-            "types": "./dist/types/index.browser.d.ts"
+            "require": "./dist/index.browser.cjs"
         },
         "node": {
+            "types": "./dist/types/index.browser.d.ts",
             "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs",
-            "types": "./dist/types/index.browser.d.ts"
+            "require": "./dist/index.node.cjs"
         }
     },
     "browser": {

--- a/packages/ws-impl/package.json
+++ b/packages/ws-impl/package.json
@@ -4,24 +4,24 @@
     "private": true,
     "exports": {
         "edge-light": {
+            "types": "./dist/types/index.browser.d.ts",
             "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs",
-            "types": "./dist/types/index.browser.d.ts"
+            "require": "./dist/index.node.cjs"
         },
         "workerd": {
+            "types": "./dist/types/index.browser.d.ts",
             "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs",
-            "types": "./dist/types/index.browser.d.ts"
+            "require": "./dist/index.node.cjs"
         },
         "browser": {
+            "types": "./dist/types/index.browser.d.ts",
             "import": "./dist/index.browser.mjs",
-            "require": "./dist/index.browser.cjs",
-            "types": "./dist/types/index.browser.d.ts"
+            "require": "./dist/index.browser.cjs"
         },
         "node": {
+            "types": "./dist/types/index.browser.d.ts",
             "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs",
-            "types": "./dist/types/index.browser.d.ts"
+            "require": "./dist/index.node.cjs"
         }
     },
     "browser": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: ^8.3.4
         version: 8.3.4(@swc/core@1.7.26(@swc/helpers@0.5.11))(jiti@1.21.0)(postcss@8.4.45)(tsx@4.19.1)(typescript@5.6.3)(yaml@2.4.5)
       turbo:
-        specifier: ^2.2.1
-        version: 2.2.1
+        specifier: ^2.2.3
+        version: 2.2.3
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -6459,38 +6459,38 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo-darwin-64@2.2.1:
-    resolution: {integrity: sha512-jltMdSQ+7rQDVaorjW729PCw6fwAn1MgZSdoa0Gil7GZCOF3SnR/ok0uJw6G5mdm6F5XM8ZTlz+mdGzBLuBRaA==}
+  turbo-darwin-64@2.2.3:
+    resolution: {integrity: sha512-Rcm10CuMKQGcdIBS3R/9PMeuYnv6beYIHqfZFeKWVYEWH69sauj4INs83zKMTUiZJ3/hWGZ4jet9AOwhsssLyg==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.2.1:
-    resolution: {integrity: sha512-RHW0c1NonsJXXlutlZeunmhLanf0/WbeizFfYgWuTEaJE4MbbhyD/RG4Fm/7iob5kxQ4Es2TzfDPqyMqpIO0GA==}
+  turbo-darwin-arm64@2.2.3:
+    resolution: {integrity: sha512-+EIMHkuLFqUdJYsA3roj66t9+9IciCajgj+DVek+QezEdOJKcRxlvDOS2BUaeN8kEzVSsNiAGnoysFWYw4K0HA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.2.1:
-    resolution: {integrity: sha512-RasrjV+i2B90hoR8r6B2Btf2/ebNT5MJbhkpY0G1EN06E1IkjCKfAXj/1Dwmjy9+Zo0NC2r69L3HxRrtpar8jQ==}
+  turbo-linux-64@2.2.3:
+    resolution: {integrity: sha512-UBhJCYnqtaeOBQLmLo8BAisWbc9v9daL9G8upLR+XGj6vuN/Nz6qUAhverN4Pyej1g4Nt1BhROnj6GLOPYyqxQ==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.2.1:
-    resolution: {integrity: sha512-LNkUUJuu1gNkhlo7Ky/zilXEiajLoGlWLiKT1XV5neEf+x1s+aU9Hzd/+HhSVMiyI8l7z6zLbrM1a6+v4co/SQ==}
+  turbo-linux-arm64@2.2.3:
+    resolution: {integrity: sha512-hJYT9dN06XCQ3jBka/EWvvAETnHRs3xuO/rb5bESmDfG+d9yQjeTMlhRXKrr4eyIMt6cLDt1LBfyi+6CQ+VAwQ==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.2.1:
-    resolution: {integrity: sha512-Mn5tlFrLzlQ6tW6wTWNlyT1osXuDUg0VT1VAjRpmRXlK2Zi3oKVVG0rs0nkkq4rmuheryD1xyuGPN9nFKbAn/A==}
+  turbo-windows-64@2.2.3:
+    resolution: {integrity: sha512-NPrjacrZypMBF31b4HE4ROg4P3nhMBPHKS5WTpMwf7wydZ8uvdEHpESVNMOtqhlp857zbnKYgP+yJF30H3N2dQ==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.2.1:
-    resolution: {integrity: sha512-bvYOJ3SMN00yiem+uAqwRMbUMau/KiMzJYxnD0YkFo6INc08z8gZi5g0GLZAR7g/L3JegktX3UQW2cJvryjvLg==}
+  turbo-windows-arm64@2.2.3:
+    resolution: {integrity: sha512-fnNrYBCqn6zgKPKLHu4sOkihBI/+0oYFr075duRxqUZ+1aLWTAGfHZLgjVeLh3zR37CVzuerGIPWAEkNhkWEIw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.2.1:
-    resolution: {integrity: sha512-clZFkh6U6NpsLKBVZYRjlZjRTfju1Z5STqvFVaOGu5443uM75alJe1nCYH9pQ9YJoiOvXAqA2rDHWN5kLS9JMg==}
+  turbo@2.2.3:
+    resolution: {integrity: sha512-5lDvSqIxCYJ/BAd6rQGK/AzFRhBkbu4JHVMLmGh/hCb7U3CqSnr5Tjwfy9vc+/5wG2DJ6wttgAaA7MoCgvBKZQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -12878,32 +12878,32 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo-darwin-64@2.2.1:
+  turbo-darwin-64@2.2.3:
     optional: true
 
-  turbo-darwin-arm64@2.2.1:
+  turbo-darwin-arm64@2.2.3:
     optional: true
 
-  turbo-linux-64@2.2.1:
+  turbo-linux-64@2.2.3:
     optional: true
 
-  turbo-linux-arm64@2.2.1:
+  turbo-linux-arm64@2.2.3:
     optional: true
 
-  turbo-windows-64@2.2.1:
+  turbo-windows-64@2.2.3:
     optional: true
 
-  turbo-windows-arm64@2.2.1:
+  turbo-windows-arm64@2.2.3:
     optional: true
 
-  turbo@2.2.1:
+  turbo@2.2.3:
     optionalDependencies:
-      turbo-darwin-64: 2.2.1
-      turbo-darwin-arm64: 2.2.1
-      turbo-linux-64: 2.2.1
-      turbo-linux-arm64: 2.2.1
-      turbo-windows-64: 2.2.1
-      turbo-windows-arm64: 2.2.1
+      turbo-darwin-64: 2.2.3
+      turbo-darwin-arm64: 2.2.3
+      turbo-linux-64: 2.2.3
+      turbo-linux-arm64: 2.2.3
+      turbo-windows-64: 2.2.3
+      turbo-windows-arm64: 2.2.3
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -56,22 +56,27 @@
         },
         "test:live-with-test-validator": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["$TURBO_DEFAULT$", "src/**"]
+            "inputs": ["$TURBO_DEFAULT$", "src/**"],
+            "outputs": []
         },
         "test:prettier": {
-            "inputs": ["$TURBO_DEFAULT$", "*"]
+            "inputs": ["$TURBO_DEFAULT$", "*"],
+            "outputs": []
         },
         "test:typecheck": {
             "dependsOn": ["^compile:typedefs"],
-            "inputs": ["$TURBO_DEFAULT$", "tsconfig.*", "src/**"]
+            "inputs": ["$TURBO_DEFAULT$", "tsconfig.*", "src/**"],
+            "outputs": []
         },
         "test:unit:browser": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["$TURBO_DEFAULT$", "../../.agave/**/version.yml", "src/**"]
+            "inputs": ["$TURBO_DEFAULT$", "../../.agave/**/version.yml", "src/**"],
+            "outputs": []
         },
         "test:unit:node": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["$TURBO_DEFAULT$", "../../.agave/**/version.yml", "src/**"]
+            "inputs": ["$TURBO_DEFAULT$", "../../.agave/**/version.yml", "src/**"],
+            "outputs": []
         },
         "test:treeshakability:browser": {
             "dependsOn": ["compile:js"]


### PR DESCRIPTION
Apparently `types` does not get used if it comes after `require` or `imports` here. A warning from `tsup` led me here.
