### PR TITLE
fix: Add missing fields to SimulatedTransactionResponse

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -956,6 +956,11 @@ export type TransactionReturnData = {
   data: [string, TransactionReturnDataEncoding];
 };
 
+export type ReplacementBlockhash = {
+  blockhash: string;
+  lastValidBlockHeight: number;
+};
+
 export type SimulateTransactionConfig = {
   /** Optional parameter used to enable signature verification before simulation */
   sigVerify?: boolean;
@@ -975,6 +980,15 @@ export type SimulateTransactionConfig = {
   innerInstructions?: boolean;
 };
 
+/**
+ * Collection of addresses loaded by a transaction using address table lookups
+ * represented as base-58 encoded strings (as returned from simulation RPC)
+ */
+export type SimulatedTransactionLoadedAddresses = {
+  writable: Array<string>;
+  readonly: Array<string>;
+};
+
 export type SimulatedTransactionResponse = {
   err: TransactionError | string | null;
   logs: Array<string> | null;
@@ -982,6 +996,22 @@ export type SimulatedTransactionResponse = {
   unitsConsumed?: number;
   returnData?: TransactionReturnData | null;
   innerInstructions?: ParsedInnerInstruction[] | null;
+  /** Size of loaded accounts data in bytes */
+  loadedAccountsDataSize?: number;
+  /** Replacement blockhash when replaceRecentBlockhash config is used */
+  replacementBlockhash?: ReplacementBlockhash | null;
+  /** Transaction fee in lamports */
+  fee?: number;
+  /** SOL lamport balances before simulation for each account in the transaction */
+  preBalances?: Array<number>;
+  /** SOL lamport balances after simulation for each account in the transaction */
+  postBalances?: Array<number>;
+  /** SPL token balances before simulation */
+  preTokenBalances?: Array<TokenBalance> | null;
+  /** SPL token balances after simulation */
+  postTokenBalances?: Array<TokenBalance> | null;
+  /** Addresses loaded from address lookup tables */
+  loadedAddresses?: SimulatedTransactionLoadedAddresses | null;
 };
 const ParsedInstructionStruct = pick({
   program: string(),
@@ -993,6 +1023,29 @@ const PartiallyDecodedInstructionStruct = pick({
   programId: PublicKeyFromString,
   accounts: array(PublicKeyFromString),
   data: string(),
+});
+
+const ReplacementBlockhashStruct = pick({
+  blockhash: string(),
+  lastValidBlockHeight: number(),
+});
+
+const SimulatedTransactionLoadedAddressesStruct = pick({
+  writable: array(string()),
+  readonly: array(string()),
+});
+
+const SimulatedTransactionTokenBalanceStruct = pick({
+  accountIndex: number(),
+  mint: string(),
+  owner: optional(string()),
+  programId: optional(string()),
+  uiTokenAmount: pick({
+    amount: string(),
+    decimals: number(),
+    uiAmount: nullable(number()),
+    uiAmountString: optional(string()),
+  }),
 });
 
 const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
@@ -1037,6 +1090,20 @@ const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
           }),
         ),
       ),
+    ),
+    loadedAccountsDataSize: optional(number()),
+    replacementBlockhash: optional(nullable(ReplacementBlockhashStruct)),
+    fee: optional(number()),
+    preBalances: optional(array(number())),
+    postBalances: optional(array(number())),
+    preTokenBalances: optional(
+      nullable(array(SimulatedTransactionTokenBalanceStruct)),
+    ),
+    postTokenBalances: optional(
+      nullable(array(SimulatedTransactionTokenBalanceStruct)),
+    ),
+    loadedAddresses: optional(
+      nullable(SimulatedTransactionLoadedAddressesStruct),
     ),
   }),
 );

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -997,15 +997,15 @@ export type SimulatedTransactionResponse = {
   returnData?: TransactionReturnData | null;
   innerInstructions?: ParsedInnerInstruction[] | null;
   /** Size of loaded accounts data in bytes */
-  loadedAccountsDataSize?: number;
+  loadedAccountsDataSize?: number | null;
   /** Replacement blockhash when replaceRecentBlockhash config is used */
   replacementBlockhash?: ReplacementBlockhash | null;
   /** Transaction fee in lamports */
-  fee?: number;
+  fee?: number | null;
   /** SOL lamport balances before simulation for each account in the transaction */
-  preBalances?: Array<number>;
+  preBalances?: Array<number> | null;
   /** SOL lamport balances after simulation for each account in the transaction */
-  postBalances?: Array<number>;
+  postBalances?: Array<number> | null;
   /** SPL token balances before simulation */
   preTokenBalances?: Array<TokenBalance> | null;
   /** SPL token balances after simulation */
@@ -1091,11 +1091,11 @@ const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
         ),
       ),
     ),
-    loadedAccountsDataSize: optional(number()),
+    loadedAccountsDataSize: optional(nullable(number())),
     replacementBlockhash: optional(nullable(ReplacementBlockhashStruct)),
-    fee: optional(number()),
-    preBalances: optional(array(number())),
-    postBalances: optional(array(number())),
+    fee: optional(nullable(number())),
+    preBalances: optional(nullable(array(number()))),
+    postBalances: optional(nullable(array(number()))),
     preTokenBalances: optional(
       nullable(array(SimulatedTransactionTokenBalanceStruct)),
     ),

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -5667,6 +5667,65 @@ describe('Connection', function () {
         readonly: ['Address2222222222222222222222222222222222222'],
       });
     });
+
+    it('simulation fields with null values on error', async () => {
+      const tx = new Transaction();
+      tx.feePayer = Keypair.generate().publicKey;
+
+      const getLatestBlockhashResponse = {
+        method: 'getLatestBlockhash',
+        params: [],
+        value: {
+          blockhash: 'CSymwgTNX1j3E4qhKfJAUE41nBWEwXufoYryPbkde5RR',
+          feeCalculator: {
+            lamportsPerSignature: 5000,
+          },
+          lastValidBlockHeight: 51,
+        },
+        withContext: true,
+      };
+
+      const simulateTransactionResponse = {
+        method: 'simulateTransaction',
+        params: [],
+        value: {
+          err: 'BlockhashNotFound',
+          accounts: null,
+          logs: [],
+          unitsConsumed: 0,
+          loadedAccountsDataSize: 0,
+          replacementBlockhash: null,
+          fee: null,
+          preBalances: [0, 0],
+          postBalances: [0, 0],
+          preTokenBalances: [],
+          postTokenBalances: [],
+          loadedAddresses: {
+            writable: [],
+            readonly: [],
+          },
+        },
+        withContext: true,
+      };
+
+      await mockRpcResponse(getLatestBlockhashResponse);
+      await mockRpcResponse(simulateTransactionResponse);
+
+      const response = (await connection.simulateTransaction(tx)).value;
+
+      expect(response.err).to.eq('BlockhashNotFound');
+      expect(response.loadedAccountsDataSize).to.eq(0);
+      expect(response.replacementBlockhash).to.be.null;
+      expect(response.fee).to.be.null;
+      expect(response.preBalances).to.eql([0, 0]);
+      expect(response.postBalances).to.eql([0, 0]);
+      expect(response.preTokenBalances).to.eql([]);
+      expect(response.postTokenBalances).to.eql([]);
+      expect(response.loadedAddresses).to.eql({
+        writable: [],
+        readonly: [],
+      });
+    });
   }
 
   if (process.env.TEST_LIVE) {

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -5588,6 +5588,85 @@ describe('Connection', function () {
         programId: '83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri',
       });
     });
+
+    it('new simulation fields on simulateTransaction', async () => {
+      const tx = new Transaction();
+      tx.feePayer = Keypair.generate().publicKey;
+
+      const getLatestBlockhashResponse = {
+        method: 'getLatestBlockhash',
+        params: [],
+        value: {
+          blockhash: 'CSymwgTNX1j3E4qhKfJAUE41nBWEwXufoYryPbkde5RR',
+          feeCalculator: {
+            lamportsPerSignature: 5000,
+          },
+          lastValidBlockHeight: 51,
+        },
+        withContext: true,
+      };
+
+      const simulateTransactionResponse = {
+        method: 'simulateTransaction',
+        params: [],
+        value: {
+          err: null,
+          accounts: null,
+          logs: ['Program log: test'],
+          unitsConsumed: 1000,
+          loadedAccountsDataSize: 2048,
+          replacementBlockhash: {
+            blockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N',
+            lastValidBlockHeight: 100,
+          },
+          fee: 5000,
+          preBalances: [1000000000, 0],
+          postBalances: [999995000, 5000],
+          preTokenBalances: [
+            {
+              accountIndex: 1,
+              mint: 'So11111111111111111111111111111111111111112',
+              owner: 'CSymwgTNX1j3E4qhKfJAUE41nBWEwXufoYryPbkde5RR',
+              uiTokenAmount: {
+                amount: '1000000',
+                decimals: 9,
+                uiAmount: 0.001,
+                uiAmountString: '0.001',
+              },
+            },
+          ],
+          postTokenBalances: [],
+          loadedAddresses: {
+            writable: ['Address1111111111111111111111111111111111111'],
+            readonly: ['Address2222222222222222222222222222222222222'],
+          },
+        },
+        withContext: true,
+      };
+
+      await mockRpcResponse(getLatestBlockhashResponse);
+      await mockRpcResponse(simulateTransactionResponse);
+
+      const response = (await connection.simulateTransaction(tx)).value;
+
+      expect(response.loadedAccountsDataSize).to.eq(2048);
+      expect(response.replacementBlockhash).to.eql({
+        blockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N',
+        lastValidBlockHeight: 100,
+      });
+      expect(response.fee).to.eq(5000);
+      expect(response.preBalances).to.eql([1000000000, 0]);
+      expect(response.postBalances).to.eql([999995000, 5000]);
+      expect(response.preTokenBalances).to.have.lengthOf(1);
+      expect(response.preTokenBalances![0].mint).to.eq(
+        'So11111111111111111111111111111111111111112',
+      );
+      expect(response.postTokenBalances).to.eql([]);
+      expect(response.loadedAddresses).to.eql({
+        writable: ['Address1111111111111111111111111111111111111'],
+        readonly: ['Address2222222222222222222222222222222222222'],
+      });
+    });
   }
 
   if (process.env.TEST_LIVE) {


### PR DESCRIPTION
## Summary
- Add 8 missing fields to `SimulatedTransactionResponse` from Solana RPC spec
- Add corresponding Superstruct schemas for runtime validation
- Add tests for the new simulation response fields

**New fields:**
- `loadedAccountsDataSize` - size of loaded accounts data in bytes
- `replacementBlockhash` - blockhash when `replaceRecentBlockhash` is used
- `fee` - transaction fee in lamports
- `preBalances` / `postBalances` - SOL balances before/after simulation
- `preTokenBalances` / `postTokenBalances` - SPL token balances
- `loadedAddresses` - addresses loaded from address lookup tables

These fields bring `simulateTransaction` to parity with `getTransaction`, enabling developers to evaluate transaction effects without guessing from logs.

Ref: https://github.com/anza-xyz/agave/pull/6750