### PR TITLE
feat: support InstructionPlan inputs in Transaction.add and Message compilers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,7 @@ These notes summarize the user-facing changes that landed since 1.98.4.
 - The deprecated FeeCalculator surface was removed, including `FeeCalculator`, `getRecentBlockhash`, `getRecentBlockhashAndContext`, and `getFeeCalculatorForBlockhash`.
 - The legacy `Account` class was removed.
 - Deprecated BufferLayout-based internals and compatibility surfaces were removed in favor of codec-backed implementations.
+- `Transaction.add(...)` now narrows its inputs with `instanceof Transaction` and `instanceof TransactionInstruction` instead of the previous `'instructions' in item` / `'data' in item` duck-typing checks. Loose "Transaction-like" or "TransactionInstruction-like" objects that aren't real instances will no longer be accepted at runtime. Well-typed TypeScript callers are unaffected.
 
 ## API And Runtime Changes
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-terser": "^1.0.0",
+    "@solana-program/token": "^0.13.0",
     "@solana/addresses": "^6.8.0",
     "@solana/rpc-subscriptions-api": "^6.8.0",
     "@solana/rpc-types": "^6.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@rollup/plugin-terser':
         specifier: ^1.0.0
         version: 1.0.0(rollup@4.28.1)
+      '@solana-program/token':
+        specifier: ^0.13.0
+        version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/addresses':
         specifier: ^6.8.0
         version: 6.8.0(typescript@5.9.3)
@@ -877,51 +880,61 @@ packages:
     resolution: {integrity: sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.28.1':
     resolution: {integrity: sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.28.1':
     resolution: {integrity: sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.28.1':
     resolution: {integrity: sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.28.1':
     resolution: {integrity: sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.28.1':
     resolution: {integrity: sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.28.1':
     resolution: {integrity: sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.28.1':
     resolution: {integrity: sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.28.1':
     resolution: {integrity: sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.28.1':
     resolution: {integrity: sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.28.1':
     resolution: {integrity: sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==}
@@ -1026,6 +1039,11 @@ packages:
     resolution: {integrity: sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==}
     peerDependencies:
       '@solana/kit': ^6.1.0
+
+  '@solana-program/token@0.13.0':
+    resolution: {integrity: sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==}
+    peerDependencies:
+      '@solana/kit': ^6.5.0
 
   '@solana/accounts@6.8.0':
     resolution: {integrity: sha512-rXjFYVopaEw1H2PTBQbRjKr+0i4EFuBEhRT5E0dI4cMaabSb4KKypC2gaf47+6cjU3hMlM1AcsyIs72/MqAVBw==}
@@ -5441,6 +5459,11 @@ snapshots:
 
   '@solana-program/system@0.12.0(@solana/kit@6.8.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)
+
+  '@solana-program/token@0.13.0(@solana/kit@6.8.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana-program/system': 0.12.0(@solana/kit@6.8.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/kit': 6.8.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
   '@solana/accounts@6.8.0(typescript@5.9.3)':

--- a/src/kit-adapters/instruction-plan.ts
+++ b/src/kit-adapters/instruction-plan.ts
@@ -1,0 +1,35 @@
+import {
+  flattenInstructionPlan,
+  type Instruction as KitInstruction,
+  type InstructionPlan,
+  isInstructionPlan,
+  isSingleInstructionPlan,
+} from '@solana/kit';
+
+/**
+ * Flatten any `InstructionPlan` items in `items` into their underlying
+ * `Instruction`s, leaving non-plan items untouched. `MessagePackerInstructionPlan`
+ * leaves are rejected — they are designed to span multiple transactions and
+ * cannot be honored inside a single transaction / message.
+ */
+export function expandInstructionPlans<T>(
+  items: ReadonlyArray<T | InstructionPlan>,
+): Array<T | KitInstruction> {
+  const out: Array<T | KitInstruction> = [];
+  for (const item of items) {
+    if (isInstructionPlan(item)) {
+      for (const leaf of flattenInstructionPlan(item)) {
+        if (!isSingleInstructionPlan(leaf)) {
+          throw new Error(
+            `Unsupported InstructionPlan leaf kind "${leaf.kind}". ` +
+              `MessagePackerInstructionPlan cannot be honored inside a single transaction.`,
+          );
+        }
+        out.push(leaf.instruction);
+      }
+    } else {
+      out.push(item);
+    }
+  }
+  return out;
+}

--- a/src/kit-adapters/instruction-plan.ts
+++ b/src/kit-adapters/instruction-plan.ts
@@ -33,7 +33,7 @@ export function expandInstructionPlans<T>(
         if (!isSingleInstructionPlan(leaf)) {
           throw new Error(
             `Unsupported InstructionPlan leaf kind "${leaf.kind}". ` +
-              `MessagePackerInstructionPlan cannot be honored inside a single transaction.`,
+              `This plan type cannot be honored inside a single transaction.`,
           );
         }
         out.push(leaf.instruction);

--- a/src/kit-adapters/instruction-plan.ts
+++ b/src/kit-adapters/instruction-plan.ts
@@ -10,7 +10,7 @@ import type {TransactionInstruction} from '../transaction/legacy';
 
 /**
  * The canonical input shape accepted by message- and transaction-message-level
- * compilers. 
+ * compilers.
  */
 export type InstructionInput =
   | TransactionInstruction

--- a/src/kit-adapters/instruction-plan.ts
+++ b/src/kit-adapters/instruction-plan.ts
@@ -6,6 +6,17 @@ import {
   isSingleInstructionPlan,
 } from '@solana/kit';
 
+import type {TransactionInstruction} from '../transaction/legacy';
+
+/**
+ * The canonical input shape accepted by message- and transaction-message-level
+ * compilers. 
+ */
+export type InstructionInput =
+  | TransactionInstruction
+  | KitInstruction
+  | InstructionPlan;
+
 /**
  * Flatten any `InstructionPlan` items in `items` into their underlying
  * `Instruction`s, leaving non-plan items untouched. `MessagePackerInstructionPlan`

--- a/src/message/legacy.ts
+++ b/src/message/legacy.ts
@@ -8,6 +8,7 @@ import {
   type CompiledTransactionMessage,
   type CompiledTransactionMessageWithLifetime,
   type Instruction as KitInstruction,
+  type InstructionPlan,
 } from '@solana/kit';
 
 import {Address} from '../address';
@@ -18,6 +19,7 @@ import {
 } from './index';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
+import {expandInstructionPlans} from '../kit-adapters/instruction-plan';
 import type {TransactionInstruction} from '../transaction/legacy';
 import {CompiledKeys} from './compiled-keys';
 import {MessageAccountKeys} from './account-keys';
@@ -63,7 +65,9 @@ export type MessageArgs = {
 
 export type CompileLegacyArgs = {
   payerKey: Address;
-  instructions: Array<TransactionInstruction | KitInstruction>;
+  instructions: Array<
+    TransactionInstruction | KitInstruction | InstructionPlan
+  >;
   recentBlockhash: Blockhash;
 };
 
@@ -118,10 +122,11 @@ export class Message {
   }
 
   static compile(args: CompileLegacyArgs): Message {
-    const instructions = args.instructions.map(instruction =>
-      isKitInstruction(instruction)
-        ? toLegacyInstructionFields(instruction)
-        : instruction,
+    const instructions = expandInstructionPlans(args.instructions).map(
+      instruction =>
+        isKitInstruction(instruction)
+          ? toLegacyInstructionFields(instruction)
+          : instruction,
     );
     const compiledKeys = CompiledKeys.compile(instructions, args.payerKey);
     const [header, staticAccountKeys] = compiledKeys.getMessageComponents();

--- a/src/message/legacy.ts
+++ b/src/message/legacy.ts
@@ -7,8 +7,6 @@ import {
   type Blockhash,
   type CompiledTransactionMessage,
   type CompiledTransactionMessageWithLifetime,
-  type Instruction as KitInstruction,
-  type InstructionPlan,
 } from '@solana/kit';
 
 import {Address} from '../address';
@@ -19,8 +17,10 @@ import {
 } from './index';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
-import {expandInstructionPlans} from '../kit-adapters/instruction-plan';
-import type {TransactionInstruction} from '../transaction/legacy';
+import {
+  expandInstructionPlans,
+  type InstructionInput,
+} from '../kit-adapters/instruction-plan';
 import {CompiledKeys} from './compiled-keys';
 import {MessageAccountKeys} from './account-keys';
 import {toPackedUint8Array, toUint8ArrayView} from '../utils/typed-array';
@@ -65,9 +65,7 @@ export type MessageArgs = {
 
 export type CompileLegacyArgs = {
   payerKey: Address;
-  instructions: Array<
-    TransactionInstruction | KitInstruction | InstructionPlan
-  >;
+  instructions: Array<InstructionInput>;
   recentBlockhash: Blockhash;
 };
 

--- a/src/message/v0.ts
+++ b/src/message/v0.ts
@@ -5,8 +5,6 @@ import {
   type Blockhash,
   type CompiledTransactionMessage,
   type CompiledTransactionMessageWithLifetime,
-  type Instruction as KitInstruction,
-  type InstructionPlan,
 } from '@solana/kit';
 
 import {
@@ -17,10 +15,12 @@ import {
 import {Address} from '../address';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
-import {expandInstructionPlans} from '../kit-adapters/instruction-plan';
+import {
+  expandInstructionPlans,
+  type InstructionInput,
+} from '../kit-adapters/instruction-plan';
 import {toPackedUint8Array, toUint8ArrayView} from '../utils/typed-array';
 import {VERSION_PREFIX_MASK} from '../transaction/constants';
-import type {TransactionInstruction} from '../transaction/legacy';
 import {AddressLookupTableAccount} from '../programs';
 import {CompiledKeys} from './compiled-keys';
 import {AccountKeysFromLookups, MessageAccountKeys} from './account-keys';
@@ -49,9 +49,7 @@ export type MessageV0Args = {
 
 export type CompileV0Args = {
   payerKey: Address;
-  instructions: Array<
-    TransactionInstruction | KitInstruction | InstructionPlan
-  >;
+  instructions: Array<InstructionInput>;
   recentBlockhash: Blockhash;
   addressLookupTableAccounts?: Array<AddressLookupTableAccount>;
 };

--- a/src/message/v0.ts
+++ b/src/message/v0.ts
@@ -6,6 +6,7 @@ import {
   type CompiledTransactionMessage,
   type CompiledTransactionMessageWithLifetime,
   type Instruction as KitInstruction,
+  type InstructionPlan,
 } from '@solana/kit';
 
 import {
@@ -16,6 +17,7 @@ import {
 import {Address} from '../address';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
+import {expandInstructionPlans} from '../kit-adapters/instruction-plan';
 import {toPackedUint8Array, toUint8ArrayView} from '../utils/typed-array';
 import {VERSION_PREFIX_MASK} from '../transaction/constants';
 import type {TransactionInstruction} from '../transaction/legacy';
@@ -47,7 +49,9 @@ export type MessageV0Args = {
 
 export type CompileV0Args = {
   payerKey: Address;
-  instructions: Array<TransactionInstruction | KitInstruction>;
+  instructions: Array<
+    TransactionInstruction | KitInstruction | InstructionPlan
+  >;
   recentBlockhash: Blockhash;
   addressLookupTableAccounts?: Array<AddressLookupTableAccount>;
 };
@@ -197,10 +201,11 @@ export class MessageV0 {
   }
 
   static compile(args: CompileV0Args): MessageV0 {
-    const instructions = args.instructions.map(instruction =>
-      isKitInstruction(instruction)
-        ? toLegacyInstructionFields(instruction)
-        : instruction,
+    const instructions = expandInstructionPlans(args.instructions).map(
+      instruction =>
+        isKitInstruction(instruction)
+          ? toLegacyInstructionFields(instruction)
+          : instruction,
     );
     const compiledKeys = CompiledKeys.compile(instructions, args.payerKey);
 

--- a/src/transaction/legacy.ts
+++ b/src/transaction/legacy.ts
@@ -399,11 +399,12 @@ export class Transaction {
       Transaction | TransactionInstructionCtorFields | InstructionInput
     >
   ): Transaction {
-    if (items.length === 0) {
+    const expanded = expandInstructionPlans(items);
+    if (expanded.length === 0) {
       throw new Error('No instructions');
     }
 
-    expandInstructionPlans(items).forEach(item => {
+    expanded.forEach(item => {
       if (item instanceof Transaction) {
         this.instructions = this.instructions.concat(item.instructions);
       } else if (isKitInstruction(item)) {

--- a/src/transaction/legacy.ts
+++ b/src/transaction/legacy.ts
@@ -1,7 +1,6 @@
 import {
   type Blockhash,
   fixDecoderSize,
-  flattenInstructionPlan,
   getArrayDecoder,
   getBase58Codec,
   getBytesDecoder,
@@ -10,8 +9,6 @@ import {
   getStructDecoder,
   type Instruction as KitInstruction,
   type InstructionPlan,
-  isInstructionPlan,
-  isSingleInstructionPlan,
 } from '@solana/kit';
 
 import {PACKET_DATA_SIZE, SIGNATURE_LENGTH_IN_BYTES} from './constants';
@@ -20,6 +17,7 @@ import {Message} from '../message';
 import {Address} from '../address';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
+import {expandInstructionPlans} from '../kit-adapters/instruction-plan';
 import invariant from '../utils/assert';
 import type {Signer} from '../keypair';
 import type {CompiledInstruction} from '../message';
@@ -408,28 +406,14 @@ export class Transaction {
       throw new Error('No instructions');
     }
 
-    const pushKitInstruction = (ix: KitInstruction) => {
-      this.instructions.push(
-        new TransactionInstruction(toLegacyInstructionFields(ix)),
-      );
-    };
-
-    items.forEach((item: any) => {
-      if (isInstructionPlan(item)) {
-        for (const leaf of flattenInstructionPlan(item)) {
-          if (!isSingleInstructionPlan(leaf)) {
-            throw new Error(
-              `Transaction.add: unsupported InstructionPlan leaf kind "${leaf.kind}". ` +
-                `MessagePackerInstructionPlan cannot be honored inside a single legacy Transaction.`,
-            );
-          }
-          pushKitInstruction(leaf.instruction);
-        }
-      } else if ('instructions' in item) {
+    expandInstructionPlans(items).forEach(item => {
+      if (item instanceof Transaction) {
         this.instructions = this.instructions.concat(item.instructions);
       } else if (isKitInstruction(item)) {
-        pushKitInstruction(item);
-      } else if ('data' in item && 'programId' in item && 'keys' in item) {
+        this.instructions.push(
+          new TransactionInstruction(toLegacyInstructionFields(item)),
+        );
+      } else if (item instanceof TransactionInstruction) {
         this.instructions.push(item);
       } else {
         this.instructions.push(new TransactionInstruction(item));

--- a/src/transaction/legacy.ts
+++ b/src/transaction/legacy.ts
@@ -1,6 +1,7 @@
 import {
   type Blockhash,
   fixDecoderSize,
+  flattenInstructionPlan,
   getArrayDecoder,
   getBase58Codec,
   getBytesDecoder,
@@ -8,6 +9,9 @@ import {
   getShortU16Encoder,
   getStructDecoder,
   type Instruction as KitInstruction,
+  type InstructionPlan,
+  isInstructionPlan,
+  isSingleInstructionPlan,
 } from '@solana/kit';
 
 import {PACKET_DATA_SIZE, SIGNATURE_LENGTH_IN_BYTES} from './constants';
@@ -381,9 +385,15 @@ export class Transaction {
   }
 
   /**
-   * Add one or more instructions to this Transaction
+   * Add one or more instructions to this Transaction.
    *
-   * @param {Array< Transaction | TransactionInstruction | TransactionInstructionCtorFields | KitInstruction >} items - Instructions to add to the Transaction
+   * `InstructionPlan` inputs are flattened in order and each leaf instruction
+   * is appended. Parallel sub-trees collapse to sequential order in the
+   * single-transaction context. `MessagePackerInstructionPlan` leaves are
+   * rejected at runtime — they are designed to span multiple transactions and
+   * cannot be honored inside a single legacy `Transaction`.
+   *
+   * @param {Array< Transaction | TransactionInstruction | TransactionInstructionCtorFields | KitInstruction | InstructionPlan >} items - Instructions or plans to add to the Transaction
    */
   add(
     ...items: Array<
@@ -391,19 +401,34 @@ export class Transaction {
       | TransactionInstruction
       | TransactionInstructionCtorFields
       | KitInstruction
+      | InstructionPlan
     >
   ): Transaction {
     if (items.length === 0) {
       throw new Error('No instructions');
     }
 
+    const pushKitInstruction = (ix: KitInstruction) => {
+      this.instructions.push(
+        new TransactionInstruction(toLegacyInstructionFields(ix)),
+      );
+    };
+
     items.forEach((item: any) => {
-      if ('instructions' in item) {
+      if (isInstructionPlan(item)) {
+        for (const leaf of flattenInstructionPlan(item)) {
+          if (!isSingleInstructionPlan(leaf)) {
+            throw new Error(
+              `Transaction.add: unsupported InstructionPlan leaf kind "${leaf.kind}". ` +
+                `MessagePackerInstructionPlan cannot be honored inside a single legacy Transaction.`,
+            );
+          }
+          pushKitInstruction(leaf.instruction);
+        }
+      } else if ('instructions' in item) {
         this.instructions = this.instructions.concat(item.instructions);
       } else if (isKitInstruction(item)) {
-        this.instructions.push(
-          new TransactionInstruction(toLegacyInstructionFields(item)),
-        );
+        pushKitInstruction(item);
       } else if ('data' in item && 'programId' in item && 'keys' in item) {
         this.instructions.push(item);
       } else {

--- a/src/transaction/legacy.ts
+++ b/src/transaction/legacy.ts
@@ -7,8 +7,6 @@ import {
   getShortU16Decoder,
   getShortU16Encoder,
   getStructDecoder,
-  type Instruction as KitInstruction,
-  type InstructionPlan,
 } from '@solana/kit';
 
 import {PACKET_DATA_SIZE, SIGNATURE_LENGTH_IN_BYTES} from './constants';
@@ -17,7 +15,10 @@ import {Message} from '../message';
 import {Address} from '../address';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
-import {expandInstructionPlans} from '../kit-adapters/instruction-plan';
+import {
+  expandInstructionPlans,
+  type InstructionInput,
+} from '../kit-adapters/instruction-plan';
 import invariant from '../utils/assert';
 import type {Signer} from '../keypair';
 import type {CompiledInstruction} from '../message';
@@ -391,15 +392,11 @@ export class Transaction {
    * rejected at runtime — they are designed to span multiple transactions and
    * cannot be honored inside a single legacy `Transaction`.
    *
-   * @param {Array< Transaction | TransactionInstruction | TransactionInstructionCtorFields | KitInstruction | InstructionPlan >} items - Instructions or plans to add to the Transaction
+   * @param {Array< Transaction | TransactionInstructionCtorFields | InstructionInput >} items - Instructions or plans to add to the Transaction
    */
   add(
     ...items: Array<
-      | Transaction
-      | TransactionInstruction
-      | TransactionInstructionCtorFields
-      | KitInstruction
-      | InstructionPlan
+      Transaction | TransactionInstructionCtorFields | InstructionInput
     >
   ): Transaction {
     if (items.length === 0) {

--- a/src/transaction/message.ts
+++ b/src/transaction/message.ts
@@ -1,7 +1,12 @@
-import type {Blockhash, Instruction as KitInstruction} from '@solana/kit';
+import type {
+  Blockhash,
+  Instruction as KitInstruction,
+  InstructionPlan,
+} from '@solana/kit';
 
 import {fromKitInstruction} from '../kit-adapters/instruction';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
+import {expandInstructionPlans} from '../kit-adapters/instruction-plan';
 import {AccountKeysFromLookups} from '../message/account-keys';
 import assert from '../utils/assert';
 import {Message, MessageV0, VersionedMessage} from '../message';
@@ -11,7 +16,9 @@ import {type AccountMeta, TransactionInstruction} from './legacy';
 
 export type TransactionMessageArgs = {
   payerKey: Address;
-  instructions: Array<TransactionInstruction | KitInstruction>;
+  instructions: Array<
+    TransactionInstruction | KitInstruction | InstructionPlan
+  >;
   recentBlockhash: Blockhash;
 };
 
@@ -30,10 +37,11 @@ export class TransactionMessage {
 
   constructor(args: TransactionMessageArgs) {
     this.payerKey = args.payerKey;
-    this.instructions = args.instructions.map(instruction =>
-      isKitInstruction(instruction)
-        ? fromKitInstruction(instruction)
-        : instruction,
+    this.instructions = expandInstructionPlans(args.instructions).map(
+      instruction =>
+        isKitInstruction(instruction)
+          ? fromKitInstruction(instruction)
+          : instruction,
     );
     this.recentBlockhash = args.recentBlockhash;
   }

--- a/src/transaction/message.ts
+++ b/src/transaction/message.ts
@@ -1,12 +1,11 @@
-import type {
-  Blockhash,
-  Instruction as KitInstruction,
-  InstructionPlan,
-} from '@solana/kit';
+import type {Blockhash} from '@solana/kit';
 
 import {fromKitInstruction} from '../kit-adapters/instruction';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
-import {expandInstructionPlans} from '../kit-adapters/instruction-plan';
+import {
+  expandInstructionPlans,
+  type InstructionInput,
+} from '../kit-adapters/instruction-plan';
 import {AccountKeysFromLookups} from '../message/account-keys';
 import assert from '../utils/assert';
 import {Message, MessageV0, VersionedMessage} from '../message';
@@ -16,9 +15,7 @@ import {type AccountMeta, TransactionInstruction} from './legacy';
 
 export type TransactionMessageArgs = {
   payerKey: Address;
-  instructions: Array<
-    TransactionInstruction | KitInstruction | InstructionPlan
-  >;
+  instructions: Array<InstructionInput>;
   recentBlockhash: Blockhash;
 };
 

--- a/test/message-tests/legacy.test.ts
+++ b/test/message-tests/legacy.test.ts
@@ -2,6 +2,8 @@ import {
   AccountRole,
   blockhash,
   getBase58Decoder,
+  getMessagePackerInstructionPlanFromInstructions,
+  sequentialInstructionPlan,
   type Instruction as KitInstruction,
 } from '@solana/kit';
 import {expect} from 'chai';
@@ -143,6 +145,51 @@ describe('Message', () => {
     expect(messageFromKitInstruction.instructions[0].data).to.eql(
       BASE58_DECODER.decode(new Uint8Array(1)),
     );
+  });
+
+  it('compiles with an InstructionPlan input', () => {
+    const keys = createTestKeys(5);
+    const payerKey = keys[0];
+    const kitIx = (data: number): KitInstruction => ({
+      accounts: [
+        {address: keys[1].toBase58(), role: AccountRole.WRITABLE_SIGNER},
+      ],
+      data: new Uint8Array([data]),
+      programAddress: keys[4].toBase58(),
+    });
+
+    const fromPlan = Message.compile({
+      instructions: [sequentialInstructionPlan([kitIx(1), kitIx(2)])],
+      payerKey,
+      recentBlockhash: TEST_RECENT_BLOCKHASH,
+    });
+    const fromFlat = Message.compile({
+      instructions: [kitIx(1), kitIx(2)],
+      payerKey,
+      recentBlockhash: TEST_RECENT_BLOCKHASH,
+    });
+
+    expect(fromPlan.serialize()).to.deep.equal(fromFlat.serialize());
+  });
+
+  it('throws when compiling a plan containing a MessagePackerInstructionPlan leaf', () => {
+    const keys = createTestKeys(5);
+    const payerKey = keys[0];
+    const packer = getMessagePackerInstructionPlanFromInstructions([
+      {
+        accounts: [],
+        data: new Uint8Array([0]),
+        programAddress: keys[4].toBase58(),
+      },
+    ]);
+
+    expect(() =>
+      Message.compile({
+        instructions: [packer],
+        payerKey,
+        recentBlockhash: TEST_RECENT_BLOCKHASH,
+      }),
+    ).to.throw(/Unsupported InstructionPlan leaf kind/);
   });
 
   it('serializes to a Uint8Array result', () => {

--- a/test/message-tests/v0.test.ts
+++ b/test/message-tests/v0.test.ts
@@ -1,6 +1,8 @@
 import {
   AccountRole,
   blockhash,
+  getMessagePackerInstructionPlanFromInstructions,
+  sequentialInstructionPlan,
   type Instruction as KitInstruction,
 } from '@solana/kit';
 import {expect} from 'chai';
@@ -304,6 +306,55 @@ describe('MessageV0', () => {
     expect(messageFromKitInstruction.serialize()).to.deep.equal(
       messageFromLegacyInstruction.serialize(),
     );
+  });
+
+  it('compiles with an InstructionPlan input', () => {
+    const keys = createTestKeys(7);
+    const payerKey = keys[0];
+    const lookupTable = createTestLookupTable(keys);
+    const kitIx = (data: number): KitInstruction => ({
+      accounts: [
+        {address: keys[1].toBase58(), role: AccountRole.WRITABLE_SIGNER},
+        {address: keys[5].toBase58(), role: AccountRole.WRITABLE},
+      ],
+      data: new Uint8Array([data]),
+      programAddress: keys[3].toBase58(),
+    });
+
+    const fromPlan = MessageV0.compile({
+      addressLookupTableAccounts: [lookupTable],
+      instructions: [sequentialInstructionPlan([kitIx(1), kitIx(2)])],
+      payerKey,
+      recentBlockhash: TEST_RECENT_BLOCKHASH,
+    });
+    const fromFlat = MessageV0.compile({
+      addressLookupTableAccounts: [lookupTable],
+      instructions: [kitIx(1), kitIx(2)],
+      payerKey,
+      recentBlockhash: TEST_RECENT_BLOCKHASH,
+    });
+
+    expect(fromPlan.serialize()).to.deep.equal(fromFlat.serialize());
+  });
+
+  it('throws when compiling a plan containing a MessagePackerInstructionPlan leaf', () => {
+    const keys = createTestKeys(7);
+    const payerKey = keys[0];
+    const packer = getMessagePackerInstructionPlanFromInstructions([
+      {
+        accounts: [],
+        data: new Uint8Array([0]),
+        programAddress: keys[3].toBase58(),
+      },
+    ]);
+
+    expect(() =>
+      MessageV0.compile({
+        instructions: [packer],
+        payerKey,
+        recentBlockhash: TEST_RECENT_BLOCKHASH,
+      }),
+    ).to.throw(/Unsupported InstructionPlan leaf kind/);
   });
 
   it('serialize and deserialize', () => {

--- a/test/transaction-tests/message.test.ts
+++ b/test/transaction-tests/message.test.ts
@@ -1,6 +1,8 @@
 import {
   AccountRole,
   blockhash,
+  getMessagePackerInstructionPlanFromInstructions,
+  sequentialInstructionPlan,
   type Instruction as KitInstruction,
 } from '@solana/kit';
 import {expect} from 'chai';
@@ -236,5 +238,53 @@ describe('TransactionMessage', () => {
         addressLookupTableAccounts,
       }).serialize(),
     );
+  });
+
+  it('accepts an InstructionPlan in the constructor', () => {
+    const keys = createTestKeys(5);
+    const payerKey = keys[0];
+    const kitIx = (data: number): KitInstruction => ({
+      accounts: [
+        {address: keys[1].toBase58(), role: AccountRole.WRITABLE_SIGNER},
+      ],
+      data: new Uint8Array([data]),
+      programAddress: keys[4].toBase58(),
+    });
+
+    const fromPlan = new TransactionMessage({
+      instructions: [sequentialInstructionPlan([kitIx(1), kitIx(2)])],
+      payerKey,
+      recentBlockhash: TEST_RECENT_BLOCKHASH,
+    });
+    const fromFlat = new TransactionMessage({
+      instructions: [kitIx(1), kitIx(2)],
+      payerKey,
+      recentBlockhash: TEST_RECENT_BLOCKHASH,
+    });
+
+    expect(fromPlan.compileToLegacyMessage().serialize()).to.deep.equal(
+      fromFlat.compileToLegacyMessage().serialize(),
+    );
+  });
+
+  it('throws when constructed with a MessagePackerInstructionPlan input', () => {
+    const keys = createTestKeys(5);
+    const payerKey = keys[0];
+    const packer = getMessagePackerInstructionPlanFromInstructions([
+      {
+        accounts: [],
+        data: new Uint8Array([0]),
+        programAddress: keys[4].toBase58(),
+      },
+    ]);
+
+    expect(
+      () =>
+        new TransactionMessage({
+          instructions: [packer],
+          payerKey,
+          recentBlockhash: TEST_RECENT_BLOCKHASH,
+        }),
+    ).to.throw(/Unsupported InstructionPlan leaf kind/);
   });
 });

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -1653,7 +1653,7 @@ describe('VersionedTransaction', () => {
       ]);
 
       expect(() => new Transaction().add(packer)).to.throw(
-        /unsupported InstructionPlan leaf kind/,
+        /Unsupported InstructionPlan leaf kind/,
       );
     });
   });

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -1,8 +1,13 @@
 import {
+  AccountRole,
   blockhash,
   getBase58Decoder,
   getBlockhashDecoder,
+  getMessagePackerInstructionPlanFromInstructions,
+  sequentialInstructionPlan,
+  singleInstructionPlan,
   type Blockhash,
+  type Instruction as KitInstruction,
 } from '@solana/kit';
 import {expect} from 'chai';
 
@@ -1474,6 +1479,181 @@ describe('VersionedTransaction', () => {
         transaction.addSignature(signer3.publicKey, new Uint8Array(64));
       }).to.throw(
         `Can not add signature; \`${signer3.publicKey.toBase58()}\` is not required to sign this transaction`,
+      );
+    });
+  });
+
+  describe('add(InstructionPlan)', () => {
+    const makeKitIx = (
+      programAddress: Address,
+      payload: number,
+    ): KitInstruction => ({
+      accounts: [],
+      data: new Uint8Array([payload]),
+      programAddress: programAddress.toBase58(),
+    });
+
+    it('flattens a SingleInstructionPlan into one instruction', () => {
+      const programId = getUniqueAddress();
+      const tx = new Transaction().add(
+        singleInstructionPlan(makeKitIx(programId, 7)),
+      );
+
+      expect(tx.instructions).to.have.length(1);
+      expect(tx.instructions[0].programId.toBase58()).to.eq(
+        programId.toBase58(),
+      );
+      expect(tx.instructions[0].data).to.eql(new Uint8Array([7]));
+    });
+
+    it('flattens a SequentialInstructionPlan preserving order', () => {
+      const programA = getUniqueAddress();
+      const programB = getUniqueAddress();
+      const tx = new Transaction().add(
+        sequentialInstructionPlan([
+          makeKitIx(programA, 1),
+          makeKitIx(programB, 2),
+        ]),
+      );
+
+      expect(tx.instructions).to.have.length(2);
+      expect(tx.instructions[0].programId.toBase58()).to.eq(
+        programA.toBase58(),
+      );
+      expect(tx.instructions[0].data).to.eql(new Uint8Array([1]));
+      expect(tx.instructions[1].programId.toBase58()).to.eq(
+        programB.toBase58(),
+      );
+      expect(tx.instructions[1].data).to.eql(new Uint8Array([2]));
+    });
+
+    it('flattens nested sequential plans', () => {
+      const [a, b, c] = [
+        getUniqueAddress(),
+        getUniqueAddress(),
+        getUniqueAddress(),
+      ];
+      const tx = new Transaction().add(
+        sequentialInstructionPlan([
+          makeKitIx(a, 1),
+          sequentialInstructionPlan([makeKitIx(b, 2), makeKitIx(c, 3)]),
+        ]),
+      );
+      expect(tx.instructions.map(ix => ix.programId.toBase58())).to.eql([
+        a.toBase58(),
+        b.toBase58(),
+        c.toBase58(),
+      ]);
+      expect(tx.instructions.map(ix => ix.data[0])).to.eql([1, 2, 3]);
+    });
+
+    it('maps Kit AccountRole onto legacy isSigner/isWritable', () => {
+      const programId = getUniqueAddress();
+      const writableSigner = getUniqueAddress();
+      const readonlySigner = getUniqueAddress();
+      const writable = getUniqueAddress();
+      const readonly = getUniqueAddress();
+      const ix: KitInstruction = {
+        accounts: [
+          {
+            address: writableSigner.toBase58(),
+            role: AccountRole.WRITABLE_SIGNER,
+          },
+          {
+            address: readonlySigner.toBase58(),
+            role: AccountRole.READONLY_SIGNER,
+          },
+          {address: writable.toBase58(), role: AccountRole.WRITABLE},
+          {address: readonly.toBase58(), role: AccountRole.READONLY},
+        ],
+        data: new Uint8Array([0]),
+        programAddress: programId.toBase58(),
+      };
+
+      const tx = new Transaction().add(singleInstructionPlan(ix));
+
+      const [k0, k1, k2, k3] = tx.instructions[0].keys;
+      expect(k0).to.deep.include({isSigner: true, isWritable: true});
+      expect(k1).to.deep.include({isSigner: true, isWritable: false});
+      expect(k2).to.deep.include({isSigner: false, isWritable: true});
+      expect(k3).to.deep.include({isSigner: false, isWritable: false});
+    });
+
+    it('mixes InstructionPlan inputs with other accepted inputs in a single call', () => {
+      const programId = getUniqueAddress();
+      const legacyIx = new TransactionInstruction({
+        keys: [],
+        programId,
+        data: Buffer.from([9]),
+      });
+
+      const tx = new Transaction().add(
+        legacyIx,
+        sequentialInstructionPlan([makeKitIx(programId, 1)]),
+        makeKitIx(programId, 2),
+      );
+
+      expect(tx.instructions.map(ix => ix.data[0])).to.eql([9, 1, 2]);
+    });
+
+    it('flattens a real codama-client plan (getCreateMintInstructionPlan)', async () => {
+      const {TOKEN_PROGRAM_ADDRESS, getCreateMintInstructionPlan} =
+        await import('@solana-program/token');
+      const {createNoopSigner, address: kitAddress} = await import(
+        '@solana/kit'
+      );
+
+      const payer = createNoopSigner(
+        kitAddress((await generateKeypair()).address.toBase58()),
+      );
+      const newMint = createNoopSigner(
+        kitAddress((await generateKeypair()).address.toBase58()),
+      );
+
+      const tx = new Transaction().add(
+        getCreateMintInstructionPlan({
+          decimals: 6,
+          mintAccountLamports: 1461600,
+          mintAuthority: payer.address,
+          newMint,
+          payer,
+        }),
+      );
+
+      expect(tx.instructions).to.have.length(2);
+
+      const [createAccount, initMint] = tx.instructions;
+      expect(createAccount.programId.toBase58()).to.eq(
+        SystemProgram.programId.toBase58(),
+      );
+      expect(createAccount.keys.map(k => k.pubkey.toBase58())).to.eql([
+        payer.address.toString(),
+        newMint.address.toString(),
+      ]);
+      // Both accounts are WRITABLE_SIGNER in createAccount.
+      expect(createAccount.keys.every(k => k.isSigner && k.isWritable)).to.be
+        .true;
+
+      expect(initMint.programId.toBase58()).to.eq(TOKEN_PROGRAM_ADDRESS);
+      expect(initMint.keys).to.have.length(1);
+      expect(initMint.keys[0].pubkey.toBase58()).to.eq(
+        newMint.address.toString(),
+      );
+      expect(initMint.keys[0]).to.deep.include({
+        isSigner: false,
+        isWritable: true,
+      });
+    });
+
+    it('throws when the plan resolves to a MessagePackerInstructionPlan leaf', () => {
+      const programId = getUniqueAddress();
+      const packer = getMessagePackerInstructionPlanFromInstructions([
+        makeKitIx(programId, 1),
+        makeKitIx(programId, 2),
+      ]);
+
+      expect(() => new Transaction().add(packer)).to.throw(
+        /unsupported InstructionPlan leaf kind/,
       );
     });
   });

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -1645,6 +1645,12 @@ describe('VersionedTransaction', () => {
       });
     });
 
+    it('throws "No instructions" when every input is an empty plan', () => {
+      expect(() =>
+        new Transaction().add(sequentialInstructionPlan([])),
+      ).to.throw('No instructions');
+    });
+
     it('throws when the plan resolves to a MessagePackerInstructionPlan leaf', () => {
       const programId = getUniqueAddress();
       const packer = getMessagePackerInstructionPlanFromInstructions([


### PR DESCRIPTION
## Summary
- `Transaction.add()`, `Message.compile()`, `MessageV0.compile()`, and the `TransactionMessage` constructor all now accept `@solana/kit` `InstructionPlan` inputs in addition to legacy/`Kit` instructions.
- Plans are flattened in order via kit's `flattenInstructionPlan`; `MessagePackerInstructionPlan` leaves are rejected (cannot be honored inside a single transaction/message).
- Shared helper `expandInstructionPlans()` and shared `InstructionInput` type live in `src/kit-adapters/instruction-plan.ts` and are used by all four entry points.
- `Transaction.add()` body cleaned up: duck-typed `any` branches replaced with `instanceof Transaction` / `instanceof TransactionInstruction`.

This lets callers pass codama-client plan builders (e.g. `getCreateMintInstructionPlan` from `@solana-program/token`) directly into any of the entry points:

```ts
import { getCreateMintInstructionPlan } from '@solana-program/token';

const tx = new Transaction().add(
  getCreateMintInstructionPlan({
    decimals: 6,
    mintAuthority: payer.address,
    newMint,
    payer,
  }),
);
```

## Test plan
- [x] `pnpm test:typecheck`
- [x] `pnpm test:lint`
- [x] `pnpm test:prettier`
- [x] `pnpm test:unit` — 793 passing (7 new tests across `Transaction.add`, `Message.compile`, `MessageV0.compile`, `TransactionMessage`, plus a real-builder test using `@solana-program/token`'s `getCreateMintInstructionPlan`)