### PR TITLE
added blockheight to BlockResponse and VersionedBlockResponse

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1999,6 +1999,7 @@ const GetConfirmedSignaturesForAddress2RpcResult = jsonRpcResult(
       err: TransactionErrorResult,
       memo: nullable(string()),
       blockTime: optional(nullable(number())),
+      blockHeight: nullable(number()),
     }),
   ),
 );
@@ -2014,6 +2015,7 @@ const GetSignaturesForAddressRpcResult = jsonRpcResult(
       err: TransactionErrorResult,
       memo: nullable(string()),
       blockTime: optional(nullable(number())),
+      blockHeight: nullable(number()),
     }),
   ),
 );

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1294,6 +1294,8 @@ export type ParsedTransactionWithMeta = {
  * A processed block fetched from the RPC API
  */
 export type BlockResponse = {
+  /** Block height of this block */
+  blockHeight: number | null;
   /** Blockhash of this block */
   blockhash: Blockhash;
   /** Blockhash of this block's parent */
@@ -1410,6 +1412,8 @@ export type ParsedNoneModeBlockResponse = Omit<
  * A processed block fetched from the RPC API
  */
 export type VersionedBlockResponse = {
+  /** Block height of this block */
+  blockHeight: number | null;
   /** Blockhash of this block */
   blockhash: Blockhash;
   /** Blockhash of this block's parent */

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2554,6 +2554,7 @@ const GetConfirmedBlockRpcResult = jsonRpcResult(
       ),
       rewards: optional(array(RewardsResult)),
       blockTime: nullable(number()),
+      blockHeight: nullable(number()),
     }),
   ),
 );
@@ -2569,6 +2570,7 @@ const GetBlockSignaturesRpcResult = jsonRpcResult(
       parentSlot: number(),
       signatures: array(string()),
       blockTime: nullable(number()),
+      blockHeight: nullable(number()),
     }),
   ),
 );


### PR DESCRIPTION
![Screenshot 2024-11-25 172002](https://github.com/user-attachments/assets/1c5dde11-17b3-4309-82f0-de2476bb20e5)
![Screenshot 2024-11-25 172045](https://github.com/user-attachments/assets/002eb185-1a01-4610-9428-966216518b14)
![Screenshot 2024-11-25 172100](https://github.com/user-attachments/assets/ae375afa-1133-4927-bb54-340ea9c22e32)

added blockheight to BlockResponse and VersionedBlockResponse
linted and tested , the error is now gone because the property is added in the return type , solving #1969 
