### PR TITLE
fix: set isSigner to false for authority in ALT creation

### DIFF
--- a/src/programs/address-lookup-table/index.ts
+++ b/src/programs/address-lookup-table/index.ts
@@ -293,7 +293,7 @@ export class AddressLookupTableProgram {
       },
       {
         pubkey: params.authority,
-        isSigner: true,
+        isSigner: false,
         isWritable: false,
       },
       {


### PR DESCRIPTION
Fixes #3762

The on-chain logic no longer requires the authority to be a signer when creating an Address Lookup Table (after Solana PR #27248). This change aligns the JS SDK with the runtime behavior.