### PR TITLE
fix(ed25519): make signature verification non-throwing for malformed inputs

### DIFF
--- a/src/utils/ed25519.ts
+++ b/src/utils/ed25519.ts
@@ -40,4 +40,23 @@ export const sign = (
   message: Parameters<typeof ed25519.sign>[0],
   secretKey: Ed25519SecretKey,
 ) => ed25519.sign(message, secretKey.slice(0, 32));
-export const verify = ed25519.verify;
+// NOTE: `@noble/curves` may throw for malformed inputs (wrong lengths, etc.).
+// web3.js is often used with partially-constructed / user-supplied transactions,
+// so we treat malformed signatures / pubkeys as a failed verification instead of
+// bubbling an exception (which can become an application-level DoS).
+export function verify(
+  signature: Parameters<typeof ed25519.verify>[0],
+  message: Parameters<typeof ed25519.verify>[1],
+  publicKey: Parameters<typeof ed25519.verify>[2],
+): boolean {
+  try {
+    // Ed25519 expects 64-byte signatures and 32-byte public keys.
+    // Returning `false` here keeps callers' logic intact (invalid signature),
+    // while avoiding unexpected throws.
+    if ((signature as Uint8Array).length !== 64) return false;
+    if ((publicKey as Uint8Array).length !== 32) return false;
+    return ed25519.verify(signature, message, publicKey);
+  } catch {
+    return false;
+  }
+}

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -961,6 +961,23 @@ describe('Transaction', () => {
       expect(expectedTransaction.verifySignatures(false)).to.be.true;
     });
 
+    it('treats malformed signature lengths as invalid instead of throwing', () => {
+      expectedTransaction.partialSign(sender);
+
+      // Simulate a corrupted / user-mutated transaction.
+      // Historically, some ed25519 verify implementations throw on bad lengths.
+      // We want web3.js to treat this as an invalid signature (false), not crash.
+      expectedTransaction.signatures[0].signature = Buffer.alloc(63, 1);
+
+      expect(() => expectedTransaction.verifySignatures(false)).to.not.throw();
+      expect(expectedTransaction.verifySignatures(false)).to.be.false;
+
+      // And serialize() should fail with the normal signature verification error.
+      expect(() => expectedTransaction.serialize()).to.throw(
+        /Signature verification failed\./,
+      );
+    });
+
     it('throws for wrong sig with only one sig present', () => {
       // Add one required sigs
       expectedTransaction.partialSign(feePayer);


### PR DESCRIPTION
## Summary
`@solana/web3.js` re-exports `ed25519.verify` from `@noble/curves`. Some malformed inputs (wrong signature/public-key lengths) can cause `ed25519.verify` to throw, which can bubble up into `Transaction.verifySignatures()` / `Transaction.serialize({ verifySignatures: true })` callers.

This PR hardens verification by:
- Returning `false` for invalid input lengths (signature != 64 bytes, public key != 32 bytes)
- Catching any thrown errors from the underlying library and returning `false`

This makes signature verification robust against corrupted/untrusted serialized transactions without changing behavior for valid signatures.

## Impact
Prevents unexpected exceptions (potential app-level DoS) when verifying signatures on untrusted or corrupted transaction data.

## Tests
Adds a unit test that ensures malformed signature lengths are treated as invalid (no throw) and that `serialize()` fails with the normal "Signature verification failed." error.

- `pnpm test:unit`