### PR TITLE
fix: correct getParsedBlock return type for full transaction details

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4907,7 +4907,7 @@ export class Connection {
   async getParsedBlock(
     slot: number,
     rawConfig?: GetVersionedBlockConfig,
-  ): Promise<ParsedAccountsModeBlockResponse>;
+  ): Promise<ParsedBlockResponse>;
 
   // eslint-disable-next-line no-dupe-class-members
   async getParsedBlock(


### PR DESCRIPTION
## Summary

Closes #3773

`getParsedBlock()` returns `ParsedAccountsModeBlockResponse` when `transactionDetails` is `'full'` (or not specified). It should return `ParsedBlockResponse`.

## Root cause

The first overload signature at `connection.ts:4907-4910` is the default/catch-all that matches when `transactionDetails` is not `'accounts'` or `'none'`. It incorrectly returns `ParsedAccountsModeBlockResponse` instead of `ParsedBlockResponse`.

```typescript
// Before (wrong): default case returns accounts-mode type
async getParsedBlock(
  slot: number,
  rawConfig?: GetVersionedBlockConfig,
): Promise<ParsedAccountsModeBlockResponse>;  // ❌

// After (correct): default case returns full parsed block type
): Promise<ParsedBlockResponse>;  // ✓
```

## Why this is correct

- `ParsedBlockResponse` includes full `transactions` with `ParsedTransaction` (parsed instructions, account keys, etc.)
- `ParsedAccountsModeBlockResponse` is the reduced type for `transactionDetails: 'accounts'` only
- `getBlock()` follows this exact pattern — its default overload returns `VersionedBlockResponse`, not the accounts-mode variant

## Test plan

- [x] 1-line type fix, matches `getBlock()` overload pattern
- [x] TypeScript overload resolution now selects correct return type for `'full'`/default