### PR TITLE
fix: prevent infinite loop in _updateSubscriptions when socket is closed

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6308,10 +6308,6 @@ export class Connection {
                     ...subscription,
                     state: 'unsubscribing',
                   });
-                  this._setSubscription(hash, {
-                    ...subscription,
-                    state: 'unsubscribing',
-                  });
                   try {
                     await this._rpcWebSocket.call(unsubscribeMethod, [
                       serverSubscriptionId,
@@ -6321,6 +6317,22 @@ export class Connection {
                       console.error(`${unsubscribeMethod} error:`, e.message);
                     }
                     if (!isCurrentConnectionStillActive()) {
+                      return;
+                    }
+                    // If the socket is no longer open, don't retry the
+                    // unsubscribe — the server-side subscription is
+                    // effectively dead. When a new connection is
+                    // established, subscriptions will be re-evaluated.
+                    const socketReadyState =
+                      (this._rpcWebSocket as any)._ws?.readyState;
+                    if (
+                      socketReadyState !== undefined &&
+                      socketReadyState !== 1 /* WebSocket.OPEN */
+                    ) {
+                      this._setSubscription(hash, {
+                        ...subscription,
+                        state: 'unsubscribed',
+                      });
                       return;
                     }
                     // TODO: Maybe add an 'errored' state or a retry limit?


### PR DESCRIPTION
## Problem

When a WebSocket transitions to CLOSING/CLOSED state without triggering a new generation, `_updateSubscriptions()` enters an infinite recursive loop (#3761).

**The flow:**
1. Subscription is in `subscribed` state and needs to be torn down
2. `_rpcWebSocket.call(unsubscribeMethod)` fails because the socket is closed (readyState=2)
3. Error is caught, `isCurrentConnectionStillActive()` returns `true` (generation counter unchanged)
4. State is reset back to `subscribed`
5. `_updateSubscriptions()` is called recursively → back to step 2
6. **Infinite loop** with no backoff or exit condition

This causes a storm of `accountUnsubscribe error` console messages and eventually crashes the process.

## Fix

**1. Check WebSocket readyState before retrying:**
If the socket is no longer `OPEN`, mark the subscription as `unsubscribed` instead of retrying. The server-side subscription is effectively dead — when a new connection is established, subscriptions will be re-evaluated through the normal reconnection path.

**2. Remove duplicate `_setSubscription` call:**
The `unsubscribing` state was being set twice in the same block (copy-paste artifact).

## Risk

**Low.** This is a defensive guard that only activates when the socket is already dead. Normal subscription/unsubscription flow is unaffected. The existing reconnection logic handles resubscription when a new connection is established.

Fixes #3761