### PR TITLE
fix: use type-only import for JSONRPCError

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -27,7 +27,7 @@ import {
 } from 'superstruct';
 import type {Struct} from 'superstruct';
 import RpcClient from 'jayson/lib/client/browser';
-import {JSONRPCError} from 'jayson';
+import type {JSONRPCError} from 'jayson';
 
 import {EpochSchedule} from './epoch-schedule';
 import {SendTransactionError, SolanaJSONRPCError} from './errors';


### PR DESCRIPTION
## Summary
Switch `JSONRPCError` import in `src/connection.ts` to a type-only import.

## Why
This avoids loading the `jayson` runtime entry just for a type, which reduces unnecessary runtime dependency loading and helps with Node.js deprecation-noise scenarios reported in #3788.

## Changes
- `import {JSONRPCError} from 'jayson'`
- `import type {JSONRPCError} from 'jayson'`

## Validation
- `pnpm run test:typecheck`
- `pnpm run compile:js`

Closes #3788
