### PR TITLE
Add `Response#headers` to errors thrown from the HTTP transport

### DIFF
--- a/.changeset/silent-wolves-cry.md
+++ b/.changeset/silent-wolves-cry.md
@@ -1,0 +1,21 @@
+---
+'@solana/rpc-transport-http': patch
+'@solana/errors': patch
+---
+
+When the HTTP transport throws an error, you can now access the response headers through `e.context.headers`. This can be useful, for instance, if the HTTP error is a 429 Rate Limit error, and the response contains a `Retry-After` header.
+
+```ts
+try {
+    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+} catch (e) {
+    if (isSolanaError(e, SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR)) {
+        if (e.context.code === 429 /* rate limit error */) {
+            const retryAfterHeaderValue = e.context.headers.get('Retry-After');
+            if (retryAfterHeaderValue != null) {
+                // ...
+            }
+        }
+    }
+}
+```

--- a/.changeset/silent-wolves-cry.md
+++ b/.changeset/silent-wolves-cry.md
@@ -1,6 +1,6 @@
 ---
-'@solana/rpc-transport-http': patch
-'@solana/errors': patch
+'@solana/rpc-transport-http': minor
+'@solana/errors': minor
 ---
 
 When the HTTP transport throws an error, you can now access the response headers through `e.context.headers`. This can be useful, for instance, if the HTTP error is a 429 Rate Limit error, and the response contains a `Retry-After` header.

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -506,6 +506,7 @@ export type SolanaErrorContext = DefaultUnspecifiedErrorContextToUndefined<
             value: bigint;
         };
         [SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR]: {
+            headers: Headers;
             message: string;
             statusCode: number;
         };

--- a/packages/rpc-transport-http/src/http-transport.ts
+++ b/packages/rpc-transport-http/src/http-transport.ts
@@ -65,6 +65,7 @@ export function createHttpTransport(config: Config): RpcTransport {
         const response = await fetch(url, requestInfo);
         if (!response.ok) {
             throw new SolanaError(SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR, {
+                headers: response.headers,
                 message: response.statusText,
                 statusCode: response.status,
             });


### PR DESCRIPTION
# Summary

Sometimes the response headers have useful information, like your rate limit status. Your program might like access to those headers to decide what to do next.

```ts
try {
  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
} catch (e) {
  if (isSolanaError(e, SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR)) {
    if (e.context.code === 429 /* rate limit error */) {
      const retryAfterHeaderValue = e.context.headers.get("Retry-After");
      if (retryAfterHeaderValue != null) {
        // ...
      }
    }
  }
}
```

Fixes #3563.

# Test Plan

```
cd packages/rpc-transport-http
pnpm turbo test:unit:node test:unit:browser
```