### PR TITLE
fix: remove stale preflightCommitment workaround in sendEncodedTransaction

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6024,9 +6024,7 @@ export class Connection {
     const config: any = {encoding: 'base64'};
     const skipPreflight = options && options.skipPreflight;
     const preflightCommitment =
-      skipPreflight === true
-        ? 'processed' // FIXME Remove when https://github.com/anza-xyz/agave/pull/483 is deployed.
-        : (options && options.preflightCommitment) || this.commitment;
+      (options && options.preflightCommitment) || this.commitment;
 
     if (options && options.maxRetries != null) {
       config.maxRetries = options.maxRetries;


### PR DESCRIPTION
## Summary

Removes a stale workaround in `sendEncodedTransaction()` that was added to work around a validator bug.

Closes #3733

## Background

In `sendEncodedTransaction()`, there was a FIXME comment explaining that `preflightCommitment` was hardcoded to `'processed'` when `skipPreflight === true`:

```typescript
// Before
const preflightCommitment =
  skipPreflight === true
    ? 'processed' // FIXME Remove when https://github.com/anza-xyz/agave/pull/483 is deployed.
    : (options && options.preflightCommitment) || this.commitment;
```

This workaround was added to work around a bug in the Agave validator where skipping preflight with non-`processed` commitment could cause issues with `last_valid_block_height` calculation.

## Why It's Safe to Remove

[anza-xyz/agave#483](https://github.com/anza-xyz/agave/pull/483) was **merged on 2024-04-03** — almost 2 years ago. The fix has been deployed to mainnet validators for well over a year.

## Change

```typescript
// After
const preflightCommitment =
  (options && options.preflightCommitment) || this.commitment;
```

`preflightCommitment` now behaves consistently regardless of `skipPreflight`:
- Uses `options.preflightCommitment` if explicitly provided
- Falls back to `connection.commitment`

## Impact

**Behavior change:** When `skipPreflight: true` and no explicit `preflightCommitment` is passed, the value sent to the RPC changes from hardcoded `'processed'` to the connection's configured `commitment` level (typically `'finalized'` on mainnet).

**Risk:** Low — the workaround's target bug has been fixed at the validator level. The RPC parameter is now passed correctly per user intent.

## Testing

No new test needed — this is a logic simplification in an existing code path. Existing tests cover `sendEncodedTransaction()` behavior.