### PR TITLE
fix getParsedBlock full return type

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4906,20 +4906,27 @@ export class Connection {
    */
   async getParsedBlock(
     slot: number,
-    rawConfig?: GetVersionedBlockConfig,
-  ): Promise<ParsedAccountsModeBlockResponse>;
+    rawConfig: GetVersionedBlockConfig & {transactionDetails: 'full'},
+  ): Promise<ParsedBlockResponse | null>;
 
   // eslint-disable-next-line no-dupe-class-members
   async getParsedBlock(
     slot: number,
     rawConfig: GetVersionedBlockConfig & {transactionDetails: 'accounts'},
-  ): Promise<ParsedAccountsModeBlockResponse>;
+  ): Promise<ParsedAccountsModeBlockResponse | null>;
 
   // eslint-disable-next-line no-dupe-class-members
   async getParsedBlock(
     slot: number,
     rawConfig: GetVersionedBlockConfig & {transactionDetails: 'none'},
-  ): Promise<ParsedNoneModeBlockResponse>;
+  ): Promise<ParsedNoneModeBlockResponse | null>;
+
+  // eslint-disable-next-line no-dupe-class-members
+  async getParsedBlock(
+    slot: number,
+    rawConfig?: GetVersionedBlockConfig,
+  ): Promise<ParsedBlockResponse | null>;
+
   // eslint-disable-next-line no-dupe-class-members
   async getParsedBlock(
     slot: number,

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -43,6 +43,7 @@ import {
   InflationGovernor,
   InflationRate,
   Logs,
+  ParsedBlockResponse,
   SignatureResult,
   SlotInfo,
 } from '../src/connection';
@@ -3772,12 +3773,14 @@ describe('Connection', function () {
           ],
         },
       });
-      await expect(
-        connection.getParsedBlock(1, {
+      const block: ParsedBlockResponse | null = await connection.getParsedBlock(
+        1,
+        {
           maxSupportedTransactionVersion: 0,
           transactionDetails: 'full',
-        }),
-      ).not.to.eventually.be.rejected;
+        },
+      );
+      expect(block).to.not.be.null;
     });
 
     it('can deserialize a response when `transactionDetails` is `none`', async () => {


### PR DESCRIPTION
## Summary

Fixes the TypeScript return type overloads for `connection.getParsedBlock()` when `transactionDetails` is `"full"` or omitted.

The runtime implementation already deserializes full parsed blocks for these cases, but the overload currently resolves to `ParsedAccountsModeBlockResponse`, which omits the full parsed transaction shape.

Closes #3773.

## Changes

- Add an explicit `"full"` overload returning `ParsedBlockResponse | null`
- Update the default/omitted config overload to return `ParsedBlockResponse | null`
- Preserve specialized return types for `"accounts"` and `"none"`
- Update the existing `"full"` deserialize test to assert assignment to `ParsedBlockResponse | null`

## Testing

- `prettier --check src/connection.ts test/connection.test.ts`
- `tsc --noEmit --skipLibCheck --typeRoots .\node_modules\@types`
- `mocha --require tsx test/connection.test.ts --grep "transactionDetails.*full"`