### PR TITLE
fix: correct return types for getParsedBlock overloads

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4907,7 +4907,13 @@ export class Connection {
   async getParsedBlock(
     slot: number,
     rawConfig?: GetVersionedBlockConfig,
-  ): Promise<ParsedAccountsModeBlockResponse>;
+  ): Promise<ParsedBlockResponse>;
+
+  // eslint-disable-next-line no-dupe-class-members
+  async getParsedBlock(
+    slot: number,
+    rawConfig: GetVersionedBlockConfig & {transactionDetails: 'full'},
+  ): Promise<ParsedBlockResponse>;
 
   // eslint-disable-next-line no-dupe-class-members
   async getParsedBlock(


### PR DESCRIPTION
## Summary

Fixes #3773.

`getParsedBlock` with `transactionDetails: 'full'` (or omitted, since `'full'` is the Solana RPC default) incorrectly returns `ParsedAccountsModeBlockResponse`. It should return `ParsedBlockResponse`.

## Root Cause

The overload signatures were missing an explicit `transactionDetails: 'full'` case, and the default overload (no `transactionDetails` specified) was typed to return `ParsedAccountsModeBlockResponse` instead of `ParsedBlockResponse`. Since the Solana RPC defaults to `transactionDetails: 'full'`, the default overload should return full transaction data.

## Changes

- Default overload (no `transactionDetails`) → `ParsedBlockResponse`
- New explicit `transactionDetails: 'full'` overload → `ParsedBlockResponse`
- Existing `'accounts'` and `'none'` overloads unchanged

## Testing

No new tests needed — existing tests at `test/connection.test.ts:3776` already call `getParsedBlock` with `transactionDetails: 'full'` and verify it doesn't reject. TypeScript type-check passes with no new errors introduced.