### PR TITLE
Fetch the latest 100 Agave releases when finding 2.1.x test validator

### DIFF
--- a/scripts/get-latest-validator-release-version.sh
+++ b/scripts/get-latest-validator-release-version.sh
@@ -2,7 +2,7 @@
 (
     set -e
     version=$(node -e \
-      'fetch("https://api.github.com/repos/anza-xyz/agave/releases").then(res => res.json().then(rs => rs.filter(r => !r.prerelease && r.tag_name.startsWith("v2.1."))).then(x => console.log(x[0].tag_name)));'
+      'fetch("https://api.github.com/repos/anza-xyz/agave/releases?per_page=100").then(res => res.json().then(rs => rs.filter(r => !r.prerelease && r.tag_name.startsWith("v2.1."))).then(x => console.log(x[0].tag_name)));'
     )
     if [ -z $version ]; then
       exit 3


### PR DESCRIPTION
The PR workflow is currently failing, because it is unable to find an Agave release with the 2.1 tag

The [Github API used](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28) returns only the latest 30 releases by default. This PR updates it to fetch the latest 100 releases instead.

Longer term, it would be better to use a more current version of the test validator if possible. If 2.1 continues to be used then eventually the script will need to be updated to paginate the API instead.