### PR TITLE
Override `feePayer` signer with matching address

### DIFF
--- a/.changeset/warm-lizards-report.md
+++ b/.changeset/warm-lizards-report.md
@@ -1,0 +1,5 @@
+---
+'@solana/signers': patch
+---
+
+Override `feePayer` signer when the address matches the existing one. This is because users may want to provide a different wallet from the same address.

--- a/packages/signers/src/__tests__/fee-payer-signer-test.ts
+++ b/packages/signers/src/__tests__/fee-payer-signer-test.ts
@@ -29,9 +29,10 @@ describe('setTransactionMessageFeePayerSigner', () => {
             const txWithFeePayerB = setTransactionMessageFeePayerSigner(feePayerB, txWithFeePayerA);
             expect(txWithFeePayerB).toHaveProperty('feePayer', feePayerB);
         });
-        it('returns the original transaction when trying to set the same fee payer again', () => {
+        it('overrides the fee payer signer even when the existing fee payer address is the same', () => {
             const txWithSameFeePayer = setTransactionMessageFeePayerSigner(feePayerA, txWithFeePayerA);
-            expect(txWithFeePayerA).toBe(txWithSameFeePayer);
+            expect(txWithSameFeePayer).toHaveProperty('feePayer', feePayerA);
+            expect(txWithSameFeePayer).not.toBe(txWithFeePayerA);
         });
     });
     describe('given a transaction with a non-signer fee payer already set', () => {

--- a/packages/signers/src/fee-payer-signer.ts
+++ b/packages/signers/src/fee-payer-signer.ts
@@ -1,6 +1,6 @@
 import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { isTransactionSigner, TransactionSigner } from './transaction-signer';
+import { TransactionSigner } from './transaction-signer';
 
 export interface ITransactionMessageWithFeePayerSigner<
     TAddress extends string = string,
@@ -17,14 +17,6 @@ export function setTransactionMessageFeePayerSigner<
     feePayer: TransactionSigner<TFeePayerAddress>,
     transactionMessage: TTransactionMessage,
 ): ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & Omit<TTransactionMessage, 'feePayer'> {
-    if (
-        'feePayer' in transactionMessage &&
-        feePayer.address === transactionMessage.feePayer?.address &&
-        isTransactionSigner(transactionMessage.feePayer)
-    ) {
-        return transactionMessage as unknown as ITransactionMessageWithFeePayerSigner<TFeePayerAddress> &
-            Omit<TTransactionMessage, 'feePayer'>;
-    }
     Object.freeze(feePayer);
     const out = { ...transactionMessage, feePayer };
     Object.freeze(out);


### PR DESCRIPTION
This PR changes the `setTransactionMessageFeePayerSigner` helper function such that, it will always override the fee payer even when the address of the existing `TransactionSigner` matches the one provided. This is because users may want to provide a different wallet from the same address.

Addresses https://github.com/solana-labs/solana-web3.js/issues/2897.