### PR TITLE
fix: correct getParsedBlock default overload return type

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4907,7 +4907,7 @@ export class Connection {
   async getParsedBlock(
     slot: number,
     rawConfig?: GetVersionedBlockConfig,
-  ): Promise<ParsedAccountsModeBlockResponse>;
+  ): Promise<ParsedBlockResponse | null>;
 
   // eslint-disable-next-line no-dupe-class-members
   async getParsedBlock(


### PR DESCRIPTION
## Problem

The first overload of `getParsedBlock()` (called without config or with default `transactionDetails`) incorrectly declared its return type as `ParsedAccountsModeBlockResponse`.

## Root Cause

The default overload at line 4907 was typed as:
```ts
async getParsedBlock(
    slot: number,
    rawConfig?: GetVersionedBlockConfig,
  ): Promise<ParsedAccountsModeBlockResponse>;
```

However, the actual implementation routes to `GetParsedBlockRpcResult` in the `default` switch case, which maps to `ParsedBlockResponse` — the full block with complete transaction details.

## Fix

Changed the first overload return type from `ParsedAccountsModeBlockResponse` to `ParsedBlockResponse | null`, matching the actual runtime behavior and aligning with the pattern used by `getBlock()` (non-parsed variant).

Fixes #3773