### PR TITLE
Enable eslint rule and disable errors due on data flexibility

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,7 @@ export default [
             '@typescript-eslint/no-unsafe-return': 'off',
             '@typescript-eslint/only-throw-error': 'off',
             '@typescript-eslint/prefer-promise-reject-errors': 'off',
-            '@typescript-eslint/restrict-plus-operands': 'off',
+            '@typescript-eslint/restrict-plus-operands': 'error',
             '@typescript-eslint/restrict-template-expressions': 'error',
             '@typescript-eslint/unbound-method': 'off',
             'jest/expect-expect': [

--- a/packages/fast-stable-stringify/src/index.ts
+++ b/packages/fast-stable-stringify/src/index.ts
@@ -29,9 +29,11 @@ function stringify(val: unknown, isArrayProp: boolean) {
                     str = '[';
                     max = (val as unknown[]).length - 1;
                     for (i = 0; i < max; i++) {
+                        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
                         str += stringify((val as unknown[])[i], true) + ',';
                     }
                     if (max > -1) {
+                        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
                         str += stringify((val as unknown[])[i], true);
                     }
                     return str + ']';
@@ -48,6 +50,7 @@ function stringify(val: unknown, isArrayProp: boolean) {
                             if (str) {
                                 str += ',';
                             }
+                            // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
                             str += JSON.stringify(key) + ':' + propVal;
                         }
                         i++;
@@ -78,6 +81,7 @@ export default function (val: unknown): string;
 export default function (val: unknown): string | undefined {
     const returnVal = stringify(val, false);
     if (returnVal !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
         return '' + returnVal;
     }
 }


### PR DESCRIPTION
Following solana-labs/web3.js-issue-conveyer#4 , this PR intends to activate the eslint rule @typescript-eslint/restrict-plus-operands.

The few discovered errors have been disabled to support possible data values different than strings.