### PR TITLE
Add missing space attribute to accounts

### DIFF
--- a/.changeset/nervous-emus-move.md
+++ b/.changeset/nervous-emus-move.md
@@ -1,0 +1,6 @@
+---
+'@solana/rpc-types': patch
+'@solana/accounts': patch
+---
+
+Add missing `space` attribute to `AccountInfoBase` and `BaseAccount`

--- a/packages/accounts/src/__tests__/decode-account-test.ts
+++ b/packages/accounts/src/__tests__/decode-account-test.ts
@@ -22,6 +22,7 @@ describe('decodeAccount', () => {
             executable: false,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 3n,
         };
 
         // And a mock decoder.
@@ -37,6 +38,7 @@ describe('decodeAccount', () => {
             executable: false,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 3n,
         });
 
         // And the decoder to have been called with the encoded account data.
@@ -51,6 +53,7 @@ describe('decodeAccount', () => {
             executable: false,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 3n,
         };
 
         // And a mock decoder.

--- a/packages/accounts/src/__tests__/fetch-account-test.ts
+++ b/packages/accounts/src/__tests__/fetch-account-test.ts
@@ -23,6 +23,7 @@ describe('fetchEncodedAccount', () => {
                 executable: false,
                 lamports: 1_000_000_000n,
                 owner: '9999',
+                space: 6n,
             },
         });
 
@@ -38,6 +39,7 @@ describe('fetchEncodedAccount', () => {
             exists: true,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 6n,
         });
 
         // And the getAccountInfo RPC method to have been called with the given address and an explicit base64 encoding.
@@ -73,6 +75,7 @@ describe('fetchEncodedAccount', () => {
                 executable: false,
                 lamports: 1_000_000_000n,
                 owner: '9999',
+                space: 6n,
             },
         });
 
@@ -98,11 +101,12 @@ describe('fetchJsonParsedAccount', () => {
                         type: 'token',
                     },
                     program: 'splToken',
-                    space: 165n,
+                    space: 165n, // The space field is provided again on some JSON-parsed RPC response.
                 },
                 executable: false,
                 lamports: 1_000_000_000n,
                 owner: '9999',
+                space: 165n,
             },
         });
 
@@ -119,6 +123,7 @@ describe('fetchJsonParsedAccount', () => {
             exists: true,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 165n,
         });
 
         // And the getAccountInfo RPC method to have been called with the given address and an explicit jsonParsed encoding.
@@ -188,6 +193,7 @@ describe('fetchEncodedAccounts', () => {
                 executable: false,
                 lamports: 1_000_000_000n,
                 owner: '9999',
+                space: 6n,
             },
         });
 
@@ -206,6 +212,7 @@ describe('fetchEncodedAccounts', () => {
             exists: true,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 6n,
         });
 
         // And account B is returned as a non-existing account.
@@ -229,6 +236,7 @@ describe('fetchEncodedAccounts', () => {
                 executable: false,
                 lamports: 1_000_000_000n,
                 owner: '9999',
+                space: 6n,
             },
         });
 
@@ -258,11 +266,12 @@ describe('fetchJsonParsedAccounts', () => {
                         type: 'token',
                     },
                     program: 'splToken',
-                    space: 165n,
+                    space: 165n, // The space field is provided again on some JSON-parsed RPC response.
                 },
                 executable: false,
                 lamports: 1_000_000_000n,
                 owner: '9999',
+                space: 165n,
             },
         });
 
@@ -282,6 +291,7 @@ describe('fetchJsonParsedAccounts', () => {
             exists: true,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 165n,
         });
 
         // And account B is returned as a non-existing account.

--- a/packages/accounts/src/__tests__/parse-account-test.ts
+++ b/packages/accounts/src/__tests__/parse-account-test.ts
@@ -17,6 +17,7 @@ describe('parseBase64RpcAccount', () => {
             executable: false,
             lamports: 1_000_000_000n,
             owner: '9999',
+            space: 6n,
         };
 
         // When we parse that RPC account using the parseBase64RpcAccount function.
@@ -33,6 +34,7 @@ describe('parseBase64RpcAccount', () => {
             exists: true,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 6n,
         });
     });
 
@@ -58,6 +60,7 @@ describe('parseBase64RpcAccount', () => {
             executable: false,
             lamports: 1_000_000_000n,
             owner: '9999',
+            space: 6n,
         };
 
         // When we parse that RPC account using the parseBase64RpcAccount function.
@@ -88,6 +91,7 @@ describe('parseBase58RpcAccount', () => {
             executable: false,
             lamports: 1_000_000_000n,
             owner: '9999',
+            space: 6n,
         };
 
         // When we parse that RPC account using the parseBase58RpcAccount function.
@@ -104,6 +108,7 @@ describe('parseBase58RpcAccount', () => {
             exists: true,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 6n,
         });
     });
 
@@ -115,6 +120,7 @@ describe('parseBase58RpcAccount', () => {
             executable: false,
             lamports: 1_000_000_000n,
             owner: '9999',
+            space: 6n,
         };
 
         // When we parse that RPC account using the parseBase58RpcAccount function.
@@ -131,6 +137,7 @@ describe('parseBase58RpcAccount', () => {
             exists: true,
             lamports: 1_000_000_000n,
             programAddress: '9999',
+            space: 6n,
         });
     });
 
@@ -156,6 +163,7 @@ describe('parseBase58RpcAccount', () => {
             executable: false,
             lamports: 1_000_000_000n,
             owner: '9999',
+            space: 6n,
         };
 
         // When we parse that RPC account using the parseBase58RpcAccount function.
@@ -188,11 +196,12 @@ describe('parseJsonRpcAccount', () => {
                     type: 'token',
                 },
                 program: 'splToken',
-                space: 165n,
+                space: 165n, // The space field is provided again on some JSON-parsed RPC response.
             },
             executable: false,
             lamports: 1_000_000_000n,
             owner: '9999',
+            space: 165n,
         };
 
         // When we parse that RPC account using the parseJsonRpcAccount function and a custom data type.
@@ -210,6 +219,7 @@ describe('parseJsonRpcAccount', () => {
             exists: true,
             lamports: lamports(1_000_000_000n),
             programAddress: '9999' as Address<'9999'>,
+            space: 165n,
         } as Account<MyData>);
     });
 
@@ -238,11 +248,12 @@ describe('parseJsonRpcAccount', () => {
                     type: 'token',
                 },
                 program: 'splToken',
-                space: 165n,
+                space: 165n, // The space field is provided again on some JSON-parsed RPC response.
             },
             executable: false,
             lamports: 1_000_000_000n,
             owner: '9999',
+            space: 165n,
         };
 
         // When we parse that RPC account using the parseJsonRpcAccount function.

--- a/packages/accounts/src/account.ts
+++ b/packages/accounts/src/account.ts
@@ -10,6 +10,7 @@ export type BaseAccount = {
     readonly executable: boolean;
     readonly lamports: Lamports;
     readonly programAddress: Address;
+    readonly space: bigint;
 };
 
 /** Defines a Solana account with its generic details and parsed or encoded data. */

--- a/packages/accounts/src/parse-account.ts
+++ b/packages/accounts/src/parse-account.ts
@@ -76,5 +76,6 @@ function parseBaseAccount(rpcAccount: AccountInfoBase): BaseAccount {
         executable: rpcAccount.executable,
         lamports: rpcAccount.lamports,
         programAddress: rpcAccount.owner,
+        space: rpcAccount.space,
     });
 }

--- a/packages/library/src/__tests__/decompile-transaction-message-fetching-lookup-tables-test.ts
+++ b/packages/library/src/__tests__/decompile-transaction-message-fetching-lookup-tables-test.ts
@@ -269,6 +269,7 @@ describe('decompileTransactionMessageFetchingLookupTables', () => {
                 exists: true,
                 lamports: 0n as Lamports,
                 programAddress: 'program' as Address,
+                space: 0n,
             },
             {
                 address: lookupTableAddress2,
@@ -279,6 +280,7 @@ describe('decompileTransactionMessageFetchingLookupTables', () => {
                 exists: true,
                 lamports: 0n as Lamports,
                 programAddress: 'program' as Address,
+                space: 0n,
             },
         ];
 

--- a/packages/rpc-types/src/account-info.ts
+++ b/packages/rpc-types/src/account-info.ts
@@ -17,6 +17,8 @@ export type AccountInfoBase = Readonly<{
     owner: Address;
     /** the epoch at which this account will next owe rent */
     rentEpoch: bigint;
+    /** the size of the account data in bytes (excluding the 128 bytes of header) */
+    space: bigint;
 }>;
 
 /** @deprecated */


### PR DESCRIPTION
This PR adds the missing `space` attribute to:
- The `AccountInfoBase` type from `@solana/rpc-types`.
- The `BaseAccount` type from `@solana/accounts`.

### Tests

In terms of tests, I just needed to update some existing one that were using mock data but all the ones using a local validator (including `jsonParsed` fetches) are already asserting that we get a `space` attribute. We were just not capturing it in the types.

### Release

I believe this is a `patch` change because, even though this is _adding_ a type attribute, the data was already there so we are just _fixing_ our type representation to match the data correctly. Lmk if you agree with this as we're figuring out our stance of versioning/releasing.

---

Addresses #3569