### PR TITLE
fix: prevent infinite loop in _updateSubscriptions when WebSocket is closing

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6203,7 +6203,16 @@ export class Connection {
 
     const activeWebSocketGeneration = this._rpcWebSocketGeneration;
     const isCurrentConnectionStillActive = () => {
-      return activeWebSocketGeneration === this._rpcWebSocketGeneration;
+      if (activeWebSocketGeneration !== this._rpcWebSocketGeneration) {
+        return false;
+      }
+      // Guard against stale `_rpcWebSocketConnected` flag: the socket
+      // may have entered the CLOSING (2) or CLOSED (3) state before the
+      // 'close' event fires and flips the flag. Without this check,
+      // recursive calls to `_updateSubscriptions` keep retrying RPC
+      // calls on a dead socket, causing an infinite loop (#3761).
+      const readyState = this._rpcWebSocket.readyState;
+      return readyState === 0 /* CONNECTING */ || readyState === 1 /* OPEN */;
     };
 
     await Promise.all(

--- a/src/rpc-websocket.ts
+++ b/src/rpc-websocket.ts
@@ -38,6 +38,9 @@ export default class RpcWebSocketClient extends CommonClient {
     };
     super(webSocketFactory, address, options, generate_request_id);
   }
+  get readyState(): WebSocket['readyState'] {
+    return this.underlyingSocket?.readyState ?? 3 /* WebSocket.CLOSED */;
+  }
   call(
     ...args: Parameters<CommonClient['call']>
   ): ReturnType<CommonClient['call']> {

--- a/test/connection-subscriptions.test.ts
+++ b/test/connection-subscriptions.test.ts
@@ -37,6 +37,12 @@ function stubRpcWebSocket(
     }
   });
   stub(socket, 'call');
+  // Expose readyState so that `isCurrentConnectionStillActive()` sees the
+  // socket as OPEN (1) when mockOpen is true, matching real behaviour.
+  Object.defineProperty(socket, 'readyState', {
+    get: () => (mockOpen ? 1 /* OPEN */ : 3 /* CLOSED */),
+    configurable: true,
+  });
   return socket as unknown as SinonStubbedInstance<Client>;
 }
 
@@ -953,6 +959,120 @@ describe('Subscriptions', () => {
           {commitment: 'finalized', encoding: 'base64'},
         ],
       );
+    });
+
+    describe('WebSocket readyState guard in _updateSubscriptions (issue #3761)', () => {
+      /**
+       * Regression tests for an infinite loop caused by
+       * `isCurrentConnectionStillActive()` not checking the WebSocket
+       * readyState. When the socket enters CLOSING (2) or CLOSED (3) state
+       * before the 'close' event fires, RPC calls fail immediately but the
+       * generation-only guard considers the connection still active, causing
+       * an infinite retry loop.
+       */
+      let connection: Connection;
+      let stubbedSocket: SinonStubbedInstance<Client>;
+
+      beforeEach(() => {
+        connection = new Connection(url);
+        stubbedSocket = stubRpcWebSocket(connection);
+      });
+
+      afterEach(() => {
+        stubbedSocket.close();
+      });
+
+      it('breaks out of retry loop when socket enters CLOSING state during unsubscribe', async () => {
+        const serverSubscriptionId = 42;
+        const clientSubscriptionId = connection.onAccountChange(
+          PublicKey.default,
+          spy(),
+        );
+
+        // Establish the subscription via a normal open/subscribe cycle.
+        stubbedSocket.call
+          .withArgs('accountSubscribe')
+          .resolves(serverSubscriptionId);
+        stubbedSocket.emit('open');
+        await new Promise(resolve => setImmediate(resolve));
+
+        // Simulate the socket transitioning to CLOSING state.
+        // This can happen when the server initiates a close or the network
+        // drops. The 'close' event hasn't fired yet, so the generation
+        // counter is still the same and _rpcWebSocketConnected is still true.
+        Object.defineProperty(stubbedSocket, 'readyState', {
+          get: () => 2 /* WebSocket.CLOSING */,
+          configurable: true,
+        });
+
+        stubbedSocket.call
+          .withArgs('accountUnsubscribe', [serverSubscriptionId])
+          .rejects(
+            new Error(
+              'Tried to call a JSON-RPC method `accountUnsubscribe` but the socket was not `CONNECTING` or `OPEN` (`readyState` was 2)',
+            ),
+          );
+
+        // Track recursion depth of _updateSubscriptions.
+        let updateCallCount = 0;
+        const originalUpdate = (
+          connection as any
+        )._updateSubscriptions.bind(connection);
+        (connection as any)._updateSubscriptions = async function () {
+          updateCallCount++;
+          if (updateCallCount > 10) {
+            throw new Error(
+              'Infinite loop detected: _updateSubscriptions called more than 10 times',
+            );
+          }
+          return originalUpdate();
+        };
+
+        // Remove the listener — this triggers unsubscribe which will fail.
+        // Without the readyState guard, this would recurse indefinitely.
+        await connection.removeAccountChangeListener(clientSubscriptionId);
+
+        // The guard should bail after the first failed unsubscribe attempt.
+        expect(updateCallCount).to.be.lessThan(5);
+      });
+
+      it('breaks out of retry loop when socket enters CLOSED state during subscribe', async () => {
+        // Create a subscription while the connection is open.
+        connection.onAccountChange(PublicKey.default, spy());
+        stubbedSocket.emit('open');
+
+        // First subscribe attempt succeeds — but then the socket dies.
+        // Simulate a CLOSED socket before the 'close' event fires.
+        stubbedSocket.call.withArgs('accountSubscribe').rejects(
+          new Error(
+            'Tried to call a JSON-RPC method `accountSubscribe` but the socket was not `CONNECTING` or `OPEN` (`readyState` was 3)',
+          ),
+        );
+        Object.defineProperty(stubbedSocket, 'readyState', {
+          get: () => 3 /* WebSocket.CLOSED */,
+          configurable: true,
+        });
+
+        let updateCallCount = 0;
+        const originalUpdate = (
+          connection as any
+        )._updateSubscriptions.bind(connection);
+        (connection as any)._updateSubscriptions = async function () {
+          updateCallCount++;
+          if (updateCallCount > 10) {
+            throw new Error(
+              'Infinite loop detected: _updateSubscriptions called more than 10 times',
+            );
+          }
+          return originalUpdate();
+        };
+
+        // Force a re-subscription attempt.
+        await (connection as any)._updateSubscriptions();
+
+        // Should not recurse infinitely.
+        expect(updateCallCount).to.be.lessThan(5);
+      });
     });
   });
 });


### PR DESCRIPTION
## Problem

Fixes #3761

When a WebSocket connection transitions to `CLOSING` (readyState 2) or `CLOSED` (readyState 3) state, there is a window between the socket becoming unusable and the `close` event firing. During this window:

1. `_rpcWebSocketConnected` is still `true` (it only flips when `_wsOnClose` runs)
2. `_rpcWebSocketGeneration` hasn't incremented yet
3. `isCurrentConnectionStillActive()` still returns `true`

Any RPC call (`call`/`notify`) on the `RpcWebSocketClient` will reject immediately with:
```
Tried to call a JSON-RPC method `accountUnsubscribe` but the socket was not
`CONNECTING` or `OPEN` (`readyState` was 2)
```

But the error handler in `_updateSubscriptions()` sees the connection as still active, resets the subscription state, and calls `_updateSubscriptions()` recursively — which immediately fails again, creating a **tight infinite loop** that floods logs and can crash the process.

**Real-world impact**: This has been observed in production with Drift Protocol SDK users on Railway, where the log storm reached 500 logs/sec and caused instance crashes.

## Root Cause

`isCurrentConnectionStillActive()` only checks the generation counter:

```ts
const isCurrentConnectionStillActive = () => {
  return activeWebSocketGeneration === this._rpcWebSocketGeneration;
};
```

This misses the case where the socket is dying but the `close` event hasn't fired yet. The `readyState` transitions happen synchronously on the socket, but the `close` event is asynchronous — there's a real gap where the generation counter is stale.

## Solution

1. **Expose `readyState`** on `RpcWebSocketClient` via a getter that delegates to the underlying socket (defaults to `CLOSED` when no socket exists)

2. **Guard `isCurrentConnectionStillActive()`** to also verify the socket is in a usable state (`CONNECTING` or `OPEN`):

```ts
const isCurrentConnectionStillActive = () => {
  if (activeWebSocketGeneration !== this._rpcWebSocketGeneration) {
    return false;
  }
  const readyState = this._rpcWebSocket.readyState;
  return readyState === 0 /* CONNECTING */ || readyState === 1 /* OPEN */;
};
```

This breaks the recursive loop immediately when the socket is no longer usable, allowing the normal reconnection flow to take over when the `close` event eventually fires.

## Changes

| File | Change |
|------|--------|
| `src/rpc-websocket.ts` | Added `readyState` getter (+3 lines) |
| `src/connection.ts` | Extended `isCurrentConnectionStillActive()` with readyState check (+10 lines) |
| `test/connection-subscriptions.test.ts` | Updated test stub to track readyState + added 2 regression tests (+120 lines) |

## Testing

- All **198** subscription tests pass (previously 14 retry tests were failing because the test stub didn't expose `readyState` — fixed by having the stub track open/close state)
- Added regression tests for:
  - Socket in CLOSING state during unsubscribe (the exact scenario from #3761)
  - Socket in CLOSED state during subscribe (same root cause, different path)
- Both tests verify that `_updateSubscriptions()` doesn't exceed a reasonable call count (< 5), catching any infinite loop

## Notes

- Uses numeric constants (`0`, `1`, `3`) instead of `WebSocket.CONNECTING/OPEN/CLOSED` to avoid Node.js/browser compatibility issues, consistent with the existing pattern in `rpc-websocket.ts`
- This is a minimal, targeted fix — no behavioral changes to the happy path