### PR TITLE
fix: export ClientSubscriptionId type

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -90,7 +90,7 @@ interface IWSRequestParams {
   [x: number]: any;
 }
 
-type ClientSubscriptionId = number;
+export type ClientSubscriptionId = number;
 /** @internal */ type ServerSubscriptionId = number;
 /** @internal */ type SubscriptionConfigHash = string;
 /** @internal */ type SubscriptionDisposeFn = () => Promise<void>;


### PR DESCRIPTION
## Summary

Fixes #3745

`ClientSubscriptionId` type is defined in `src/connection.ts` but not exported, preventing users from importing it from the SDK.

## Fix

Added the `export` keyword to the `ClientSubscriptionId` type alias so users can import it directly from `@solana/web3.js`.

## Test Plan

- TypeScript compilation should pass
- Users should be able to import: `import { ClientSubscriptionId } from '@solana/web3.js'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)