### PR TITLE
Remove Mergify rule that adds community reviewers group to community PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,26 +12,6 @@ pull_request_rules:
       label:
         add:
           - community
-  - name: Request review of community contributions from community PR subscribers
-    conditions:
-      - author≠@core-contributors
-      - author≠@spl-maintainers
-      - author≠@spl-triage
-      - author≠@spl-write
-      - author≠mergify[bot]
-      - author≠dependabot[bot]
-      - author≠github-actions[bot]
-      # Only request reviews from the PR subscribers group if no one
-      # has reviewed the community PR yet. These checks only match
-      # reviewers with admin, write or maintain permission on the repository.
-      - '#approved-reviews-by=0'
-      - '#commented-reviews-by=0'
-      - '#changes-requested-reviews-by=0'
-      - '#review-requested=0'
-    actions:
-      request_reviews:
-        teams:
-          - '@solana-labs/community-pr-subscribers'
   - name: Automatic merge (squash) on CI success
     conditions:
       - and:


### PR DESCRIPTION
We haven't really made use of this community reviewers' group in a few years. The core team of maintainers pretty regularly goes through community contributions as part of their normal work.
