### PR TITLE
Issue 2978: Verify signature for address helper

### DIFF
--- a/packages/keys/README.md
+++ b/packages/keys/README.md
@@ -179,3 +179,21 @@ if (!(await verifySignature(publicKey, signature, data))) {
     throw new Error('The data were *not* signed by the private key associated with `publicKey`');
 }
 ```
+
+### `verifySignatureForAddress()`
+
+This helper function verifies if a digital signature was produced by signing specific data with the private key associated with a given address. It simplifies the process of verifying signatures by internally handling the conversion of the address to a public Ed25519 key.
+
+```ts
+import { verifySignatureForAddress } from '@solana/keys';
+
+const signedByAddress = 'ED1WqT2hWJLSZtj4TtTdoovmpMrr7zpkUdbfxmcJR1Fq';
+const signature = new Uint8Array([/* ...signature bytes... */]);
+const data = new Uint8Array([/* ...data bytes... */]);
+
+const isVerified = await verifySignatureForAddress(signedByAddress, signature, data);
+
+if (!isVerified) {
+    throw new Error(`The signature is not valid for the provided address: ${signedByAddress}`);
+}
+```

--- a/packages/keys/src/signatures.ts
+++ b/packages/keys/src/signatures.ts
@@ -75,3 +75,37 @@ export async function verifySignature(
     assertVerificationCapabilityIsAvailable();
     return await crypto.subtle.verify('Ed25519', key, signature, data);
 }
+
+
+export async function verifySignatureForAddress(
+    address: string,
+    signature: Uint8Array,
+    messageBytes: Uint8Array
+): Promise<boolean> {
+    try {
+        // Encode the address to bytes
+        const addressBytes: ReadonlyUint8Array = new Uint8Array(getBase58Encoder().encode(address));
+
+        // Create a public Ed25519 key from the address bytes
+        const publicKey = await crypto.subtle.importKey(
+            'raw',
+            addressBytes,
+            'Ed25519',
+            true,
+            ['verify']
+        );
+
+        // Verify the signature using the public key
+        const isValid = await crypto.subtle.verify(
+            'Ed25519',
+            publicKey,
+            signature,
+            messageBytes
+        );
+
+        return isValid;
+    } catch (error) {
+        console.error('Error verifying signature:', error);
+        return false;
+    }
+}


### PR DESCRIPTION
Closes solana-labs/web3.js-issue-conveyer#11 

Added documentation for the verifySignatureForAddress helper function, which simplifies the process of verifying digital signatures for a given address. The function internally converts the address to a public key and verifies the signature for the associated data.