### PR TITLE
Enable eslint restrict-template-expressions plugin has a few extra linting errors

### DIFF
--- a/examples/deserialize-transaction/src/example.ts
+++ b/examples/deserialize-transaction/src/example.ts
@@ -310,7 +310,7 @@ const decompiledTransactionMessage = await decompileTransactionMessageFetchingLo
 // This is the same data structure that was created before we first signed the transaction
 
 // We can see the fee payer:
-log.info(`[step 3] The transaction fee payer is ${decompiledTransactionMessage.feePayer}`);
+log.info(`[step 3] The transaction fee payer is ${decompiledTransactionMessage.feePayer.address}`);
 
 // And the lifetime constraint:
 log.info(decompiledTransactionMessage.lifetimeConstraint, '[step 3] The transaction lifetime constraint');

--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -28,6 +28,7 @@ export function getHumanReadableErrorMessage<TErrorCode extends SolanaErrorCode>
             const variableName = messageFormatString.slice(state[START_INDEX] + 1, endIndex);
 
             fragments.push(
+                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions 
                 variableName in context ? `${context[variableName as keyof typeof context]}` : `$${variableName}`,
             );
         } else if (state[TYPE] === StateType.Text) {
@@ -43,8 +44,8 @@ export function getHumanReadableErrorMessage<TErrorCode extends SolanaErrorCode>
                     messageFormatString[0] === '\\'
                         ? StateType.EscapeSequence
                         : messageFormatString[0] === '$'
-                          ? StateType.Variable
-                          : StateType.Text,
+                            ? StateType.Variable
+                            : StateType.Text,
             };
             return;
         }

--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -28,8 +28,10 @@ export function getHumanReadableErrorMessage<TErrorCode extends SolanaErrorCode>
             const variableName = messageFormatString.slice(state[START_INDEX] + 1, endIndex);
 
             fragments.push(
-                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions 
-                variableName in context ? `${context[variableName as keyof typeof context]}` : `$${variableName}`,
+                variableName in context
+                    ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+                      `${context[variableName as keyof typeof context]}`
+                    : `$${variableName}`,
             );
         } else if (state[TYPE] === StateType.Text) {
             fragments.push(messageFormatString.slice(state[START_INDEX], endIndex));
@@ -44,8 +46,8 @@ export function getHumanReadableErrorMessage<TErrorCode extends SolanaErrorCode>
                     messageFormatString[0] === '\\'
                         ? StateType.EscapeSequence
                         : messageFormatString[0] === '$'
-                            ? StateType.Variable
-                            : StateType.Text,
+                          ? StateType.Variable
+                          : StateType.Text,
             };
             return;
         }

--- a/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
@@ -71,6 +71,7 @@ describe('createHttpTransport', () => {
                 thrownError = e as SolanaError<typeof SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR>;
             }
             expect(thrownError).toBeDefined();
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions 
             expect(`${thrownError.context.headers}`).not.toMatch(/doNotLog/);
         });
     });

--- a/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
@@ -71,7 +71,7 @@ describe('createHttpTransport', () => {
                 thrownError = e as SolanaError<typeof SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR>;
             }
             expect(thrownError).toBeDefined();
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions 
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             expect(`${thrownError.context.headers}`).not.toMatch(/doNotLog/);
         });
     });


### PR DESCRIPTION
While I was adding an extra eslint rule, I realized that there were a few extra linting errors from restrict-template-expressions rule. 

One of them I had to comment it because when it gets stringified, it leaks relevant information. Probably it should be sanitized first. 