### PR TITLE
fix: correct return type for getParsedBlock with transactionDetails full

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4907,7 +4907,7 @@ export class Connection {
   async getParsedBlock(
     slot: number,
     rawConfig?: GetVersionedBlockConfig,
-  ): Promise<ParsedAccountsModeBlockResponse>;
+  ): Promise<ParsedBlockResponse>;
 
   // eslint-disable-next-line no-dupe-class-members
   async getParsedBlock(


### PR DESCRIPTION
## Summary

Fixes #3773

`connection.getParsedBlock()` returns the wrong TypeScript type when `transactionDetails` is `'full'` (or omitted, since `'full'` is the default). The return type is `ParsedAccountsModeBlockResponse` but should be `ParsedBlockResponse`.

## Fix

Corrected the return type overload so that `transactionDetails: 'full'` (and the default case) returns `Promise<ParsedBlockResponse>` as documented in the JSON RPC specification.

## Test Plan

- TypeScript compilation should pass
- Existing tests should continue to pass
- Users calling `getParsedBlock()` with `transactionDetails: 'full'` will now get the correct type with full transaction details