### PR TITLE
fix: avoid unsubscribe retry loop on closed websocket

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -35,7 +35,7 @@ import fetchImpl from './fetch-impl';
 import {DurableNonce, NonceAccount} from './nonce-account';
 import {PublicKey} from './publickey';
 import {Signer} from './keypair';
-import RpcWebSocketClient from './rpc-websocket';
+import RpcWebSocketClient, {RpcWebSocketConnectionError} from './rpc-websocket';
 import {MS_PER_SLOT} from './timing';
 import {
   Transaction,
@@ -6319,6 +6319,18 @@ export class Connection {
                   } catch (e) {
                     if (e instanceof Error) {
                       console.error(`${unsubscribeMethod} error:`, e.message);
+                    }
+                    if (
+                      e instanceof RpcWebSocketConnectionError &&
+                      (e.readyState === 2 /* WebSocket.CLOSING */ ||
+                        e.readyState === 3) /* WebSocket.CLOSED */
+                    ) {
+                      this._setSubscription(hash, {
+                        ...subscription,
+                        state: 'unsubscribed',
+                      });
+                      await this._updateSubscriptions();
+                      return;
                     }
                     if (!isCurrentConnectionStillActive()) {
                       return;

--- a/src/rpc-websocket.ts
+++ b/src/rpc-websocket.ts
@@ -11,6 +11,24 @@ interface IHasReadyState {
   readyState: WebSocket['readyState'];
 }
 
+export class RpcWebSocketConnectionError extends Error {
+  constructor(
+    public readonly methodName: string,
+    public readonly readyState: WebSocket['readyState'] | undefined,
+    action: 'call a JSON-RPC method' | 'send a JSON-RPC notification',
+  ) {
+    super(
+      'Tried to ' +
+        action +
+        ' `' +
+        methodName +
+        '` but the socket was not `CONNECTING` or `OPEN` (`readyState` was ' +
+        readyState +
+        ')',
+    );
+  }
+}
+
 export default class RpcWebSocketClient extends CommonClient {
   private underlyingSocket: IHasReadyState | undefined;
   constructor(
@@ -46,12 +64,10 @@ export default class RpcWebSocketClient extends CommonClient {
       return super.call(...args);
     }
     return Promise.reject(
-      new Error(
-        'Tried to call a JSON-RPC method `' +
-          args[0] +
-          '` but the socket was not `CONNECTING` or `OPEN` (`readyState` was ' +
-          readyState +
-          ')',
+      new RpcWebSocketConnectionError(
+        args[0],
+        readyState,
+        'call a JSON-RPC method',
       ),
     );
   }
@@ -63,12 +79,10 @@ export default class RpcWebSocketClient extends CommonClient {
       return super.notify(...args);
     }
     return Promise.reject(
-      new Error(
-        'Tried to send a JSON-RPC notification `' +
-          args[0] +
-          '` but the socket was not `CONNECTING` or `OPEN` (`readyState` was ' +
-          readyState +
-          ')',
+      new RpcWebSocketConnectionError(
+        args[0],
+        readyState,
+        'send a JSON-RPC notification',
       ),
     );
   }

--- a/test/connection-subscriptions.test.ts
+++ b/test/connection-subscriptions.test.ts
@@ -14,7 +14,7 @@ import {
   SlotChangeCallback,
   SlotUpdateCallback,
 } from '../src';
-import type Client from '../src/rpc-websocket';
+import Client, {RpcWebSocketConnectionError} from '../src/rpc-websocket';
 import {url} from './url';
 
 use(sinonChai);
@@ -455,7 +455,8 @@ describe('Subscriptions', () => {
                   'Expected a function to have been assigned to `acknowledgeUnsubscribe` in the test',
                 );
               };
-              let fatalUnsubscribe = (): void => {
+              let fatalUnsubscribe = (reason?: unknown): void => {
+                void reason;
                 expect.fail(
                   'Expected a function to have been assigned to `fatalUnsubscribe` in the test',
                 );
@@ -523,6 +524,21 @@ describe('Subscriptions', () => {
                     subscriptionMethod.replace('Subscribe', 'Unsubscribe'),
                     [serverSubscriptionId],
                   );
+                });
+              });
+              describe('if that unsubscribe fails because the socket is closing', () => {
+                beforeEach(async () => {
+                  stubbedSocket.call.resetHistory();
+                  await fatalUnsubscribe(
+                    new RpcWebSocketConnectionError(
+                      subscriptionMethod.replace('Subscribe', 'Unsubscribe'),
+                      2,
+                      'call a JSON-RPC method',
+                    ),
+                  );
+                });
+                it('does not retry the unsubscribe request on the closing socket', () => {
+                  expect(stubbedSocket.call).not.to.have.been.called;
                 });
               });
               describe('then having the socket connection error', () => {


### PR DESCRIPTION
#### Problem

When an unsubscribe RPC call fails because the underlying websocket is already closing or closed, `_updateSubscriptions()` currently treats it like a retryable unsubscribe failure. It restores the subscription to `subscribed` and recurses, which can keep retrying the same unsubscribe call on the dead socket.

Fixes #3761.

#### Summary of Changes

- Preserve websocket `readyState` on the local RPC websocket error.
- Treat unsubscribe failures from closing/closed sockets as locally unsubscribed instead of retrying them.
- Add subscription regression coverage for the closing-socket unsubscribe path.

#### Test plan

- `pnpm exec cross-env NODE_ENV=test NODE_OPTIONS='--import tsx' mocha './test/connection-subscriptions.test.ts' --grep 'socket is closing'`
- `pnpm run test:typecheck`
- `pnpm run test:prettier`
- `PATH="$PWD/node_modules/.pnpm/node_modules/.bin:$PATH" pnpm run test:lint`
- `pnpm run test:unit`
- `pnpm run compile:js`
- `git diff --check`
