### PR TITLE
Add missing export for LiteralUnionCodec

### DIFF
--- a/.changeset/hot-hotels-sort.md
+++ b/.changeset/hot-hotels-sort.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+`LiteralUnionCodec` is now exported from `@solana/codecs-data-structures`

--- a/packages/codecs-data-structures/src/index.ts
+++ b/packages/codecs-data-structures/src/index.ts
@@ -8,6 +8,7 @@ export * from './discriminated-union';
 export * from './enum';
 export * from './hidden-prefix';
 export * from './hidden-suffix';
+export * from './literal-union';
 export * from './map';
 export * from './nullable';
 export * from './set';


### PR DESCRIPTION
Add missing export for `*` from `literal-union.ts` to `@solana/codecs-data-structures`.