### PR TITLE
fix: key length check in decodeMerge

### DIFF
--- a/src/programs/stake.ts
+++ b/src/programs/stake.ts
@@ -369,7 +369,7 @@ export class StakeInstruction {
    */
   static decodeMerge(instruction: TransactionInstruction): MergeStakeParams {
     this.checkProgramId(instruction.programId);
-    this.checkKeyLength(instruction.keys, 3);
+    this.checkKeyLength(instruction.keys, 5);
     decodeData(STAKE_INSTRUCTION_LAYOUTS.Merge, instruction.data);
 
     return {


### PR DESCRIPTION
Merge builds with 5 keys:
https://github.com/solana-foundation/solana-web3.js/blob/c85c8fd39ad0aa3b554db38d3a0113fed65b106e/src/programs/stake.ts#L884-L894

See also `instruction.keys[4].pubkey` access when throws when there are less than 5 keys

