### PR TITLE
fix: guardedSplice deleteCount guard when items are specified

### DIFF
--- a/src/utils/guarded-array-utils.ts
+++ b/src/utils/guarded-array-utils.ts
@@ -22,7 +22,7 @@ export function guardedSplice<T>(
 ): T[] {
   const [start] = args;
   if (
-    args.length === 2 // Implies that `deleteCount` was supplied
+    args.length >= 2 // Implies that `deleteCount` was supplied
       ? start + (args[1] ?? 0) > byteArray.length
       : start >= byteArray.length
   ) {


### PR DESCRIPTION
1. `guardedSplice` is documented to be guarded
2. `guardedSplice` is documented to support all of `guardedSplice(start)`, `guardedSplice(start, count)` and `guardedSplice(start, count, ...items)`

When items were specified, `count` guard was silently ignored as it performed a strict `args.length === 2` check