### PR TITLE
The online/offline checker now presumes that `globalThis` is the event target

### DIFF
--- a/.changeset/six-zoos-explode.md
+++ b/.changeset/six-zoos-explode.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-subscriptions': patch
+---
+
+The online/offline checker in the subscriptions implementation no longer throws an error when hosted in the Content Scripts environment of a browser extension

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-autopinger-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-autopinger-test.ts
@@ -10,7 +10,7 @@ describe('getRpcSubscriptionsChannelWithAutoping', () => {
     let mockOn: jest.Mock;
     let mockSend: jest.Mock;
     let mockWindowAddEventListener: jest.Mock;
-    let originalWindowAddEventListener: typeof globalThis.window.addEventListener;
+    let originalWindowAddEventListener: typeof globalThis.addEventListener;
     function receiveError(error?: unknown) {
         mockOn.mock.calls.filter(([type]) => type === 'error').forEach(([_, listener]) => listener(error));
     }
@@ -25,8 +25,8 @@ describe('getRpcSubscriptionsChannelWithAutoping', () => {
     beforeEach(() => {
         jest.useFakeTimers();
         if (__BROWSER__) {
-            originalWindowAddEventListener = globalThis.window.addEventListener;
-            globalThis.window.addEventListener = mockWindowAddEventListener = jest.fn();
+            originalWindowAddEventListener = globalThis.addEventListener;
+            globalThis.addEventListener = mockWindowAddEventListener = jest.fn();
         }
         mockOn = jest.fn().mockReturnValue(() => {});
         mockSend = jest.fn().mockResolvedValue(void 0);
@@ -37,7 +37,7 @@ describe('getRpcSubscriptionsChannelWithAutoping', () => {
     });
     afterEach(() => {
         if (__BROWSER__) {
-            globalThis.window.addEventListener = originalWindowAddEventListener;
+            globalThis.addEventListener = originalWindowAddEventListener;
         }
     });
     it('sends a ping message to the channel at the specified interval', async () => {

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-autopinger.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-autopinger.ts
@@ -48,14 +48,14 @@ export function getRpcSubscriptionsChannelWithAutoping<TChannel extends RpcSubsc
         restartPingTimer();
     }
     if (__BROWSER__) {
-        globalThis.window.addEventListener(
+        globalThis.addEventListener(
             'offline',
             function handleOffline() {
                 clearInterval(intervalId);
             },
             { signal: pingerAbortController.signal },
         );
-        globalThis.window.addEventListener(
+        globalThis.addEventListener(
             'online',
             function handleOnline() {
                 sendPing();


### PR DESCRIPTION
# Summary

In the isolated Content Scripts environment, `globalThis.window` is apparently not a thing. In this PR we eliminate that nesting and presume that the event target for listening to online/offline events is `globalThis` itself.

# Test Plan

Tested that `globalThis.addEventListener('offline', () => {})` fires the callback in Brave when the network connection goes down. Presumed that the same is true for all other browsers.

Fixes #3652.