### PR TITLE
Add a failing test that verifies we can subscribe to an RPC subscription method

### DIFF
--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -83,6 +83,9 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/subscribable": "workspace:*"
     },
+    "devDependencies": {
+        "@solana/addresses": "workspace:*"
+    },
     "peerDependencies": {
         "typescript": ">=5"
     },

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-functional-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-functional-test.ts
@@ -1,0 +1,40 @@
+import { Address } from '@solana/addresses';
+import { AccountNotificationsApi, SolanaRpcSubscriptionsApi } from '@solana/rpc-subscriptions-api';
+import { createSubscriptionRpc, RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
+
+import {
+    createDefaultRpcSubscriptionsTransport,
+    createDefaultSolanaRpcSubscriptionsChannelCreator,
+    createSolanaRpcSubscriptionsApi,
+} from '..';
+
+function createLocalhostSolanaRpcSubscriptions(): RpcSubscriptions<SolanaRpcSubscriptionsApi> {
+    return createSubscriptionRpc({
+        api: createSolanaRpcSubscriptionsApi(),
+        transport: createDefaultRpcSubscriptionsTransport({
+            createChannel: createDefaultSolanaRpcSubscriptionsChannelCreator({ url: 'ws://localhost:8900' }),
+        }),
+    });
+}
+
+describe('accountNotifications', () => {
+    let rpcSubscriptions: RpcSubscriptions<AccountNotificationsApi>;
+    beforeEach(() => {
+        rpcSubscriptions = createLocalhostSolanaRpcSubscriptions();
+    });
+
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('can subscribe to account notifications', async () => {
+        expect.hasAssertions();
+        const abortSignal = new AbortController().signal;
+        const subscriptionPromise = rpcSubscriptions
+            .accountNotifications('4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc' as Address)
+            .subscribe({ abortSignal });
+
+        await expect(subscriptionPromise).resolves.toEqual(
+            expect.objectContaining({
+                [Symbol.asyncIterator]: expect.any(Function),
+            }),
+        );
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,6 +897,10 @@ importers:
       typescript:
         specifier: '>=5'
         version: 5.5.2
+    devDependencies:
+      '@solana/addresses':
+        specifier: workspace:*
+        version: link:../addresses
 
   packages/rpc-subscriptions-api:
     dependencies:


### PR DESCRIPTION
In rc2 there's a bug where `await rpcSubscriptions.anyNotifications().subscribe()` hangs. Unlike `rpc-api` [all tests in `rpc-subscriptions-api` are currently commented out.  ](https://github.com/solana-labs/solana-web3.js/blob/master/packages/rpc-subscriptions-api/src/__tests__/account-notifications-test.ts)

This PR adds a (currently failing) test to subscribe to notifications against the localhost test validator.

Notes:

- I've put this test in `rpc-subscriptions` rather than `rpc-subscriptions-api` because it relies on transport functions from `rpc-subscriptions`. If we wanted to build a full suite of `rpc-subscriptions-api` tests later then we should probably move these transport functions to a different package where they could be a dependency of `rpc-subscriptions-api`. We currently have `rpc-transport-http` for this on the `rpc-api` side. 

- I used `it.skip` instead of `it.failing` because the test times out rather than failing, and Jest doesn't treat that as a pass for `it.failing`. Anyway I don't plan to leave it failing long! 