### PR TITLE
fix: update `base-x` to 3.0.11 in lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1772,8 +1772,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  base-x@3.0.9:
-    resolution: {integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==}
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
   base64-arraybuffer@0.1.5:
     resolution: {integrity: sha512-437oANT9tP582zZMwSvZGy2nmSeAb8DW2me3y+Uv1Wp2Rulr8Mqlyrv3E7MLxmsiaPSMMDmiDVzgE+e8zlMx9g==}
@@ -6034,7 +6034,7 @@ snapshots:
 
   '@types/bs58@4.0.1':
     dependencies:
-      base-x: 3.0.9
+      base-x: 3.0.11
 
   '@types/chai-as-promised@8.0.1':
     dependencies:
@@ -6404,7 +6404,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base-x@3.0.9:
+  base-x@3.0.11:
     dependencies:
       safe-buffer: 5.2.1
 
@@ -6473,7 +6473,7 @@ snapshots:
 
   bs58@4.0.1:
     dependencies:
-      base-x: 3.0.9
+      base-x: 3.0.11
 
   buffer-from@1.1.2: {}
 


### PR DESCRIPTION
```shell
$ pnpm ls --depth 100 -r base-x
Legend: production dependency, optional only, dev only

@solana/web3.js@1.0.0-maintenance /home/sol/src/solana-web3.js

dependencies:
borsh 0.7.0
└─┬ bs58 4.0.1
  └── base-x 3.0.11
bs58 4.0.1
└── base-x 3.0.11

devDependencies:
@types/bs58 4.0.1
└── base-x 3.0.11
```