### PR TITLE
fix: export ClientSubscriptionId type

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -90,7 +90,7 @@ interface IWSRequestParams {
   [x: number]: any;
 }
 
-type ClientSubscriptionId = number;
+export type ClientSubscriptionId = number;
 /** @internal */ type ServerSubscriptionId = number;
 /** @internal */ type SubscriptionConfigHash = string;
 /** @internal */ type SubscriptionDisposeFn = () => Promise<void>;


### PR DESCRIPTION
## Summary

This PR addresses issue #3745 by exporting the `ClientSubscriptionId` type from `src/connection.ts`.

## Problem

`ClientSubscriptionId` is currently used as a return type for multiple public subscription methods:
- `onAccountChange()`
- `onProgramAccountChange()`
- `onSlotChange()`
- `onSignature()`
- `onLogsSubscribe()`

It's also used as a parameter type for:
- `removeAccountChangeListener(id: ClientSubscriptionId)`
- `removeSlotChangeListener(id: ClientSubscriptionId)`

However, the type is not exported, making it impossible for TypeScript users to reference it when storing subscription IDs.

## Current Workaround

Users must use `number` directly instead of the semantic type:
```typescript
const subId: number = connection.onAccountChange(...);
```

## Solution

Export the type to allow proper TypeScript usage:
```typescript
const subId: ClientSubscriptionId = connection.onAccountChange(...);
```

## Changes

- Added `export` keyword to `ClientSubscriptionId` type declaration (line 93)

## Risk Assessment

**Very Low:**
- This is a type-only change with no runtime behavior
- The type is already part of the public API surface (used in exported method signatures)
- Backward compatible - existing code continues to work
- Simply makes an implicit contract explicit

## Testing

No new tests needed - this is a pure TypeScript type export that doesn't affect runtime behavior.

Fixes #3745