### PR TITLE
fix(stake): fix incorrect isWritable flag for SYSVAR_CLOCK_PUBKEY in …

### DIFF
--- a/src/programs/stake.ts
+++ b/src/programs/stake.ts
@@ -728,7 +728,7 @@ export class StakeProgram {
 
     const keys = [
       {pubkey: stakePubkey, isSigner: false, isWritable: true},
-      {pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: true},
+      {pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false},
       {pubkey: authorizedPubkey, isSigner: true, isWritable: false},
     ];
     if (custodianPubkey) {


### PR DESCRIPTION
This PR fixes a compatibility issue when delegating a stake account via a multisig transaction.

**Problem**

When attempting to authorize a stake account via a Squads multisig transaction, the transaction fails due to incorrect account flags—specifically, `SYSVAR_CLOCK_PUBKEY` was incorrectly marked as writable.

This leads to a runtime error under multisig constraints, where stricter account validation is enforced.

Failing Transaction (squads multisig): https://solscan.io/tx/5cVGJUQdobnzh6k28qqANYnPdeqsUcSd6RqvwKQk5efaC8J2vCkWzfdDXgDUj3Vvd3Tb1bhv61d2VnsbpQKnGGZB

**Solution**

This change updates the instruction layout in `StakeProgram.authorize` to set isWritable=false for the `SYSVAR_CLOCK_PUBKEY`.

The clock sysvar appears to be read-only and does not require write access.
With this change, stake authorization functions correctly in both single-signer and multisig scenarios.
