### PR TITLE
Dissolve `U64` and `I64` RPC types

### DIFF
--- a/.changeset/fair-moles-collect.md
+++ b/.changeset/fair-moles-collect.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-types': patch
+---
+
+Remove `U64` and `I64` types in favour of `bigint`

--- a/packages/accounts/src/rpc-api/common.ts
+++ b/packages/accounts/src/rpc-api/common.ts
@@ -1,5 +1,3 @@
-import type { U64 } from '@solana/rpc-types';
-
 export type JsonParsedDataResponse<TData = object> = Readonly<{
     parsed: {
         info?: TData;
@@ -7,5 +5,5 @@ export type JsonParsedDataResponse<TData = object> = Readonly<{
     };
     // Name of the program that owns this account.
     program: string;
-    space: U64;
+    space: bigint;
 }>;

--- a/packages/rpc-api/src/__typetests__/get-block-type-test.ts
+++ b/packages/rpc-api/src/__typetests__/get-block-type-test.ts
@@ -10,7 +10,6 @@ import type {
     TokenBalance,
     TransactionError,
     TransactionStatus,
-    U64,
 } from '@solana/rpc-types';
 import { TransactionVersion } from '@solana/transaction-messages';
 
@@ -503,7 +502,7 @@ void (async () => {
     }
 
     type ExpectedMetaForFullBase58 = {
-        computeUnitsConsumed?: U64;
+        computeUnitsConsumed?: bigint;
         err: TransactionError | null;
         fee: Lamports;
         innerInstructions: readonly Readonly<{
@@ -728,7 +727,7 @@ void (async () => {
     }
 
     type ExpectedMetaForFullBase64 = {
-        computeUnitsConsumed?: U64;
+        computeUnitsConsumed?: bigint;
         err: TransactionError | null;
         fee: Lamports;
         innerInstructions: readonly Readonly<{
@@ -927,7 +926,7 @@ void (async () => {
         | ExpectedPartiallyDecodedTransactionInstruction;
 
     type ExpectedMetaForFullJsonParsedBase = {
-        computeUnitsConsumed?: U64;
+        computeUnitsConsumed?: bigint;
         err: TransactionError | null;
         fee: Lamports;
         innerInstructions: readonly Readonly<{
@@ -1092,7 +1091,7 @@ void (async () => {
     };
 
     type ExpectedMetaForFullJsonBase = {
-        computeUnitsConsumed?: U64;
+        computeUnitsConsumed?: bigint;
         err: TransactionError | null;
         fee: Lamports;
         innerInstructions: readonly Readonly<{

--- a/packages/rpc-api/src/getBlock.ts
+++ b/packages/rpc-api/src/getBlock.ts
@@ -9,7 +9,6 @@ import type {
     TransactionForFullBase64,
     TransactionForFullJson,
     TransactionForFullJsonParsed,
-    U64,
     UnixTimestamp,
 } from '@solana/rpc-types';
 import type { TransactionVersion } from '@solana/transaction-messages';
@@ -18,7 +17,7 @@ import type { TransactionVersion } from '@solana/transaction-messages';
 
 type GetBlockApiResponseBase = Readonly<{
     /** The number of blocks beneath this block */
-    blockHeight: U64;
+    blockHeight: bigint;
     /** Estimated production time, as Unix timestamp */
     blockTime: UnixTimestamp;
     /** the blockhash of this block */

--- a/packages/rpc-api/src/getBlockHeight.ts
+++ b/packages/rpc-api/src/getBlockHeight.ts
@@ -1,6 +1,6 @@
-import type { Commitment, Slot, U64 } from '@solana/rpc-types';
+import type { Commitment, Slot } from '@solana/rpc-types';
 
-type GetBlockHeightApiResponse = U64;
+type GetBlockHeightApiResponse = bigint;
 
 export type GetBlockHeightApi = {
     /**

--- a/packages/rpc-api/src/getBlockProduction.ts
+++ b/packages/rpc-api/src/getBlockProduction.ts
@@ -1,8 +1,8 @@
 import type { Address } from '@solana/addresses';
-import type { Commitment, Slot, SolanaRpcResponse, U64 } from '@solana/rpc-types';
+import type { Commitment, Slot, SolanaRpcResponse } from '@solana/rpc-types';
 
-type NumberOfLeaderSlots = U64;
-type NumberOfBlocksProduced = U64;
+type NumberOfLeaderSlots = bigint;
+type NumberOfBlocksProduced = bigint;
 
 type SlotRange = Readonly<{
     firstSlot: Slot;

--- a/packages/rpc-api/src/getEpochInfo.ts
+++ b/packages/rpc-api/src/getEpochInfo.ts
@@ -1,18 +1,18 @@
-import type { Commitment, Slot, U64 } from '@solana/rpc-types';
+import type { Commitment, Slot } from '@solana/rpc-types';
 
 type GetEpochInfoApiResponse = Readonly<{
     /** the current slot */
     absoluteSlot: Slot;
     /** the current block height */
-    blockHeight: U64;
+    blockHeight: bigint;
     /** the current epoch */
-    epoch: U64;
+    epoch: bigint;
     /** the current slot relative to the start of the current epoch */
-    slotIndex: U64;
+    slotIndex: bigint;
     /** the number of slots in this epoch */
-    slotsInEpoch: U64;
+    slotsInEpoch: bigint;
     /** total number of transactions processed without error since genesis */
-    transactionCount: U64 | null;
+    transactionCount: bigint | null;
 }>;
 
 export type GetEpochInfoApi = {

--- a/packages/rpc-api/src/getEpochSchedule.ts
+++ b/packages/rpc-api/src/getEpochSchedule.ts
@@ -1,14 +1,12 @@
-import type { U64 } from '@solana/rpc-types';
-
 type GetEpochScheduleApiResponse = Readonly<{
     /** first normal-length epoch, log2(slotsPerEpoch) - log2(MINIMUM_SLOTS_PER_EPOCH) */
-    firstNormalEpoch: U64;
+    firstNormalEpoch: bigint;
     /** MINIMUM_SLOTS_PER_EPOCH * (2^(firstNormalEpoch) - 1) */
-    firstNormalSlot: U64;
+    firstNormalSlot: bigint;
     /** the number of slots before beginning of an epoch to calculate a leader schedule for that epoch */
-    leaderScheduleSlotOffset: U64;
+    leaderScheduleSlotOffset: bigint;
     /** the maximum number of slots in each epoch */
-    slotsPerEpoch: U64;
+    slotsPerEpoch: bigint;
     /** whether epochs start short and grow */
     warmup: boolean;
 }>;

--- a/packages/rpc-api/src/getInflationRate.ts
+++ b/packages/rpc-api/src/getInflationRate.ts
@@ -1,8 +1,8 @@
-import type { F64UnsafeSeeDocumentation, U64 } from '@solana/rpc-types';
+import type { F64UnsafeSeeDocumentation } from '@solana/rpc-types';
 
 type GetInflationRateApiResponse = Readonly<{
     /** Epoch for which these values are valid */
-    epoch: U64;
+    epoch: bigint;
     /** Inflation allocated to the foundation */
     foundation: F64UnsafeSeeDocumentation;
     /** Total inflation */

--- a/packages/rpc-api/src/getInflationReward.ts
+++ b/packages/rpc-api/src/getInflationReward.ts
@@ -1,12 +1,12 @@
 import type { Address } from '@solana/addresses';
-import type { Commitment, Lamports, Slot, U64 } from '@solana/rpc-types';
+import type { Commitment, Lamports, Slot } from '@solana/rpc-types';
 
 type GetInflationRewardApiConfig = Readonly<{
     // Defaults to `finalized`
     commitment?: Commitment;
     // An epoch for which the reward occurs.
     // If omitted, the previous epoch will be used
-    epoch?: U64;
+    epoch?: bigint;
     // The minimum slot that the request can be evaluated at
     minContextSlot?: Slot;
 }>;
@@ -19,7 +19,7 @@ type InflationReward = Readonly<{
     // The slot in which the rewards are effective
     effectiveSlot: Slot;
     // Epoch for which reward occurred
-    epoch: U64;
+    epoch: bigint;
     // Post balance of the account in lamports
     postBalance: Lamports;
 }>;

--- a/packages/rpc-api/src/getLatestBlockhash.ts
+++ b/packages/rpc-api/src/getLatestBlockhash.ts
@@ -1,10 +1,10 @@
-import type { Blockhash, Commitment, Slot, SolanaRpcResponse, U64 } from '@solana/rpc-types';
+import type { Blockhash, Commitment, Slot, SolanaRpcResponse } from '@solana/rpc-types';
 
 type GetLatestBlockhashApiResponse = Readonly<{
     /** a Hash as base-58 encoded string */
     blockhash: Blockhash;
     /** last block height at which the blockhash will be valid */
-    lastValidBlockHeight: U64;
+    lastValidBlockHeight: bigint;
 }>;
 
 export type GetLatestBlockhashApi = {

--- a/packages/rpc-api/src/getMinimumBalanceForRentExemption.ts
+++ b/packages/rpc-api/src/getMinimumBalanceForRentExemption.ts
@@ -1,4 +1,4 @@
-import type { Commitment, Lamports, U64 } from '@solana/rpc-types';
+import type { Commitment, Lamports } from '@solana/rpc-types';
 
 type GetMinimumBalanceForRentExemptionApiResponse = Lamports;
 
@@ -7,7 +7,7 @@ export type GetMinimumBalanceForRentExemptionApi = {
      * Returns the minimum balance to exempt an account of a certain size from rent
      */
     getMinimumBalanceForRentExemption(
-        size: U64,
+        size: bigint,
         config?: Readonly<{
             commitment?: Commitment;
         }>,

--- a/packages/rpc-api/src/getRecentPerformanceSamples.ts
+++ b/packages/rpc-api/src/getRecentPerformanceSamples.ts
@@ -1,12 +1,12 @@
-import type { Slot, U64 } from '@solana/rpc-types';
+import type { Slot } from '@solana/rpc-types';
 
 type PerformanceSample = Readonly<{
     /** Number of non-vote transactions in sample. */
-    numNonVoteTransactions: U64;
+    numNonVoteTransactions: bigint;
     /** Number of slots in sample */
-    numSlots: U64;
+    numSlots: bigint;
     /** Number of transactions in sample */
-    numTransactions: U64;
+    numTransactions: bigint;
     /** Number of seconds in a sample window */
     samplePeriodSecs: number;
     /** Slot in which sample was taken at */

--- a/packages/rpc-api/src/getSignatureStatuses.ts
+++ b/packages/rpc-api/src/getSignatureStatuses.ts
@@ -1,5 +1,5 @@
 import type { Signature } from '@solana/keys';
-import type { Commitment, Slot, SolanaRpcResponse, TransactionError, U64 } from '@solana/rpc-types';
+import type { Commitment, Slot, SolanaRpcResponse, TransactionError } from '@solana/rpc-types';
 
 /** @deprecated */
 type TransactionStatusOk = Readonly<{
@@ -21,7 +21,7 @@ type SignatureStatusResult = Readonly<{
      * Number of blocks since signature confirmation, null if rooted,
      * as well as finalized by a supermajority of the cluster
      */
-    confirmations: U64 | null;
+    confirmations: bigint | null;
     /** Error if transaction failed, null if transaction succeeded */
     err: TransactionError | null;
     /** The slot the transaction was processed */

--- a/packages/rpc-api/src/getTokenAccountsByDelegate.ts
+++ b/packages/rpc-api/src/getTokenAccountsByDelegate.ts
@@ -11,7 +11,6 @@ import type {
     DataSlice,
     Slot,
     SolanaRpcResponse,
-    U64,
 } from '@solana/rpc-types';
 
 type TokenAccountInfoWithJsonData = Readonly<{
@@ -22,7 +21,7 @@ type TokenAccountInfoWithJsonData = Readonly<{
         };
         /** Name of the program that owns this account. */
         program: Address;
-        space: U64;
+        space: bigint;
     }>;
 }>;
 

--- a/packages/rpc-api/src/getTokenAccountsByOwner.ts
+++ b/packages/rpc-api/src/getTokenAccountsByOwner.ts
@@ -11,7 +11,6 @@ import type {
     DataSlice,
     Slot,
     SolanaRpcResponse,
-    U64,
 } from '@solana/rpc-types';
 
 type TokenAccountInfoWithJsonData = Readonly<{
@@ -22,7 +21,7 @@ type TokenAccountInfoWithJsonData = Readonly<{
         };
         /** Name of the program that owns this account. */
         program: Address;
-        space: U64;
+        space: bigint;
     }>;
 }>;
 

--- a/packages/rpc-api/src/getTransaction.ts
+++ b/packages/rpc-api/src/getTransaction.ts
@@ -12,7 +12,6 @@ import type {
     TokenBalance,
     TransactionError,
     TransactionStatus,
-    U64,
     UnixTimestamp,
 } from '@solana/rpc-types';
 import type { TransactionVersion } from '@solana/transaction-messages';
@@ -26,7 +25,7 @@ type ReturnData = {
 
 type TransactionMetaBase = Readonly<{
     /** number of compute units consumed by the transaction */
-    computeUnitsConsumed?: U64;
+    computeUnitsConsumed?: bigint;
     /** Error if transaction failed, null if transaction succeeded. */
     err: TransactionError | null;
     /** fee this transaction was charged */

--- a/packages/rpc-api/src/getTransactionCount.ts
+++ b/packages/rpc-api/src/getTransactionCount.ts
@@ -1,6 +1,6 @@
-import type { Commitment, Slot, U64 } from '@solana/rpc-types';
+import type { Commitment, Slot } from '@solana/rpc-types';
 
-type GetTransactionCountApiResponse = U64;
+type GetTransactionCountApiResponse = bigint;
 
 export type GetTransactionCountApi = {
     /**

--- a/packages/rpc-api/src/getVoteAccounts.ts
+++ b/packages/rpc-api/src/getVoteAccounts.ts
@@ -1,15 +1,14 @@
 import type { Address } from '@solana/addresses';
-import type { Commitment, Slot, U64 } from '@solana/rpc-types';
+import type { Commitment, Epoch, Slot } from '@solana/rpc-types';
 
-type Epoch = U64;
-type Credits = U64;
-type PreviousCredits = U64;
+type Credits = bigint;
+type PreviousCredits = bigint;
 
 type EpochCredit = [Epoch, Credits, PreviousCredits];
 
 type VoteAccount<TVotePubkey extends Address> = Readonly<{
     /** the stake, in lamports, delegated to this vote account and active in this epoch */
-    activatedStake: U64;
+    activatedStake: bigint;
     /** percentage (0-100) of rewards payout owed to the vote account */
     commission: number;
     /** Latest history of earned credits for up to five epochs */
@@ -17,7 +16,7 @@ type VoteAccount<TVotePubkey extends Address> = Readonly<{
     /** whether the vote account is staked for this epoch */
     epochVoteAccount: boolean;
     /** Most recent slot voted on by this vote account */
-    lastVote: U64;
+    lastVote: bigint;
     /** Validator identity */
     nodePubkey: Address;
     /** Current root slot for this vote account */
@@ -34,7 +33,7 @@ type GetVoteAccountsApiResponse<TVotePubkey extends Address> = Readonly<{
 type GetVoteAccountsConfig<TVotePubkey extends Address> = Readonly<{
     commitment?: Commitment;
     /** Specify the number of slots behind the tip that a validator must fall to be considered delinquent. **NOTE:** For the sake of consistency between ecosystem products, _it is **not** recommended that this argument be specified._ */
-    delinquentSlotDistance?: U64;
+    delinquentSlotDistance?: bigint;
     /** Do not filter out delinquent validators with no stake */
     keepUnstakedDelinquents?: boolean;
     /** Only return results for this validator vote address */

--- a/packages/rpc-api/src/simulateTransaction.ts
+++ b/packages/rpc-api/src/simulateTransaction.ts
@@ -13,7 +13,6 @@ import type {
     TransactionError,
     TransactionForFullMetaInnerInstructionsParsed,
     TransactionForFullMetaInnerInstructionsUnparsed,
-    U64,
 } from '@solana/rpc-types';
 import type { Base64EncodedWireTransaction } from '@solana/transactions';
 
@@ -104,7 +103,7 @@ type SimulateTransactionApiResponseBase = Readonly<{
         programId: Address;
     }> | null;
     /** The number of compute budget units consumed during the processing of this transaction */
-    unitsConsumed?: U64;
+    unitsConsumed?: bigint;
 }>;
 
 type SimulateTransactionApiResponseWithAccounts<T extends AccountInfoBase> = Readonly<{

--- a/packages/rpc-subscriptions-api/src/__typetests__/account-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/account-notifications-type-test.ts
@@ -8,7 +8,6 @@ import type {
     Base64EncodedZStdCompressedDataResponse,
     Lamports,
     SolanaRpcResponse,
-    U64,
 } from '@solana/rpc-types';
 
 import type { AccountNotificationsApi } from '../account-notifications';
@@ -24,7 +23,7 @@ type TNotificationBase = Readonly<{
     executable: boolean;
     lamports: Lamports;
     owner: Address;
-    rentEpoch: U64;
+    rentEpoch: bigint;
 }>;
 
 // No optional configs
@@ -131,7 +130,7 @@ rpcSubscriptions.accountNotifications(pubkey, { encoding: 'jsonParsed' }) satisf
                 | Readonly<{
                       parsed: unknown;
                       program: string;
-                      space: U64;
+                      space: bigint;
                   }>;
         }
     >
@@ -147,7 +146,7 @@ rpcSubscriptions
                     | Readonly<{
                           parsed: unknown;
                           program: string;
-                          space: U64;
+                          space: bigint;
                       }>;
             }
         >

--- a/packages/rpc-subscriptions-api/src/__typetests__/block-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/block-notifications-type-test.ts
@@ -13,7 +13,6 @@ import type {
     TokenBalance,
     TransactionError,
     TransactionStatus,
-    U64,
 } from '@solana/rpc-types';
 import type { TransactionVersion } from '@solana/transaction-messages';
 
@@ -716,7 +715,7 @@ rpcSubscriptions
 >;
 
 type ExpectedMetaForFullBase58 = {
-    computeUnitsConsumed?: U64;
+    computeUnitsConsumed?: bigint;
     err: TransactionError | null;
     fee: Lamports;
     innerInstructions: readonly Readonly<{
@@ -983,7 +982,7 @@ rpcSubscriptions
 >;
 
 type ExpectedMetaForFullBase64 = {
-    computeUnitsConsumed?: U64;
+    computeUnitsConsumed?: bigint;
     err: TransactionError | null;
     fee: Lamports;
     innerInstructions: readonly Readonly<{
@@ -1213,7 +1212,7 @@ type ExpectedTransactionInstructionForFullJsonParsed =
     | ExpectedPartiallyDecodedTransactionInstruction;
 
 type ExpectedMetaForFullJsonParsedBase = {
-    computeUnitsConsumed?: U64;
+    computeUnitsConsumed?: bigint;
     err: TransactionError | null;
     fee: Lamports;
     innerInstructions: readonly Readonly<{
@@ -1397,7 +1396,7 @@ type ExpectedTransactionInstructionForFullJson = {
 };
 
 type ExpectedMetaForFullJsonBase = {
-    computeUnitsConsumed?: U64;
+    computeUnitsConsumed?: bigint;
     err: TransactionError | null;
     fee: Lamports;
     innerInstructions: readonly Readonly<{

--- a/packages/rpc-subscriptions-api/src/__typetests__/program-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/program-notifications-type-test.ts
@@ -9,7 +9,6 @@ import type {
     Base64EncodedZStdCompressedDataResponse,
     Lamports,
     SolanaRpcResponse,
-    U64,
 } from '@solana/rpc-types';
 
 import type { ProgramNotificationsApi } from '../program-notifications';
@@ -25,7 +24,7 @@ type TNotificationBase = Readonly<{
         executable: boolean;
         lamports: Lamports;
         owner: Address;
-        rentEpoch: U64;
+        rentEpoch: bigint;
     }>;
     pubkey: Address;
 }>;
@@ -161,7 +160,7 @@ rpcSubscriptions.programNotifications(programId, {
                     | Readonly<{
                           parsed: unknown;
                           program: string;
-                          space: U64;
+                          space: bigint;
                       }>;
             };
         }
@@ -179,7 +178,7 @@ rpcSubscriptions
                         | Readonly<{
                               parsed: unknown;
                               program: string;
-                              space: U64;
+                              space: bigint;
                           }>;
                 };
             }
@@ -194,7 +193,7 @@ rpcSubscriptions
             memcmp: {
                 bytes: 'bytes' as Base58EncodedBytes,
                 encoding: 'base58',
-                offset: 0n as U64,
+                offset: 0n,
             },
         },
     ],
@@ -207,7 +206,7 @@ rpcSubscriptions
             memcmp: {
                 bytes: 'bytes' as Base58EncodedBytes,
                 encoding: 'base64',
-                offset: 0n as U64,
+                offset: 0n,
             },
         },
     ],
@@ -218,7 +217,7 @@ rpcSubscriptions
             memcmp: {
                 bytes: 'bytes' as Base64EncodedBytes,
                 encoding: 'base64',
-                offset: 0n as U64,
+                offset: 0n,
             },
         },
     ],
@@ -231,7 +230,7 @@ rpcSubscriptions
             memcmp: {
                 bytes: 'bytes' as Base64EncodedBytes,
                 encoding: 'base58',
-                offset: 0n as U64,
+                offset: 0n,
             },
         },
     ],

--- a/packages/rpc-subscriptions-api/src/__typetests__/slots-updates-notifications-type-test.ts
+++ b/packages/rpc-subscriptions-api/src/__typetests__/slots-updates-notifications-type-test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import type { PendingRpcSubscriptionsRequest, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
-import type { Slot, U64 } from '@solana/rpc-types';
+import type { Slot } from '@solana/rpc-types';
 
 import type { SlotsUpdatesNotificationsApi } from '../slots-updates-notifications';
 
@@ -9,7 +9,7 @@ const rpcSubscriptions = null as unknown as RpcSubscriptions<SlotsUpdatesNotific
 type TNotification = Readonly<{
     parent?: Slot;
     slot: Slot;
-    timestamp: U64;
+    timestamp: bigint;
     type: 'completed' | 'createdBank' | 'dead' | 'firstShredReceived' | 'frozen' | 'optimisticConfirmation' | 'root';
 }>;
 rpcSubscriptions.slotsUpdatesNotifications() satisfies PendingRpcSubscriptionsRequest<TNotification>;

--- a/packages/rpc-subscriptions-api/src/block-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/block-notifications.ts
@@ -10,7 +10,6 @@ import type {
     TransactionForFullBase64,
     TransactionForFullJson,
     TransactionForFullJsonParsed,
-    U64,
     UnixTimestamp,
 } from '@solana/rpc-types';
 import type { TransactionVersion } from '@solana/transaction-messages';
@@ -30,7 +29,7 @@ type BlockNotificationsNotificationBase = Readonly<{
 
 type BlockNotificationsNotificationBlock = Readonly<{
     /** The number of blocks beneath this block */
-    blockHeight: U64;
+    blockHeight: bigint;
     /** Estimated production time, as Unix timestamp */
     blockTime: UnixTimestamp;
     /** the blockhash of this block */

--- a/packages/rpc-subscriptions-api/src/program-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/program-notifications.ts
@@ -10,22 +10,21 @@ import type {
     Base64EncodedBytes,
     Commitment,
     SolanaRpcResponse,
-    U64,
 } from '@solana/rpc-types';
 
 type ProgramNotificationsMemcmpFilterBase58 = Readonly<{
     bytes: Base58EncodedBytes;
     encoding: 'base58';
-    offset: U64;
+    offset: bigint;
 }>;
 
 type ProgramNotificationsMemcmpFilterBase64 = Readonly<{
     bytes: Base64EncodedBytes;
     encoding: 'base64';
-    offset: U64;
+    offset: bigint;
 }>;
 
-type ProgramNotificationsDatasizeFilter = U64;
+type ProgramNotificationsDatasizeFilter = bigint;
 
 type ProgramNotificationsApiNotificationBase<TData> = SolanaRpcResponse<
     Readonly<{

--- a/packages/rpc-subscriptions-api/src/slots-updates-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/slots-updates-notifications.ts
@@ -1,8 +1,8 @@
-import type { Slot, U64 } from '@solana/rpc-types';
+import type { Slot } from '@solana/rpc-types';
 
 type SlotsUpdatesNotificationsApiNotificationBase = Readonly<{
     slot: Slot;
-    timestamp: U64;
+    timestamp: bigint;
     type: 'completed' | 'firstShredReceived' | 'optimisticConfirmation' | 'root';
 }>;
 
@@ -20,10 +20,10 @@ type SlotsUpdatesNotificationsApiNotificationDead = Readonly<{
 
 type SlotsUpdatesNotificationsApiNotificationFrozen = Readonly<{
     stats: Readonly<{
-        maxTransactionsPerEntry: U64;
-        numFailedTransactions: U64;
-        numSuccessfulTransactions: U64;
-        numTransactionEntries: U64;
+        maxTransactionsPerEntry: bigint;
+        numFailedTransactions: bigint;
+        numSuccessfulTransactions: bigint;
+        numTransactionEntries: bigint;
     }>;
     type: 'frozen';
 }> &

--- a/packages/rpc-types/src/account-filters.ts
+++ b/packages/rpc-types/src/account-filters.ts
@@ -1,5 +1,3 @@
-import type { U64 } from './typed-numbers';
-
 export type DataSlice = Readonly<{
     length: number;
     offset: number;
@@ -9,10 +7,10 @@ export type GetProgramAccountsMemcmpFilter = Readonly<{
     memcmp: Readonly<{
         bytes: string;
         encoding: 'base58' | 'base64';
-        offset: U64;
+        offset: bigint;
     }>;
 }>;
 
 export type GetProgramAccountsDatasizeFilter = Readonly<{
-    dataSize: U64;
+    dataSize: bigint;
 }>;

--- a/packages/rpc-types/src/account-info.ts
+++ b/packages/rpc-types/src/account-info.ts
@@ -7,7 +7,6 @@ import type {
     Base64EncodedZStdCompressedDataResponse,
 } from './encoded-bytes';
 import type { Lamports } from './lamports';
-import type { U64 } from './typed-numbers';
 
 export type AccountInfoBase = Readonly<{
     /** indicates if the account contains a program (and is strictly read-only) */
@@ -17,7 +16,7 @@ export type AccountInfoBase = Readonly<{
     /** pubkey of the program this account has been assigned to */
     owner: Address;
     /** the epoch at which this account will next owe rent */
-    rentEpoch: U64;
+    rentEpoch: bigint;
 }>;
 
 /** @deprecated */
@@ -48,7 +47,7 @@ export type AccountInfoWithJsonData = Readonly<{
               };
               // Name of the program that owns this account.
               program: string;
-              space: U64;
+              space: bigint;
           }>;
 }>;
 

--- a/packages/rpc-types/src/transaction.ts
+++ b/packages/rpc-types/src/transaction.ts
@@ -5,7 +5,7 @@ import type { Base58EncodedBytes, Base58EncodedDataResponse, Base64EncodedDataRe
 import type { Lamports } from './lamports';
 import type { TokenBalance } from './token-balance';
 import type { TransactionError } from './transaction-error';
-import type { SignedLamports, U64 } from './typed-numbers';
+import type { SignedLamports } from './typed-numbers';
 
 type TransactionVersion = 'legacy' | 0;
 
@@ -118,7 +118,7 @@ export type TransactionForAccounts<TMaxSupportedTransactionVersion extends Trans
 
 type TransactionForFullMetaBase = Readonly<{
     /** number of compute units consumed by the transaction */
-    computeUnitsConsumed?: U64;
+    computeUnitsConsumed?: bigint;
     /** Error if transaction failed, null if transaction succeeded. */
     err: TransactionError | null;
     /** fee this transaction was charged */

--- a/packages/rpc-types/src/typed-numbers.ts
+++ b/packages/rpc-types/src/typed-numbers.ts
@@ -1,12 +1,9 @@
-export type U64 = bigint;
-export type I64 = bigint;
-
-export type Slot = U64;
-export type Epoch = U64;
+export type Slot = bigint;
+export type Epoch = bigint;
 
 // Specifically being used to denote micro-lamports, which are 0.000001 lamports.
-export type MicroLamports = U64 & { readonly __brand: unique symbol };
-export type SignedLamports = I64;
+export type MicroLamports = bigint & { readonly __brand: unique symbol };
+export type SignedLamports = bigint;
 
 // FIXME(solana-labs/solana/issues/30341)
 // <https://stackoverflow.com/questions/45929493/node-js-maximum-safe-floating-point-number/57225494#57225494>


### PR DESCRIPTION
This PR removes the `U64` and `I64` types by replacing their instances with `bigint`, as [requested in this thread](https://github.com/solana-labs/solana-web3.js/pull/3456#discussion_r1816692768).