### PR TITLE
fix(types): export ClientSubscriptionId from connection.ts (closes #3745)

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -90,7 +90,7 @@ interface IWSRequestParams {
   [x: number]: any;
 }
 
-type ClientSubscriptionId = number;
+export type ClientSubscriptionId = number;
 /** @internal */ type ServerSubscriptionId = number;
 /** @internal */ type SubscriptionConfigHash = string;
 /** @internal */ type SubscriptionDisposeFn = () => Promise<void>;


### PR DESCRIPTION
## What
Adds the `export` keyword to the `ClientSubscriptionId` type definition in `src/connection.ts` so it becomes re-exported through `src/index.ts`.

## Why
Closes #3745

`ClientSubscriptionId` was defined at line 93 of `src/connection.ts` but was missing the `export` keyword. Since `src/index.ts` uses `export * from './connection'`, only exported declarations get re-exported. Consumers trying to import this type get a TypeScript error:

```ts
import { ClientSubscriptionId } from "@solana/web3.js";
// Error TS2305: Module has no exported member 'ClientSubscriptionId'
```

## Change
Single-line change in `src/connection.ts`:

```diff
-type ClientSubscriptionId = number;
+export type ClientSubscriptionId = number;
```

## Impact
- Type-only export, zero runtime cost
- No breaking changes
- Fixes ergonomics for downstream type consumers (wallet adapters, indexers, subscription managers)

## Internal types preserved
The other types immediately below (e.g., `ServerSubscriptionId`, `SubscriptionConfigHash`) are intentionally left without `export` — they're marked `/** @internal */` and used only within the `Connection` class.

## Tested
Manually verified the type is now reachable:
```ts
import { ClientSubscriptionId } from "@solana/web3.js";
const id: ClientSubscriptionId = 5; // OK
```
