### PR TITLE
Enable rule @typescript-eslint/restrict-template-expressions and fix the only error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ export default [
             '@typescript-eslint/only-throw-error': 'off',
             '@typescript-eslint/prefer-promise-reject-errors': 'off',
             '@typescript-eslint/restrict-plus-operands': 'off',
-            '@typescript-eslint/restrict-template-expressions': 'off',
+            '@typescript-eslint/restrict-template-expressions': 'error',
             '@typescript-eslint/unbound-method': 'off',
             'jest/expect-expect': [
                 'error',

--- a/examples/react-app/eslint.config.mjs
+++ b/examples/react-app/eslint.config.mjs
@@ -27,7 +27,7 @@ export default [
             '@typescript-eslint/no-misused-promises': 'off',
             '@typescript-eslint/no-unsafe-argument': 'off',
             '@typescript-eslint/no-unsafe-assignment': 'off',
-            '@typescript-eslint/restrict-template-expressions': 'off',
+            '@typescript-eslint/restrict-template-expressions': 'error',
             'react-refresh/only-export-components': [
                 'warn',
                 {

--- a/examples/react-app/src/components/Balance.tsx
+++ b/examples/react-app/src/components/Balance.tsx
@@ -34,7 +34,7 @@ export function Balance({ account }: Props) {
                     title="Failed to fetch account balance"
                 />
                 <Text>
-                    <Tooltip content={`Could not fetch balance: ${getErrorMessage(error, 'Unknown reason')}`}>
+                    <Tooltip content={<>Could not fetch balance: {getErrorMessage(error, 'Unknown reason')}</>}>
                         <ExclamationTriangleIcon
                             color="red"
                             style={{ height: 16, verticalAlign: 'text-bottom', width: 16 }}


### PR DESCRIPTION
This PR intends to fix a small part of issue #3465 

Specifically, it changes the rule @typescript-eslint/restrict-template-expressions, which is currently set to off, to error.