### PR TITLE
refactor(message): use kit codecs instead of hand-rolled decoders

### DIFF
--- a/src/message/legacy.ts
+++ b/src/message/legacy.ts
@@ -1,26 +1,16 @@
 import {
-  fixDecoderSize,
-  fixEncoderSize,
-  getBlockhashDecoder,
-  getBlockhashEncoder,
-  getArrayDecoder,
-  getArrayEncoder,
   getBase58Decoder,
   getBase58Encoder,
-  getBytesDecoder,
-  getBytesEncoder,
-  getShortU16Decoder,
-  getShortU16Encoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getCompiledTransactionMessageDecoder,
+  getCompiledTransactionMessageEncoder,
+  type Address as KitAddress,
   type Blockhash,
+  type CompiledTransactionMessage,
+  type CompiledTransactionMessageWithLifetime,
   type Instruction as KitInstruction,
 } from '@solana/kit';
 
-import {Address, PUBLIC_KEY_LENGTH} from '../address';
-import {PACKET_DATA_SIZE, VERSION_PREFIX_MASK} from '../transaction/constants';
+import {Address} from '../address';
 import {
   MessageHeader,
   MessageAddressTableLookup,
@@ -33,34 +23,13 @@ import {CompiledKeys} from './compiled-keys';
 import {MessageAccountKeys} from './account-keys';
 import {toPackedUint8Array, toUint8ArrayView} from '../utils/typed-array';
 
-const SHORT_U16_ENCODER = getShortU16Encoder();
-const SHORT_U16_DECODER = getShortU16Decoder();
-const U8_DECODER = getU8Decoder();
-const U8_ENCODER = getU8Encoder();
 const BASE58_ENCODER = getBase58Encoder();
 const BASE58_DECODER = getBase58Decoder();
-const BLOCKHASH_ENCODER = getBlockhashEncoder();
-const BLOCKHASH_DECODER = getBlockhashDecoder();
-const PUBLIC_KEY_DECODER = fixDecoderSize(getBytesDecoder(), PUBLIC_KEY_LENGTH);
-const COMPILED_INSTRUCTION_DECODER = getStructDecoder([
-  ['programIdIndex', U8_DECODER],
-  ['accounts', getArrayDecoder(U8_DECODER, {size: SHORT_U16_DECODER})],
-  ['data', getArrayDecoder(U8_DECODER, {size: SHORT_U16_DECODER})],
-]);
-const MESSAGE_DECODER = getStructDecoder([
-  ['numRequiredSignatures', U8_DECODER],
-  ['numReadonlySignedAccounts', U8_DECODER],
-  ['numReadonlyUnsignedAccounts', U8_DECODER],
-  [
-    'accountKeys',
-    getArrayDecoder(PUBLIC_KEY_DECODER, {size: SHORT_U16_DECODER}),
-  ],
-  ['recentBlockhash', PUBLIC_KEY_DECODER],
-  [
-    'instructions',
-    getArrayDecoder(COMPILED_INSTRUCTION_DECODER, {size: SHORT_U16_DECODER}),
-  ],
-]);
+const MESSAGE_ENCODER = getCompiledTransactionMessageEncoder();
+const MESSAGE_DECODER = getCompiledTransactionMessageDecoder();
+
+type LegacyCompiled = Extract<CompiledTransactionMessage, {version: 'legacy'}> &
+  CompiledTransactionMessageWithLifetime;
 
 /**
  * An instruction to execute by a program
@@ -206,131 +175,53 @@ export class Message {
   }
 
   serialize(): Uint8Array {
-    const numKeys = this.accountKeys.length;
-    const keyCount = SHORT_U16_ENCODER.encode(numKeys);
-
-    const instructions = this.instructions.map(instruction => {
-      const {accounts, programIdIndex} = instruction;
-      const data = Array.from(BASE58_ENCODER.encode(instruction.data));
-
-      return {
-        programIdIndex,
-        keyIndicesCount: SHORT_U16_ENCODER.encode(accounts.length),
-        keyIndices: accounts,
-        dataLength: SHORT_U16_ENCODER.encode(data.length),
-        data,
-      };
+    const encoded = MESSAGE_ENCODER.encode({
+      version: 'legacy',
+      header: {
+        numSignerAccounts: this.header.numRequiredSignatures,
+        numReadonlySignerAccounts: this.header.numReadonlySignedAccounts,
+        numReadonlyNonSignerAccounts: this.header.numReadonlyUnsignedAccounts,
+      },
+      staticAccounts: this.accountKeys.map(key => key.toBase58() as KitAddress),
+      lifetimeToken: this.recentBlockhash,
+      instructions: this.instructions.map(ix => ({
+        programAddressIndex: ix.programIdIndex,
+        accountIndices: ix.accounts,
+        data: Uint8Array.from(BASE58_ENCODER.encode(ix.data)),
+      })),
     });
+    return toPackedUint8Array(encoded);
+  }
 
-    const instructionBuffer = new Uint8Array(PACKET_DATA_SIZE);
-    const instructionCount = SHORT_U16_ENCODER.encode(instructions.length);
-    instructionBuffer.set(instructionCount, 0);
-    let instructionBufferLength = instructionCount.length;
-
-    instructions.forEach(instruction => {
-      const instructionLayout = getStructEncoder([
-        ['programIdIndex', U8_ENCODER],
-        [
-          'keyIndicesCount',
-          fixEncoderSize(getBytesEncoder(), instruction.keyIndicesCount.length),
-        ],
-        [
-          'keyIndices',
-          getArrayEncoder(U8_ENCODER, {size: instruction.keyIndices.length}),
-        ],
-        [
-          'dataLength',
-          fixEncoderSize(getBytesEncoder(), instruction.dataLength.length),
-        ],
-        ['data', getArrayEncoder(U8_ENCODER, {size: instruction.data.length})],
-      ]);
-      const encodedInstruction = instructionLayout.encode(instruction);
-      instructionBuffer.set(encodedInstruction, instructionBufferLength);
-      instructionBufferLength += encodedInstruction.length;
+  /** @internal Construct a {@link Message} from a kit-decoded compiled message. */
+  static fromCompiledMessage(decoded: LegacyCompiled): Message {
+    return new Message({
+      header: {
+        numRequiredSignatures: decoded.header.numSignerAccounts,
+        numReadonlySignedAccounts: decoded.header.numReadonlySignerAccounts,
+        numReadonlyUnsignedAccounts:
+          decoded.header.numReadonlyNonSignerAccounts,
+      },
+      accountKeys: decoded.staticAccounts.map(addr => new Address(addr)),
+      recentBlockhash: decoded.lifetimeToken as Blockhash,
+      instructions: decoded.instructions.map(ix => ({
+        programIdIndex: ix.programAddressIndex,
+        accounts: [...(ix.accountIndices ?? [])],
+        data: BASE58_DECODER.decode(ix.data ?? new Uint8Array(0)),
+      })),
     });
-
-    const instructionData = instructionBuffer.subarray(
-      0,
-      instructionBufferLength,
-    );
-
-    const signDataLayout = getStructEncoder([
-      ['numRequiredSignatures', fixEncoderSize(getBytesEncoder(), 1)],
-      ['numReadonlySignedAccounts', fixEncoderSize(getBytesEncoder(), 1)],
-      ['numReadonlyUnsignedAccounts', fixEncoderSize(getBytesEncoder(), 1)],
-      ['keyCount', fixEncoderSize(getBytesEncoder(), keyCount.length)],
-      [
-        'keys',
-        getArrayEncoder(fixEncoderSize(getBytesEncoder(), PUBLIC_KEY_LENGTH), {
-          size: numKeys,
-        }),
-      ],
-      ['recentBlockhash', fixEncoderSize(getBytesEncoder(), PUBLIC_KEY_LENGTH)],
-    ]);
-
-    const transaction = {
-      numRequiredSignatures: Uint8Array.from([
-        this.header.numRequiredSignatures,
-      ]),
-      numReadonlySignedAccounts: Uint8Array.from([
-        this.header.numReadonlySignedAccounts,
-      ]),
-      numReadonlyUnsignedAccounts: Uint8Array.from([
-        this.header.numReadonlyUnsignedAccounts,
-      ]),
-      keyCount,
-      keys: this.accountKeys.map(key => key.toBytes()),
-      recentBlockhash: BLOCKHASH_ENCODER.encode(this.recentBlockhash),
-    };
-
-    const signData = new Uint8Array(2048);
-    const encodedSignData = signDataLayout.encode(transaction);
-    signData.set(encodedSignData, 0);
-    const length = encodedSignData.length;
-    signData.set(instructionData, length);
-    return toPackedUint8Array(
-      signData.subarray(0, length + instructionData.length),
-    );
   }
 
   /**
    * Decode a compiled message into a Message object.
    */
   static from(buffer: Uint8Array | Array<number>): Message {
-    const decodedMessage = MESSAGE_DECODER.decode(toUint8ArrayView(buffer));
-
-    const numRequiredSignatures = decodedMessage.numRequiredSignatures;
-    if (
-      numRequiredSignatures !==
-      (numRequiredSignatures & VERSION_PREFIX_MASK)
-    ) {
+    const decoded = MESSAGE_DECODER.decode(toUint8ArrayView(buffer));
+    if (decoded.version !== 'legacy') {
       throw new Error(
         'Versioned messages must be deserialized with VersionedMessage.deserialize()',
       );
     }
-
-    const accountKeys = decodedMessage.accountKeys.map(
-      account => new Address(account),
-    );
-    const instructions: CompiledInstruction[] = decodedMessage.instructions.map(
-      instruction => ({
-        programIdIndex: instruction.programIdIndex,
-        accounts: [...instruction.accounts],
-        data: BASE58_DECODER.decode(toUint8ArrayView(instruction.data)),
-      }),
-    );
-
-    const messageArgs = {
-      header: {
-        numRequiredSignatures,
-        numReadonlySignedAccounts: decodedMessage.numReadonlySignedAccounts,
-        numReadonlyUnsignedAccounts: decodedMessage.numReadonlyUnsignedAccounts,
-      },
-      recentBlockhash: BLOCKHASH_DECODER.decode(decodedMessage.recentBlockhash),
-      accountKeys,
-      instructions,
-    };
-
-    return new Message(messageArgs);
+    return Message.fromCompiledMessage(decoded);
   }
 }

--- a/src/message/v0.ts
+++ b/src/message/v0.ts
@@ -1,19 +1,10 @@
 import {
-  fixDecoderSize,
-  fixEncoderSize,
-  getBlockhashDecoder,
-  getBlockhashEncoder,
-  getArrayDecoder,
-  getArrayEncoder,
-  getBytesDecoder,
-  getBytesEncoder,
-  getShortU16Decoder,
-  getShortU16Encoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getCompiledTransactionMessageDecoder,
+  getCompiledTransactionMessageEncoder,
+  type Address as KitAddress,
   type Blockhash,
+  type CompiledTransactionMessage,
+  type CompiledTransactionMessageWithLifetime,
   type Instruction as KitInstruction,
 } from '@solana/kit';
 
@@ -22,59 +13,21 @@ import {
   MessageAddressTableLookup,
   MessageCompiledInstruction,
 } from './index';
-import {Address, PUBLIC_KEY_LENGTH} from '../address';
+import {Address} from '../address';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
-import assert from '../utils/assert';
-import {toUint8ArrayView} from '../utils/typed-array';
-import {PACKET_DATA_SIZE, VERSION_PREFIX_MASK} from '../transaction/constants';
+import {toPackedUint8Array, toUint8ArrayView} from '../utils/typed-array';
+import {VERSION_PREFIX_MASK} from '../transaction/constants';
 import type {TransactionInstruction} from '../transaction/legacy';
 import {AddressLookupTableAccount} from '../programs';
 import {CompiledKeys} from './compiled-keys';
 import {AccountKeysFromLookups, MessageAccountKeys} from './account-keys';
 
-const BYTES_ENCODER = getBytesEncoder();
-const SHORT_U16_ENCODER = getShortU16Encoder();
-const SHORT_U16_DECODER = getShortU16Decoder();
-const U8_DECODER = getU8Decoder();
-const U8_ENCODER = getU8Encoder();
-const BLOCKHASH_ENCODER = getBlockhashEncoder();
-const BLOCKHASH_DECODER = getBlockhashDecoder();
-const PUBLIC_KEY_DECODER = fixDecoderSize(getBytesDecoder(), PUBLIC_KEY_LENGTH);
-const COMPILED_INSTRUCTION_DECODER = getStructDecoder([
-  ['programIdIndex', U8_DECODER],
-  ['accountKeyIndexes', getArrayDecoder(U8_DECODER, {size: SHORT_U16_DECODER})],
-  ['data', getArrayDecoder(U8_DECODER, {size: SHORT_U16_DECODER})],
-]);
-const ADDRESS_TABLE_LOOKUP_DECODER = getStructDecoder([
-  ['accountKey', PUBLIC_KEY_DECODER],
-  ['writableIndexes', getArrayDecoder(U8_DECODER, {size: SHORT_U16_DECODER})],
-  ['readonlyIndexes', getArrayDecoder(U8_DECODER, {size: SHORT_U16_DECODER})],
-]);
-const MESSAGE_V0_DECODER = getStructDecoder([
-  ['prefix', U8_DECODER],
-  [
-    'header',
-    getStructDecoder([
-      ['numRequiredSignatures', U8_DECODER],
-      ['numReadonlySignedAccounts', U8_DECODER],
-      ['numReadonlyUnsignedAccounts', U8_DECODER],
-    ]),
-  ],
-  [
-    'staticAccountKeys',
-    getArrayDecoder(PUBLIC_KEY_DECODER, {size: SHORT_U16_DECODER}),
-  ],
-  ['recentBlockhash', PUBLIC_KEY_DECODER],
-  [
-    'compiledInstructions',
-    getArrayDecoder(COMPILED_INSTRUCTION_DECODER, {size: SHORT_U16_DECODER}),
-  ],
-  [
-    'addressTableLookups',
-    getArrayDecoder(ADDRESS_TABLE_LOOKUP_DECODER, {size: SHORT_U16_DECODER}),
-  ],
-]);
+const MESSAGE_ENCODER = getCompiledTransactionMessageEncoder();
+const MESSAGE_DECODER = getCompiledTransactionMessageDecoder();
+
+type V0Compiled = Extract<CompiledTransactionMessage, {version: 0}> &
+  CompiledTransactionMessageWithLifetime;
 
 /**
  * Message constructor arguments
@@ -283,206 +236,72 @@ export class MessageV0 {
   }
 
   serialize(): Uint8Array {
-    const encodedStaticAccountKeysLength = SHORT_U16_ENCODER.encode(
-      this.staticAccountKeys.length,
-    );
-
-    const serializedInstructions = this.serializeInstructions();
-    const encodedInstructionsLength = SHORT_U16_ENCODER.encode(
-      this.compiledInstructions.length,
-    );
-
-    const serializedAddressTableLookups = this.serializeAddressTableLookups();
-    const encodedAddressTableLookupsLength = SHORT_U16_ENCODER.encode(
-      this.addressTableLookups.length,
-    );
-
-    const messageLayout = getStructEncoder([
-      ['prefix', U8_ENCODER],
-      [
-        'header',
-        getStructEncoder([
-          ['numRequiredSignatures', U8_ENCODER],
-          ['numReadonlySignedAccounts', U8_ENCODER],
-          ['numReadonlyUnsignedAccounts', U8_ENCODER],
-        ]),
-      ],
-      [
-        'staticAccountKeysLength',
-        fixEncoderSize(
-          getBytesEncoder(),
-          encodedStaticAccountKeysLength.length,
-        ),
-      ],
-      [
-        'staticAccountKeys',
-        getArrayEncoder(fixEncoderSize(getBytesEncoder(), PUBLIC_KEY_LENGTH), {
-          size: this.staticAccountKeys.length,
-        }),
-      ],
-      ['recentBlockhash', fixEncoderSize(getBytesEncoder(), PUBLIC_KEY_LENGTH)],
-      [
-        'instructionsLength',
-        fixEncoderSize(getBytesEncoder(), encodedInstructionsLength.length),
-      ],
-      [
-        'serializedInstructions',
-        fixEncoderSize(getBytesEncoder(), serializedInstructions.length),
-      ],
-      [
-        'addressTableLookupsLength',
-        fixEncoderSize(
-          getBytesEncoder(),
-          encodedAddressTableLookupsLength.length,
-        ),
-      ],
-      [
-        'serializedAddressTableLookups',
-        fixEncoderSize(getBytesEncoder(), serializedAddressTableLookups.length),
-      ],
-    ]);
-
-    const MESSAGE_VERSION_0_PREFIX = 1 << 7;
-    const encodedMessage = messageLayout.encode({
-      prefix: MESSAGE_VERSION_0_PREFIX,
-      header: this.header,
-      staticAccountKeysLength: encodedStaticAccountKeysLength,
-      staticAccountKeys: this.staticAccountKeys.map(key => key.toBytes()),
-      recentBlockhash: BLOCKHASH_ENCODER.encode(this.recentBlockhash),
-      instructionsLength: encodedInstructionsLength,
-      serializedInstructions,
-      addressTableLookupsLength: encodedAddressTableLookupsLength,
-      serializedAddressTableLookups,
+    const encoded = MESSAGE_ENCODER.encode({
+      version: 0,
+      header: {
+        numSignerAccounts: this.header.numRequiredSignatures,
+        numReadonlySignerAccounts: this.header.numReadonlySignedAccounts,
+        numReadonlyNonSignerAccounts: this.header.numReadonlyUnsignedAccounts,
+      },
+      staticAccounts: this.staticAccountKeys.map(
+        key => key.toBase58() as KitAddress,
+      ),
+      lifetimeToken: this.recentBlockhash,
+      instructions: this.compiledInstructions.map(ix => ({
+        programAddressIndex: ix.programIdIndex,
+        accountIndices: ix.accountKeyIndexes,
+        data: ix.data,
+      })),
+      addressTableLookups: this.addressTableLookups.map(lookup => ({
+        lookupTableAddress: lookup.accountKey.toBase58() as KitAddress,
+        writableIndexes: lookup.writableIndexes,
+        readonlyIndexes: lookup.readonlyIndexes,
+      })),
     });
-    return toUint8ArrayView(encodedMessage);
+    return toPackedUint8Array(encoded);
   }
 
-  private serializeInstructions(): Uint8Array {
-    let serializedLength = 0;
-    const serializedInstructions = new Uint8Array(PACKET_DATA_SIZE);
-    for (const instruction of this.compiledInstructions) {
-      const encodedAccountKeyIndexesLength = SHORT_U16_ENCODER.encode(
-        instruction.accountKeyIndexes.length,
-      );
-
-      const encodedDataLength = SHORT_U16_ENCODER.encode(
-        instruction.data.length,
-      );
-
-      const instructionLayout = getStructEncoder([
-        ['programIdIndex', U8_ENCODER],
-        [
-          'encodedAccountKeyIndexesLength',
-          fixEncoderSize(
-            getBytesEncoder(),
-            encodedAccountKeyIndexesLength.length,
-          ),
-        ],
-        [
-          'accountKeyIndexes',
-          getArrayEncoder(U8_ENCODER, {
-            size: instruction.accountKeyIndexes.length,
-          }),
-        ],
-        [
-          'encodedDataLength',
-          fixEncoderSize(getBytesEncoder(), encodedDataLength.length),
-        ],
-        ['data', fixEncoderSize(getBytesEncoder(), instruction.data.length)],
-      ]);
-
-      serializedLength = instructionLayout.write(
-        {
-          programIdIndex: instruction.programIdIndex,
-          encodedAccountKeyIndexesLength,
-          accountKeyIndexes: instruction.accountKeyIndexes,
-          encodedDataLength,
-          data: instruction.data,
-        },
-        serializedInstructions,
-        serializedLength,
-      );
-    }
-
-    return serializedInstructions.slice(0, serializedLength);
-  }
-
-  private serializeAddressTableLookups(): Uint8Array {
-    const bytes = new Uint8Array(PACKET_DATA_SIZE);
-    let offset = 0;
-    for (const lookup of this.addressTableLookups) {
-      offset = BYTES_ENCODER.write(lookup.accountKey.toBytes(), bytes, offset);
-      offset = SHORT_U16_ENCODER.write(
-        lookup.writableIndexes.length,
-        bytes,
-        offset,
-      );
-      offset = BYTES_ENCODER.write(
-        Uint8Array.from(lookup.writableIndexes),
-        bytes,
-        offset,
-      );
-      offset = SHORT_U16_ENCODER.write(
-        lookup.readonlyIndexes.length,
-        bytes,
-        offset,
-      );
-      offset = BYTES_ENCODER.write(
-        Uint8Array.from(lookup.readonlyIndexes),
-        bytes,
-        offset,
-      );
-    }
-
-    return bytes.slice(0, offset);
+  /** @internal Construct a {@link MessageV0} from a kit-decoded compiled message. */
+  static fromCompiledMessage(decoded: V0Compiled): MessageV0 {
+    return new MessageV0({
+      header: {
+        numRequiredSignatures: decoded.header.numSignerAccounts,
+        numReadonlySignedAccounts: decoded.header.numReadonlySignerAccounts,
+        numReadonlyUnsignedAccounts:
+          decoded.header.numReadonlyNonSignerAccounts,
+      },
+      staticAccountKeys: decoded.staticAccounts.map(addr => new Address(addr)),
+      recentBlockhash: decoded.lifetimeToken as Blockhash,
+      compiledInstructions: decoded.instructions.map(ix => ({
+        programIdIndex: ix.programAddressIndex,
+        accountKeyIndexes: [...(ix.accountIndices ?? [])],
+        data: ix.data ? Uint8Array.from(ix.data) : new Uint8Array(0),
+      })),
+      addressTableLookups: (decoded.addressTableLookups ?? []).map(lookup => ({
+        accountKey: new Address(lookup.lookupTableAddress),
+        writableIndexes: [...lookup.writableIndexes],
+        readonlyIndexes: [...lookup.readonlyIndexes],
+      })),
+    });
   }
 
   static deserialize(serializedMessage: Uint8Array): MessageV0 {
     const prefix = serializedMessage[0];
     const maskedPrefix = prefix & VERSION_PREFIX_MASK;
-    assert(
-      prefix !== maskedPrefix,
-      `Expected versioned message but received legacy message`,
-    );
-
-    const version = maskedPrefix;
-    assert(
-      version === 0,
-      `Expected versioned message with version 0 but found version ${version}`,
-    );
-
-    const decodedMessage = MESSAGE_V0_DECODER.decode(serializedMessage);
-
-    const header: MessageHeader = decodedMessage.header;
-
-    const staticAccountKeys = decodedMessage.staticAccountKeys.map(
-      accountKey => new Address(accountKey),
-    );
-
-    const recentBlockhash = BLOCKHASH_DECODER.decode(
-      Uint8Array.from(decodedMessage.recentBlockhash),
-    );
-
-    const compiledInstructions: MessageCompiledInstruction[] =
-      decodedMessage.compiledInstructions.map(instruction => ({
-        programIdIndex: instruction.programIdIndex,
-        accountKeyIndexes: [...instruction.accountKeyIndexes],
-        data: Uint8Array.from(instruction.data),
-      }));
-
-    const addressTableLookups: MessageAddressTableLookup[] =
-      decodedMessage.addressTableLookups.map(lookup => ({
-        accountKey: new Address(lookup.accountKey),
-        writableIndexes: [...lookup.writableIndexes],
-        readonlyIndexes: [...lookup.readonlyIndexes],
-      }));
-
-    return new MessageV0({
-      header,
-      staticAccountKeys,
-      recentBlockhash,
-      compiledInstructions,
-      addressTableLookups,
-    });
+    if (prefix === maskedPrefix) {
+      throw new Error('Expected versioned message but received legacy message');
+    }
+    if (maskedPrefix !== 0) {
+      throw new Error(
+        `Expected versioned message with version 0 but found version ${maskedPrefix}`,
+      );
+    }
+    const decoded = MESSAGE_DECODER.decode(toUint8ArrayView(serializedMessage));
+    if (decoded.version !== 0) {
+      throw new Error(
+        `Expected versioned message with version 0 but found version ${decoded.version}`,
+      );
+    }
+    return MessageV0.fromCompiledMessage(decoded);
   }
 }

--- a/src/message/versioned.ts
+++ b/src/message/versioned.ts
@@ -1,6 +1,11 @@
+import {getCompiledTransactionMessageDecoder} from '@solana/kit';
+
 import {VERSION_PREFIX_MASK} from '../transaction/constants';
+import {toUint8ArrayView} from '../utils/typed-array';
 import {Message} from './legacy';
 import {MessageV0} from './v0';
+
+const MESSAGE_DECODER = getCompiledTransactionMessageDecoder();
 
 export type VersionedMessage = Message | MessageV0;
 
@@ -21,16 +26,20 @@ export const VersionedMessage = {
   deserialize: (serializedMessage: Uint8Array): VersionedMessage => {
     const version =
       VersionedMessage.deserializeMessageVersion(serializedMessage);
-    if (version === 'legacy') {
-      return Message.from(serializedMessage);
-    }
-
-    if (version === 0) {
-      return MessageV0.deserialize(serializedMessage);
-    } else {
+    if (version !== 'legacy' && version !== 0) {
       throw new Error(
         `Transaction message version ${version} deserialization is not supported`,
       );
     }
+    const decoded = MESSAGE_DECODER.decode(toUint8ArrayView(serializedMessage));
+    if (decoded.version === 'legacy') {
+      return Message.fromCompiledMessage(decoded);
+    }
+    if (decoded.version === 0) {
+      return MessageV0.fromCompiledMessage(decoded);
+    }
+    throw new Error(
+      `Transaction message version ${decoded.version} deserialization is not supported`,
+    );
   },
 };


### PR DESCRIPTION
## Summary
- Replace hand-rolled struct decoders/encoders in `src/message/legacy.ts` and `src/message/v0.ts` with `getCompiledTransactionMessageEncoder` / `getCompiledTransactionMessageDecoder` from `@solana/kit`.
- `versioned.ts` now single-decodes via kit and dispatches to internal `fromCompiledMessage` helpers on `Message` / `MessageV0`.
- Public `Message` / `MessageV0` API unchanged; a small adapter handles kit↔web3.js field naming (`header.numSignerAccounts` ↔ `numRequiredSignatures`, `staticAccounts`, `lifetimeToken`, etc.).
- `serialize()` uses `toPackedUint8Array(encoded)` to avoid an unconditional copy when the encoder returns a tightly packed view.
- `lifetimeToken` is treated as required (decoder return type is `CompiledTransactionMessage & CompiledTransactionMessageWithLifetime`) — no `?? ''` fallback that could silently produce invalid blockhashes.

Net: ~280 lines removed.

## Test plan
- [x] `pnpm test:typecheck`
- [x] `pnpm test:lint`
- [x] `pnpm test:prettier`
- [x] `pnpm test:unit` (780 passing)