### PR TITLE
fix: allow nullable costUnits in transaction meta

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1094,7 +1094,7 @@ export type ParsedTransactionMeta = {
   /** The compute units consumed after processing the transaction */
   computeUnitsConsumed?: number;
   /** The cost units consumed after processing the transaction */
-  costUnits?: number;
+  costUnits?: number | null;
 };
 
 export type CompiledInnerInstruction = {
@@ -1127,7 +1127,7 @@ export type ConfirmedTransactionMeta = {
   /** The compute units consumed after processing the transaction */
   computeUnitsConsumed?: number;
   /** The cost units consumed after processing the transaction */
-  costUnits?: number;
+  costUnits?: number | null;
 };
 
 /**
@@ -2373,7 +2373,7 @@ const ConfirmedTransactionMetaResult = pick({
   postTokenBalances: optional(nullable(array(TokenBalanceResult))),
   loadedAddresses: optional(LoadedAddressesResult),
   computeUnitsConsumed: optional(number()),
-  costUnits: optional(number()),
+  costUnits: optional(nullable(number())),
 });
 
 /**
@@ -2399,7 +2399,7 @@ const ParsedConfirmedTransactionMetaResult = pick({
   postTokenBalances: optional(nullable(array(TokenBalanceResult))),
   loadedAddresses: optional(LoadedAddressesResult),
   computeUnitsConsumed: optional(number()),
-  costUnits: optional(number()),
+  costUnits: optional(nullable(number())),
 });
 
 const TransactionVersionStruct = union([literal(0), literal('legacy')]);


### PR DESCRIPTION
## Problem

Some RPC providers (e.g. Helius) return `null` for `meta.costUnits` instead of omitting the field entirely. The current superstruct validator uses `optional(number())`, which accepts `undefined` but rejects `null`, causing a `StructError` at runtime:

```
StructError: At path: meta.costUnits -- Expected a number, but received: null
```

This mirrors how `computeUnitsConsumed` was handled before — the field is optional and can legitimately be `null` from certain RPC responses.

## Fix

- Change superstruct validators from `optional(number())` to `optional(nullable(number()))` in both `ConfirmedTransactionMetaResult` and `ParsedConfirmedTransactionMetaResult`
- Update TypeScript types (`ConfirmedTransactionMeta` and `ParsedTransactionMeta`) from `costUnits?: number` to `costUnits?: number | null`

This is consistent with how other nullable fields in the same structs are handled (e.g. `logMessages`, `preTokenBalances`, `commission`).

Fixes #3756