### PR TITLE
manifest fixes 

### DIFF
--- a/.changeset/empty-wombats-guess.md
+++ b/.changeset/empty-wombats-guess.md
@@ -1,0 +1,20 @@
+---
+"@solana/addresses": patch
+"@solana/assertions": patch
+"@solana/codecs-core": patch
+"@solana/codecs-data-structures": patch
+"@solana/codecs-numbers": patch
+"@solana/codecs-strings": patch
+"@solana/compat": patch
+"@solana/errors": patch
+"@solana/keys": patch
+"@solana/options": patch
+"@solana/react": patch
+"@solana/signers": patch
+"@solana/subscribable": patch
+"@solana/sysvars": patch
+"@solana/transaction-confirmation": patch
+"@solana/webcrypto-ed25519-polyfill": patch
+---
+
+A two-versions-old version of Node LTS is now specified everywhere via the `engines` field, including the one in the root of the `pnpm` workspace, and engine-strictness is delegated to the `.npmrc` files.

--- a/package.json
+++ b/package.json
@@ -53,9 +53,8 @@
         "typedoc-plugin-missing-exports": "^3.0.0",
         "typescript": "^5.6.3"
     },
-    "engineStrict": true,
     "engines": {
-        "node": ">=14.0.0",
+        "node": ">=20.18.0",
         "npm": "please-use-pnpm",
         "pnpm": "^9",
         "yarn": "please-use-pnpm"

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/assertions": "workspace:*",
         "@solana/codecs-core": "workspace:*",

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/errors": "workspace:*"
     },

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -71,9 +71,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/errors": "workspace:*"
     },

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/codecs-core": "workspace:*",
         "@solana/codecs-numbers": "workspace:*",

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/codecs-core": "workspace:*",
         "@solana/errors": "workspace:*"

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -71,9 +71,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/codecs-core": "workspace:*",
         "@solana/codecs-numbers": "workspace:*",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/addresses": "workspace:*",
         "@solana/codecs-core": "workspace:*",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -71,9 +71,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -71,9 +71,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/assertions": "workspace:*",
         "@solana/codecs-core": "workspace:*",

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/codecs-core": "workspace:*",
         "@solana/codecs-data-structures": "workspace:*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/addresses": "workspace:*",
         "@solana/errors": "workspace:*",

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/addresses": "workspace:*",
         "@solana/codecs-core": "workspace:*",

--- a/packages/subscribable/package.json
+++ b/packages/subscribable/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/errors": "workspace:*"
     },

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -70,9 +70,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/accounts": "workspace:*",
         "@solana/codecs": "workspace:*",

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -69,9 +69,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@solana/addresses": "workspace:*",
         "@solana/codecs-strings": "workspace:*",

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -67,9 +67,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "engine": {
-        "node": ">=17.4"
-    },
     "dependencies": {
         "@noble/ed25519": "^2.0.0"
     },


### PR DESCRIPTION
- removes unnecesary + misleading `engine` field in all package manifests (this field should serve no purpose and differs from the actual `engines` field specified in all of these manifests)
- remove `engineStrict` field from root manifest (outdated + overwritten by `engine-strict = true` in .npmrc regardless)
- update root manifest `engines.node` to `>=20.18.0`