### PR TITLE
Wrap `feePayer` attribute in an object

### DIFF
--- a/.changeset/red-moose-flash.md
+++ b/.changeset/red-moose-flash.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': patch
+---
+
+Change `feePayer` type of transaction messages from `Address` to `{ address: Address }`

--- a/examples/signers/src/example.ts
+++ b/examples/signers/src/example.ts
@@ -104,7 +104,7 @@ async function signTransaction(signer: TransactionPartialSigner, transactionMess
  */
 async function signTransactionWithSigners(transactionMessage: CompilableTransactionMessage) {
     const signedTransaction = await partiallySignTransactionMessageWithSigners(transactionMessage);
-    const signature = signedTransaction.signatures[transactionMessage.feePayer];
+    const signature = signedTransaction.signatures[transactionMessage.feePayer.address];
     log.info(
         { signature: signature ? getBase58Decoder().decode(signature) : null },
         '>>  Signing a transfer SOL transaction using its registered signers',

--- a/packages/library/src/__tests__/compute-limit-internal-test.ts
+++ b/packages/library/src/__tests__/compute-limit-internal-test.ts
@@ -28,7 +28,7 @@ describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPOR
     let simulateTransaction: jest.Mock;
     beforeEach(() => {
         mockTransactionMessage = {
-            feePayer: '7U8VWgTUucttJPt5Bbkt48WknWqRGBfstBt8qqLHnfPT' as Address,
+            feePayer: { address: '7U8VWgTUucttJPt5Bbkt48WknWqRGBfstBt8qqLHnfPT' as Address },
             instructions: [],
             version: 0,
         };

--- a/packages/signers/src/__tests__/fee-payer-signer-test.ts
+++ b/packages/signers/src/__tests__/fee-payer-signer-test.ts
@@ -18,7 +18,7 @@ describe('setTransactionMessageFeePayerSigner', () => {
     });
     it('sets the fee payer signer on the transaction', () => {
         const txWithFeePayerA = setTransactionMessageFeePayerSigner(feePayerSignerA, baseTx);
-        expect(txWithFeePayerA).toHaveProperty('feePayer', feePayerSignerA.address);
+        expect(txWithFeePayerA).toHaveProperty('feePayer', { address: feePayerSignerA.address });
         expect(txWithFeePayerA).toHaveProperty('feePayerSigner', feePayerSignerA);
     });
     describe('given a transaction with a fee payer signer already set', () => {
@@ -26,13 +26,13 @@ describe('setTransactionMessageFeePayerSigner', () => {
         beforeEach(() => {
             txWithFeePayerA = {
                 ...baseTx,
-                feePayer: feePayerSignerA.address,
+                feePayer: { address: feePayerSignerA.address },
                 feePayerSigner: feePayerSignerA,
             };
         });
         it('sets the new fee payer on the transaction when it differs from the existing one', () => {
             const txWithFeePayerB = setTransactionMessageFeePayerSigner(feePayerSignerB, txWithFeePayerA);
-            expect(txWithFeePayerB).toHaveProperty('feePayer', feePayerSignerB.address);
+            expect(txWithFeePayerB).toHaveProperty('feePayer', { address: feePayerSignerB.address });
             expect(txWithFeePayerB).toHaveProperty('feePayerSigner', feePayerSignerB);
         });
         it('returns the original transaction when trying to set the same fee payer again', () => {
@@ -45,17 +45,17 @@ describe('setTransactionMessageFeePayerSigner', () => {
         beforeEach(() => {
             txWithFeePayerA = {
                 ...baseTx,
-                feePayer: feePayerSignerA.address,
+                feePayer: { address: feePayerSignerA.address },
             };
         });
         it('sets the new fee payer on the transaction when it differs from the existing one', () => {
             const txWithFeePayerB = setTransactionMessageFeePayerSigner(feePayerSignerB, txWithFeePayerA);
-            expect(txWithFeePayerB).toHaveProperty('feePayer', feePayerSignerB.address);
+            expect(txWithFeePayerB).toHaveProperty('feePayer', { address: feePayerSignerB.address });
             expect(txWithFeePayerB).toHaveProperty('feePayerSigner', feePayerSignerB);
         });
         it('returns a new transaction instance when setting the same fee payer but as a signer this time', () => {
             const txWithSameFeePayer = setTransactionMessageFeePayerSigner(feePayerSignerA, txWithFeePayerA);
-            expect(txWithSameFeePayer).toHaveProperty('feePayer', feePayerSignerA.address);
+            expect(txWithSameFeePayer).toHaveProperty('feePayer', { address: feePayerSignerA.address });
             expect(txWithSameFeePayer).toHaveProperty('feePayerSigner', feePayerSignerA);
             expect(txWithFeePayerA).not.toBe(txWithSameFeePayer);
         });

--- a/packages/signers/src/fee-payer-signer.ts
+++ b/packages/signers/src/fee-payer-signer.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { BaseTransactionMessage } from '@solana/transaction-messages';
+import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { TransactionSigner } from './transaction-signer';
 
@@ -7,29 +7,30 @@ export interface ITransactionMessageWithFeePayerSigner<
     TAddress extends string = string,
     TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
 > {
-    readonly feePayer: Address<TAddress>;
+    readonly feePayer: { address: Address<TAddress> };
     readonly feePayerSigner: TSigner;
 }
 
 export function setTransactionMessageFeePayerSigner<
     TFeePayerAddress extends string,
-    TTransactionMessage extends BaseTransactionMessage,
+    TTransactionMessage extends BaseTransactionMessage &
+        Partial<ITransactionMessageWithFeePayer | ITransactionMessageWithFeePayerSigner>,
 >(
     feePayerSigner: TransactionSigner<TFeePayerAddress>,
     transactionMessage: TTransactionMessage,
 ): ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & Omit<TTransactionMessage, 'feePayer' | 'feePayerSigner'> {
-    if ('feePayer' in transactionMessage && feePayerSigner.address === transactionMessage.feePayer) {
+    if ('feePayer' in transactionMessage && feePayerSigner.address === transactionMessage.feePayer?.address) {
         if ('feePayerSigner' in transactionMessage)
-            return transactionMessage as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> &
+            return transactionMessage as unknown as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> &
                 Omit<TTransactionMessage, 'feePayer' | 'feePayerSigner'>;
         const out = { ...transactionMessage, feePayerSigner };
         Object.freeze(out);
-        return out as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> &
+        return out as unknown as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> &
             Omit<TTransactionMessage, 'feePayer' | 'feePayerSigner'>;
     }
     const out = {
         ...transactionMessage,
-        feePayer: feePayerSigner.address,
+        feePayer: Object.freeze({ address: feePayerSigner.address }),
         feePayerSigner,
     };
     Object.freeze(out);

--- a/packages/transaction-messages/src/__tests__/decompile-message-test.ts
+++ b/packages/transaction-messages/src/__tests__/decompile-message-test.ts
@@ -35,7 +35,7 @@ describe('decompileTransactionMessage', () => {
             const transaction = decompileTransactionMessage(compiledTransaction);
 
             expect(transaction.version).toBe(0);
-            expect(transaction.feePayer).toEqual(feePayer);
+            expect(transaction.feePayer.address).toEqual(feePayer);
             expect(transaction.lifetimeConstraint).toEqual({
                 blockhash,
                 lastValidBlockHeight: U64_MAX,
@@ -357,7 +357,7 @@ describe('decompileTransactionMessage', () => {
             };
 
             expect(transaction.instructions).toStrictEqual([expectedInstruction]);
-            expect(transaction.feePayer).toStrictEqual(nonceAuthorityAddress);
+            expect(transaction.feePayer.address).toStrictEqual(nonceAuthorityAddress);
             expect(transaction.lifetimeConstraint).toStrictEqual({ nonce });
         });
 

--- a/packages/transaction-messages/src/__tests__/fee-payer-test.ts
+++ b/packages/transaction-messages/src/__tests__/fee-payer-test.ts
@@ -20,23 +20,43 @@ describe('setTransactionMessageFeePayer', () => {
     });
     it('sets the fee payer on the transaction', () => {
         const txWithFeePayerA = setTransactionMessageFeePayer(EXAMPLE_FEE_PAYER_A, baseTx);
-        expect(txWithFeePayerA).toHaveProperty('feePayer', EXAMPLE_FEE_PAYER_A);
+        expect(txWithFeePayerA).toHaveProperty('feePayer', { address: EXAMPLE_FEE_PAYER_A });
     });
     describe('given a transaction with a fee payer already set', () => {
         let txWithFeePayerA: BaseTransactionMessage & ITransactionMessageWithFeePayer;
         beforeEach(() => {
             txWithFeePayerA = {
                 ...baseTx,
-                feePayer: EXAMPLE_FEE_PAYER_A,
+                feePayer: { address: EXAMPLE_FEE_PAYER_A },
             };
         });
         it('sets the new fee payer on the transaction when it differs from the existing one', () => {
             const txWithFeePayerB = setTransactionMessageFeePayer(EXAMPLE_FEE_PAYER_B, txWithFeePayerA);
-            expect(txWithFeePayerB).toHaveProperty('feePayer', EXAMPLE_FEE_PAYER_B);
+            expect(txWithFeePayerB).toHaveProperty('feePayer', { address: EXAMPLE_FEE_PAYER_B });
         });
         it('returns the original transaction when trying to set the same fee payer again', () => {
             const txWithSameFeePayer = setTransactionMessageFeePayer(EXAMPLE_FEE_PAYER_A, txWithFeePayerA);
             expect(txWithFeePayerA).toBe(txWithSameFeePayer);
+        });
+    });
+    describe('given a transaction with a fee payer with extra properties set', () => {
+        let txWithFeePayerA: BaseTransactionMessage & {
+            readonly feePayer: Readonly<{ address: Address; extra: 'extra' }>;
+        };
+        beforeEach(() => {
+            txWithFeePayerA = {
+                ...baseTx,
+                feePayer: { address: EXAMPLE_FEE_PAYER_A, extra: 'extra' },
+            };
+        });
+        it('sets the new fee payer on the transaction when it differs from the existing one', () => {
+            const txWithFeePayerB = setTransactionMessageFeePayer(EXAMPLE_FEE_PAYER_B, txWithFeePayerA);
+            expect(txWithFeePayerB).toHaveProperty('feePayer', { address: EXAMPLE_FEE_PAYER_B });
+        });
+        it('sets the new fee payer on the transaction even when it is the same as the existing one', () => {
+            const txWithSameFeePayer = setTransactionMessageFeePayer(EXAMPLE_FEE_PAYER_A, txWithFeePayerA);
+            expect(txWithSameFeePayer).toHaveProperty('feePayer', { address: EXAMPLE_FEE_PAYER_A });
+            expect(txWithSameFeePayer).not.toBe(txWithFeePayerA);
         });
     });
     it('freezes the object', () => {

--- a/packages/transaction-messages/src/compile/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/message-test.ts
@@ -22,7 +22,7 @@ describe('compileTransactionMessage', () => {
     let baseTx: CompilableTransactionMessage;
     beforeEach(() => {
         baseTx = {
-            feePayer: 'abc' as Address<'abc'>,
+            feePayer: { address: 'abc' as Address<'abc'> },
             instructions: [],
             lifetimeConstraint: MOCK_LIFETIME_CONSTRAINT,
             version: 0,

--- a/packages/transaction-messages/src/compile/message.ts
+++ b/packages/transaction-messages/src/compile/message.ts
@@ -33,7 +33,7 @@ export function compileTransactionMessage(
     transaction: CompilableTransactionMessage,
 ): VersionedCompiledTransactionMessage;
 export function compileTransactionMessage(transaction: CompilableTransactionMessage): CompiledTransactionMessage {
-    const addressMap = getAddressMapFromInstructions(transaction.feePayer, transaction.instructions);
+    const addressMap = getAddressMapFromInstructions(transaction.feePayer.address, transaction.instructions);
     const orderedAccounts = getOrderedAccountsFromAddressMap(addressMap);
     return {
         ...(transaction.version !== 'legacy'

--- a/packages/transaction-messages/src/fee-payer.ts
+++ b/packages/transaction-messages/src/fee-payer.ts
@@ -3,23 +3,39 @@ import { Address } from '@solana/addresses';
 import { BaseTransactionMessage } from './transaction-message';
 
 export interface ITransactionMessageWithFeePayer<TAddress extends string = string> {
-    readonly feePayer: Address<TAddress>;
+    readonly feePayer: Readonly<{ address: Address<TAddress> }>;
 }
 
 export function setTransactionMessageFeePayer<
     TFeePayerAddress extends string,
-    TTransaction extends BaseTransactionMessage,
+    TTransactionMessage extends BaseTransactionMessage & Partial<ITransactionMessageWithFeePayer>,
 >(
     feePayer: Address<TFeePayerAddress>,
-    transaction: TTransaction,
-): ITransactionMessageWithFeePayer<TFeePayerAddress> & Omit<TTransaction, 'feePayer'> {
-    if ('feePayer' in transaction && feePayer === transaction.feePayer) {
-        return transaction as ITransactionMessageWithFeePayer<TFeePayerAddress> & Omit<TTransaction, 'feePayer'>;
+    transactionMessage: TTransactionMessage,
+): ITransactionMessageWithFeePayer<TFeePayerAddress> & Omit<TTransactionMessage, 'feePayer'> {
+    if (
+        'feePayer' in transactionMessage &&
+        feePayer === transactionMessage.feePayer?.address &&
+        isAddressOnlyFeePayer(transactionMessage.feePayer)
+    ) {
+        return transactionMessage as unknown as ITransactionMessageWithFeePayer<TFeePayerAddress> &
+            Omit<TTransactionMessage, 'feePayer'>;
     }
     const out = {
-        ...transaction,
-        feePayer,
+        ...transactionMessage,
+        feePayer: Object.freeze({ address: feePayer }),
     };
     Object.freeze(out);
     return out;
+}
+
+function isAddressOnlyFeePayer(
+    feePayer: Partial<ITransactionMessageWithFeePayer>['feePayer'],
+): feePayer is { address: Address } {
+    return (
+        !!feePayer &&
+        'address' in feePayer &&
+        typeof feePayer.address === 'string' &&
+        Object.keys(feePayer).length === 1
+    );
 }


### PR DESCRIPTION
This PR changes the `feePayer` type for transaction messages from `Address` to `{ address: Address }`. This allows us, in a follow-up PR, to use the same `feePayer` attribute to store `TransactionSigners` which, in turn, allows us to override `TransactionSigners` with non-signer fee payers and vice-versa.

Addresses https://github.com/solana-labs/solana-web3.js/issues/2899.