### PR TITLE
Fix rent epoch type

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -10,6 +10,7 @@ import {Agent as NodeHttpsAgent} from 'https';
 import {
   type as pick,
   number,
+  bigint,
   string,
   array,
   boolean,
@@ -1930,7 +1931,7 @@ const AccountInfoResult = pick({
   owner: PublicKeyFromString,
   lamports: number(),
   data: BufferFromRawAccountData,
-  rentEpoch: number(),
+  rentEpoch: bigint(),
 });
 
 /**


### PR DESCRIPTION
So, for some reason rpc's return `2 ^ 64 - 1` as `rentEpoch`. Obviously, this is larger than `Number` in JS, so I switched the types to `bigint` and it all works now.

I'm a newby in Solana and have no idea why this works.

See https://github.com/solana-labs/solana-program-library/issues/7635 for the reference.