### PR TITLE
fix: correct default return type for getParsedBlock()

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4907,7 +4907,13 @@ export class Connection {
   async getParsedBlock(
     slot: number,
     rawConfig?: GetVersionedBlockConfig,
-  ): Promise<ParsedAccountsModeBlockResponse>;
+  ): Promise<ParsedBlockResponse>;
+
+  // eslint-disable-next-line no-dupe-class-members
+  async getParsedBlock(
+    slot: number,
+    rawConfig: GetVersionedBlockConfig & {transactionDetails: 'full'},
+  ): Promise<ParsedBlockResponse>;
 
   // eslint-disable-next-line no-dupe-class-members
   async getParsedBlock(


### PR DESCRIPTION
## Problem

The first overload signature of `getParsedBlock()` incorrectly returns `ParsedAccountsModeBlockResponse` when no `transactionDetails` is specified in the config:

```typescript
async getParsedBlock(
  slot: number,
  rawConfig?: GetVersionedBlockConfig,
): Promise<ParsedAccountsModeBlockResponse>;  // ← wrong
```

Per the [RPC docs](https://solana.com/docs/rpc/http/getblock) and the [inline comment](https://github.com/solana-foundation/solana-web3.js/blob/maintenance/v1.x/src/connection.ts#L563-L570), the default `transactionDetails` is `'full'`, so the default return type should be `ParsedBlockResponse`.

The implementation already handles this correctly (the `default` case in the switch statement uses `GetParsedBlockRpcResult`), so this is purely a type-level fix.

## Changes

1. **Fixed default overload** return type from `ParsedAccountsModeBlockResponse` → `ParsedBlockResponse`
2. **Added explicit `'full'` overload** so `{ transactionDetails: 'full' }` correctly resolves to `ParsedBlockResponse`

## Before/After

```typescript
// Before: incorrectly typed as ParsedAccountsModeBlockResponse
const block = await connection.getParsedBlock(slot);
//    ^? ParsedAccountsModeBlockResponse (wrong - missing transactions field)

// After: correctly typed as ParsedBlockResponse
const block = await connection.getParsedBlock(slot);
//    ^? ParsedBlockResponse (correct - includes full transaction details)
```

Fixes #3773