### PR TITLE
docs(skill): add @solana/spl-token → @solana-program/token migration …

### DIFF
--- a/docs/web3js-spl-token-migration.md
+++ b/docs/web3js-spl-token-migration.md
@@ -1,0 +1,359 @@
+# Migrating from `@solana/spl-token` to `@solana-program/token`
+
+This guide is for application and SDK developers upgrading token-program usage as part of a `@solana/web3.js` v1 → v3 migration.
+
+`@solana/spl-token` was the long-standing community client for the SPL Token program. With web3.js v3, kit codecs and Codama-generated program clients become first-class — so the token program now ships an official kit-native client at [`@solana-program/token`](https://www.npmjs.com/package/@solana-program/token). The Codama-generated surface mirrors every token instruction, account, and PDA.
+
+v3 web3.js keeps the familiar `Connection`, `Keypair`, `Transaction`, `SystemProgram`, and `sendAndConfirmTransaction` surface from 1.x, but `Transaction.add(...)` now natively accepts kit-shaped instructions from `@solana-program/token` — and also kit `InstructionPlan` inputs, so the non-generated `@solana-program/token` helpers that return plans (`getCreateMintInstructionPlan`, `getMintToATAInstructionPlan(Async)`, `getTransferToATAInstructionPlan(Async)`) drop directly into `.add(...)`. The `Message` / `MessageV0` compilers accept the same inputs. So migrating off `@solana/spl-token` does **not** require adopting kit transaction messages, plugin clients, or a kit RPC.
+
+If you want to use this guide as reusable agent context, the token migration is covered by the v1→v3 migration skill at [`skills/web3js-v1-to-v3-migration/reference/spl-token.md`](../skills/web3js-v1-to-v3-migration/reference/spl-token.md).
+
+If your mints live on Token-2022, the equivalent client is [`@solana-program/token-2022`](https://www.npmjs.com/package/@solana-program/token-2022). Everything below applies; only the package name and the explicit `tokenProgram` argument on ATA derivation change.
+
+## Why this migration is needed
+
+- **`Address` replaces `PublicKey`.** Every token-program argument that used to be a `PublicKey` is now a branded `Address` string. v3 web3.js's own `Address` class exposes `.toBase58()` typed as that kit-branded string, so it bridges cleanly — but you must call `.toBase58()` at the boundary to keep the types aligned.
+- **PDA derivation is async.** `getAssociatedTokenAddressSync` is gone; the kit-native equivalent is `findAssociatedTokenPda(...)` which returns a `Promise<[Address, ProgramDerivedAddressBump]>`.
+- **`getOrCreateAssociatedTokenAccount` has no single-call equivalent.** The idiomatic replacement is to derive the ATA, include `getCreateAssociatedTokenIdempotentInstruction(...)` in the same transaction, and let the program no-op if the account already exists.
+- **`MintLayout`/`AccountLayout` are gone.** Account data is decoded through Codama codecs (`getMintDecoder()` / `getTokenDecoder()`) that work on `Uint8Array` and surface `bigint` for amounts, supply, and lamports.
+
+## Major migration themes
+
+- **Type swap.** `PublicKey` → `Address`. `TOKEN_PROGRAM_ID` → `TOKEN_PROGRAM_ADDRESS`. `ASSOCIATED_TOKEN_PROGRAM_ID` → `ASSOCIATED_TOKEN_PROGRAM_ADDRESS`. `NATIVE_MINT` → inline `'So11111111111111111111111111111111111111112'` as `Address` (not currently exported).
+- **Instruction builders rename.** `createXInstruction(...)` becomes `getXInstruction({...})` with a single object argument and `Address`-typed accounts.
+- **High-level helpers are decomposed — but plan helpers re-bundle the common cases.** The most common spl-token "do-it-all" helpers (`createMint`, `mintTo` + ATA, `transfer` + ATA) have non-generated plan helpers in `@solana-program/token` that bundle the two-instruction sequence into one `sequentialInstructionPlan(...)`. Drop them straight into `Transaction.add(...)`. For everything else (`burn`, `approve`, `revoke`, `setAuthority`, `freezeAccount`, `thawAccount`, `closeAccount`), it's still "build the instruction, append, send".
+- **Reads use codecs.** Replace `getMint`/`getAccount` with `connection.getAccountInfo(address)` + `getMintDecoder().decode(data)` / `getTokenDecoder().decode(data)`.
+
+## Plan helpers (preferred path for the common cases)
+
+`@solana-program/token` ships a small set of non-generated helpers that return kit `InstructionPlan`s — sequential bundles of two or three underlying instructions. v3 `Transaction.add(...)` flattens these for you (1.x had no notion of plans). This is the lowest-churn replacement for the most-used spl-token helpers:
+
+| `@solana/spl-token` helper                  | `@solana-program/token` plan helper                              |
+| ------------------------------------------- | ---------------------------------------------------------------- |
+| `createMint(...)`                           | `getCreateMintInstructionPlan({ payer, newMint, decimals, mintAuthority, freezeAuthority? })` |
+| `mintToChecked(...)` + ensure-ATA           | `getMintToATAInstructionPlan(...)` / `getMintToATAInstructionPlanAsync(...)` |
+| `transferChecked(...)` + ensure-dest-ATA    | `getTransferToATAInstructionPlan(...)` / `getTransferToATAInstructionPlanAsync(...)` |
+
+The `*Async` variants derive the ATA(s) via `findAssociatedTokenPda` so you don't have to call it explicitly. All helpers take `TransactionSigner` for signer-typed fields (`payer`, `newMint`, `mintAuthority`, `authority`). A v3 `Keypair` **is** a `TransactionSigner` — it extends Kit's `KeyPairSigner` — so pass the keypair straight in, no shim needed. Actual signing still happens via v3's `sendAndConfirmTransaction(connection, tx, [keypair, ...])`.
+
+There's also `getBatchInstruction([...])`, which packs multiple non-batch token instructions into a single CPI-friendly batch instruction. Not a plan — use it where you'd otherwise emit many small ixs.
+
+## API mapping
+
+### Constants and addresses
+
+| `@solana/spl-token`              | `@solana-program/token`                  |
+| -------------------------------- | ---------------------------------------- |
+| `TOKEN_PROGRAM_ID`               | `TOKEN_PROGRAM_ADDRESS`                  |
+| `ASSOCIATED_TOKEN_PROGRAM_ID`    | `ASSOCIATED_TOKEN_PROGRAM_ADDRESS`       |
+| `NATIVE_MINT`                    | Inline `'So11111111111111111111111111111111111111112' as Address` |
+| `MINT_SIZE`                      | `getMintSize()`                          |
+| `ACCOUNT_SIZE`                   | `getTokenSize()`                         |
+
+All `PublicKey`-typed arguments on instruction builders are now `Address`-typed. The v3 web3.js `Address` class's `.toBase58()` returns the kit-branded `Address` string — use that to bridge whenever you pass a v3 `Keypair.publicKey` (or another v3 `Address` instance) into an `@solana-program/token` builder.
+
+### Bridging v3 `Address` class ↔ kit-branded `Address` string
+
+The v3 `Address` from `@solana/web3.js` is a class; `@solana-program/token` builders expect the kit-branded string. They are different types even though they wrap the same bytes.
+
+```ts
+import { Address, Keypair } from '@solana/web3.js';
+import { TOKEN_PROGRAM_ADDRESS, getInitializeMint2Instruction } from '@solana-program/token';
+
+const payer = await Keypair.generate();
+
+// v3 SystemProgram wants the v3 Address class — Keypair.publicKey returns one.
+SystemProgram.createAccount({ fromPubkey: payer.publicKey, /* ... */ });
+
+// Kit builders want the kit-branded Address — call .toBase58().
+getInitializeMint2Instruction({
+  mint: mint.publicKey.toBase58(),
+  decimals: 6,
+  mintAuthority: payer.publicKey.toBase58(),
+  freezeAuthority: null,
+});
+
+// Going the other way: wrap a kit Address into the v3 class.
+const TOKEN_PROGRAM = new Address(TOKEN_PROGRAM_ADDRESS);
+```
+
+### Associated Token Account derivation
+
+```ts
+// @solana/spl-token
+const ata = getAssociatedTokenAddressSync(mint, owner);
+
+// @solana-program/token
+const [ata] = await findAssociatedTokenPda({
+  mint,                            // kit Address
+  owner,                           // kit Address
+  tokenProgram: TOKEN_PROGRAM_ADDRESS, // explicit; required for Token-2022
+});
+```
+
+`findAssociatedTokenPda` is async — surrounding functions must be `async`. It returns the kit-branded `Address`; wrap it in `new Address(ata)` if you need to pass it to `connection.getAccountInfo(...)`.
+
+### `getOrCreateAssociatedTokenAccount`
+
+There is no single-call equivalent. The replacement is to derive the ATA and include `getCreateAssociatedTokenIdempotentInstruction(...)` in the same transaction. The program no-ops if the account already exists.
+
+```ts
+const [ata] = await findAssociatedTokenPda({ mint, owner, tokenProgram: TOKEN_PROGRAM_ADDRESS });
+
+const createAtaIx = getCreateAssociatedTokenIdempotentInstruction({
+  payer,   // a TransactionSigner — a v3 Keypair works directly
+  ata,     // kit Address
+  owner,   // kit Address (the wallet)
+  mint,    // kit Address
+});
+
+new Transaction().add(createAtaIx, /* transfer/mintTo */);
+```
+
+If you need the decoded `Account` object after the transaction lands, fetch it with `connection.getAccountInfo(new Address(ata))` and decode with `getTokenDecoder().decode(data)`.
+
+### Instruction builders
+
+The shape changes from positional `PublicKey` arguments to a single object with `Address`-typed accounts. Naming flips from `createXInstruction` to `getXInstruction`.
+
+| `@solana/spl-token`                              | `@solana-program/token`                            |
+| ------------------------------------------------ | -------------------------------------------------- |
+| `createInitializeMintInstruction`                | `getInitializeMintInstruction`                     |
+| `createInitializeMint2Instruction`               | `getInitializeMint2Instruction`                    |
+| `createInitializeAccountInstruction`             | `getInitializeAccountInstruction`                  |
+| `createInitializeAccount3Instruction`            | `getInitializeAccount3Instruction`                 |
+| `createAssociatedTokenAccountInstruction`        | `getCreateAssociatedTokenInstruction`              |
+| `createAssociatedTokenAccountIdempotentInstruction` | `getCreateAssociatedTokenIdempotentInstruction` |
+| `createMintToInstruction`                        | `getMintToInstruction`                             |
+| `createMintToCheckedInstruction`                 | `getMintToCheckedInstruction`                      |
+| `createTransferInstruction`                      | `getTransferInstruction`                           |
+| `createTransferCheckedInstruction`               | `getTransferCheckedInstruction`                    |
+| `createBurnInstruction`                          | `getBurnInstruction`                               |
+| `createBurnCheckedInstruction`                   | `getBurnCheckedInstruction`                        |
+| `createApproveInstruction`                       | `getApproveInstruction`                            |
+| `createApproveCheckedInstruction`                | `getApproveCheckedInstruction`                     |
+| `createRevokeInstruction`                        | `getRevokeInstruction`                             |
+| `createSetAuthorityInstruction`                  | `getSetAuthorityInstruction`                       |
+| `createCloseAccountInstruction`                  | `getCloseAccountInstruction`                       |
+| `createFreezeAccountInstruction`                 | `getFreezeAccountInstruction`                      |
+| `createThawAccountInstruction`                   | `getThawAccountInstruction`                        |
+| `createSyncNativeInstruction`                    | `getSyncNativeInstruction`                         |
+| `createInitializeMultisigInstruction`            | `getInitializeMultisigInstruction`                 |
+
+`AuthorityType` is still an enum, but values are typed against the Codama-generated union (e.g. `AuthorityType.MintTokens`, `AuthorityType.FreezeAccount`).
+
+Prefer the `*Checked` variants for transfers, mints, burns, and approvals — they enforce decimals and mint identity.
+
+### Signer fields on instruction builders
+
+Several builders type the authority field as `Address | TransactionSigner` (`mintAuthority` on `getMintToCheckedInstruction`, `authority` on `getTransferCheckedInstruction`, `payer` on `getCreateAssociatedTokenIdempotentInstruction`, etc.). Passing a plain `Address` will **not** mark that account as a signer in the resulting meta. A v3 `Keypair` extends Kit's `KeyPairSigner`, so it already satisfies `TransactionSigner` — pass the keypair directly (no shim, no noop signer). The Codama builder reads `.address` (a kit-branded `Address`) off it to set the signer-role meta; actual signing still happens via `sendAndConfirmTransaction(connection, tx, [keypair])`:
+
+```ts
+getMintToCheckedInstruction({
+  mint: mint.publicKey.toBase58(),
+  token: ata,
+  mintAuthority: payer, // a v3 Keypair is a TransactionSigner
+  amount: 1_000_000n,
+  decimals: 6,
+});
+```
+
+### High-level send helpers
+
+`@solana/spl-token` exposed many helpers that built an instruction and sent it in one call (`createMint`, `mintTo`, `transfer`, `burn`, `approve`, `revoke`, `setAuthority`, `freezeAccount`, `thawAccount`, `closeAccount`, `getOrCreateAssociatedTokenAccount`). `@solana-program/token` doesn't include them as send-helpers, but it does ship non-generated **plan helpers** for the three most common multi-instruction cases — `createMint`, `mintTo` + ATA, `transfer` + ATA — that drop straight into `Transaction.add(...)`. See "Plan helpers" above. For everything else, replace the spl-token helper with explicit "build an instruction, add to a `Transaction`, send" code.
+
+### Account fetches and decoders
+
+| `@solana/spl-token`             | `@solana-program/token`                       |
+| ------------------------------- | --------------------------------------------- |
+| `getMint(connection, address)`  | `connection.getAccountInfo(address)` + `getMintDecoder().decode(data)` |
+| `getAccount(connection, addr)`  | `connection.getAccountInfo(address)` + `getTokenDecoder().decode(data)` |
+| `getMultisig(connection, addr)` | `connection.getAccountInfo(address)` + `getMultisigDecoder().decode(data)` |
+| `unpackMint(addr, accountInfo)` | `getMintDecoder().decode(uint8Array)` or `decodeMint(encodedAccount)` |
+| `unpackAccount(addr, info)`     | `getTokenDecoder().decode(uint8Array)` or `decodeToken(encodedAccount)` |
+| `MintLayout` / `AccountLayout`  | `getMintCodec()` / `getTokenCodec()`          |
+
+v3 `connection.getAccountInfo(address)` returns `{ data: Uint8Array, owner: Address, lamports, executable, ... }` — feed `data` straight into the decoder.
+
+Numeric fields on decoded mint/token state (`supply`, `amount`) are `bigint`. Authority fields (`mintAuthority`, `freezeAuthority`) come back as a kit `Option<Address>` — unwrap with `unwrapOption(...)` from `@solana/kit` or check `option.__option === 'Some'`.
+
+## Concrete before/after
+
+### Create a mint
+
+```ts
+// @solana/spl-token + web3.js v1
+import { createMint } from '@solana/spl-token';
+import { Connection, Keypair, sendAndConfirmTransaction } from '@solana/web3.js';
+
+const mint = await createMint(connection, payer, payer.publicKey, null, 6);
+```
+
+```ts
+// @solana-program/token + web3.js v3 (preferred — plan helper)
+import { getCreateMintInstructionPlan } from '@solana-program/token';
+import { Keypair, Transaction, sendAndConfirmTransaction } from '@solana/web3.js';
+
+const mint = await Keypair.generate();
+
+const tx = new Transaction().add(
+  getCreateMintInstructionPlan({
+    payer,        // v3 Keypair — a TransactionSigner
+    newMint: mint, // v3 Keypair — a TransactionSigner
+    decimals: 6,
+    mintAuthority: payer.publicKey.toBase58(),
+    freezeAuthority: null,
+  }),
+);
+await sendAndConfirmTransaction(connection, tx, [payer, mint]);
+```
+
+If you need to override the underlying steps (custom lamports, different system/token program), expand the plan to its primitives instead:
+
+```ts
+import {
+  getInitializeMint2Instruction,
+  getMintSize,
+  TOKEN_PROGRAM_ADDRESS,
+} from '@solana-program/token';
+import { Address, SystemProgram } from '@solana/web3.js';
+
+const TOKEN_PROGRAM = new Address(TOKEN_PROGRAM_ADDRESS);
+const space = BigInt(getMintSize());
+const lamports = await connection.getMinimumBalanceForRentExemption(Number(space));
+
+const tx = new Transaction().add(
+  SystemProgram.createAccount({
+    fromPubkey: payer.publicKey,
+    newAccountPubkey: mint.publicKey,
+    lamports: BigInt(lamports),
+    space,
+    programId: TOKEN_PROGRAM,
+  }),
+  getInitializeMint2Instruction({
+    mint: mint.publicKey.toBase58(),
+    decimals: 6,
+    mintAuthority: payer.publicKey.toBase58(),
+    freezeAuthority: null,
+  }),
+);
+await sendAndConfirmTransaction(connection, tx, [payer, mint]);
+```
+
+### Mint into a recipient's ATA
+
+```ts
+// @solana/spl-token
+const recipientAta = await getOrCreateAssociatedTokenAccount(
+  connection, payer, mint, recipient.publicKey,
+);
+await mintToChecked(connection, payer, mint, recipientAta.address, payer, 1_000_000n, 6);
+```
+
+```ts
+// @solana-program/token + web3.js v3 (preferred — plan helper)
+import { getMintToATAInstructionPlanAsync } from '@solana-program/token';
+
+const tx = new Transaction().add(
+  await getMintToATAInstructionPlanAsync({
+    payer,
+    owner: recipient.publicKey.toBase58(),
+    mint: mint.publicKey.toBase58(),
+    mintAuthority: payer,
+    amount: 1_000_000n,
+    decimals: 6,
+    // ata omitted → derived via findAssociatedTokenPda inside the helper
+  }),
+);
+await sendAndConfirmTransaction(connection, tx, [payer]);
+```
+
+To stay explicit (or when the ATA is already known and you want to skip the extra PDA derivation), drop the `Async`:
+
+```ts
+const [ata] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: recipient.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS,
+});
+
+new Transaction().add(
+  getMintToATAInstructionPlan({
+    payer,
+    ata,
+    owner: recipient.publicKey.toBase58(),
+    mint: mint.publicKey.toBase58(),
+    mintAuthority: payer,
+    amount: 1_000_000n,
+    decimals: 6,
+  }),
+);
+```
+
+### Transfer to a (possibly new) recipient
+
+```ts
+// @solana/spl-token
+const destinationAta = await getOrCreateAssociatedTokenAccount(
+  connection, payer, mint, recipient,
+);
+await transferChecked(
+  connection, payer, sourceAta, mint, destinationAta.address, owner, amount, decimals,
+);
+```
+
+```ts
+// @solana-program/token + web3.js v3 (preferred — plan helper)
+import { getTransferToATAInstructionPlanAsync } from '@solana-program/token';
+
+const tx = new Transaction().add(
+  await getTransferToATAInstructionPlanAsync({
+    payer,
+    mint: mint.toBase58(),
+    authority: owner, // v3 Keypair — a TransactionSigner
+    recipient: recipient.toBase58(),
+    amount,
+    decimals,
+    // source / destination omitted → both derived via findAssociatedTokenPda
+  }),
+);
+await sendAndConfirmTransaction(connection, tx, [payer, owner]);
+```
+
+### Read a mint and a token account
+
+```ts
+// @solana/spl-token
+const mintInfo = await getMint(connection, mint);            // { supply: bigint, decimals: number, ... }
+const accountInfo = await getAccount(connection, tokenAccount); // { amount: bigint, owner: PublicKey, ... }
+```
+
+```ts
+// @solana-program/token + web3.js v3
+import { getMintDecoder, getTokenDecoder } from '@solana-program/token';
+
+const mintRaw = await connection.getAccountInfo(mint);
+const tokenRaw = await connection.getAccountInfo(tokenAccount);
+if (!mintRaw || !tokenRaw) throw new Error('not found');
+
+const mintData = getMintDecoder().decode(mintRaw.data);   // { supply: bigint, decimals: number, mintAuthority: Option<Address>, ... }
+const tokenData = getTokenDecoder().decode(tokenRaw.data); // { amount: bigint, owner: Address, delegate: Option<Address>, ... }
+```
+
+`mintData.supply` and `tokenData.amount` are `bigint`. `tokenData.owner` is now the kit-branded `Address` string, not a `PublicKey`. `mintAuthority` / `freezeAuthority` / `delegate` come back as kit `Option<Address>` — unwrap with `unwrapOption(...)` from `@solana/kit`.
+
+## Gotchas
+
+- **Don't keep both clients on the same code path.** `TOKEN_PROGRAM_ID` (PublicKey) and `TOKEN_PROGRAM_ADDRESS` (`Address`) compare-and-collapse to different things; mixing them in one transaction is a top source of subtle bugs.
+- **Bridge the two `Address` types deliberately.** v3 web3.js's `Address` class and `@solana-program/token`'s kit-branded `Address` string are different at the type level. Call `.toBase58()` when passing v3 → kit, and `new Address(kitAddr)` when passing kit → v3.
+- **Pass a `Keypair` to signer fields.** Builder fields typed `Address | TransactionSigner` only emit a signer-role account meta when given the signer branch. A v3 `Keypair` extends Kit's `KeyPairSigner`, so it already is a `TransactionSigner` — pass it straight through (no shim, no noop signer). Actual signing happens via `sendAndConfirmTransaction(connection, tx, [keypair])`.
+- **Classic vs Token-2022.** `@solana-program/token` targets the classic Token program. For Token-2022 mints, swap to `@solana-program/token-2022` and pass that program's address through `findAssociatedTokenPda({ tokenProgram })`. Don't hardcode `TOKEN_PROGRAM_ADDRESS` in code paths that can see either mint.
+- **`bigint` everywhere amounts live.** `amount`, `supply`, and lamports are `bigint`. Don't `Number(...)`-coerce them on the hot path — convert only at JSON or UI boundaries, and check for safe-range issues.
+- **`Option<Address>` on authorities.** `mintAuthority`, `freezeAuthority`, and `delegate` are kit `Option<Address>` values, not nullable strings. Unwrap them explicitly before printing or comparing.
+- **`Buffer` vs `Uint8Array`.** Codama codecs work on `Uint8Array`. v3 `connection.getAccountInfo(addr).data` is already `Uint8Array`. If you previously did `MintLayout.decode(accountInfo.data)` against a `Buffer`, switch to `getMintDecoder().decode(uint8Array)` and stop carrying `Buffer` through the app.
+- **Migration order.** This migration usually rides on top of a broader `@solana/web3.js` v1 → v3 migration. Do that one first (see [`docs/web3js-v1-to-v3-migration.md`](./web3js-v1-to-v3-migration.md)) so `Address`, async `Keypair.generate()`, `bigint`, and `Uint8Array` are already in place when you swap the token client.
+- **`MessagePackerInstructionPlan` is not accepted.** `Transaction.add(...)` flattens `sequentialInstructionPlan` / `parallelInstructionPlan` / `singleInstructionPlan` trees, but it rejects `MessagePackerInstructionPlan` leaves at runtime — those plan kinds are designed to span multiple transactions and can't be honored inside one. The `@solana-program/token` plan helpers above all return `sequentialInstructionPlan`s, so they're safe; the gotcha applies if you build plans yourself.
+
+## Verifying the migration
+
+See [`experiments/`](../experiments/) for runnable side-by-side scripts that exercise create-mint, ATA create + mintTo, transferChecked, and read-state in both shapes against a local validator.

--- a/docs/web3js-v1-to-v3-migration.md
+++ b/docs/web3js-v1-to-v3-migration.md
@@ -6,6 +6,8 @@ The v3 API is still class-based, but non-trivial TypeScript consumers should exp
 
 If you want to use this guide as reusable agent context, this repository also publishes a skill at [`skills/web3js-v1-to-v3-migration/SKILL.md`](../skills/web3js-v1-to-v3-migration/SKILL.md).
 
+If the migration also touches `@solana/spl-token`, see the companion guide [`docs/web3js-spl-token-migration.md`](./web3js-spl-token-migration.md) and the token reference in the migration skill at [`skills/web3js-v1-to-v3-migration/reference/spl-token.md`](../skills/web3js-v1-to-v3-migration/reference/spl-token.md) for the `@solana/spl-token` → `@solana-program/token` migration.
+
 ## Major migration themes
 
 - **Keys and identity**: `Address` is canonical and `PublicKey` is now a deprecated alias.
@@ -34,6 +36,7 @@ If you want to use this guide as reusable agent context, this repository also pu
 
 ### 3. Async key generation and PDA derivation
 
+- The `Keypair` constructor is no longer public: `new Keypair(...)` no longer compiles. Use `await Keypair.generate()` for fresh keys, and `await Keypair.fromSecretKey(...)` / `await Keypair.fromSeed(...)` when restoring from existing bytes.
 - Replace sync assumptions around `Keypair.generate()`, `Keypair.fromSecretKey(...)`, `Keypair.fromSeed(...)`, and PDA derivation helpers with async flows.
 - In tests and stories that only need a unique address, prefer a local dummy public-key helper over async key generation churn.
 

--- a/skills/web3js-v1-to-v3-migration/SKILL.md
+++ b/skills/web3js-v1-to-v3-migration/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: web3js-v1-to-v3-migration
-description: 'Migrate legacy @solana/web3.js v1 applications to v3. Use when auditing or fixing code after upgrading for Address/PublicKey changes, Keypair.address vs publicKey changes, Kit signer API interop, removed unique/Account/FeeCalculator APIs, async Keypair and transaction flows, Connection commitment and bigint changes, Buffer-to-Uint8Array migration, readonly RPC results, and SDK-specific type changes.'
+description: 'Migrate legacy @solana/web3.js v1 applications to v3, including the `@solana/spl-token` → `@solana-program/token` token surface. Use when auditing or fixing code after upgrading for Address/PublicKey changes, Keypair.address vs publicKey changes, Kit signer API interop, removed unique/Account/FeeCalculator APIs, async Keypair and transaction flows, Connection commitment and bigint changes, Buffer-to-Uint8Array migration, readonly RPC results, SDK-specific type changes, and token-program migration.'
 user-invocable: true
 ---
 
 # Web3.js V1 To V3 Migration
 
 For human-facing background, see [`docs/web3js-v1-to-v3-migration.md`](../../docs/web3js-v1-to-v3-migration.md). This skill is the execution-oriented companion for agents fixing code.
+
+If the migration also touches `@solana/spl-token` usage (token instructions, ATAs, mint/account fetches), read [`reference/spl-token.md`](./reference/spl-token.md) for that surface — it covers `@solana/spl-token` → `@solana-program/token` while staying on the v3 `Connection`/`Transaction`/`Keypair` API. Load it as soon as Fast Triage (below) turns up any `@solana/spl-token` imports.
 
 ## When to Use
 
@@ -33,7 +35,7 @@ Use regex-capable search for these patterns before chasing softer type churn:
 - `new Account`
 - `FeeCalculator|getRecentBlockhash|getRecentBlockhashAndContext|getFeeCalculatorForBlockhash`
 - `sign|partialSign|VersionedTransaction.sign`
-- `Keypair.generate\(\)\.publicKey|Keypair.generate\(|fromSecretKey\(|fromSeed\(|createProgramAddressSync|findProgramAddressSync`
+- `new Keypair\(|Keypair.generate\(\)\.publicKey|Keypair.generate\(|fromSecretKey\(|fromSeed\(|createProgramAddressSync|findProgramAddressSync`
 - `keypair\.address\.|\.address\.toBytes|\.address\.equals|\.address\.toBase58`
 - `createNoopSigner|createSignerFromKeyPair|KeyPairSigner|MessagePartialSigner|TransactionPartialSigner|signMessages|signTransactions`
 - app-local wrappers around message signing or signature verification
@@ -43,6 +45,7 @@ Use regex-capable search for these patterns before chasing softer type churn:
 - `Buffer.from|Buffer.alloc|Buffer.concat`
 - arithmetic or comparisons on `slot`, `blockHeight`, `context.slot`, `transactionCount`, `minContextSlot`
 - `.sort\(|\.push\(|logMessages|readonly`
+- `from ['"]@solana/spl-token['"]` — if present, the migration also touches the token surface; read [`reference/spl-token.md`](./reference/spl-token.md) and follow its workflow for those call sites.
 
 ## Recommended Agent Workflow
 
@@ -76,6 +79,7 @@ Check whether the app only uses public keys as opaque values, or whether it depe
 
 Find call sites that previously assumed sync behavior for signature verification, key generation, message signing, transaction signing, PDA derivation, or legacy transaction serialization.
 
+- The `Keypair` constructor is no longer public — `new Keypair(...)` will fail to typecheck. Replace it with `await Keypair.generate()` (or `await Keypair.fromSecretKey(...)` / `await Keypair.fromSeed(...)` when reconstructing from existing bytes).
 - Add `await` to current async methods: `transaction.sign(...)`, `transaction.partialSign(...)`, and `versionedTransaction.sign(...)`.
 - Prefer Kit-compatible signer APIs when integrating with Kit, Kit Plugins, Codama-generated clients, browser wallets, ledgers, or custom signing systems. `Keypair` now provides `signMessages(...)`, `signTransactions(...)`, and `keyPair`, and structurally satisfies Kit's `KeyPairSigner` shape so it can be passed directly to Kit APIs that accept one.
 - Pass compatible Kit `MessagePartialSigner` or `TransactionPartialSigner` values directly to web3.js transaction signing APIs instead of adapting them through noop signers only to satisfy legacy types.
@@ -247,4 +251,18 @@ This skill should activate for prompts such as:
 - "find bigint breakages after upgrading web3.js"
 - "convert Buffer-based Solana code to Uint8Array"
 - "fix readonly array errors after upgrading web3.js"
+- "replace `new Keypair()` after upgrading web3.js"
 - "review this v1 to v3 migration PR"
+- "migrate @solana/spl-token to @solana-program/token"
+- "replace spl-token with the kit token client"
+- "convert createTransferCheckedInstruction to kit"
+- "replace getAssociatedTokenAddressSync with findAssociatedTokenPda"
+- "replace getOrCreateAssociatedTokenAccount in v3"
+- "swap getMint/getAccount for getMintDecoder/getTokenDecoder"
+- "replace TOKEN_PROGRAM_ID with TOKEN_PROGRAM_ADDRESS"
+- "audit this app for spl-token leftovers after v3 migration"
+
+For token-program prompts, follow [`reference/spl-token.md`](./reference/spl-token.md).
+
+## Related Skills
+- [[solana-kit]] — general `@solana/kit` primitives (transactions, accounts, RPC). Only relevant if the project is moving beyond v3 web3.js to a kit-native stack.

--- a/skills/web3js-v1-to-v3-migration/reference/spl-token.md
+++ b/skills/web3js-v1-to-v3-migration/reference/spl-token.md
@@ -123,7 +123,8 @@ const createAtaIx = getCreateAssociatedTokenIdempotentInstruction({
   owner,   // kit Address (the wallet)
   mint,    // kit Address
 });
-new Transaction().add(createAtaIx, /* transfer/mintTo */);
+const tx = new Transaction().add(createAtaIx, /* transfer/mintTo */);
+await sendAndConfirmTransaction(connection, tx, [payer]);
 ```
 
 If the app's flow needs the decoded `Account` object after sending, fetch it with `connection.getAccountInfo(new Address(ata))` and decode with `getTokenDecoder().decode(data)`.

--- a/skills/web3js-v1-to-v3-migration/reference/spl-token.md
+++ b/skills/web3js-v1-to-v3-migration/reference/spl-token.md
@@ -1,0 +1,313 @@
+# `@solana/spl-token` → `@solana-program/token` (token surface)
+
+Reference companion to the v1→v3 migration skill, loaded when the migration touches token-program usage. For human-facing background, see [`docs/web3js-spl-token-migration.md`](../../../docs/web3js-spl-token-migration.md).
+
+## When this applies
+- The v1→v3 migration also touches `@solana/spl-token`: token instructions, ATAs, mint/account fetches, or token-account decoding.
+- The codebase still imports `createMintToInstruction`, `createTransferCheckedInstruction`, `getOrCreateAssociatedTokenAccount`, `getAssociatedTokenAddressSync`, `getMint`, `getAccount`, `MintLayout`, `AccountLayout`, `TOKEN_PROGRAM_ID`, or `ASSOCIATED_TOKEN_PROGRAM_ID`.
+
+If the mint is owned by Token-2022 (extensions, transfer hooks, etc.), use `@solana-program/token-2022` instead — the naming, instruction surface, and steps below are otherwise identical; only the package and the `tokenProgram` argument on ATA derivation differ.
+
+## Goal
+Migrate token-program usage from `@solana/spl-token` to `@solana-program/token` while staying on v3 `@solana/web3.js`'s `Connection` / `Transaction` / `Keypair` / `sendAndConfirmTransaction` surface. Do **not** rewrite the surrounding code to kit transaction messages, plugin clients, or a kit RPC — v3 web3.js bridges to `@solana-program/token` natively and that's the minimal-churn migration path.
+
+## Operating Model
+- Work in narrow, behavior-scoped slices: imports → PDA derivation → instruction builders → high-level helpers → account reads.
+- The bulk of churn is mechanical: `createXInstruction(...)` → `getXInstruction(...)`, `PublicKey` → `Address` (call `.toBase58()` on v3 `Address` instances at builder boundaries), sync ATA derivation → async `findAssociatedTokenPda`, `getMint`/`getAccount` → `connection.getAccountInfo(...)` + `getMintDecoder().decode(data)` / `getTokenDecoder().decode(data)`.
+- Keep `Connection`, `Transaction`, `Keypair`, `SystemProgram`, and `sendAndConfirmTransaction` from `@solana/web3.js`. v3 `Transaction.add(ix)` / `Message` / `MessageV0` accepts kit-shaped instructions and instruction plans and can support `@solana-program/token` instruction generators directly (1.x did not — that's the bridge that makes the rest of this migration possible) (e.g., `getCreateMintInstructionPlan`, `getMintToATAInstructionPlan(Async)`, `getTransferToATAInstructionPlan(Async)` from `@solana-program/token`) can be passed straight into `.add(...)`. No manual conversion, no kit transaction-message pipeline.
+- Do not keep `@solana/spl-token` alongside `@solana-program/token` for the same code path — the constants and types diverge (`PublicKey` vs `Address`) and silently mixing them is the most common source of bugs.
+
+## Preferred Path: `@solana-program/token` Plan Helpers
+For the three highest-churn spl-token helpers (`createMint`, `mintTo` + ATA, `transfer` + ATA), `@solana-program/token` ships non-generated plan helpers that bundle the `SystemProgram.createAccount` / `getCreateAssociatedTokenIdempotentInstruction` + checked instruction pair into a single `sequentialInstructionPlan(...)`. v3 `Transaction.add(...)` flattens these directly:
+
+- `getCreateMintInstructionPlan({ payer, newMint, decimals, mintAuthority, freezeAuthority? })` — replaces `createMint`. Internally: `getCreateAccountInstruction` (@solana-program/system) + `getInitializeMint2Instruction`.
+- `getMintToATAInstructionPlan({ payer, ata, owner, mint, mintAuthority, amount, decimals })` / `getMintToATAInstructionPlanAsync(...)` — replaces `mintToChecked` + idempotent ATA create. The `Async` variant derives `ata` via `findAssociatedTokenPda` for you.
+- `getTransferToATAInstructionPlan({ payer, source, destination, recipient, mint, authority, amount, decimals })` / `getTransferToATAInstructionPlanAsync(...)` — replaces `transferChecked` + idempotent destination-ATA create. The `Async` variant derives `source` and `destination` for you when omitted.
+
+These helpers all take `TransactionSigner` for `payer` / `newMint` / authority fields where applicable. A v3 `Keypair` **is** a `TransactionSigner` (it extends Kit's `KeyPairSigner`), so pass the keypair directly — see step 6. Actual signing still happens via `sendAndConfirmTransaction(connection, tx, [keypair, ...])`.
+
+When a plan helper exists for the operation you're migrating, **prefer it over hand-rolling the equivalent two-instruction sequence** — fewer call sites, fewer chances to forget the idempotent create or to pass `owner` where the builder expects `ata`.
+
+## Fast Triage
+Use regex-capable search for these patterns before chasing softer churn:
+
+- `from ['"]@solana/spl-token['"]`
+- `TOKEN_PROGRAM_ID|ASSOCIATED_TOKEN_PROGRAM_ID|TOKEN_2022_PROGRAM_ID`
+- `getAssociatedTokenAddress(Sync)?\(`
+- `getOrCreateAssociatedTokenAccount\(`
+- `createAssociatedTokenAccount(Idempotent)?(Instruction)?\(`
+- `createInitializeMint(2)?Instruction\(|createMint\(`
+- `createMintTo(Checked)?Instruction\(|mintTo\(`
+- `createTransfer(Checked)?Instruction\(|\btransfer\(.*spl-token`
+- `createBurn(Checked)?Instruction\(|burn\(`
+- `createApproveInstruction\(|createRevokeInstruction\(|approve\(|revoke\(`
+- `createSetAuthorityInstruction\(|setAuthority\(|AuthorityType\.`
+- `createCloseAccountInstruction\(|closeAccount\(`
+- `createFreezeAccountInstruction\(|createThawAccountInstruction\(`
+- `createSyncNativeInstruction\(|NATIVE_MINT`
+- `getMint\(|getAccount\(|getMultipleAccounts\(.*spl-token`
+- `unpackMint\(|unpackAccount\(|MintLayout|AccountLayout|MINT_SIZE|ACCOUNT_SIZE`
+
+## Recommended Agent Workflow
+
+### 1. Swap the dependency
+Replace `@solana/spl-token` with `@solana-program/token` in `package.json` and update imports. Do not leave both installed unless a sibling package still needs spl-token — in that case isolate spl-token usage behind one module and migrate the rest.
+
+```ts
+// before
+import {
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  createMintToCheckedInstruction,
+  createTransferCheckedInstruction,
+  getOrCreateAssociatedTokenAccount,
+  getMint,
+} from '@solana/spl-token';
+
+// after
+import {
+  TOKEN_PROGRAM_ADDRESS,
+  ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  findAssociatedTokenPda,
+  getMintToCheckedInstruction,
+  getTransferCheckedInstruction,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getMintDecoder,
+  getTokenDecoder,
+} from '@solana-program/token';
+```
+
+### 2. Replace constants and address types
+- `TOKEN_PROGRAM_ID` (PublicKey) → `TOKEN_PROGRAM_ADDRESS` (kit-branded `Address`)
+- `ASSOCIATED_TOKEN_PROGRAM_ID` → `ASSOCIATED_TOKEN_PROGRAM_ADDRESS`
+- `NATIVE_MINT` (PublicKey) → inline `'So11111111111111111111111111111111111111112' as KitAddress`. `@solana-program/token@0.13.0` does **not** export `NATIVE_MINT_ADDRESS` — don't try to import it.
+- All `PublicKey` arguments on instruction builders become kit-branded `Address`. v3 web3.js's `Address` class exposes `.toBase58()` typed as the kit brand — call it at the boundary whenever passing v3 `Keypair.publicKey` or another v3 `Address` into a `@solana-program/token` builder. Going the other direction, wrap a kit `Address` with `new Address(kitAddr)` when v3 `Connection.getAccountInfo` / `SystemProgram` needs the v3 class.
+
+### 3. Replace ATA derivation
+`getAssociatedTokenAddressSync(mint, owner, allowOwnerOffCurve?, programId?, associatedTokenProgramId?)` is sync and PublicKey-typed. `findAssociatedTokenPda` is async and returns `[Address, ProgramDerivedAddressBump]`.
+
+```ts
+// before
+const ata = getAssociatedTokenAddressSync(mint, owner);
+
+// after
+const [ata] = await findAssociatedTokenPda({
+  mint,                            // kit Address
+  owner,                           // kit Address
+  tokenProgram: TOKEN_PROGRAM_ADDRESS, // omit for default; required for Token-2022
+});
+```
+
+Mark surrounding functions `async` and propagate `await` outward. Tests and fixtures that previously inlined `getAssociatedTokenAddressSync(...)` should be updated too rather than wrapped in `Promise.resolve(...)`.
+
+### 4. Replace `getOrCreateAssociatedTokenAccount`
+There is no single-call equivalent. The idiom is to derive the ATA and include `getCreateAssociatedTokenIdempotentInstruction(...)` in the same `Transaction` — the program no-ops if the account already exists.
+
+```ts
+// before
+const ata = await getOrCreateAssociatedTokenAccount(connection, payer, mint, owner);
+
+// after
+const [ata] = await findAssociatedTokenPda({ mint, owner, tokenProgram: TOKEN_PROGRAM_ADDRESS });
+const createAtaIx = getCreateAssociatedTokenIdempotentInstruction({
+  payer,   // a v3 Keypair — it's a TransactionSigner (see step 6)
+  ata,     // kit Address
+  owner,   // kit Address (the wallet)
+  mint,    // kit Address
+});
+new Transaction().add(createAtaIx, /* transfer/mintTo */);
+```
+
+If the app's flow needs the decoded `Account` object after sending, fetch it with `connection.getAccountInfo(new Address(ata))` and decode with `getTokenDecoder().decode(data)`.
+
+### 5. Replace instruction builders
+The naming is `createXInstruction(...)` → `getXInstruction(...)`, argument order moves to a single object, and PublicKeys become kit-branded `Address` strings. Prefer the `*Checked` variants where they exist — they're safer (enforce decimals and mint identity).
+
+| `@solana/spl-token`                              | `@solana-program/token`                            |
+| ------------------------------------------------ | -------------------------------------------------- |
+| `createInitializeMintInstruction`                | `getInitializeMintInstruction`                     |
+| `createInitializeMint2Instruction`               | `getInitializeMint2Instruction`                    |
+| `createInitializeAccountInstruction`             | `getInitializeAccountInstruction`                  |
+| `createInitializeAccount3Instruction`            | `getInitializeAccount3Instruction`                 |
+| `createAssociatedTokenAccountInstruction`        | `getCreateAssociatedTokenInstruction`              |
+| `createAssociatedTokenAccountIdempotent…`        | `getCreateAssociatedTokenIdempotentInstruction`    |
+| `createMintToInstruction`                        | `getMintToInstruction`                             |
+| `createMintToCheckedInstruction`                 | `getMintToCheckedInstruction`                      |
+| `createTransferInstruction`                      | `getTransferInstruction`                           |
+| `createTransferCheckedInstruction`               | `getTransferCheckedInstruction`                    |
+| `createBurnInstruction`                          | `getBurnInstruction`                               |
+| `createBurnCheckedInstruction`                   | `getBurnCheckedInstruction`                        |
+| `createApproveInstruction`                       | `getApproveInstruction`                            |
+| `createApproveCheckedInstruction`                | `getApproveCheckedInstruction`                     |
+| `createRevokeInstruction`                        | `getRevokeInstruction`                             |
+| `createSetAuthorityInstruction`                  | `getSetAuthorityInstruction`                       |
+| `createCloseAccountInstruction`                  | `getCloseAccountInstruction`                       |
+| `createFreezeAccountInstruction`                 | `getFreezeAccountInstruction`                      |
+| `createThawAccountInstruction`                   | `getThawAccountInstruction`                        |
+| `createSyncNativeInstruction`                    | `getSyncNativeInstruction`                         |
+| `createInitializeMultisigInstruction`            | `getInitializeMultisigInstruction`                 |
+
+Example:
+
+```ts
+// before
+const ix = createTransferCheckedInstruction(
+  source, mint, destination, ownerPubkey, amount, decimals,
+);
+
+// after
+const ix = getTransferCheckedInstruction({
+  source,                  // kit Address
+  mint,                    // kit Address
+  destination,             // kit Address
+  authority: owner,        // a v3 Keypair — it's a TransactionSigner (see step 6)
+  amount,                  // bigint | number
+  decimals,                // number
+});
+```
+
+For `setAuthority`, `AuthorityType` enum values move from numeric `AuthorityType.MintTokens` to the codama `AuthorityType` union — use the named variant, e.g. `{ authorityType: AuthorityType.MintTokens }`.
+
+### 6. Pass keypairs to signer-typed fields
+Several `@solana-program/token` builders type a field as `Address | TransactionSigner` (`mintAuthority` on `getMintToCheckedInstruction`, `authority` on `getTransferCheckedInstruction`, `payer` on `getCreateAssociatedTokenIdempotentInstruction`, etc.). Passing a plain `Address` will **not** emit a signer-role account meta. A v3 `Keypair` extends Kit's `KeyPairSigner` (`isKeyPairSigner(keypair) === true`), so it already satisfies `TransactionSigner` — pass the keypair directly, no shim or noop signer required. The builder reads `.address` (a kit-branded `Address`) off it to set the signer-role meta; actual signing still happens via v3's `sendAndConfirmTransaction(connection, tx, [keypair])`:
+
+```ts
+const ix = getMintToCheckedInstruction({
+  mint: mint.publicKey.toBase58(),
+  token: ata,
+  mintAuthority: payer, // a v3 Keypair is a TransactionSigner
+  amount: 1_000_000n,
+  decimals: 6,
+});
+```
+
+Then `mintAuthority: payer`, `authority: owner`, etc.
+
+### 7. Replace high-level "do-it-all" helpers
+The spl-token helpers that sent a transaction in one call (`createMint`, `mintTo`, `transfer`, `burn`, `approve`, `revoke`, `setAuthority`, `freezeAccount`, `thawAccount`, `closeAccount`, `getOrCreateAssociatedTokenAccount`) have no single-call equivalent in `@solana-program/token`. Replace each with either (a) a `@solana-program/token` plan helper dropped into `Transaction.add(...)` where one exists (preferred — see "Preferred Path" above), or (b) explicit "build the instruction(s), add to a `Transaction`, send" code.
+
+`createMint` collapses to a single `getCreateMintInstructionPlan(...)` call inside `Transaction.add(...)` — `Transaction.add` flattens the plan internally:
+
+```ts
+import { getCreateMintInstructionPlan } from '@solana-program/token';
+
+const mint = await Keypair.generate();
+const tx = new Transaction().add(
+  getCreateMintInstructionPlan({
+    payer,         // v3 Keypair — a TransactionSigner
+    newMint: mint, // v3 Keypair — a TransactionSigner
+    decimals: 6,
+    mintAuthority: payer.publicKey.toBase58(),
+    freezeAuthority: null,
+  }),
+);
+await sendAndConfirmTransaction(connection, tx, [payer, mint]);
+```
+
+If you need to opt out of the plan helper (custom funding lamports beyond `mintAccountLamports`, a different program layout, etc.), expand it back to `SystemProgram.createAccount(...)` + `getInitializeMint2Instruction(...)` manually:
+
+```ts
+const space = BigInt(getMintSize());
+const lamports = await connection.getMinimumBalanceForRentExemption(Number(space));
+
+const tx = new Transaction().add(
+  SystemProgram.createAccount({
+    fromPubkey: payer.publicKey,
+    newAccountPubkey: mint.publicKey,
+    lamports: BigInt(lamports),
+    space,
+    programId: new Address(TOKEN_PROGRAM_ADDRESS), // bridge to v3 Address class
+  }),
+  getInitializeMint2Instruction({
+    mint: mint.publicKey.toBase58(),
+    decimals: 6,
+    mintAuthority: payer.publicKey.toBase58(),
+    freezeAuthority: null,
+  }),
+);
+await sendAndConfirmTransaction(connection, tx, [payer, mint]);
+```
+
+For `mintTo`/`transfer` into a (possibly new) ATA, prefer the `*Async` plan helpers — they derive the ATA, emit the idempotent create, and emit the checked instruction in one call:
+
+```ts
+import { getMintToATAInstructionPlanAsync, getTransferToATAInstructionPlanAsync } from '@solana-program/token';
+
+const mintToTx = new Transaction().add(
+  await getMintToATAInstructionPlanAsync({
+    payer,
+    owner: recipient.publicKey.toBase58(),
+    mint: mint.publicKey.toBase58(),
+    mintAuthority: payer,
+    amount: 1_000_000n,
+    decimals: 6,
+  }),
+);
+await sendAndConfirmTransaction(connection, mintToTx, [payer]);
+
+const transferTx = new Transaction().add(
+  await getTransferToATAInstructionPlanAsync({
+    payer,
+    mint: mint.publicKey.toBase58(),
+    authority: owner,
+    recipient: recipient.publicKey.toBase58(),
+    amount,
+    decimals,
+    // source / destination omitted → derived via findAssociatedTokenPda
+  }),
+);
+await sendAndConfirmTransaction(connection, transferTx, [payer, owner]);
+```
+
+### 8. Replace mint/account fetches and decoders
+v3 `connection.getAccountInfo(address)` returns `{ data: Uint8Array, owner: Address, lamports, executable, ... }`. Feed `data` straight into a `@solana-program/token` decoder.
+
+| spl-token                       | @solana-program/token via v3 Connection                                  |
+| ------------------------------- | ------------------------------------------------------------------------ |
+| `getMint(connection, address)`  | `connection.getAccountInfo(address)` + `getMintDecoder().decode(data)`   |
+| `getAccount(connection, addr)`  | `connection.getAccountInfo(addr)` + `getTokenDecoder().decode(data)`     |
+| `getMultisig(connection, addr)` | `connection.getAccountInfo(addr)` + `getMultisigDecoder().decode(data)`  |
+| `unpackMint(addr, accountInfo)` | `getMintDecoder().decode(uint8Array)` or `decodeMint(encodedAccount)`    |
+| `unpackAccount(addr, info)`     | `getTokenDecoder().decode(uint8Array)` or `decodeToken(encodedAccount)`  |
+| `MintLayout` / `AccountLayout`  | `getMintCodec()` / `getTokenCodec()`                                     |
+| `MINT_SIZE` / `ACCOUNT_SIZE`    | `getMintSize()` / `getTokenSize()`                                       |
+
+Numeric fields are `bigint` (`supply`, `amount`). Authority fields (`mintAuthority`, `freezeAuthority`, `delegate`) come back as kit `Option<Address>` — unwrap with `unwrapOption(...)` from `@solana/kit` or check `option.__option === 'Some'`. There is no synchronous `unpack` equivalent that takes a raw `Buffer` — v3's `getAccountInfo(...).data` is already `Uint8Array`.
+
+### 9. Transaction assembly stays the same
+Keep `new Transaction().add(...)`, `sendAndConfirmTransaction(connection, tx, [signers])`, and v3 `Keypair` signing — the surface from 1.x is preserved. v3 `Transaction.add(...)` converts kit-shaped instructions to the v3 `TransactionInstruction` shape internally — signer roles are preserved, and your existing keypairs sign via the same `sendAndConfirmTransaction` path. `Transaction.add(...)` (and the `Message` / `MessageV0` compilers) also accept kit `InstructionPlan` inputs: `sequentialInstructionPlan` / `parallelInstructionPlan` trees are flattened in order; `MessagePackerInstructionPlan` leaves (multi-transaction plans) are rejected at runtime because they can't be honored inside a single transaction.
+
+### 10. Revalidate by slice
+After each slice (imports, ATA derivation, one instruction surface, fetches), run the narrowest test or smoke check that exercises it before widening. Token bugs frequently surface only on-chain (wrong program address, wrong decimals, off-curve owner) — a passing typecheck is not sufficient.
+
+## Decision Rules
+
+### Checked vs unchecked variants
+- Prefer `*Checked` variants for `transfer`, `mintTo`, `burn`, `approve` — they enforce decimals and mint identity.
+- Keep unchecked variants only when migrating code that intentionally avoids the decimals check and you've confirmed that's still correct.
+
+### Classic Token vs Token-2022
+- If the mint is owned by the classic Token program, use `@solana-program/token`.
+- If the mint is owned by Token-2022 (extensions, transfer hooks, etc.), use `@solana-program/token-2022`. The workflow is identical; only the package and the `tokenProgram` argument on ATA derivation differ.
+- If the code path supports both, pass the owning program address through explicitly — do not hardcode `TOKEN_PROGRAM_ADDRESS`.
+
+### `PublicKey` at the boundary
+- Inside the migrated module, use the v3 `Address` class for everything that touches `SystemProgram` / `Connection`, and call `.toBase58()` to produce the kit-branded string at every `@solana-program/token` builder boundary.
+- At third-party boundaries that still hand back v1 `PublicKey`, convert once (`new Address(pk.toBase58())`) and keep the v3 `Address` downstream. Do not let v1 `PublicKey` propagate.
+
+## Common Failure Modes
+The steps above cover the mechanical swaps. These are the silent bugs they don't make obvious:
+
+- Mixing `TOKEN_PROGRAM_ID` (PublicKey) and `TOKEN_PROGRAM_ADDRESS` (Kit branded `Address`) in the same call site — types may collapse to `string` at the wrong spot and the instruction silently targets the wrong program.
+- **`owner` vs `ata` swap** — `findAssociatedTokenPda({ owner, mint, tokenProgram })` returns the ATA; `owner` is the wallet. Passing one where the builder expects the other compiles fine and fails on-chain.
+- **`bigint` leakage** — `amount`/`supply` come out of `getTokenDecoder()`/`getMintDecoder()` as `bigint`. Code that does math, `JSON.stringify`, or UI display expecting `number` breaks at runtime, not compile time.
+- **`Option<Address>` fields** — `mintAuthority` / `freezeAuthority` / `delegate` decode to kit `Option<Address>` (`{__option: 'Some', value: '...'}`), not a bare address. Unwrap with `unwrapOption(...)` from `@solana/kit`.
+- **`Buffer` pooled-view hazard** — if a legacy path hands you a `Buffer` (not v3's `Uint8Array` from `getAccountInfo`), convert with `new Uint8Array(buf)` before decoding; `Buffer`'s pooled-view semantics can yield wrong bytes after `slice`.
+
+## Done When
+- Fast Triage patterns above all come back clean (or isolated to one controlled boundary).
+- Authority/payer fields receive a `Keypair` (a `TransactionSigner`), not a bare `Address`.
+- Token-2022 paths use `@solana-program/token-2022`, and program ownership is explicit at any call site that can see either.
+- Project typechecks, and the narrowest affected tests — or an on-chain smoke path exercising mint → ATA create → mint-to → transfer → balance read — pass.
+- Package.json no longer includes `@solana/spl-token`

--- a/skills/web3js-v1-to-v3-migration/reference/spl-token.md
+++ b/skills/web3js-v1-to-v3-migration/reference/spl-token.md
@@ -84,6 +84,13 @@ import {
 - `NATIVE_MINT` (PublicKey) → inline `'So11111111111111111111111111111111111111112' as KitAddress`. `@solana-program/token@0.13.0` does **not** export `NATIVE_MINT_ADDRESS` — don't try to import it.
 - All `PublicKey` arguments on instruction builders become kit-branded `Address`. v3 web3.js's `Address` class exposes `.toBase58()` typed as the kit brand — call it at the boundary whenever passing v3 `Keypair.publicKey` or another v3 `Address` into a `@solana-program/token` builder. Going the other direction, wrap a kit `Address` with `new Address(kitAddr)` when v3 `Connection.getAccountInfo` / `SystemProgram` needs the v3 class.
 
+> [!IMPORTANT]
+> **In v3 web3.js, `PublicKey` is an alias of the `Address` class** (`export const PublicKey = Address` in `src/publickey.ts`) — not the v1 `PublicKey`. If the codebase is already on v3, every `PublicKey` you see is already a v3 `Address` instance. Two failure modes to avoid:
+> - **Do not** "get a kit address" via `new Address(addr.toBase58())`. That re-wraps the value into the v3 `Address` **class** (the opposite of what a `@solana-program/token` builder wants). To produce the kit-branded string for a builder, just call `addr.toBase58()`.
+> - `new Address(...)` converts a kit-branded **string** (or a real v1 `PublicKey` from an un-migrated dependency) **into** the v3 `Address` class. Only reach for it when handing a value to `SystemProgram` / `Connection`, never to feed a `@solana-program/token` builder.
+>
+> Quick rule: **builder boundary → `.toBase58()`; `SystemProgram`/`Connection` boundary → `new Address(...)`.**
+
 ### 3. Replace ATA derivation
 `getAssociatedTokenAddressSync(mint, owner, allowOwnerOffCurve?, programId?, associatedTokenProgramId?)` is sync and PublicKey-typed. `findAssociatedTokenPda` is async and returns `[Address, ProgramDerivedAddressBump]`.
 
@@ -293,13 +300,17 @@ After each slice (imports, ATA derivation, one instruction surface, fetches), ru
 - If the code path supports both, pass the owning program address through explicitly — do not hardcode `TOKEN_PROGRAM_ADDRESS`.
 
 ### `PublicKey` at the boundary
+First, know which `PublicKey` you have. In **v3 web3.js, `PublicKey` is just an alias of the `Address` class** (`export const PublicKey = Address`) — so in an already-migrated codebase a `PublicKey` value *is* a v3 `Address` instance and needs no conversion to itself. Only an **un-migrated** dependency hands back a genuine v1 `PublicKey`.
+
 - Inside the migrated module, use the v3 `Address` class for everything that touches `SystemProgram` / `Connection`, and call `.toBase58()` to produce the kit-branded string at every `@solana-program/token` builder boundary.
-- At third-party boundaries that still hand back v1 `PublicKey`, convert once (`new Address(pk.toBase58())`) and keep the v3 `Address` downstream. Do not let v1 `PublicKey` propagate.
+- **Never write `new Address(addr.toBase58())` to obtain a kit address.** When `addr` is already a v3 `Address` (including a v3 `PublicKey`), that round-trips back into the v3 `Address` class — not the kit-branded string a builder expects. Use `addr.toBase58()` for the builder; pass `addr` itself (or `new Address(kitString)`) when a `SystemProgram` / `Connection` API wants the class.
+- At third-party boundaries that still hand back a genuine v1 `PublicKey`, convert once (`new Address(pk.toBase58())`) and keep the v3 `Address` downstream. Do not let v1 `PublicKey` propagate.
 
 ## Common Failure Modes
 The steps above cover the mechanical swaps. These are the silent bugs they don't make obvious:
 
 - Mixing `TOKEN_PROGRAM_ID` (PublicKey) and `TOKEN_PROGRAM_ADDRESS` (Kit branded `Address`) in the same call site — types may collapse to `string` at the wrong spot and the instruction silently targets the wrong program.
+- **Double-wrapping an already-migrated address** — in v3, `PublicKey` is an alias of the `Address` class, so `new Address(addr.toBase58())` on a value that's already a v3 `Address` produces the v3 class again, not the kit-branded string a `@solana-program/token` builder needs. Reach for `.toBase58()` at builder boundaries and reserve `new Address(...)` for `SystemProgram` / `Connection`.
 - **`owner` vs `ata` swap** — `findAssociatedTokenPda({ owner, mint, tokenProgram })` returns the ATA; `owner` is the wallet. Passing one where the builder expects the other compiles fine and fails on-chain.
 - **`bigint` leakage** — `amount`/`supply` come out of `getTokenDecoder()`/`getMintDecoder()` as `bigint`. Code that does math, `JSON.stringify`, or UI display expecting `number` breaks at runtime, not compile time.
 - **`Option<Address>` fields** — `mintAuthority` / `freezeAuthority` / `delegate` decode to kit `Option<Address>` (`{__option: 'Some', value: '...'}`), not a bare address. Unwrap with `unwrapOption(...)` from `@solana/kit`.


### PR DESCRIPTION
…guide

Adds @solana/spl-token → @solana-program/token migration coverage to the v1→v3 upgrade path:

- docs/web3js-spl-token-migration.md: human-facing migration guide
- skills/web3js-v1-to-v3-migration/reference/spl-token.md: execution-oriented token surface, loaded on demand when spl-token usage is present
- web3js-v1-to-v3-migration SKILL/doc: extend description, Fast Triage, and trigger phrases to cover the token surface and point at the reference

Covers instruction-builder swaps, async ATA derivation, plan helpers, Keypair-as-TransactionSigner, and bigint/Option decoding.