### PR TITLE
Accept bigints in RPC error factories

### DIFF
--- a/.changeset/silver-otters-doubt.md
+++ b/.changeset/silver-otters-doubt.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': patch
+---
+
+Accept bigints in RPC error factories, fixing functions such as `isProgramError`

--- a/packages/errors/src/__tests__/instruction-error-test.ts
+++ b/packages/errors/src/__tests__/instruction-error-test.ts
@@ -70,10 +70,10 @@ describe('getSolanaErrorFromInstructionError', () => {
             expect(error).toEqual(new SolanaError(expectedCode as SolanaErrorCode, { index: 123 }));
         },
     );
-    it.failing.each(EXPECTED_ERROR_CODES)(
+    it.each(EXPECTED_ERROR_CODES)(
         'produces the correct `SolanaError` for a `%s` error with a bigint index',
         (transactionError, expectedCode) => {
-            const error = getSolanaErrorFromInstructionError(123n as unknown as number, transactionError);
+            const error = getSolanaErrorFromInstructionError(123n, transactionError);
             expect(error).toEqual(new SolanaError(expectedCode as SolanaErrorCode, { index: 123 }));
         },
     );
@@ -86,7 +86,7 @@ describe('getSolanaErrorFromInstructionError', () => {
             }),
         );
     });
-    it.failing('produces the correct `SolanaError` for a `Custom` error with a bigint code', () => {
+    it('produces the correct `SolanaError` for a `Custom` error with a bigint code', () => {
         const error = getSolanaErrorFromInstructionError(123, { Custom: 789n });
         expect(error).toEqual(
             new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, {

--- a/packages/errors/src/__tests__/json-rpc-error-test.ts
+++ b/packages/errors/src/__tests__/json-rpc-error-test.ts
@@ -35,9 +35,9 @@ describe('getSolanaErrorFromJsonRpcError', () => {
         const error = getSolanaErrorFromJsonRpcError({ code, message: 'o no' });
         expect(error).toHaveProperty('context.__code', 123);
     });
-    it.failing('converts bigint codes to numbers', () => {
+    it('converts bigint codes to numbers', () => {
         const code = 123n;
-        const error = getSolanaErrorFromJsonRpcError({ code: code as unknown as number, message: 'o no' });
+        const error = getSolanaErrorFromJsonRpcError({ code, message: 'o no' });
         expect(error).toHaveProperty('context.__code', 123);
     });
     describe.each([

--- a/packages/errors/src/__tests__/transaction-error-test.ts
+++ b/packages/errors/src/__tests__/transaction-error-test.ts
@@ -58,7 +58,7 @@ describe('getSolanaErrorFromTransactionError', () => {
             }),
         );
     });
-    it.failing('produces the correct `SolanaError` for a `DuplicateInstruction` error with a bigint index', () => {
+    it('produces the correct `SolanaError` for a `DuplicateInstruction` error with a bigint index', () => {
         const error = getSolanaErrorFromTransactionError({ DuplicateInstruction: 1n });
         expect(error).toEqual(
             new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__DUPLICATE_INSTRUCTION, {
@@ -74,7 +74,7 @@ describe('getSolanaErrorFromTransactionError', () => {
             }),
         );
     });
-    it.failing('produces the correct `SolanaError` for a `InsufficientFundsForRent` error with a bigint index', () => {
+    it('produces the correct `SolanaError` for a `InsufficientFundsForRent` error with a bigint index', () => {
         const error = getSolanaErrorFromTransactionError({ InsufficientFundsForRent: { account_index: 1n } });
         expect(error).toEqual(
             new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_RENT, {
@@ -92,19 +92,16 @@ describe('getSolanaErrorFromTransactionError', () => {
             }),
         );
     });
-    it.failing(
-        'produces the correct `SolanaError` for a `ProgramExecutionTemporarilyRestricted` error with a bigint index',
-        () => {
-            const error = getSolanaErrorFromTransactionError({
-                ProgramExecutionTemporarilyRestricted: { account_index: 1n },
-            });
-            expect(error).toEqual(
-                new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__PROGRAM_EXECUTION_TEMPORARILY_RESTRICTED, {
-                    accountIndex: 1,
-                }),
-            );
-        },
-    );
+    it('produces the correct `SolanaError` for a `ProgramExecutionTemporarilyRestricted` error with a bigint index', () => {
+        const error = getSolanaErrorFromTransactionError({
+            ProgramExecutionTemporarilyRestricted: { account_index: 1n },
+        });
+        expect(error).toEqual(
+            new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__PROGRAM_EXECUTION_TEMPORARILY_RESTRICTED, {
+                accountIndex: 1,
+            }),
+        );
+    });
     it("returns the unknown error when encountering an enum name that's missing from the map", () => {
         const error = getSolanaErrorFromTransactionError('ThisDoesNotExist');
         expect(error).toEqual(

--- a/packages/errors/src/instruction-error.ts
+++ b/packages/errors/src/instruction-error.ts
@@ -67,9 +67,10 @@ const ORDERED_ERROR_NAMES = [
 ];
 
 export function getSolanaErrorFromInstructionError(
-    index: number,
+    index: bigint | number,
     instructionError: string | { [key: string]: unknown },
 ): SolanaError {
+    const numberIndex = Number(index);
     return getSolanaErrorFromRpcError(
         {
             errorCodeBaseOffset: 4615001,
@@ -77,21 +78,21 @@ export function getSolanaErrorFromInstructionError(
                 if (errorCode === SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN) {
                     return {
                         errorName: rpcErrorName,
-                        index,
+                        index: numberIndex,
                         ...(rpcErrorContext !== undefined ? { instructionErrorContext: rpcErrorContext } : null),
                     };
                 } else if (errorCode === SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM) {
                     return {
-                        code: rpcErrorContext as number,
-                        index,
+                        code: Number(rpcErrorContext as bigint | number),
+                        index: numberIndex,
                     };
                 } else if (errorCode === SOLANA_ERROR__INSTRUCTION_ERROR__BORSH_IO_ERROR) {
                     return {
                         encodedData: rpcErrorContext as string,
-                        index,
+                        index: numberIndex,
                     };
                 }
-                return { index };
+                return { index: numberIndex };
             },
             orderedErrorNames: ORDERED_ERROR_NAMES,
             rpcEnumError: instructionError,

--- a/packages/errors/src/json-rpc-error.ts
+++ b/packages/errors/src/json-rpc-error.ts
@@ -22,7 +22,7 @@ import { safeCaptureStackTrace } from './stack-trace';
 import { getSolanaErrorFromTransactionError } from './transaction-error';
 
 interface RpcErrorResponse {
-    code: number;
+    code: bigint | number;
     data?: unknown;
     message: string;
 }
@@ -88,8 +88,9 @@ export interface RpcSimulateTransactionResult {
     unitsConsumed: number | null;
 }
 
-export function getSolanaErrorFromJsonRpcError({ code, data, message }: RpcErrorResponse): SolanaError {
+export function getSolanaErrorFromJsonRpcError({ code: rawCode, data, message }: RpcErrorResponse): SolanaError {
     let out: SolanaError;
+    const code = Number(rawCode);
     if (code === SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE) {
         const { err, ...preflightErrorContext } = data as RpcSimulateTransactionResult;
         const causeObject = err ? { cause: getSolanaErrorFromTransactionError(err) } : null;

--- a/packages/errors/src/transaction-error.ts
+++ b/packages/errors/src/transaction-error.ts
@@ -75,14 +75,14 @@ export function getSolanaErrorFromTransactionError(transactionError: string | { 
                     };
                 } else if (errorCode === SOLANA_ERROR__TRANSACTION_ERROR__DUPLICATE_INSTRUCTION) {
                     return {
-                        index: rpcErrorContext as number,
+                        index: Number(rpcErrorContext as bigint | number),
                     };
                 } else if (
                     errorCode === SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_RENT ||
                     errorCode === SOLANA_ERROR__TRANSACTION_ERROR__PROGRAM_EXECUTION_TEMPORARILY_RESTRICTED
                 ) {
                     return {
-                        accountIndex: (rpcErrorContext as { account_index: number }).account_index,
+                        accountIndex: Number((rpcErrorContext as { account_index: bigint | number }).account_index),
                     };
                 }
             },

--- a/packages/rpc-transport-http/src/http-transport-for-solana-rpc.ts
+++ b/packages/rpc-transport-http/src/http-transport-for-solana-rpc.ts
@@ -15,27 +15,9 @@ type Config = Readonly<{
 export function createHttpTransportForSolanaRpc(config: Config): RpcTransport {
     return createHttpTransport({
         ...config,
-        fromJson: (rawResponse: string, payload: unknown) => {
-            if (!isSolanaRequest(payload)) return JSON.parse(rawResponse);
-            const response = parseJsonWithBigInts(rawResponse);
-            // Error codes are always numbers.
-            if (isErrorResponse(response)) {
-                return { ...response, error: { ...response.error, code: Number(response.error.code) } };
-            }
-            return response;
-        },
+        fromJson: (rawResponse: string, payload: unknown) =>
+            isSolanaRequest(payload) ? parseJsonWithBigInts(rawResponse) : JSON.parse(rawResponse),
         toJson: (payload: unknown) =>
             isSolanaRequest(payload) ? stringifyJsonWithBigints(payload) : JSON.stringify(payload),
     });
-}
-
-function isErrorResponse(value: unknown): value is { error: { code: bigint } } {
-    return (
-        !!value &&
-        typeof value === 'object' &&
-        'error' in value &&
-        !!value.error &&
-        typeof value.error === 'object' &&
-        'code' in value.error
-    );
 }


### PR DESCRIPTION
This PR makes the failing tests introduced in the previous PR pass.

See https://github.com/solana-labs/solana-web3.js/pull/3518.