### PR TITLE
Fix #3735: Improve error handling for malformed RPC responses in transaction methods

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -5793,7 +5793,21 @@ export class Connection {
 
       const args = [encodedTransaction, config];
       const unsafeRes = await this._rpcRequest('simulateTransaction', args);
-      const res = create(unsafeRes, SimulatedTransactionResponseStruct);
+
+      let res;
+      try {
+        res = create(unsafeRes, SimulatedTransactionResponseStruct);
+      } catch (err) {
+        // Handle superstruct validation errors gracefully
+        throw new SendTransactionError({
+          action: 'simulate',
+          signature: '',
+          transactionMessage: `Failed to parse response from RPC server. ${
+            err instanceof Error ? err.message : 'Unknown parsing error'
+          }`,
+        });
+      }
+
       if ('error' in res) {
         throw new Error('failed to simulate transaction: ' + res.error.message);
       }
@@ -5891,7 +5905,21 @@ export class Connection {
 
     const args = [encodedTransaction, config];
     const unsafeRes = await this._rpcRequest('simulateTransaction', args);
-    const res = create(unsafeRes, SimulatedTransactionResponseStruct);
+
+    let res;
+    try {
+      res = create(unsafeRes, SimulatedTransactionResponseStruct);
+    } catch (err) {
+      // Handle superstruct validation errors gracefully
+      throw new SendTransactionError({
+        action: 'simulate',
+        signature: '',
+        transactionMessage: `Failed to parse response from RPC server. ${
+          err instanceof Error ? err.message : 'Unknown parsing error'
+        }`,
+      });
+    }
+
     if ('error' in res) {
       let logs;
       if ('data' in res.error) {
@@ -6037,7 +6065,21 @@ export class Connection {
 
     const args = [encodedTransaction, config];
     const unsafeRes = await this._rpcRequest('sendTransaction', args);
-    const res = create(unsafeRes, SendTransactionRpcResult);
+
+    let res;
+    try {
+      res = create(unsafeRes, SendTransactionRpcResult);
+    } catch (err) {
+      // Handle superstruct validation errors gracefully
+      throw new SendTransactionError({
+        action: skipPreflight ? 'send' : 'simulate',
+        signature: '',
+        transactionMessage: `Failed to parse response from RPC server. ${
+          err instanceof Error ? err.message : 'Unknown parsing error'
+        }`,
+      });
+    }
+
     if ('error' in res) {
       let logs = undefined;
       if ('data' in res.error) {


### PR DESCRIPTION
#### Problem

When transactions fail due to malformed RPC responses or network issues, the Solana Web3.js library throws generic superstruct validation errors that are difficult for developers to debug. Instead of meaningful error messages, users receive cryptic errors like:

Se: Expected the value to satisfy a union of `type | type`, but received: [object Object]

This makes it extremely challenging to diagnose transaction failures and provide appropriate user feedback in applications.

#### Summary of Changes

- Enhanced error handling in `sendEncodedTransaction` method: Wrapped superstruct validation calls in try-catch blocks to intercept validation failures and convert them to meaningful `SendTransactionError` instances.

- Enhanced error handling in `simulateTransaction` method: Applied the same error handling pattern to both VersionedTransaction and Transaction code paths to ensure consistent error reporting across all transaction simulation scenarios.

- Improved error messages: Replace generic superstruct validation errors with descriptive messages that clearly indicate RPC response parsing failures, including the underlying error details for better debugging.

- Maintained backward compatibility: All changes preserve existing API contracts while improving the error handling experience.

The fix ensures that when RPC responses don't match expected schemas due to network issues, server errors, or malformed data, developers receive clear, actionable `SendTransactionError` messages instead of cryptic validation errors.

Fixes #3735