### PR TITLE
fix: catch unhandled rejection in confirmTransaction status polling

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3988,7 +3988,7 @@ export class Connection {
               },
             });
           }
-        })();
+        })().catch(reject);
       } catch (err) {
         reject(err);
       }


### PR DESCRIPTION
## Summary

Closes #3787

When the RPC returns 429 (rate limited) during `confirmTransaction()`, the error crashes the Node.js process with an unhandled rejection instead of properly rejecting the Promise.

## Root cause

`connection.ts:3943-3991` — an async IIFE inside the `confirmationPromise` constructor polls `getSignatureStatus()`. The IIFE has no `.catch()` handler and is not awaited, so if `getSignatureStatus` rejects (e.g. 429 after retries exhausted), the rejection escapes the Promise boundary entirely.

```typescript
// Before: fire-and-forget — rejection crashes process
(async () => {
    await subscriptionSetupPromise;
    const response = await this.getSignatureStatus(signature); // can reject on 429
    // ...
})(); // ← no .catch()

// After: rejection routed to outer Promise's reject handler
})().catch(reject);
```

## Fix

1 line: add `.catch(reject)` to the IIFE. The `reject` function is already in scope from the `new Promise((resolve, reject) => { ... })` constructor. RPC errors from the polling path now surface as normal rejected Promises that callers can handle with try/catch or `.catch()`.

## Test plan

- [x] Error propagation path: 429 errors from `getSignatureStatus` now reject the `confirmTransaction` Promise instead of becoming unhandled rejections
- [x] Happy path unchanged: successful confirmations still resolve normally
- [x] Existing error paths unchanged: `value.err` rejections (line 3956) still work