### PR TITLE
fix: export ClientSubscriptionId type

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -90,7 +90,7 @@ interface IWSRequestParams {
   [x: number]: any;
 }
 
-type ClientSubscriptionId = number;
+export type ClientSubscriptionId = number;
 /** @internal */ type ServerSubscriptionId = number;
 /** @internal */ type SubscriptionConfigHash = string;
 /** @internal */ type SubscriptionDisposeFn = () => Promise<void>;


### PR DESCRIPTION
## Summary

Closes #3745

`ClientSubscriptionId` is used as a return type by subscription methods (e.g., `onAccountChange`, `onProgramAccountChange`) but was declared as a non-exported `type`, preventing consumers from typing variables that store subscription IDs.

## Fix

Add `export` keyword to the type declaration at `connection.ts:93`.

```typescript
// Before
type ClientSubscriptionId = number;

// After
export type ClientSubscriptionId = number;
```